### PR TITLE
docs: add pre-commit installation step

### DIFF
--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -40,6 +40,14 @@ Generate a Fernet encryption key for database credential storage:
 python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
 ```
 
+Install and set up pre-commit hooks:
+
+```bash
+uv run pre-commit install
+```
+
+This installs hooks that run ruff linting and formatting checks before each commit.
+
 Run migrations and create a superuser:
 
 ```bash


### PR DESCRIPTION
## Summary
- Adds `uv run pre-commit install` step to the installation docs
- Placed after `uv sync` and before running migrations, so hooks are set up early in the dev setup flow

## Test plan
- [ ] Verify the docs page at https://dimagi-rad.github.io/scout/getting-started/installation/ renders the new section correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)