### PR TITLE
Style unstyled allauth pages (login, signup, OAuth)

### DIFF
--- a/templates/allauth/layouts/base.html
+++ b/templates/allauth/layouts/base.html
@@ -1,0 +1,301 @@
+{% load i18n %}
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>
+            {% block head_title %}Scout{% endblock head_title %} - Scout
+        </title>
+        <style>
+            *,
+            *::before,
+            *::after {
+                box-sizing: border-box;
+                margin: 0;
+                padding: 0;
+            }
+
+            body {
+                font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+                    "Helvetica Neue", Arial, sans-serif;
+                background-color: #f9fafb;
+                color: #1a1a1a;
+                min-height: 100vh;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                padding: 1rem;
+            }
+
+            .page-wrapper {
+                width: 100%;
+                max-width: 24rem;
+            }
+
+            .card {
+                background: #fff;
+                border: 1px solid #e5e5e5;
+                border-radius: 0.75rem;
+                box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+                overflow: hidden;
+            }
+
+            .card-header {
+                text-align: center;
+                padding: 1.5rem 1.5rem 0;
+            }
+
+            .card-header .brand {
+                font-size: 1.5rem;
+                font-weight: 700;
+                color: #1a1a1a;
+                margin-bottom: 0.25rem;
+            }
+
+            .card-header .subtitle {
+                font-size: 0.875rem;
+                color: #737373;
+            }
+
+            .card-body {
+                padding: 1.5rem;
+            }
+
+            /* Messages */
+            .messages {
+                margin-bottom: 1rem;
+            }
+
+            .messages ul {
+                list-style: none;
+            }
+
+            .messages li {
+                padding: 0.625rem 0.875rem;
+                border-radius: 0.5rem;
+                font-size: 0.875rem;
+                background: #fef3c7;
+                color: #92400e;
+                border: 1px solid #fde68a;
+                margin-bottom: 0.5rem;
+            }
+
+            .messages li:last-child {
+                margin-bottom: 0;
+            }
+
+            /* Typography */
+            h1 {
+                font-size: 1.25rem;
+                font-weight: 600;
+                color: #1a1a1a;
+                margin-bottom: 0.5rem;
+            }
+
+            p {
+                font-size: 0.875rem;
+                color: #525252;
+                margin-bottom: 1rem;
+                line-height: 1.5;
+            }
+
+            a {
+                color: #1a1a1a;
+                font-weight: 500;
+                text-decoration: underline;
+                text-underline-offset: 2px;
+            }
+
+            a:hover {
+                color: #404040;
+            }
+
+            /* Forms */
+            form {
+                margin: 0;
+            }
+
+            form p {
+                margin-bottom: 1rem;
+            }
+
+            label {
+                display: block;
+                font-size: 0.875rem;
+                font-weight: 500;
+                color: #1a1a1a;
+                margin-bottom: 0.375rem;
+            }
+
+            input[type="text"],
+            input[type="email"],
+            input[type="password"],
+            input[type="url"],
+            input[type="number"],
+            input[type="tel"],
+            textarea,
+            select {
+                width: 100%;
+                padding: 0.5rem 0.75rem;
+                font-size: 0.875rem;
+                line-height: 1.5;
+                color: #1a1a1a;
+                background-color: #fff;
+                border: 1px solid #e5e5e5;
+                border-radius: 0.375rem;
+                box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+                transition: border-color 0.15s, box-shadow 0.15s;
+                outline: none;
+            }
+
+            input[type="text"]:focus,
+            input[type="email"]:focus,
+            input[type="password"]:focus,
+            input[type="url"]:focus,
+            input[type="number"]:focus,
+            input[type="tel"]:focus,
+            textarea:focus,
+            select:focus {
+                border-color: #a3a3a3;
+                box-shadow: 0 0 0 2px rgba(163, 163, 163, 0.25);
+            }
+
+            /* Checkbox / radio alignment */
+            input[type="checkbox"],
+            input[type="radio"] {
+                margin-right: 0.5rem;
+                vertical-align: middle;
+            }
+
+            input[type="checkbox"] + label,
+            input[type="radio"] + label {
+                display: inline;
+                font-weight: 400;
+            }
+
+            /* Buttons */
+            button,
+            input[type="submit"],
+            .btn {
+                display: inline-flex;
+                align-items: center;
+                justify-content: center;
+                width: 100%;
+                padding: 0.5rem 1rem;
+                font-size: 0.875rem;
+                font-weight: 500;
+                line-height: 1.5;
+                color: #fafafa;
+                background-color: #1a1a1a;
+                border: 1px solid #1a1a1a;
+                border-radius: 0.375rem;
+                cursor: pointer;
+                transition: background-color 0.15s, border-color 0.15s;
+                text-decoration: none;
+            }
+
+            button:hover,
+            input[type="submit"]:hover,
+            .btn:hover {
+                background-color: #333;
+                border-color: #333;
+            }
+
+            button:focus-visible,
+            input[type="submit"]:focus-visible,
+            .btn:focus-visible {
+                outline: 2px solid #a3a3a3;
+                outline-offset: 2px;
+            }
+
+            /* Help text */
+            .helptext,
+            form p span {
+                display: block;
+                font-size: 0.75rem;
+                color: #737373;
+                margin-top: 0.25rem;
+            }
+
+            /* Error list */
+            .errorlist {
+                list-style: none;
+                padding: 0;
+                margin: 0 0 0.5rem;
+            }
+
+            .errorlist li {
+                font-size: 0.8125rem;
+                color: #dc2626;
+                margin-bottom: 0.25rem;
+            }
+
+            /* Horizontal rule */
+            hr {
+                border: none;
+                border-top: 1px solid #e5e5e5;
+                margin: 1.25rem 0;
+            }
+
+            /* Navigation links at bottom of card */
+            .nav-links {
+                text-align: center;
+                padding: 1rem 1.5rem;
+                border-top: 1px solid #e5e5e5;
+                font-size: 0.8125rem;
+                color: #737373;
+            }
+
+            .nav-links a {
+                color: #525252;
+                font-weight: 500;
+            }
+
+            .nav-links a:hover {
+                color: #1a1a1a;
+            }
+
+            /* Utility for lists rendered by allauth */
+            ul {
+                list-style: none;
+            }
+
+            li {
+                margin-bottom: 0.25rem;
+            }
+        </style>
+        {% block extra_head %}
+        {% endblock extra_head %}
+    </head>
+    <body>
+        <div class="page-wrapper">
+            <div class="card">
+                <div class="card-header">
+                    <div class="brand">Scout</div>
+                </div>
+                <div class="card-body">
+                    {% if messages %}
+                        <div class="messages">
+                            <ul>
+                                {% for message in messages %}<li>{{ message }}</li>{% endfor %}
+                            </ul>
+                        </div>
+                    {% endif %}
+                    {% block content %}
+                    {% endblock content %}
+                </div>
+                <div class="nav-links">
+                    {% if user.is_authenticated %}
+                        <a href="/">{% trans "Back to Scout" %}</a>
+                    {% else %}
+                        <a href="{% url 'account_login' %}">{% trans "Sign In" %}</a>
+                    {% endif %}
+                </div>
+            </div>
+        </div>
+        {% block extra_body %}
+        {% endblock extra_body %}
+    </body>
+</html>


### PR DESCRIPTION
## Summary
- All django-allauth rendered pages (login, signup, 3rd-party signup, logout, error pages) were completely unstyled — just raw HTML with no CSS
- Added a single template override (`templates/allauth/layouts/base.html`) with inline CSS that matches the React frontend's card-based design
- Styled: centered card layout, Scout branding, form inputs, buttons, error messages, navigation links

## Pages affected
- `/accounts/login/`
- `/accounts/signup/`
- `/accounts/3rdparty/signup/` (OAuth completion)
- `/accounts/logout/`
- `/accounts/3rdparty/` error pages

## Test plan
- [ ] Visit `/accounts/login/` — should show styled card with Scout branding
- [ ] Visit `/accounts/3rdparty/signup/` — should show styled signup form
- [ ] Visit `/accounts/logout/` — should show styled confirmation
- [ ] Verify form submission still works correctly
- [ ] Check on mobile viewport (card is responsive, max-width 24rem)

🤖 Generated with [Claude Code](https://claude.com/claude-code)