### PR TITLE
fix: replace embed OAuth popup with direct navigation

### DIFF
--- a/apps/users/auth_views.py
+++ b/apps/users/auth_views.py
@@ -4,7 +4,6 @@ import json
 import logging
 
 from allauth.socialaccount.models import SocialAccount, SocialApp, SocialToken
-from django.conf import settings as django_settings
 from django.contrib.auth import authenticate, get_user_model, login, logout
 from django.contrib.auth.password_validation import validate_password
 from django.contrib.sites.models import Site
@@ -239,14 +238,13 @@ def providers_view(request):
             else:
                 token_status[provider] = "connected"
 
-    _prefix = getattr(django_settings, "FORCE_SCRIPT_NAME", "") or ""
-
     providers = []
     for app in apps:
         entry = {
             "id": app.provider,
             "name": PROVIDER_DISPLAY.get(app.provider, app.name),
-            "login_url": f"{_prefix}/accounts/{app.provider}/login/",
+            # No prefix — the frontend prepends BASE_PATH to all API-provided URLs
+            "login_url": f"/accounts/{app.provider}/login/",
         }
         if request.user.is_authenticated:
             # SocialAccount.provider stores the provider_id (e.g. "commcare_prod"),

--- a/config/settings/connectlabs.py
+++ b/config/settings/connectlabs.py
@@ -19,11 +19,11 @@ SECURE_SSL_REDIRECT = False
 # Scout is served under /scout/ path prefix on the ALB
 FORCE_SCRIPT_NAME = env("FORCE_SCRIPT_NAME", default="/scout")
 
-# Override redirect URLs to include the path prefix — Django doesn't prepend
-# FORCE_SCRIPT_NAME to these literal paths, so the OAuth popup would land on
-# ConnectLabs (/) instead of Scout (/scout/) after login.
-LOGIN_REDIRECT_URL = "/scout/"
-LOGOUT_REDIRECT_URL = "/scout/"
+# After OAuth login, return to the connect-labs embed page (not the Scout
+# standalone app). The embed iframe detects the session cookie automatically
+# since everything is same-origin.
+LOGIN_REDIRECT_URL = "/labs/scout/"
+LOGOUT_REDIRECT_URL = "/labs/scout/"
 
 # Allow iframe embedding from labs.connect.dimagi.com (same origin)
 X_FRAME_OPTIONS = "SAMEORIGIN"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -37,16 +37,6 @@ export default function App() {
     }
   }, [fetchMe, isPublicPage, isEmbedPage])
 
-  // If opened as a popup (e.g. for OAuth from the embed widget), close
-  // automatically once the user is authenticated so control returns to
-  // the parent page. This is the original approach that worked reliably.
-  useEffect(() => {
-    if (document.cookie.includes("scout_auth_popup=1") && authStatus === "authenticated") {
-      document.cookie = "scout_auth_popup=;max-age=0;path=/"
-      window.close()
-    }
-  }, [authStatus])
-
   if (isPublicPage) {
     return getPublicPageComponent()
   }

--- a/frontend/src/components/LoginForm/LoginForm.tsx
+++ b/frontend/src/components/LoginForm/LoginForm.tsx
@@ -21,7 +21,6 @@ export function LoginForm() {
   const [providers, setProviders] = useState<OAuthProvider[]>([])
   const authError = useAppStore((s) => s.authError)
   const login = useAppStore((s) => s.authActions.login)
-  const fetchMe = useAppStore((s) => s.authActions.fetchMe)
   const { isEmbed } = useEmbedParams()
 
   useEffect(() => {
@@ -42,22 +41,13 @@ export function LoginForm() {
     }
   }
 
-  function openLoginPopup() {
-    // Open standalone Scout in a popup — user logs in there normally.
-    // A cookie signals that this is a popup, so App.tsx auto-closes it
-    // once authenticated. The iframe polls for popup close then re-fetches auth.
-    document.cookie = "scout_auth_popup=1;path=/;max-age=300;SameSite=Lax"
-    const popup = window.open(`${BASE_PATH}/`, "scout-oauth", "width=500,height=700")
-
-    if (!popup) return
-
-    const interval = setInterval(() => {
-      if (!popup || popup.closed) {
-        clearInterval(interval)
-        fetchMe()
-      }
-    }, 500)
-  }
+  // In embed mode, OAuth navigates the top-level page (target="_top") so
+  // the OAuth provider's consent page isn't constrained to the iframe.
+  // After login, LOGIN_REDIRECT_URL sends the user back to the embed page
+  // and the iframe picks up the session cookie (same-origin, no popup needed).
+  const oauthReturnUrl = isEmbed
+    ? (document.referrer ? new URL(document.referrer).pathname : "/labs/scout/")
+    : `${BASE_PATH}/`
 
   return (
     <div className="flex min-h-screen items-center justify-center p-4">
@@ -112,29 +102,20 @@ export function LoginForm() {
               </div>
               <div className="space-y-2">
                 {providers.map((provider) => (
-                  isEmbed ? (
-                    <Button
-                      key={provider.id}
-                      variant="outline"
-                      className="w-full"
-                      data-testid={`oauth-login-${provider.id}`}
-                      onClick={openLoginPopup}
+                  <Button
+                    key={provider.id}
+                    variant="outline"
+                    className="w-full"
+                    asChild
+                    data-testid={`oauth-login-${provider.id}`}
+                  >
+                    <a
+                      href={`${BASE_PATH}${provider.login_url}?next=${encodeURIComponent(oauthReturnUrl)}`}
+                      target={isEmbed ? "_top" : undefined}
                     >
                       {provider.name}
-                    </Button>
-                  ) : (
-                    <Button
-                      key={provider.id}
-                      variant="outline"
-                      className="w-full"
-                      asChild
-                      data-testid={`oauth-login-${provider.id}`}
-                    >
-                      <a href={`${BASE_PATH}${provider.login_url}?next=${BASE_PATH}/`}>
-                        {provider.name}
-                      </a>
-                    </Button>
-                  )
+                    </a>
+                  </Button>
                 ))}
               </div>
             </>


### PR DESCRIPTION
## Summary

- Replace the popup-based OAuth flow with simple `target="_top"` links. Since Scout and connect-labs are same-origin, there are no cross-site cookie issues and the popup was unnecessary complexity.
- Fix double `BASE_PATH` prefix on OAuth URLs. The providers API was prepending `FORCE_SCRIPT_NAME` to `login_url`, but the frontend already prepends `BASE_PATH`, producing `/scout/scout/accounts/...` which hit the SPA fallback instead of Django's allauth.
- Update `LOGIN_REDIRECT_URL` in connectlabs settings to `/labs/scout/` so OAuth returns to the embed page.
- Remove dead popup cookie detection code from App.tsx.

## Test plan

- [ ] Navigate to labs.connect.dimagi.com/labs/scout/
- [ ] Click "CommCare Connect" in the Scout login form
- [ ] Verify it goes directly to the OAuth authorization page (no second login form)
- [ ] Authorize and verify you return to the embed page, fully authenticated
- [ ] Verify standalone (non-embed) OAuth still works at /scout/

🤖 Generated with [Claude Code](https://claude.com/claude-code)