### PR TITLE
fix: resolve 404 on embedded Scout sidebar navigation

### DIFF
--- a/frontend/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/Sidebar/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react"
-import { Link, useNavigate } from "react-router-dom"
+import { Link, useLocation, useNavigate } from "react-router-dom"
 import {
   MessageSquare,
   BookOpen,
@@ -37,6 +37,8 @@ export function Sidebar() {
   const newThread = useAppStore((s) => s.uiActions.newThread)
   const selectThread = useAppStore((s) => s.uiActions.selectThread)
   const [showCreateModal, setShowCreateModal] = useState(false)
+  const location = useLocation()
+  const pathPrefix = location.pathname.startsWith("/embed") ? "/embed" : ""
 
   // Fetch domains on mount
   useEffect(() => {
@@ -54,7 +56,7 @@ export function Sidebar() {
     <aside className="flex h-screen w-64 flex-col border-r bg-background">
       {/* Logo */}
       <div className="flex h-14 items-center border-b px-4">
-        <Link to="/" className="flex items-center gap-2 font-semibold">
+        <Link to={`${pathPrefix}/`} className="flex items-center gap-2 font-semibold">
           <span className="text-lg">Scout</span>
         </Link>
       </div>
@@ -87,7 +89,7 @@ export function Sidebar() {
               </DropdownMenuItem>
             ))}
             <DropdownMenuSeparator />
-            <DropdownMenuItem onSelect={() => navigate("/workspaces")}>
+            <DropdownMenuItem onSelect={() => navigate(`${pathPrefix}/workspaces`)}>
               Manage workspaces…
             </DropdownMenuItem>
             {/* Defer modal open so Radix can finish closing the dropdown before the Dialog mounts its own focus trap */}
@@ -103,11 +105,11 @@ export function Sidebar() {
 
       {/* Navigation */}
       <nav className="space-y-1 p-4">
-        <NavItem to="/" icon={MessageSquare} label="Chat" />
-        <NavItem to="/artifacts" icon={LayoutDashboard} label="Artifacts" />
-        <NavItem to="/knowledge" icon={BookOpen} label="Knowledge" />
-        <NavItem to="/recipes" icon={ChefHat} label="Recipes" />
-        <NavItem to="/data-dictionary" icon={Database} label="Data Dictionary" />
+        <NavItem to={`${pathPrefix}/`} icon={MessageSquare} label="Chat" />
+        <NavItem to={`${pathPrefix}/artifacts`} icon={LayoutDashboard} label="Artifacts" />
+        <NavItem to={`${pathPrefix}/knowledge`} icon={BookOpen} label="Knowledge" />
+        <NavItem to={`${pathPrefix}/recipes`} icon={ChefHat} label="Recipes" />
+        <NavItem to={`${pathPrefix}/data-dictionary`} icon={Database} label="Data Dictionary" />
       </nav>
 
       {/* Thread History */}
@@ -120,7 +122,7 @@ export function Sidebar() {
             variant="ghost"
             size="icon"
             className="h-6 w-6"
-            onClick={() => { newThread(); navigate("/chat") }}
+            onClick={() => { newThread(); navigate(`${pathPrefix}/chat`) }}
             data-testid="sidebar-new-chat"
           >
             <Plus className="h-3.5 w-3.5" />
@@ -130,7 +132,7 @@ export function Sidebar() {
           {threads.map((thread) => (
             <button
               key={thread.id}
-              onClick={() => { selectThread(thread.id); navigate("/chat") }}
+              onClick={() => { selectThread(thread.id); navigate(`${pathPrefix}/chat`) }}
               data-testid={`sidebar-thread-${thread.id}`}
               className={`w-full rounded-md px-3 py-1.5 text-left text-sm truncate transition-colors ${
                 thread.id === threadId
@@ -156,7 +158,7 @@ export function Sidebar() {
           asChild
           data-testid="sidebar-connections"
         >
-          <Link to="/settings/connections">
+          <Link to={`${pathPrefix}/settings/connections`}>
             <Link2 className="mr-2 h-4 w-4" />
             Connected Accounts
           </Link>

--- a/frontend/src/pages/EmbedPage.tsx
+++ b/frontend/src/pages/EmbedPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useCallback } from "react"
-import { RouterProvider, createBrowserRouter } from "react-router-dom"
+import { RouterProvider, createBrowserRouter, Navigate } from "react-router-dom"
 import { BASE_PATH } from "@/config"
 import { useAppStore } from "@/store/store"
 import { LoginForm } from "@/components/LoginForm/LoginForm"
@@ -9,6 +9,8 @@ import { ChatPanel } from "@/components/ChatPanel/ChatPanel"
 import { ArtifactsPage } from "@/pages/ArtifactsPage"
 import { KnowledgePage } from "@/pages/KnowledgePage"
 import { RecipesPage } from "@/pages/RecipesPage"
+import { DataDictionaryPage } from "@/pages/DataDictionaryPage"
+import { ConnectionsPage } from "@/pages/ConnectionsPage"
 import { useEmbedMessaging } from "@/hooks/useEmbedMessaging"
 import { useEmbedParams } from "@/hooks/useEmbedParams"
 
@@ -25,6 +27,10 @@ const embedRouter = createBrowserRouter([
       { path: "knowledge/:id", element: <KnowledgePage /> },
       { path: "recipes", element: <RecipesPage /> },
       { path: "recipes/:id", element: <RecipesPage /> },
+      { path: "recipes/:id/runs/:runId", element: <RecipesPage /> },
+      { path: "data-dictionary", element: <DataDictionaryPage /> },
+      { path: "settings/connections", element: <ConnectionsPage /> },
+      { path: "*", element: <Navigate to="/embed" replace /> },
     ],
   },
 ], { basename: BASE_PATH || undefined })


### PR DESCRIPTION
## Summary

When Scout is embedded at `/scout/embed/` inside connect-labs, clicking any sidebar nav item (Chat, Artifacts, Knowledge, Recipes, Data Dictionary) caused a React Router 404. The sidebar links used absolute paths (`/artifacts`) which resolved to `/scout/artifacts` via the router basename, but the embed router only has routes under `/embed/*`.

**Changes:**
- **Sidebar.tsx**: Detect embed mode via `useLocation()` and prefix all navigation links with `/embed` when running inside the embed layout
- **EmbedPage.tsx**: Add missing routes (`data-dictionary`, `settings/connections`, `recipes/:id/runs/:runId`) and a catch-all redirect to the embed router

## Test plan

- [x] Load Scout at `labs.connect.dimagi.com/labs/scout/` — sidebar renders
- [x] Click each nav item (Chat, Artifacts, Knowledge, Recipes, Data Dictionary) — no 404
- [x] Click Connected Accounts — loads correctly
- [x] Click chat history threads — navigate correctly
- [x] Standalone Scout (`localhost:5173`) still works with no prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)