### PR TITLE
fix: standardize destructive button style

### DIFF
--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -11,7 +11,7 @@ const buttonVariants = cva(
       variant: {
         default: "bg-primary text-primary-foreground hover:bg-primary/90",
         destructive:
-          "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+          "border border-destructive/40 bg-destructive/5 text-destructive hover:bg-destructive/15 focus-visible:ring-destructive/20",
         outline:
           "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
         secondary:

--- a/frontend/src/pages/ArtifactsPage/ArtifactList.tsx
+++ b/frontend/src/pages/ArtifactsPage/ArtifactList.tsx
@@ -158,23 +158,26 @@ function ArtifactCard({
                 variant="destructive"
                 size="sm"
                 onClick={onDelete}
+                data-testid={`artifact-confirm-delete-${artifact.id}`}
               >
-                Confirm
+                Confirm Delete
               </Button>
               <Button
                 variant="ghost"
                 size="sm"
                 onClick={() => setConfirmDelete(false)}
+                data-testid={`artifact-cancel-delete-${artifact.id}`}
               >
                 Cancel
               </Button>
             </div>
           ) : (
             <Button
-              variant="ghost"
+              variant="destructive"
               size="sm"
               onClick={() => setConfirmDelete(true)}
-              className="text-destructive hover:text-destructive"
+              className="ml-auto"
+              data-testid={`artifact-delete-${artifact.id}`}
             >
               <Trash2 className="mr-1 h-4 w-4" />
               Delete

--- a/frontend/src/pages/ConnectionsPage/ConnectionsPage.tsx
+++ b/frontend/src/pages/ConnectionsPage/ConnectionsPage.tsx
@@ -308,11 +308,10 @@ export function ConnectionsPage() {
                         Cancel
                       </Button>
                       <Button
-                        variant="outline"
+                        variant="destructive"
                         size="sm"
                         onClick={() => confirmRemove(domain.membership_id)}
                         disabled={removing === domain.membership_id}
-                        className="border-red-300 bg-red-50 text-red-700 hover:bg-red-100 hover:text-red-800"
                         data-testid={`confirm-remove-${domain.tenant_id}`}
                       >
                         {removing === domain.membership_id ? "Removing..." : "Confirm Remove"}
@@ -339,10 +338,9 @@ export function ConnectionsPage() {
                         Edit
                       </Button>
                       <Button
-                        variant="outline"
+                        variant="destructive"
                         size="sm"
                         onClick={() => setConfirmRemoveId(domain.membership_id)}
-                        className="border-red-300 bg-red-50 text-red-700 hover:bg-red-100 hover:text-red-800"
                         data-testid={`remove-domain-${domain.tenant_id}`}
                       >
                         Remove


### PR DESCRIPTION
## Summary
- Redefine `variant="destructive"` on the Button component to use a light red tint (`bg-destructive/5`, `border-destructive/40`, `text-destructive`) instead of the solid filled red — uses the existing CSS variable with opacity modifiers so dark mode works automatically
- Update artifact delete buttons to use `variant="destructive"` with proper `data-testid` attributes and consistent `ml-auto` alignment
- Update connections page remove buttons to also use `variant="destructive"`, removing the previous inline red classes

## Test Plan
- [ ] Visit Artifacts page — Delete button should show light red outline style
- [ ] Click Delete — Confirm Delete button should match same style
- [ ] Visit Connections page — Remove / Confirm Remove buttons should look the same
- [ ] Verify dark mode renders correctly (destructive tint derives from CSS var)