### PR TITLE
fix: knowledge page fails to load on direct navigation or refresh

### DIFF
--- a/frontend/src/pages/KnowledgePage/KnowledgePage.tsx
+++ b/frontend/src/pages/KnowledgePage/KnowledgePage.tsx
@@ -23,6 +23,7 @@ export function KnowledgePage() {
   const navigate = useNavigate()
   const importInputRef = useRef<HTMLInputElement>(null)
 
+  const activeDomainId = useAppStore((s) => s.activeDomainId)
   const knowledgeItems = useAppStore((s) => s.knowledgeItems)
   const knowledgeStatus = useAppStore((s) => s.knowledgeStatus)
   const knowledgeFilter = useAppStore((s) => s.knowledgeFilter)
@@ -47,11 +48,12 @@ export function KnowledgePage() {
   const isNew = location.pathname.endsWith("/new")
 
   useEffect(() => {
+    if (!activeDomainId) return
     fetchKnowledge({
       type: knowledgeFilter ?? undefined,
       search: knowledgeSearch || undefined,
     })
-  }, [knowledgeFilter, knowledgeSearch, fetchKnowledge])
+  }, [activeDomainId, knowledgeFilter, knowledgeSearch, fetchKnowledge])
 
   useEffect(() => {
     if (isNew) {


### PR DESCRIPTION
## Summary

- `KnowledgePage` fired `fetchKnowledge()` before `activeDomainId` was set in the Zustand store
- On a direct URL load or refresh, `Sidebar` kicks off the async `fetchDomains()` call but `KnowledgePage` mounts and runs its `useEffect` simultaneously — `activeDomainId` is still `null`, causing `fetchKnowledge` to throw and set status to `"error"`
- Since `activeDomainId` wasn't in the effect's dependency array, the page never retried once the domain resolved — the error state persisted until the user navigated away and back

## Fix

Added `activeDomainId` to the `useEffect` dependency array and added an early-return guard when it's `null`, matching the same pattern already used by `DataDictionaryPage`, `ArtifactPanel`, and `ChatPanel`.

## Test plan

- [ ] Refresh directly on `/knowledge` — page loads correctly
- [ ] Navigate away and back via sidebar — still works
- [ ] Hard-navigate to `/knowledge` from another tab — loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)