### PR TITLE
fix: remove excess left padding on Connections page

### DIFF
--- a/frontend/src/pages/ConnectionsPage/ConnectionsPage.tsx
+++ b/frontend/src/pages/ConnectionsPage/ConnectionsPage.tsx
@@ -181,7 +181,7 @@ export function ConnectionsPage() {
     typeof formMode === "object" ? formMode.editing.membership_id : null
 
   return (
-    <div className="mx-auto max-w-2xl space-y-8 p-6">
+    <div className="container mx-auto space-y-8 px-8 py-8">
       <div>
         <h1 className="text-2xl font-semibold">Connected Accounts</h1>
         <p className="text-sm text-muted-foreground">


### PR DESCRIPTION
## Summary
- `ConnectionsPage` used `mx-auto max-w-2xl` which centered a narrow container, creating a large left gap after the sidebar
- Changed to `container mx-auto px-8 py-8` to match the layout pattern used by Artifacts, Knowledge, Recipes, and Data Dictionary pages

## Test Plan
- [ ] Visit `/settings/connections` and confirm content starts near the sidebar, matching `/artifacts` and other pages