### PR TITLE
feat: add /refresh-data slash command to trigger data sync

### DIFF
--- a/frontend/src/components/ChatPanel/slashCommands.ts
+++ b/frontend/src/components/ChatPanel/slashCommands.ts
@@ -15,4 +15,14 @@ export const SLASH_COMMANDS: SlashCommand[] = [
       return args ? `${base}\n\n${args}` : base
     },
   },
+  {
+    name: "refresh-data",
+    description: "Pull the latest data from connected accounts",
+    buildPrompt: (args) => {
+      const base =
+        "Trigger a fresh data sync from the connected account using the run_materialization tool. " +
+        "Run the appropriate pipeline to pull the latest data, then confirm when the sync is complete."
+      return args ? `${base}\n\n${args}` : base
+    },
+  },
 ]


### PR DESCRIPTION
## Summary

- Adds `/refresh-data` slash command to `SLASH_COMMANDS` in `slashCommands.ts`
- Prompts the agent to invoke `run_materialization` MCP tool to pull the latest data from connected accounts
- Optional free-text args are appended to the prompt (e.g. `/refresh-data use the commcare_sync pipeline`)

Closes #31.

## Test plan

- [ ] `/refresh-data` appears in slash command autocomplete in the chat panel
- [ ] Triggering it causes the agent to call `run_materialization`
- [ ] Optional args after the command are appended to the prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)