### PR TITLE
fix: skip connection wizard on login when user already has connections

### DIFF
--- a/apps/chat/views.py
+++ b/apps/chat/views.py
@@ -192,12 +192,20 @@ def login_view(request):
     _record_attempt(email, True)
     login(request, user)
 
+    from apps.users.models import TenantMembership
+
+    onboarding_complete = TenantMembership.objects.filter(
+        user=user,
+        credential__isnull=False,
+    ).exists()
+
     return JsonResponse(
         {
             "id": str(user.id),
             "email": user.email,
             "name": user.get_full_name(),
             "is_staff": user.is_staff,
+            "onboarding_complete": onboarding_complete,
         }
     )
 


### PR DESCRIPTION
## Summary
- `login_view` was not including `onboarding_complete` in its response, so the field was `undefined` (falsy) on the frontend after login
- This caused the `OnboardingWizard` to always render after every login, even for users with existing connections
- Fix: compute and include `onboarding_complete` in the login response (same logic as `me_view`)

## Test Plan
- [x] Added `TestLoginOnboardingComplete` with two cases: no connections (False) and existing connections (True)
- [x] All 51 auth tests passing
- [x] Manually verified: login with existing account goes directly to main app, not the wizard
- [x] Verified logout → login flow also bypasses wizard correctly

Closes #18