### PR TITLE
feat: add landing page at API root

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -5,6 +5,7 @@ URL configuration for Scout data agent platform.
 from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
+from django.http import HttpResponse
 from django.urls import include, path
 
 from apps.chat.views import public_thread_view
@@ -12,7 +13,45 @@ from apps.projects.api.views import RefreshSchemaView
 from apps.projects.views import health_check
 from apps.recipes.api.views import PublicRecipeRunView
 
+
+def api_root(request):
+    html = """<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Scout API</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+         display: flex; align-items: center; justify-content: center;
+         min-height: 100vh; background: #f8fafc; color: #1e293b; }
+  .card { text-align: center; max-width: 28rem; padding: 2rem; }
+  h1 { font-size: 1.5rem; margin-bottom: 0.5rem; }
+  p { color: #64748b; margin-bottom: 1rem; line-height: 1.5; }
+  code { background: #e2e8f0; padding: 0.15rem 0.4rem; border-radius: 0.25rem;
+         font-size: 0.875rem; }
+  a { color: #2563eb; text-decoration: none; }
+  a:hover { text-decoration: underline; }
+</style>
+</head>
+<body>
+<div class="card">
+  <h1>Scout API Server</h1>
+  <p>This is the API backend. If you're looking for the app, head to the frontend dev server:</p>
+  <p><a href="http://localhost:5173">localhost:5173</a></p>
+  <p style="font-size: 0.85rem; color: #94a3b8;">
+    API endpoints live under <code>/api/</code> &middot;
+    Health check at <a href="/health/">/health/</a>
+  </p>
+</div>
+</body>
+</html>"""
+    return HttpResponse(html)
+
+
 urlpatterns = [
+    path("", api_root, name="api_root"),
     path("health/", health_check, name="health_check"),
     path("admin/", admin.site.urls),
     path("accounts/", include("allauth.urls")),


### PR DESCRIPTION
## Summary
- Adds a clean landing page at `localhost:8000/` explaining this is the API server
- Links to the frontend dev server at `localhost:5173`
- Prevents confusion from hitting the Django error page when accidentally navigating to the API port

## Test plan
- [ ] Visit `localhost:8000` and verify the landing page renders
- [ ] Verify existing routes (`/api/`, `/admin/`, `/health/`) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)