### PR TITLE
fix: column description input underline style

### DIFF
--- a/frontend/src/pages/DataDictionaryPage/TableDetail.tsx
+++ b/frontend/src/pages/DataDictionaryPage/TableDetail.tsx
@@ -270,7 +270,7 @@ export function TableDetail({ table }: TableDetailProps) {
                         placeholder="Add description..."
                         value={columnNotes[column.name] ?? column.description ?? ""}
                         onChange={(e) => updateColumnNote(column.name, e.target.value)}
-                        className="h-8 border-0 bg-transparent px-0 focus-visible:ring-0"
+                        className="h-8 rounded-none border-x-0 border-t-0 border-b border-input bg-transparent px-0 shadow-none focus-visible:ring-0 focus-visible:border-foreground transition-colors"
                         data-testid={`column-note-${column.name}`}
                       />
                     </TableCell>


### PR DESCRIPTION
## Summary
- Replaces full-box input style on column description fields with an underline-only style
- No top/left/right borders — renders as inline editable text
- Subtle gray bottom border at rest, darkens on keyboard focus
- Flat corners (`rounded-none`) to avoid awkward curved underline effect

## Test plan
- [ ] Navigate to Data Dictionary, select a table
- [ ] Verify "Add description..." placeholder shows with no box border, only a bottom underline
- [ ] Verify underline darkens when tabbing to the field
- [ ] Verify other inputs (Refresh Frequency, Owner, Use Cases) are visually unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)