### PR TITLE
refactor: convert sync functions to async throughout agent pipeline

### DIFF
--- a/apps/agents/graph/base.py
+++ b/apps/agents/graph/base.py
@@ -336,7 +336,7 @@ async def build_agent_graph(
 
     # --- Define graph nodes ---
 
-    def agent_node(state: AgentState) -> dict[str, Any]:
+    async def agent_node(state: AgentState) -> dict[str, Any]:
         """
         Call the LLM with the current conversation and system prompt.
 
@@ -347,7 +347,7 @@ async def build_agent_graph(
         # Filter out any prior system messages to avoid duplicates across cycles
         state_messages = [m for m in state_messages if not isinstance(m, SystemMessage)]
         messages = [SystemMessage(content=system_prompt)] + state_messages
-        response = llm_with_tools.invoke(messages)
+        response = await llm_with_tools.ainvoke(messages)
         return {"messages": [response]}
 
     def should_continue(state: AgentState) -> Literal["tools", "__end__"]:
@@ -489,7 +489,7 @@ async def _build_system_prompt(
         sections.append(f"\n## Tenant-Specific Instructions\n\n{workspace.system_prompt}\n")
 
     retriever = KnowledgeRetriever(workspace)
-    knowledge_context = await sync_to_async(retriever.retrieve)()
+    knowledge_context = await retriever.retrieve()
     if knowledge_context:
         sections.append(f"\n## Knowledge Base\n\n{knowledge_context}\n")
 

--- a/apps/agents/tools/artifact_tool.py
+++ b/apps/agents/tools/artifact_tool.py
@@ -74,7 +74,7 @@ def create_artifact_tools(
     """
 
     @tool(args_schema=CreateArtifactInput)
-    def create_artifact(
+    async def create_artifact(
         title, artifact_type, code, description="", data=None, source_queries=None
     ) -> dict[str, Any]:
         """
@@ -185,7 +185,7 @@ def create_artifact_tools(
             }
 
         try:
-            artifact = Artifact.objects.create(
+            artifact = await Artifact.objects.acreate(
                 workspace=workspace,
                 created_by=user,
                 title=title.strip(),
@@ -233,7 +233,7 @@ def create_artifact_tools(
             }
 
     @tool(args_schema=UpdateArtifactInput)
-    def update_artifact(
+    async def update_artifact(
         artifact_id, code, title=None, data=None, source_queries=None
     ) -> dict[str, Any]:
         """
@@ -284,7 +284,7 @@ def create_artifact_tools(
         try:
             # Find the existing artifact
             try:
-                original = Artifact.objects.get(id=artifact_id, workspace=workspace)
+                original = await Artifact.objects.aget(id=artifact_id, workspace=workspace)
             except Artifact.DoesNotExist:
                 return {
                     "artifact_id": None,
@@ -297,19 +297,22 @@ def create_artifact_tools(
                 }
 
             # Create a new version linked to the original
-            updates = {
-                "code": code,
-                "created_by": user,
-                "conversation_id": original.conversation_id,
-            }
-            if title is not None:
-                updates["title"] = title.strip()
-            if data is not None:
-                updates["data"] = data
-            if source_queries is not None:
-                updates["source_queries"] = source_queries
-
-            new_artifact = original.create_new_version(**updates)
+            new_artifact = Artifact(
+                workspace=workspace,
+                created_by=user,
+                title=title.strip() if title is not None else original.title,
+                description=original.description,
+                artifact_type=original.artifact_type,
+                code=code,
+                data=data if data is not None else original.data,
+                version=original.version + 1,
+                parent_artifact=original,
+                conversation_id=original.conversation_id,
+                source_queries=source_queries
+                if source_queries is not None
+                else original.source_queries,
+            )
+            await new_artifact.asave()
 
             logger.info(
                 "Created artifact version %s (v%d) from %s for workspace %s",

--- a/apps/agents/tools/learning_tool.py
+++ b/apps/agents/tools/learning_tool.py
@@ -72,7 +72,7 @@ def create_save_learning_tool(workspace: TenantWorkspace, user: User):
     """
 
     @tool
-    def save_learning(
+    async def save_learning(
         description: str,
         category: str,
         tables: list[str],
@@ -179,17 +179,17 @@ def create_save_learning_tool(workspace: TenantWorkspace, user: User):
                 # Don't fail - the table might be valid but not in the cached dictionary
 
         # Check for duplicate learnings (same description for same tables)
-        existing = AgentLearning.objects.filter(
+        existing = await AgentLearning.objects.filter(
             workspace=workspace,
             is_active=True,
             description__iexact=description.strip(),
-        ).first()
+        ).afirst()
 
         if existing:
             # Update the existing learning instead of creating a duplicate
             existing.confidence_score = min(1.0, existing.confidence_score + 0.1)
             existing.times_applied += 1
-            existing.save(update_fields=["confidence_score", "times_applied"])
+            await existing.asave(update_fields=["confidence_score", "times_applied"])
 
             logger.info(
                 "Updated existing learning %s (confidence: %.2f)",
@@ -207,7 +207,7 @@ def create_save_learning_tool(workspace: TenantWorkspace, user: User):
 
         # Create the new learning
         try:
-            learning = AgentLearning.objects.create(
+            learning = await AgentLearning.objects.acreate(
                 workspace=workspace,
                 description=description.strip(),
                 category=category,

--- a/apps/agents/tools/recipe_tool.py
+++ b/apps/agents/tools/recipe_tool.py
@@ -51,7 +51,7 @@ def create_recipe_tool(workspace: TenantWorkspace, user: User | None):
     """
 
     @tool
-    def save_as_recipe(
+    async def save_as_recipe(
         name: str,
         description: str,
         variables: list[dict[str, Any]],
@@ -209,7 +209,7 @@ def create_recipe_tool(workspace: TenantWorkspace, user: User | None):
 
         # Create the recipe
         try:
-            recipe = Recipe.objects.create(
+            recipe = await Recipe.objects.acreate(
                 workspace=workspace,
                 name=name.strip(),
                 description=description.strip() if description else "",

--- a/apps/knowledge/services/retriever.py
+++ b/apps/knowledge/services/retriever.py
@@ -30,34 +30,34 @@ class KnowledgeRetriever:
     def __init__(self, workspace: TenantWorkspace) -> None:
         self.workspace = workspace
 
-    def retrieve(self, user_question: str = "") -> str:
+    async def retrieve(self, user_question: str = "") -> str:
         """Retrieve and format all relevant knowledge as markdown."""
         sections: list[str] = []
 
-        entries_section = self._format_knowledge_entries()
+        entries_section = await self._format_knowledge_entries()
         if entries_section:
             sections.append(entries_section)
 
-        tables_section = self._format_table_knowledge()
+        tables_section = await self._format_table_knowledge()
         if tables_section:
             sections.append(tables_section)
 
-        learnings_section = self._format_agent_learnings()
+        learnings_section = await self._format_agent_learnings()
         if learnings_section:
             sections.append(learnings_section)
 
         return "\n\n".join(sections)
 
-    def _format_knowledge_entries(self) -> str:
+    async def _format_knowledge_entries(self) -> str:
         """Format knowledge entries as markdown sections."""
         entries = KnowledgeEntry.objects.filter(workspace=self.workspace).order_by("title")
 
-        if not entries.exists():
+        if not await entries.aexists():
             return ""
 
         lines: list[str] = ["## Knowledge Base", ""]
 
-        for entry in entries:
+        async for entry in entries:
             lines.append(f"### {entry.title}")
             lines.append("")
             lines.append(entry.content)
@@ -65,16 +65,16 @@ class KnowledgeRetriever:
 
         return "\n".join(lines).rstrip()
 
-    def _format_table_knowledge(self) -> str:
+    async def _format_table_knowledge(self) -> str:
         """Format table knowledge with column notes and data quality notes."""
         tables = TableKnowledge.objects.filter(workspace=self.workspace).order_by("table_name")
 
-        if not tables.exists():
+        if not await tables.aexists():
             return ""
 
         lines: list[str] = ["## Table Context (beyond schema)", ""]
 
-        for table in tables:
+        async for table in tables:
             lines.append(f"### {table.table_name}")
             lines.append("")
             lines.append(table.description)
@@ -112,19 +112,19 @@ class KnowledgeRetriever:
 
         return "\n".join(lines).rstrip()
 
-    def _format_agent_learnings(self) -> str:
+    async def _format_agent_learnings(self) -> str:
         """Format active agent learnings as a bullet list."""
         learnings = AgentLearning.objects.filter(
             workspace=self.workspace,
             is_active=True,
         ).order_by("-confidence_score", "-times_applied")[: self.MAX_AGENT_LEARNINGS]
 
-        if not learnings.exists():
+        if not await learnings.aexists():
             return ""
 
         lines: list[str] = ["## Learned Corrections", ""]
 
-        for learning in learnings:
+        async for learning in learnings:
             lines.append(f"- {learning.description}")
 
             if learning.applies_to_tables:

--- a/tests/agents/test_schema_context.py
+++ b/tests/agents/test_schema_context.py
@@ -190,7 +190,7 @@ async def test_build_system_prompt_no_schema_status_call():
         patch("apps.agents.graph.base.sync_to_async") as mock_s2a,
         patch("apps.agents.graph.base._render_full_schema") as mock_full,
     ):
-        MockKR.return_value.retrieve.return_value = ""
+        MockKR.return_value.retrieve = AsyncMock(return_value="")
         MockTS.objects.filter.return_value.afirst = AsyncMock(return_value=mock_ts)
         mock_reg.return_value.get.return_value = MagicMock()
         mock_s2a.return_value = AsyncMock(return_value=[])

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -537,18 +537,19 @@ class TestSharedArtifactView:
 # ============================================================================
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(transaction=True)
 class TestArtifactTools:
     """Tests for artifact creation and update tools."""
 
-    def test_create_artifact_tool(self, user, workspace):
+    @pytest.mark.asyncio
+    async def test_create_artifact_tool(self, user, workspace):
         """Test create_artifact tool creates an artifact correctly."""
         from apps.agents.tools.artifact_tool import create_artifact_tools
 
         tools = create_artifact_tools(workspace, user)
         create_artifact_tool = tools[0]
 
-        result = create_artifact_tool.invoke(
+        result = await create_artifact_tool.ainvoke(
             {
                 "title": "Revenue Chart",
                 "artifact_type": "react",
@@ -567,7 +568,7 @@ class TestArtifactTools:
         assert "/render" in result["render_url"]
 
         # Verify artifact was created in database
-        artifact = Artifact.objects.get(id=result["artifact_id"])
+        artifact = await Artifact.objects.aget(id=result["artifact_id"])
         assert artifact.title == "Revenue Chart"
         assert artifact.artifact_type == "react"
         assert artifact.code == "export default function Chart() { return <div>Chart</div>; }"
@@ -578,7 +579,8 @@ class TestArtifactTools:
         assert artifact.version == 1
         assert artifact.parent_artifact is None
 
-    def test_update_artifact_tool(self, user, workspace, artifact, tenant_membership):
+    @pytest.mark.asyncio
+    async def test_update_artifact_tool(self, user, workspace, artifact, tenant_membership):
         """Test update_artifact tool creates a new version of an artifact."""
         from apps.agents.tools.artifact_tool import create_artifact_tools
 
@@ -588,7 +590,7 @@ class TestArtifactTools:
         original_version = artifact.version
         new_code = "export default function Chart() { return <div>Updated Chart</div>; }"
 
-        result = update_artifact_tool.invoke(
+        result = await update_artifact_tool.ainvoke(
             {
                 "artifact_id": str(artifact.id),
                 "code": new_code,
@@ -602,13 +604,14 @@ class TestArtifactTools:
         assert result["version"] == original_version + 1
 
         # Update creates a NEW artifact (not in-place), verify the new one
-        new_artifact = Artifact.objects.get(id=result["artifact_id"])
+        new_artifact = await Artifact.objects.aget(id=result["artifact_id"])
         assert new_artifact.version == original_version + 1
         assert new_artifact.code == new_code
         assert new_artifact.title == "Updated Chart Title"
         assert new_artifact.data == {"rows": [{"x": 2, "y": 4}]}
 
-    def test_update_creates_new_version(self, user, workspace, artifact, tenant_membership):
+    @pytest.mark.asyncio
+    async def test_update_creates_new_version(self, user, workspace, artifact, tenant_membership):
         """Test that update_artifact creates new artifacts with incrementing versions."""
         from apps.agents.tools.artifact_tool import create_artifact_tools
 
@@ -618,7 +621,7 @@ class TestArtifactTools:
         original_version = artifact.version
 
         # First update - creates new artifact from original
-        result1 = update_artifact_tool.invoke(
+        result1 = await update_artifact_tool.ainvoke(
             {
                 "artifact_id": str(artifact.id),
                 "code": "export default function Chart() { return <div>Version 2</div>; }",
@@ -629,7 +632,7 @@ class TestArtifactTools:
         assert result1["version"] == original_version + 1
 
         # Second update - creates new artifact from the v2 artifact
-        result2 = update_artifact_tool.invoke(
+        result2 = await update_artifact_tool.ainvoke(
             {
                 "artifact_id": result1["artifact_id"],
                 "code": "export default function Chart() { return <div>Version 3</div>; }",

--- a/tests/test_knowledge_retriever.py
+++ b/tests/test_knowledge_retriever.py
@@ -10,6 +10,8 @@ Tests cover:
 - Retrieval filtering and prioritization
 """
 
+import pytest
+
 from apps.knowledge.models import (
     AgentLearning,
     KnowledgeEntry,
@@ -18,27 +20,32 @@ from apps.knowledge.models import (
 from apps.knowledge.services.retriever import KnowledgeRetriever
 
 
+@pytest.mark.django_db(transaction=True)
 class TestEmptyKnowledge:
     """Test retriever behavior with no knowledge."""
 
-    def test_empty_knowledge_returns_valid_string(self, workspace):
+    @pytest.mark.asyncio
+    async def test_empty_knowledge_returns_valid_string(self, workspace):
         retriever = KnowledgeRetriever(workspace)
-        result = retriever.retrieve()
+        result = await retriever.retrieve()
         assert isinstance(result, str)
         assert len(result) >= 0
 
-    def test_empty_knowledge_has_no_sections(self, workspace):
+    @pytest.mark.asyncio
+    async def test_empty_knowledge_has_no_sections(self, workspace):
         retriever = KnowledgeRetriever(workspace)
-        result = retriever.retrieve()
+        result = await retriever.retrieve()
         # No headers when empty
         assert "##" not in result
 
 
+@pytest.mark.django_db(transaction=True)
 class TestKnowledgeEntries:
     """Test retriever with knowledge entries."""
 
-    def test_single_entry(self, workspace, user):
-        KnowledgeEntry.objects.create(
+    @pytest.mark.asyncio
+    async def test_single_entry(self, workspace, user):
+        await KnowledgeEntry.objects.acreate(
             workspace=workspace,
             title="MRR",
             content="Monthly Recurring Revenue from active subscriptions\n\n```sql\nSELECT SUM(amount) FROM subscriptions WHERE status = 'active'\n```",
@@ -47,28 +54,29 @@ class TestKnowledgeEntries:
         )
 
         retriever = KnowledgeRetriever(workspace)
-        result = retriever.retrieve()
+        result = await retriever.retrieve()
 
         assert "MRR" in result
         assert "Monthly Recurring Revenue" in result
         assert "SUM(amount)" in result
 
-    def test_multiple_entries(self, workspace, user):
-        KnowledgeEntry.objects.create(
+    @pytest.mark.asyncio
+    async def test_multiple_entries(self, workspace, user):
+        await KnowledgeEntry.objects.acreate(
             workspace=workspace,
             title="MRR",
             content="Monthly Recurring Revenue",
             tags=["metric"],
             created_by=user,
         )
-        KnowledgeEntry.objects.create(
+        await KnowledgeEntry.objects.acreate(
             workspace=workspace,
             title="Soft Delete Rule",
             content="Always filter deleted_at IS NULL for active records",
             tags=["rule"],
             created_by=user,
         )
-        KnowledgeEntry.objects.create(
+        await KnowledgeEntry.objects.acreate(
             workspace=workspace,
             title="Daily Revenue Query",
             content="```sql\nSELECT DATE(created_at), SUM(amount) FROM orders GROUP BY 1\n```",
@@ -77,14 +85,15 @@ class TestKnowledgeEntries:
         )
 
         retriever = KnowledgeRetriever(workspace)
-        result = retriever.retrieve()
+        result = await retriever.retrieve()
 
         assert "MRR" in result
         assert "Soft Delete Rule" in result
         assert "Daily Revenue Query" in result
 
-    def test_entry_content_appears(self, workspace, user):
-        KnowledgeEntry.objects.create(
+    @pytest.mark.asyncio
+    async def test_entry_content_appears(self, workspace, user):
+        await KnowledgeEntry.objects.acreate(
             workspace=workspace,
             title="Revenue excludes cancelled orders",
             content="When calculating revenue, always exclude orders with status 'cancelled' or 'refunded'.",
@@ -93,17 +102,19 @@ class TestKnowledgeEntries:
         )
 
         retriever = KnowledgeRetriever(workspace)
-        result = retriever.retrieve()
+        result = await retriever.retrieve()
 
         assert "Revenue excludes cancelled orders" in result
         assert "cancelled" in result
 
 
+@pytest.mark.django_db(transaction=True)
 class TestTableKnowledge:
     """Test retriever with table knowledge."""
 
-    def test_single_table_knowledge(self, workspace, user):
-        TableKnowledge.objects.create(
+    @pytest.mark.asyncio
+    async def test_single_table_knowledge(self, workspace, user):
+        await TableKnowledge.objects.acreate(
             workspace=workspace,
             table_name="orders",
             description="Customer orders with payment and fulfillment status",
@@ -116,14 +127,15 @@ class TestTableKnowledge:
         )
 
         retriever = KnowledgeRetriever(workspace)
-        result = retriever.retrieve()
+        result = await retriever.retrieve()
 
         assert "orders" in result.lower()
         assert "Customer orders" in result or "orders" in result.lower()
 
-    def test_multiple_table_knowledge(self, workspace, user):
+    @pytest.mark.asyncio
+    async def test_multiple_table_knowledge(self, workspace, user):
         for i in range(10):
-            TableKnowledge.objects.create(
+            await TableKnowledge.objects.acreate(
                 workspace=workspace,
                 table_name=f"table_{i}",
                 description=f"Test table {i}",
@@ -132,13 +144,14 @@ class TestTableKnowledge:
             )
 
         retriever = KnowledgeRetriever(workspace)
-        result = retriever.retrieve()
+        result = await retriever.retrieve()
 
         for i in range(10):
             assert f"table_{i}" in result.lower()
 
-    def test_table_with_related_tables(self, workspace, user):
-        TableKnowledge.objects.create(
+    @pytest.mark.asyncio
+    async def test_table_with_related_tables(self, workspace, user):
+        await TableKnowledge.objects.acreate(
             workspace=workspace,
             table_name="orders",
             description="Customer orders",
@@ -150,18 +163,20 @@ class TestTableKnowledge:
         )
 
         retriever = KnowledgeRetriever(workspace)
-        result = retriever.retrieve()
+        result = await retriever.retrieve()
 
         assert "orders" in result.lower()
         if "users" in result:
             assert "related" in result.lower() or "user_id" in result
 
 
+@pytest.mark.django_db(transaction=True)
 class TestAgentLearnings:
     """Test retriever with agent learnings."""
 
-    def test_single_learning(self, workspace, user):
-        AgentLearning.objects.create(
+    @pytest.mark.asyncio
+    async def test_single_learning(self, workspace, user):
+        await AgentLearning.objects.acreate(
             workspace=workspace,
             description="Amount column is in cents, not dollars. Divide by 100.",
             category="type_mismatch",
@@ -175,12 +190,13 @@ class TestAgentLearnings:
         )
 
         retriever = KnowledgeRetriever(workspace)
-        result = retriever.retrieve()
+        result = await retriever.retrieve()
 
         assert "cents" in result.lower() or "divide by 100" in result.lower()
 
-    def test_multiple_learnings_ordered_by_confidence(self, workspace, user):
-        AgentLearning.objects.create(
+    @pytest.mark.asyncio
+    async def test_multiple_learnings_ordered_by_confidence(self, workspace, user):
+        await AgentLearning.objects.acreate(
             workspace=workspace,
             description="Low confidence learning",
             category="other",
@@ -189,7 +205,7 @@ class TestAgentLearnings:
             is_active=True,
             discovered_by_user=user,
         )
-        AgentLearning.objects.create(
+        await AgentLearning.objects.acreate(
             workspace=workspace,
             description="High confidence learning",
             category="other",
@@ -198,7 +214,7 @@ class TestAgentLearnings:
             is_active=True,
             discovered_by_user=user,
         )
-        AgentLearning.objects.create(
+        await AgentLearning.objects.acreate(
             workspace=workspace,
             description="Medium confidence learning",
             category="other",
@@ -209,15 +225,16 @@ class TestAgentLearnings:
         )
 
         retriever = KnowledgeRetriever(workspace)
-        result = retriever.retrieve()
+        result = await retriever.retrieve()
 
         if "High confidence" in result and "Low confidence" in result:
             high_pos = result.index("High confidence")
             low_pos = result.index("Low confidence")
             assert high_pos < low_pos
 
-    def test_inactive_learnings_excluded(self, workspace, user):
-        AgentLearning.objects.create(
+    @pytest.mark.asyncio
+    async def test_inactive_learnings_excluded(self, workspace, user):
+        await AgentLearning.objects.acreate(
             workspace=workspace,
             description="Active learning",
             category="other",
@@ -225,7 +242,7 @@ class TestAgentLearnings:
             is_active=True,
             discovered_by_user=user,
         )
-        AgentLearning.objects.create(
+        await AgentLearning.objects.acreate(
             workspace=workspace,
             description="Inactive learning",
             category="other",
@@ -235,13 +252,14 @@ class TestAgentLearnings:
         )
 
         retriever = KnowledgeRetriever(workspace)
-        result = retriever.retrieve()
+        result = await retriever.retrieve()
 
         assert "Active learning" in result
         assert "Inactive learning" not in result
 
-    def test_learning_with_evidence(self, workspace, user):
-        AgentLearning.objects.create(
+    @pytest.mark.asyncio
+    async def test_learning_with_evidence(self, workspace, user):
+        await AgentLearning.objects.acreate(
             workspace=workspace,
             description="Status column uses codes not names",
             category="naming",
@@ -255,16 +273,18 @@ class TestAgentLearnings:
         )
 
         retriever = KnowledgeRetriever(workspace)
-        result = retriever.retrieve()
+        result = await retriever.retrieve()
 
         assert "status" in result.lower()
 
 
+@pytest.mark.django_db(transaction=True)
 class TestFullAssembly:
     """Test retriever with all knowledge types together."""
 
-    def test_all_knowledge_types_present(self, workspace, user):
-        KnowledgeEntry.objects.create(
+    @pytest.mark.asyncio
+    async def test_all_knowledge_types_present(self, workspace, user):
+        await KnowledgeEntry.objects.acreate(
             workspace=workspace,
             title="MRR",
             content="Monthly Recurring Revenue\n\n```sql\nSELECT SUM(amount) FROM subscriptions WHERE status = 'active'\n```",
@@ -272,7 +292,7 @@ class TestFullAssembly:
             created_by=user,
         )
 
-        KnowledgeEntry.objects.create(
+        await KnowledgeEntry.objects.acreate(
             workspace=workspace,
             title="Soft Delete Rule",
             content="Always filter deleted_at IS NULL",
@@ -280,7 +300,7 @@ class TestFullAssembly:
             created_by=user,
         )
 
-        TableKnowledge.objects.create(
+        await TableKnowledge.objects.acreate(
             workspace=workspace,
             table_name="orders",
             description="Customer orders",
@@ -288,7 +308,7 @@ class TestFullAssembly:
             updated_by=user,
         )
 
-        AgentLearning.objects.create(
+        await AgentLearning.objects.acreate(
             workspace=workspace,
             description="Amount is in cents",
             category="type_mismatch",
@@ -298,15 +318,16 @@ class TestFullAssembly:
         )
 
         retriever = KnowledgeRetriever(workspace)
-        result = retriever.retrieve()
+        result = await retriever.retrieve()
 
         assert "MRR" in result
         assert "Soft Delete" in result or "deleted_at" in result
         assert "orders" in result.lower()
         assert "cents" in result.lower()
 
-    def test_knowledge_sections_clearly_separated(self, workspace, user):
-        KnowledgeEntry.objects.create(
+    @pytest.mark.asyncio
+    async def test_knowledge_sections_clearly_separated(self, workspace, user):
+        await KnowledgeEntry.objects.acreate(
             workspace=workspace,
             title="MRR",
             content="Monthly Recurring Revenue\n\n```sql\nSELECT SUM(amount) FROM subscriptions\n```",
@@ -314,7 +335,7 @@ class TestFullAssembly:
             created_by=user,
         )
 
-        KnowledgeEntry.objects.create(
+        await KnowledgeEntry.objects.acreate(
             workspace=workspace,
             title="Test Rule",
             content="Test description",
@@ -323,19 +344,21 @@ class TestFullAssembly:
         )
 
         retriever = KnowledgeRetriever(workspace)
-        result = retriever.retrieve()
+        result = await retriever.retrieve()
 
         assert len(result) > 0
         assert isinstance(result, str)
 
-    def test_knowledge_context_is_string(self, workspace):
+    @pytest.mark.asyncio
+    async def test_knowledge_context_is_string(self, workspace):
         retriever = KnowledgeRetriever(workspace)
-        result = retriever.retrieve()
+        result = await retriever.retrieve()
         assert isinstance(result, str)
 
-    def test_large_knowledge_base(self, workspace, user):
+    @pytest.mark.asyncio
+    async def test_large_knowledge_base(self, workspace, user):
         for i in range(20):
-            KnowledgeEntry.objects.create(
+            await KnowledgeEntry.objects.acreate(
                 workspace=workspace,
                 title=f"Entry {i}",
                 content=f"Content for entry {i}",
@@ -344,7 +367,7 @@ class TestFullAssembly:
             )
 
         for i in range(20):
-            TableKnowledge.objects.create(
+            await TableKnowledge.objects.acreate(
                 workspace=workspace,
                 table_name=f"table_{i}",
                 description=f"Table {i}",
@@ -352,24 +375,26 @@ class TestFullAssembly:
             )
 
         retriever = KnowledgeRetriever(workspace)
-        result = retriever.retrieve()
+        result = await retriever.retrieve()
 
         assert isinstance(result, str)
         assert len(result) > 0
 
 
+@pytest.mark.django_db(transaction=True)
 class TestRetrievalFiltering:
     """Test knowledge filtering and prioritization."""
 
-    def test_question_based_table_filtering(self, workspace, user):
-        TableKnowledge.objects.create(
+    @pytest.mark.asyncio
+    async def test_question_based_table_filtering(self, workspace, user):
+        await TableKnowledge.objects.acreate(
             workspace=workspace,
             table_name="users",
             description="User accounts and profiles",
             use_cases=["User analysis", "Authentication"],
             updated_by=user,
         )
-        TableKnowledge.objects.create(
+        await TableKnowledge.objects.acreate(
             workspace=workspace,
             table_name="orders",
             description="Customer orders and purchases",
@@ -378,9 +403,9 @@ class TestRetrievalFiltering:
         )
 
         retriever = KnowledgeRetriever(workspace)
-        result = retriever.retrieve(user_question="What is the total revenue?")
+        result = await retriever.retrieve(user_question="What is the total revenue?")
 
-        if TableKnowledge.objects.filter(workspace=workspace).count() > 1:
+        if await TableKnowledge.objects.filter(workspace=workspace).acount() > 1:
             assert "orders" in result.lower()
 
     def test_retriever_initialization(self, workspace):
@@ -388,7 +413,8 @@ class TestRetrievalFiltering:
         assert retriever.workspace == workspace
         assert hasattr(retriever, "retrieve")
 
-    def test_empty_workspace_knowledge(self, workspace):
+    @pytest.mark.asyncio
+    async def test_empty_workspace_knowledge(self, workspace):
         retriever = KnowledgeRetriever(workspace)
-        result = retriever.retrieve()
+        result = await retriever.retrieve()
         assert isinstance(result, str)

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -732,7 +732,7 @@ class TestRecipeRunner:
 # ============================================================================
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(transaction=True)
 class TestSaveAsRecipeTool:
     """Tests for the save_as_recipe tool functionality."""
 
@@ -748,13 +748,14 @@ class TestSaveAsRecipeTool:
         assert hasattr(tool, "description")
 
     @patch("apps.recipes.services.runner.build_agent_graph")
-    def test_save_as_recipe_creates_recipe(self, mock_build_graph, workspace, user):
+    @pytest.mark.asyncio
+    async def test_save_as_recipe_creates_recipe(self, mock_build_graph, workspace, user):
         """Test that save_as_recipe tool creates a recipe."""
         from apps.agents.tools.recipe_tool import create_recipe_tool
 
         tool = create_recipe_tool(workspace, user)
 
-        result = tool.invoke(
+        result = await tool.ainvoke(
             {
                 "name": "Customer Analysis",
                 "description": "Analyze customer behavior",
@@ -774,19 +775,22 @@ class TestSaveAsRecipeTool:
         assert "recipe_id" in result
 
         # Verify recipe was created
-        recipe = Recipe.objects.get(id=result["recipe_id"])
+        recipe = await Recipe.objects.aget(id=result["recipe_id"])
         assert recipe.name == "Customer Analysis"
         assert len(recipe.variables) == 1
         assert recipe.prompt == "Show {{segment}} customers"
 
     @patch("apps.recipes.services.runner.build_agent_graph")
-    def test_save_as_recipe_with_prompt_and_variables(self, mock_build_graph, workspace, user):
+    @pytest.mark.asyncio
+    async def test_save_as_recipe_with_prompt_and_variables(
+        self, mock_build_graph, workspace, user
+    ):
         """Test saving recipe with prompt template and variables."""
         from apps.agents.tools.recipe_tool import create_recipe_tool
 
         tool = create_recipe_tool(workspace, user)
 
-        result = tool.invoke(
+        result = await tool.ainvoke(
             {
                 "name": "Multi-Variable Analysis",
                 "description": "Analysis with multiple variables",
@@ -799,19 +803,20 @@ class TestSaveAsRecipeTool:
         )
 
         assert result["status"] == "created"
-        recipe = Recipe.objects.get(id=result["recipe_id"])
+        recipe = await Recipe.objects.aget(id=result["recipe_id"])
         assert recipe.prompt == "Get sales for {{year}} in {{region}} and create a visualization"
         assert len(recipe.variables) == 2
 
     @patch("apps.recipes.services.runner.build_agent_graph")
-    def test_save_as_recipe_extracts_variables(self, mock_build_graph, workspace, user):
+    @pytest.mark.asyncio
+    async def test_save_as_recipe_extracts_variables(self, mock_build_graph, workspace, user):
         """Test that save_as_recipe can extract variables from steps."""
         from apps.agents.tools.recipe_tool import create_recipe_tool
 
         tool = create_recipe_tool(workspace, user)
 
         # Agent should identify variables in prompt templates
-        result = tool.invoke(
+        result = await tool.ainvoke(
             {
                 "name": "Variable Extraction Test",
                 "description": "Test variable extraction",
@@ -823,19 +828,20 @@ class TestSaveAsRecipeTool:
             }
         )
 
-        recipe = Recipe.objects.get(id=result["recipe_id"])
+        recipe = await Recipe.objects.aget(id=result["recipe_id"])
         variable_names = recipe.get_variable_names()
         assert "category" in variable_names
         assert "threshold" in variable_names
 
     @patch("apps.recipes.services.runner.build_agent_graph")
-    def test_save_as_recipe_sets_sharing(self, mock_build_graph, workspace, user):
+    @pytest.mark.asyncio
+    async def test_save_as_recipe_sets_sharing(self, mock_build_graph, workspace, user):
         """Test that save_as_recipe can set is_shared flag."""
         from apps.agents.tools.recipe_tool import create_recipe_tool
 
         tool = create_recipe_tool(workspace, user)
 
-        result = tool.invoke(
+        result = await tool.ainvoke(
             {
                 "name": "Shared Recipe",
                 "description": "Recipe shared with project",
@@ -845,5 +851,5 @@ class TestSaveAsRecipeTool:
             }
         )
 
-        recipe = Recipe.objects.get(id=result["recipe_id"])
+        recipe = await Recipe.objects.aget(id=result["recipe_id"])
         assert recipe.is_shared is True


### PR DESCRIPTION
## Summary

- **`KnowledgeRetriever`** is now natively async (all methods use `async for`, `aexists()`, etc.), removing the `sync_to_async` wrapper that was wrapping it in `_build_system_prompt`
- **`agent_node`** in the LangGraph graph now uses `llm_with_tools.ainvoke()` instead of blocking `invoke()`, avoiding thread executor overhead on every LLM call
- **LangChain tools** (`create_artifact`, `update_artifact`, `save_learning`, `save_as_recipe`) are now `async def`, using Django's async ORM (`acreate`, `aget`, `asave`) — LangGraph's `ToolNode` awaits them directly instead of dispatching to a thread pool
- Tests updated to use `ainvoke()` and `pytest.mark.asyncio`

## What was left sync and why

| Thing | Reason |
|---|---|
| DRF `APIView` subclasses (projects, knowledge, artifacts, recipes views) | DRF class-based views don't support `async def` methods — would require rewriting as function-based views |
| `RecipeRunner.execute()` | Called from sync DRF views; `execute_async()` already exists for async callers |
| Graph nodes (`check_result_node`, `diagnose_and_retry_node`) | Pure Python state manipulation, no I/O — sync is correct |
| `_get_all_columns`, `_get_table_columns` | Use a blocking psycopg2 connection to the managed DB; already wrapped in `sync_to_async` at call sites |
| `pipeline_list_tables`, `pipeline_describe_table` | MCP server sync functions; already wrapped in `sync_to_async` in `_fetch_schema_context` |

## Does this simplify things?

Yes — the main simplification is removing the `sync_to_async` wrapper around `KnowledgeRetriever.retrieve()`. The tools being async also means fewer thread pool dispatches during agent tool execution (LangGraph's `ToolNode` will `await` them directly instead of running them in `asyncio.get_event_loop().run_in_executor()`).

## Test plan

- [x] `uv run pytest` — 534 passed, 8 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)