### PR TITLE
chore: add honcho dev runner, direnv, and doc cleanup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,16 +22,3 @@ ANTHROPIC_API_KEY=
 
 # MCP server URL (data access layer for the agent)
 # MCP_SERVER_URL=http://localhost:8100/mcp
-
-# Chainlit
-CHAINLIT_AUTH_SECRET=change-me-random-secret
-
-# Development authentication (optional - for quick local testing)
-# CHAINLIT_DEV_USERNAME=dev@example.com
-# CHAINLIT_DEV_PASSWORD=devpassword
-
-# Header authentication (for reverse proxy setups like oauth2-proxy, Authelia)
-# AUTH_USER_ID_HEADER=X-Auth-User-Id
-# AUTH_USER_EMAIL_HEADER=X-Forwarded-Email
-# AUTH_USER_NAME_HEADER=X-Forwarded-Preferred-Username
-# AUTH_HEADER_AUTO_PROVISION=false

--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,7 @@ PLATFORM_DB_PASSWORD=change-me-platform-password
 # API_PORT=8000
 
 # Django
+DJANGO_SETTINGS_MODULE=config.settings.development
 DJANGO_SECRET_KEY=change-me-generate-a-real-secret-key
 DJANGO_DEBUG=True
 DJANGO_ALLOWED_HOSTS=localhost,127.0.0.1

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+layout uv

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,9 @@ uv run python manage.py migrate           # Run migrations
 cd frontend && bun install && bun dev     # Dev server on :5173
 cd frontend && bun run build              # Production build (runs tsc first)
 
