### PR TITLE
refactor: rename TenantWorkspace.tenant_id to external_tenant_id

### DIFF
--- a/apps/agents/tools/artifact_tool.py
+++ b/apps/agents/tools/artifact_tool.py
@@ -201,7 +201,7 @@ def create_artifact_tools(
             logger.info(
                 "Created artifact %s for workspace %s: %s",
                 artifact.id,
-                workspace.tenant_id,
+                workspace.external_tenant_id,
                 title,
             )
 
@@ -220,7 +220,7 @@ def create_artifact_tools(
         except Exception as e:
             logger.exception(
                 "Failed to create artifact for workspace %s: %s",
-                workspace.tenant_id,
+                workspace.external_tenant_id,
                 str(e),
             )
             return {
@@ -319,7 +319,7 @@ def create_artifact_tools(
                 new_artifact.id,
                 new_artifact.version,
                 original.id,
-                workspace.tenant_id,
+                workspace.external_tenant_id,
             )
 
             # Build render URL
@@ -339,7 +339,7 @@ def create_artifact_tools(
             logger.exception(
                 "Failed to update artifact %s for workspace %s: %s",
                 artifact_id,
-                workspace.tenant_id,
+                workspace.external_tenant_id,
                 str(e),
             )
             return {

--- a/apps/agents/tools/learning_tool.py
+++ b/apps/agents/tools/learning_tool.py
@@ -224,7 +224,7 @@ def create_save_learning_tool(workspace: TenantWorkspace, user: User):
             logger.info(
                 "Created new learning %s for workspace %s: %s",
                 learning.id,
-                workspace.tenant_id,
+                workspace.external_tenant_id,
                 description[:50] + "..." if len(description) > 50 else description,
             )
 
@@ -240,7 +240,7 @@ def create_save_learning_tool(workspace: TenantWorkspace, user: User):
         except Exception as e:
             logger.exception(
                 "Failed to save learning for workspace %s: %s",
-                workspace.tenant_id,
+                workspace.external_tenant_id,
                 str(e),
             )
             return {

--- a/apps/agents/tools/recipe_tool.py
+++ b/apps/agents/tools/recipe_tool.py
@@ -222,7 +222,7 @@ def create_recipe_tool(workspace: TenantWorkspace, user: User | None):
             logger.info(
                 "Created recipe %s for workspace %s",
                 recipe.id,
-                workspace.tenant_id,
+                workspace.external_tenant_id,
             )
 
             return {
@@ -236,7 +236,7 @@ def create_recipe_tool(workspace: TenantWorkspace, user: User | None):
         except Exception as e:
             logger.exception(
                 "Failed to create recipe for workspace %s: %s",
-                workspace.tenant_id,
+                workspace.external_tenant_id,
                 str(e),
             )
             return {

--- a/apps/projects/models.py
+++ b/apps/projects/models.py
@@ -101,9 +101,8 @@ class TenantWorkspace(models.Model):
     def __str__(self):
         return f"{self.tenant.canonical_name} ({self.tenant.external_id})"
 
-    # Convenience properties to avoid updating all callsites at once
     @property
-    def tenant_id(self):
+    def external_tenant_id(self):
         return self.tenant.external_id
 
     @property

--- a/apps/recipes/services/runner.py
+++ b/apps/recipes/services/runner.py
@@ -212,7 +212,7 @@ class RecipeRunner:
             workspace = self.recipe.workspace
             initial_state = {
                 "messages": [HumanMessage(content=prompt)],
-                "tenant_id": workspace.tenant_id if workspace else "",
+                "tenant_id": workspace.external_tenant_id if workspace else "",
                 "tenant_name": workspace.tenant_name if workspace else "",
                 "tenant_membership_id": str(self._tenant_membership.id)
                 if self._tenant_membership
@@ -299,7 +299,7 @@ class RecipeRunner:
             workspace = self.recipe.workspace
             initial_state = {
                 "messages": [HumanMessage(content=prompt)],
-                "tenant_id": workspace.tenant_id if workspace else "",
+                "tenant_id": workspace.external_tenant_id if workspace else "",
                 "tenant_name": workspace.tenant_name if workspace else "",
                 "tenant_membership_id": str(self._tenant_membership.id)
                 if self._tenant_membership


### PR DESCRIPTION
## Summary
- Renames `TenantWorkspace.tenant_id` property to `external_tenant_id` to avoid shadowing Django's auto-generated `tenant_id` FK column (from the `OneToOneField` to `Tenant`)
- Updates all 10 callsites across `artifact_tool.py`, `learning_tool.py`, `recipe_tool.py`, and `recipes/services/runner.py`

## Test plan
- [ ] Run `uv run pytest` to confirm no regressions
- [ ] Verify agent tools still log correct tenant identifiers

🤖 Generated with [Claude Code](https://claude.com/claude-code)