### PR TITLE
fix: use full-width layout on WorkspacesPage

### DIFF
--- a/frontend/src/pages/WorkspacesPage/WorkspacesPage.tsx
+++ b/frontend/src/pages/WorkspacesPage/WorkspacesPage.tsx
@@ -45,7 +45,7 @@ export function WorkspacesPage() {
   const isLoading = domainsStatus === "loading" || domainsStatus === "idle"
 
   return (
-    <div className="mx-auto max-w-2xl px-6 py-8">
+    <div className="p-6">
       <div className="mb-6 flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-semibold" data-testid="workspaces-title">Workspaces</h1>


### PR DESCRIPTION
## Summary
- Fixes `WorkspacesPage` to use the standard full-width, flush-left page layout (`p-6`) instead of the centered, constrained layout (`mx-auto max-w-2xl px-6 py-8`)
- Aligns with the frontend layout convention used by Knowledge, Recipes, Connections, and other pages

## Test plan
- [ ] Navigate to `/workspaces` and verify the page content fills the full viewport width (bounded by the sidebar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)