### PR TITLE
Enable PKCE for all OAuth providers

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -199,11 +199,15 @@ SOCIALACCOUNT_PROVIDERS = {
     "google": {
         "SCOPE": ["profile", "email"],
         "AUTH_PARAMS": {"access_type": "online"},
+        "OAUTH_PKCE_ENABLED": True,
     },
     "github": {
         "SCOPE": ["user:email"],
+        "OAUTH_PKCE_ENABLED": True,
     },
-    "commcare_connect": {},
+    "commcare_connect": {
+        "OAUTH_PKCE_ENABLED": True,
+    },
 }
 
 


### PR DESCRIPTION
## Summary
- Enables allauth's built-in PKCE support for Google, GitHub, and CommCare Connect OAuth providers
- Hardens the OAuth authorization code flow against interception attacks
- No custom adapter code needed — allauth handles code_verifier/code_challenge generation and validation internally

## Test plan
- [ ] Verify Google OAuth login still works
- [ ] Verify GitHub OAuth login still works
- [ ] Verify CommCare Connect OAuth login still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)