+# All dev servers at once (Django :8000, MCP :8100, Vite :5173)
+uv run honcho -f Procfile.dev start
+
 # Full stack via Docker
 docker compose up                         # All services (api :8000, frontend :3000, mcp :8100)
 

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,3 @@
+web: uv run uvicorn config.asgi:application --reload --port 8000
+mcp: uv run python -m mcp_server --transport streamable-http --reload
+frontend: bash -c "cd frontend && bun dev"

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ A self-hosted platform for deploying AI agents that can query project-specific P
 - Redis
 - Node.js 18+ or Bun
 - [uv](https://docs.astral.sh/uv/) (Python package manager)
+- [direnv](https://direnv.net/) (optional, recommended) — automatically loads `.env` and activates the uv virtualenv when you `cd` into the project. Run `direnv allow` once after cloning.
 
 ### Backend
 
@@ -52,7 +53,7 @@ uv run manage.py collectstatic --noinput
 uv run manage.py createsuperuser
 
 # Start the backend (ASGI)
-DJANGO_SETTINGS_MODULE=config.settings.development uv run uvicorn config.asgi:application --host 127.0.0.1 --port 8000 --reload
+uv run uvicorn config.asgi:application --host 127.0.0.1 --port 8000 --reload
 ```
 
 ### Frontend

--- a/docs/docs/deployment/configuration.md
+++ b/docs/docs/deployment/configuration.md
@@ -19,7 +19,7 @@ Scout is configured via environment variables, typically set in a `.env` file in
 |----------|---------|-------------|
 | `DJANGO_DEBUG` | `True` | Enable debug mode. Set to `False` in production. |
 | `DJANGO_ALLOWED_HOSTS` | `localhost,127.0.0.1` | Comma-separated list of allowed host headers. |
-| `DJANGO_SETTINGS_MODULE` | -- | Settings module to use. Options: `config.settings.development`, `config.settings.production`, `config.settings.test` |
+| `DJANGO_SETTINGS_MODULE` | `config.settings.development` | Settings module to use. Options: `config.settings.development`, `config.settings.production`, `config.settings.test` |
 
 ### Security
 
@@ -39,6 +39,14 @@ Scout is configured via environment variables, typically set in a `.env` file in
 |----------|---------|-------------|
 | `MCP_SERVER_URL` | `http://localhost:8100/mcp` | URL of the MCP server for tool-based data access. |
 
+### Managed database
+
+The managed database stores materialized CommCare case data. Each CommCare domain gets its own PostgreSQL schema.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MANAGED_DATABASE_URL` | (falls back to `DATABASE_URL`) | PostgreSQL connection URL for materialized case data. In development, omit this and Scout uses the main app database with per-domain schema isolation. |
+
 ### Rate limiting
 
 | Variable | Default | Description |
@@ -53,16 +61,6 @@ Scout is configured via environment variables, typically set in a `.env` file in
 | `ANTHROPIC_API_KEY` | (empty) | Anthropic API key. Required for the agent to function. |
 
 The default LLM model (`claude-sonnet-4-5-20250929`) can be overridden per-project in the project settings.
-
-### Header-based authentication
-
-For deployments behind a reverse proxy that handles authentication (e.g., OAuth2 Proxy):
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `AUTH_USER_ID_HEADER` | (empty) | HTTP header containing the authenticated user ID. |
-| `AUTH_USER_EMAIL_HEADER` | (empty) | HTTP header containing the authenticated user email. |
-| `AUTH_USER_NAME_HEADER` | (empty) | HTTP header containing the authenticated user name. |
 
 ## Frontend environment
 

--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -7,6 +7,7 @@
 - Redis
 - Node.js 18+ or [Bun](https://bun.sh/)
 - [uv](https://docs.astral.sh/uv/) -- fast Python package manager
+- [direnv](https://direnv.net/) (optional, recommended) -- auto-loads `.env` and activates the virtualenv on `cd`. Run `direnv allow` once after cloning.
 
 ## Backend setup
 
@@ -50,9 +51,7 @@ uv run manage.py createsuperuser
 Start the ASGI development server:
 
 ```bash
-DJANGO_SETTINGS_MODULE=config.settings.development \
-  uv run uvicorn config.asgi:application \
-  --host 127.0.0.1 --port 8000 --reload
+uv run uvicorn config.asgi:application --host 127.0.0.1 --port 8000 --reload
 ```
 
 ## Frontend setup
@@ -66,6 +65,16 @@ bun dev
 ```
 
 The frontend dev server starts on `http://localhost:5173` and proxies `/api/*` requests to the backend on port 8000.
+
+## Running all dev servers at once
+
+Instead of managing three terminals, use [honcho](https://honcho.readthedocs.io/) to start Django, the MCP server, and Vite together with a single command:
+
+```bash
+uv run honcho -f Procfile.dev start
+```
+
+Each process is color-coded and labeled in the output. Ctrl+C stops all three.
 
 ## Docker setup
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,4 +91,5 @@ dev = [
     "ruff>=0.5",
     "zensical>=0.0.21",
     "requests-mock>=1.12.1",
+    "honcho>=1.1",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -778,6 +778,18 @@ wheels = [
 ]
 
 [[package]]
+name = "honcho"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/65/c8/d860888358bf5c8a6e7d78d1b508b59b0e255afd5655f243b8f65166dafd/honcho-2.0.0.tar.gz", hash = "sha256:af3815c03c634bf67d50f114253ea9fef72ecff26e4fd06b29234789ac5b8b2e", size = 45618, upload-time = "2024-10-06T14:26:53.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/1c/25631fc359955569e63f5446dbb7022c320edf9846cbe892ee5113433a7e/honcho-2.0.0-py3-none-any.whl", hash = "sha256:56dcd04fc72d362a4befb9303b1a1a812cba5da283526fbc6509be122918ddf3", size = 22093, upload-time = "2024-10-06T14:26:52.181Z" },
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -2210,6 +2222,7 @@ dev = [
 [package.dev-dependencies]
 dev = [
     { name = "factory-boy" },
+    { name = "honcho" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -2261,6 +2274,7 @@ provides-extras = ["dev"]
 [package.metadata.requires-dev]
 dev = [
     { name = "factory-boy", specifier = ">=3.3" },
+    { name = "honcho", specifier = ">=1.1" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-asyncio", specifier = ">=0.23" },
     { name = "pytest-cov", specifier = ">=4.1" },


### PR DESCRIPTION
## Summary

- Adds `Procfile.dev` + honcho so all three dev servers (Django :8000, MCP :8100, Vite :5173) start with `uv run honcho -f Procfile.dev start` — color-coded logs, auto-reload, single Ctrl+C to stop
- Commits `.envrc` (`layout uv`) for direnv users — activates the uv virtualenv and loads `.env` on `cd`
- Adds `DJANGO_SETTINGS_MODULE=config.settings.development` to `.env.example` (was previously required as an inline env var on every command)
- Cleans up docs: removes stale Chainlit/unimplemented header-auth vars, documents `MANAGED_DATABASE_URL`, updates installation guide with direnv prereq and honcho section

## Test plan

- [ ] `uv run honcho -f Procfile.dev start` launches all three servers with labeled output
- [ ] `direnv allow` in a fresh clone activates the venv automatically
- [ ] `uv run uvicorn config.asgi:application --reload` works without setting `DJANGO_SETTINGS_MODULE` inline

🤖 Generated with [Claude Code](https://claude.com/claude-code)