### PR TITLE
refactor: make build_agent_graph async

### DIFF
--- a/apps/agents/graph/base.py
+++ b/apps/agents/graph/base.py
@@ -27,6 +27,7 @@ import copy
 import logging
 from typing import TYPE_CHECKING, Any, Literal
 
+from asgiref.sync import sync_to_async
 from langchain_anthropic import ChatAnthropic
 from langchain_core.messages import SystemMessage
 from langgraph.graph import END, StateGraph
@@ -144,7 +145,7 @@ def _make_injecting_tool_node(
     return injecting_node
 
 
-def build_agent_graph(
+async def build_agent_graph(
     tenant_membership: TenantMembership,
     user: User | None = None,
     checkpointer: BaseCheckpointSaver | None = None,
@@ -191,7 +192,7 @@ def build_agent_graph(
     llm_with_tools = llm.bind_tools(llm_tool_schemas)
 
     # --- Build system prompt ---
-    system_prompt = _build_system_prompt(workspace, tenant_membership)
+    system_prompt = await _build_system_prompt(workspace, tenant_membership)
     logger.debug(
         "System prompt assembled: %d characters for tenant:%s",
         len(system_prompt),
@@ -330,7 +331,9 @@ def _build_tools(workspace: TenantWorkspace, user: User | None, mcp_tools: list)
     return tools
 
 
-def _build_system_prompt(workspace: TenantWorkspace, tenant_membership: TenantMembership) -> str:
+async def _build_system_prompt(
+    workspace: TenantWorkspace, tenant_membership: TenantMembership
+) -> str:
     """
     Assemble the complete system prompt for a tenant workspace.
 
@@ -355,7 +358,7 @@ def _build_system_prompt(workspace: TenantWorkspace, tenant_membership: TenantMe
         sections.append(f"\n## Tenant-Specific Instructions\n\n{workspace.system_prompt}\n")
 
     retriever = KnowledgeRetriever(workspace)
-    knowledge_context = retriever.retrieve()
+    knowledge_context = await sync_to_async(retriever.retrieve)()
     if knowledge_context:
         sections.append(f"\n## Knowledge Base\n\n{knowledge_context}\n")
 

--- a/apps/chat/views.py
+++ b/apps/chat/views.py
@@ -586,7 +586,7 @@ async def chat_view(request):
     # Build agent (retry once with fresh checkpointer on connection errors)
     try:
         checkpointer = await _ensure_checkpointer()
-        agent = await sync_to_async(build_agent_graph)(
+        agent = await build_agent_graph(
             tenant_membership=tenant_membership,
             user=user,
             checkpointer=checkpointer,
@@ -598,7 +598,7 @@ async def chat_view(request):
         try:
             logger.info("Retrying agent build with fresh checkpointer")
             checkpointer = await _ensure_checkpointer(force_new=True)
-            agent = await sync_to_async(build_agent_graph)(
+            agent = await build_agent_graph(
                 tenant_membership=tenant_membership,
                 user=user,
                 checkpointer=checkpointer,

--- a/apps/recipes/services/runner.py
+++ b/apps/recipes/services/runner.py
@@ -93,7 +93,7 @@ class RecipeRunner:
                 if "default" in var_def:
                     self.variable_values[var_name] = var_def["default"]
 
-    def _build_graph(self) -> CompiledStateGraph:
+    async def _build_graph(self) -> CompiledStateGraph:
         """Build or return the agent graph for execution."""
         if self._provided_graph is not None:
             return self._provided_graph
@@ -101,11 +101,11 @@ class RecipeRunner:
         if self._graph is None:
             from apps.users.models import TenantMembership
 
-            self._tenant_membership = TenantMembership.objects.filter(
+            self._tenant_membership = await TenantMembership.objects.filter(
                 user=self.user,
                 tenant_id=self.recipe.workspace.tenant_id,
-            ).first()
-            self._graph = build_agent_graph(
+            ).afirst()
+            self._graph = await build_agent_graph(
                 tenant_membership=self._tenant_membership,
                 user=self.user,
                 checkpointer=None,
@@ -180,11 +180,13 @@ class RecipeRunner:
 
     def execute(self) -> RecipeRun:
         """Execute the recipe and return the RecipeRun record."""
+        from asgiref.sync import async_to_sync
+
         self.validate_variables()
 
         self._run = self._create_run_record()
 
-        graph = self._build_graph()
+        graph = async_to_sync(self._build_graph)()
         config = {"configurable": {"thread_id": self._thread_id}}
 
         # Render the prompt
@@ -272,7 +274,7 @@ class RecipeRunner:
 
         self._thread_id = f"recipe-run-{self._run.id}"
 
-        graph = self._build_graph()
+        graph = await self._build_graph()
         config = {"configurable": {"thread_id": self._thread_id}}
 
         prompt = self.recipe.render_prompt(self.variable_values)

--- a/tests/test_agent_graph.py
+++ b/tests/test_agent_graph.py
@@ -1,5 +1,7 @@
 """Tests for the agent graph builder."""
 
+import pytest
+
 
 class TestMcpToolNames:
     """Verify MCP_TOOL_NAMES contains all tools that need tenant_id injection."""
@@ -23,20 +25,24 @@ class TestMcpToolNames:
 class TestSystemPrompt:
     """Verify the system prompt includes data availability instructions."""
 
-    def test_data_availability_section_present(self, workspace, tenant_membership):
+    @pytest.mark.django_db(transaction=True)
+    @pytest.mark.asyncio
+    async def test_data_availability_section_present(self, workspace, tenant_membership):
         from apps.agents.graph.base import _build_system_prompt
 
-        prompt = _build_system_prompt(workspace, tenant_membership)
+        prompt = await _build_system_prompt(workspace, tenant_membership)
 
         assert "Data Availability" in prompt
         assert "get_schema_status" in prompt
         assert "run_materialization" in prompt
         assert "teardown_schema" in prompt
 
-    def test_data_availability_covers_not_provisioned_case(self, workspace, tenant_membership):
+    @pytest.mark.django_db(transaction=True)
+    @pytest.mark.asyncio
+    async def test_data_availability_covers_not_provisioned_case(self, workspace, tenant_membership):
         from apps.agents.graph.base import _build_system_prompt
 
-        prompt = _build_system_prompt(workspace, tenant_membership)
+        prompt = await _build_system_prompt(workspace, tenant_membership)
 
         # Agent must know to run materialization when no data exists
         assert "not_provisioned" in prompt or "loading" in prompt.lower()


### PR DESCRIPTION
## Summary

- Converts `build_agent_graph` and `_build_system_prompt` to `async def`
- Wraps the sync `KnowledgeRetriever.retrieve()` call with `sync_to_async` so it remains safe in an async context
- Updates `RecipeRunner._build_graph` to async (using `afirst()`) and `execute` to call it via `async_to_sync`
- Removes the `sync_to_async` wrapper from the call site in `chat/views.py`
- Updates `test_agent_graph.py` to `await` the async function

No logic changes. Prerequisite for schema context injection (PR 2), which needs to `await` async DB calls inside `_build_system_prompt`.

## Test Plan
- [x] All 499 tests pass
- [x] Ruff lint/format clean