### PR TITLE
fix: add missing left padding to main content pages

### DIFF
--- a/frontend/src/pages/ArtifactsPage/ArtifactsPage.tsx
+++ b/frontend/src/pages/ArtifactsPage/ArtifactsPage.tsx
@@ -34,7 +34,7 @@ export function ArtifactsPage() {
   }, [deleteArtifact])
 
   return (
-    <div className="container mx-auto py-8">
+    <div className="container mx-auto px-8 py-8">
       {/* Header */}
       <div className="mb-8">
         <h1 className="text-2xl font-bold">Artifacts</h1>

--- a/frontend/src/pages/DataSourcesPage/DataSourcesPage.tsx
+++ b/frontend/src/pages/DataSourcesPage/DataSourcesPage.tsx
@@ -3,7 +3,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 
 export function DataSourcesPage() {
   return (
-    <div className="container mx-auto py-8">
+    <div className="container mx-auto px-8 py-8">
       <div className="mb-6">
         <h1 className="text-2xl font-bold">Data Sources</h1>
         <p className="text-muted-foreground">

--- a/frontend/src/pages/KnowledgePage/KnowledgePage.tsx
+++ b/frontend/src/pages/KnowledgePage/KnowledgePage.tsx
@@ -132,7 +132,7 @@ export function KnowledgePage() {
   const filteredItems = knowledgeItems
 
   return (
-    <div className="container mx-auto py-8">
+    <div className="container mx-auto px-8 py-8">
       {/* Header */}
       <div className="mb-8 flex items-center justify-between">
         <div>

--- a/frontend/src/pages/RecipesPage/RecipesPage.tsx
+++ b/frontend/src/pages/RecipesPage/RecipesPage.tsx
@@ -149,7 +149,7 @@ export function RecipesPage() {
     const run = recipeRuns.find((r) => r.id === runId)
     if (run) {
       return (
-        <div className="container mx-auto py-8">
+        <div className="container mx-auto px-8 py-8">
           <RecipeRunDetail
             recipe={currentRecipe}
             run={run}
@@ -164,7 +164,7 @@ export function RecipesPage() {
   // Show detail view if we have an ID
   if (id && currentRecipe) {
     return (
-      <div className="container mx-auto py-8">
+      <div className="container mx-auto px-8 py-8">
         <RecipeDetail
           recipe={currentRecipe}
           runs={recipeRuns}
@@ -209,7 +209,7 @@ export function RecipesPage() {
 
   // Show list view
   return (
-    <div className="container mx-auto py-8">
+    <div className="container mx-auto px-8 py-8">
       {/* Header */}
       <div className="mb-8">
         <h1 className="text-2xl font-bold">Recipes</h1>


### PR DESCRIPTION
## Summary
- Adds `px-8` to the `container mx-auto py-8` wrapper in Artifacts, Knowledge, Recipes, and Connections (Data Sources) pages
- Without it, content rendered flush against the sidebar border with no breathing room

## Test plan
- [ ] Visit Artifacts, Knowledge, Recipes, and Connections pages and verify left padding is present
- [ ] Chat and Data Dictionary pages (unaffected) should look unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)