### PR TITLE
Fix DB connection reliability and schema provisioning

### DIFF
--- a/apps/transformations/services/commcare_staging.py
+++ b/apps/transformations/services/commcare_staging.py
@@ -288,6 +288,9 @@ def generate_system_assets(tenant, metadata: dict) -> list[TransformationAsset]:
 
     for xmlns, form_def in form_definitions.items():
         form_name = form_def.get("name", xmlns)
+        if isinstance(form_name, dict):
+            # Localized names: {"en": "Household Registration", "fr": "..."}
+            form_name = form_name.get("en") or next(iter(form_name.values()), xmlns)
         if not isinstance(form_name, str):
             form_name = xmlns
         app_name = form_def.get("app_name", "")

--- a/apps/transformations/services/commcare_staging.py
+++ b/apps/transformations/services/commcare_staging.py
@@ -288,6 +288,8 @@ def generate_system_assets(tenant, metadata: dict) -> list[TransformationAsset]:
 
     for xmlns, form_def in form_definitions.items():
         form_name = form_def.get("name", xmlns)
+        if not isinstance(form_name, str):
+            form_name = xmlns
         app_name = form_def.get("app_name", "")
         base_slug = slugify_model_name(form_name)
 

--- a/apps/workspaces/services/schema_manager.py
+++ b/apps/workspaces/services/schema_manager.py
@@ -52,6 +52,9 @@ class SchemaManager:
         ).first()
 
         if existing:
+            # Ensure the physical schema still exists — it may have been
+            # dropped externally while the Django record remained ACTIVE.
+            self._ensure_physical_schema(schema_name)
             existing.touch()
             return existing
 
@@ -98,6 +101,25 @@ class SchemaManager:
             tenant.external_id,
         )
         return ts
+
+    def _ensure_physical_schema(self, schema_name: str) -> None:
+        """Ensure the physical PostgreSQL schema and readonly role exist.
+
+        Idempotent — safe to call on every provision(). Handles the case where
+        the physical schema was dropped externally but the Django record remains.
+        """
+        conn = get_managed_db_connection()
+        try:
+            cursor = conn.cursor()
+            cursor.execute(
+                psycopg.sql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(
+                    psycopg.sql.Identifier(schema_name)
+                )
+            )
+            self._create_readonly_role(cursor, schema_name)
+            cursor.close()
+        finally:
+            conn.close()
 
     def create_physical_schema(self, tenant_schema: TenantSchema) -> None:
         """Create the physical PostgreSQL schema for an existing TenantSchema record.

--- a/mcp_server/services/query.py
+++ b/mcp_server/services/query.py
@@ -37,7 +37,7 @@ def _get_connection(ctx: QueryContext):
     """Create a psycopg connection from context params."""
     import psycopg
 
-    return psycopg.connect(**ctx.connection_params)
+    return psycopg.connect(**ctx.connection_params, autocommit=True)
 
 
 def _execute_sync(ctx: QueryContext, sql: str, timeout_seconds: int) -> dict[str, Any]:

--- a/tests/test_schema_manager.py
+++ b/tests/test_schema_manager.py
@@ -1,5 +1,6 @@
 from unittest.mock import MagicMock, patch
 
+import psycopg.sql
 import pytest
 
 from apps.workspaces.models import TenantSchema
@@ -36,11 +37,25 @@ class TestSchemaManager:
             state="active",
         )
 
-        # No DB connection should be needed when an active schema is found
-        ts = mgr.provision(tenant_membership.tenant)
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.cursor.return_value = mock_cursor
+        mock_cursor.fetchone.return_value = (1,)  # role already exists
+
+        with patch(
+            "apps.workspaces.services.schema_manager.get_managed_db_connection",
+            return_value=mock_conn,
+        ):
+            ts = mgr.provision(tenant_membership.tenant)
 
         assert TenantSchema.objects.count() == 1  # no duplicate
         assert ts.schema_name == schema_name
+        # Verify physical schema was ensured even for existing record
+        mock_cursor.execute.assert_any_call(
+            psycopg.sql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(
+                psycopg.sql.Identifier(schema_name)
+            )
+        )
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary
- **autocommit fix**: Use `autocommit=True` on MCP query connections to prevent "current transaction is aborted" cascade errors. When `SET ROLE` or a query fails inside an implicit transaction, all subsequent statements fail with a confusing error. Autocommit isolates each statement.
- **slugify fix**: Handle CommCare form definitions where `name` is a localized dict (`{"en": "Household Registration"}`) instead of a string. Extracts the English name, falls back to first available language, then xmlns.
- **provision fix**: `SchemaManager.provision()` now ensures the physical PostgreSQL schema and readonly role exist even when a Django `TenantSchema` record already says ACTIVE. Previously, if the physical schema was dropped externally, provision returned the stale record without recreating it.

## Test plan
- [x] All 25 query tests pass
- [x] All 50 staging/slugify tests pass
- [x] All 10 schema manager tests pass (updated test for new behavior)
- [x] Deployed and verified queries work end-to-end on production

🤖 Generated with [Claude Code](https://claude.com/claude-code)