### PR TITLE
Consolidate duplicated credential resolution queries

### DIFF
--- a/apps/users/auth_views.py
+++ b/apps/users/auth_views.py
@@ -17,11 +17,12 @@ from django.views.decorators.http import require_GET, require_POST
 from apps.users.decorators import login_required_json
 from apps.users.models import TenantMembership
 from apps.users.rate_limiting import check_rate_limit, record_attempt
+from apps.users.services.credential_resolver import get_social_token
 from apps.users.services.tenant_resolution import (
     resolve_commcare_domains,
     resolve_connect_opportunities,
 )
-from apps.users.views import _get_commcare_token, _get_connect_token
+from apps.users.services.token_refresh import PROVIDER_TOKEN_URLS
 
 logger = logging.getLogger(__name__)
 
@@ -32,11 +33,6 @@ PROVIDER_DISPLAY = {
     "github": "GitHub",
     "commcare": "CommCare",
     "commcare_connect": "CommCare Connect",
-}
-
-PROVIDER_TOKEN_URLS = {
-    "commcare": "https://www.commcarehq.org/oauth/token/",
-    "commcare_connect": "https://connect.dimagi.com/o/token/",
 }
 
 
@@ -51,13 +47,13 @@ def _user_response(user, *, onboarding_complete=False):
     }
 
 
-def _try_resolve_provider(user, get_token_fn, resolve_fn, provider_name):
+def _try_resolve_provider(user, provider, resolve_fn, provider_name):
     """Attempt lazy OAuth onboarding resolution for a provider."""
-    token = get_token_fn(user)
-    if not token:
+    token_obj = get_social_token(user, provider)
+    if not token_obj:
         return False
     try:
-        resolve_fn(user, token)
+        resolve_fn(user, token_obj.token)
         return True
     except Exception:
         logger.warning("Failed to resolve %s in me_view", provider_name, exc_info=True)
@@ -87,11 +83,9 @@ def me_view(request):
     # Both providers are tried independently — a successful CommCare
     # resolution must not skip Connect.
     if not onboarding_complete:
-        commcare_ok = _try_resolve_provider(
-            user, _get_commcare_token, resolve_commcare_domains, "CommCare"
-        )
+        commcare_ok = _try_resolve_provider(user, "commcare", resolve_commcare_domains, "CommCare")
         connect_ok = _try_resolve_provider(
-            user, _get_connect_token, resolve_connect_opportunities, "Connect"
+            user, "commcare_connect", resolve_connect_opportunities, "Connect"
         )
         onboarding_complete = commcare_ok or connect_ok
 

--- a/apps/users/services/credential_resolver.py
+++ b/apps/users/services/credential_resolver.py
@@ -1,8 +1,45 @@
-"""Synchronous credential resolution for TenantMembership."""
+"""Credential resolution for TenantMembership."""
+
+from __future__ import annotations
 
 import logging
 
+from allauth.socialaccount.models import SocialToken
+from asgiref.sync import sync_to_async
+
+from apps.users.services.token_refresh import (
+    PROVIDER_TOKEN_URLS,
+    TokenRefreshError,
+    refresh_oauth_token,
+    token_needs_refresh,
+)
+
 logger = logging.getLogger(__name__)
+
+
+def _social_token_qs(user, provider: str):
+    """Return a SocialToken queryset filtered by provider-prefix rules.
+
+    - ``"commcare_connect"`` matches tokens whose provider starts with
+      ``"commcare_connect"``.
+    - Any other provider matches tokens starting with ``"commcare"`` but
+      excludes ``"commcare_connect"``.
+    """
+    if provider == "commcare_connect":
+        return SocialToken.objects.filter(
+            account__user=user,
+            account__provider__startswith="commcare_connect",
+        )
+
+    return SocialToken.objects.filter(
+        account__user=user,
+        account__provider__startswith="commcare",
+    ).exclude(account__provider__startswith="commcare_connect")
+
+
+def get_social_token(user, provider: str) -> SocialToken | None:
+    """Return the SocialToken for *user* and *provider*, or None."""
+    return _social_token_qs(user, provider).first()
 
 
 def resolve_credential(membership) -> dict | None:
@@ -29,25 +66,58 @@ def resolve_credential(membership) -> dict | None:
             logger.exception("Failed to decrypt API key for membership %s", membership.id)
             return None
 
-    # OAuth credential
-    from allauth.socialaccount.models import SocialToken
-
-    provider = membership.tenant.provider
-    if provider == "commcare_connect":
-        token_obj = SocialToken.objects.filter(
-            account__user=membership.user,
-            account__provider__startswith="commcare_connect",
-        ).first()
-    else:
-        token_obj = (
-            SocialToken.objects.filter(
-                account__user=membership.user,
-                account__provider__startswith="commcare",
-            )
-            .exclude(account__provider__startswith="commcare_connect")
-            .first()
-        )
-
+    token_obj = get_social_token(membership.user, membership.tenant.provider)
     if not token_obj:
         return None
     return {"type": "oauth", "value": token_obj.token}
+
+
+async def aresolve_credential(membership) -> dict | None:
+    """Async version of :func:`resolve_credential` with token refresh.
+
+    Like the sync variant, returns a ``{"type": ..., "value": ...}`` dict or
+    ``None``.  For OAuth tokens, attempts a refresh when the token is near
+    expiry.
+    """
+    from apps.users.models import TenantCredential
+
+    try:
+        cred_obj = await TenantCredential.objects.select_related("tenant_membership").aget(
+            tenant_membership=membership
+        )
+    except TenantCredential.DoesNotExist:
+        return None
+
+    if cred_obj.credential_type == TenantCredential.API_KEY:
+        from apps.users.adapters import decrypt_credential
+
+        try:
+            decrypted = await sync_to_async(decrypt_credential)(cred_obj.encrypted_credential)
+            return {"type": "api_key", "value": decrypted}
+        except Exception:
+            logger.exception("Failed to decrypt API key for membership %s", membership.id)
+            return None
+
+    provider = membership.tenant.provider
+    token_obj = await _social_token_qs(membership.user, provider).select_related("app").afirst()
+    if not token_obj:
+        return None
+
+    return await sync_to_async(_resolve_oauth_credential)(token_obj, provider)
+
+
+def _resolve_oauth_credential(token_obj, provider: str) -> dict:
+    """Build an OAuth credential dict, refreshing the token if near expiry."""
+    token_value = token_obj.token
+
+    if token_needs_refresh(token_obj.expires_at):
+        token_url = PROVIDER_TOKEN_URLS.get(provider)
+        if token_url and token_obj.token_secret:
+            try:
+                token_value = refresh_oauth_token(token_obj, token_url)
+            except TokenRefreshError:
+                logger.warning(
+                    "Token refresh failed for provider %s, using existing token", provider
+                )
+
+    return {"type": "oauth", "value": token_value}

--- a/apps/users/services/token_refresh.py
+++ b/apps/users/services/token_refresh.py
@@ -17,6 +17,11 @@ logger = logging.getLogger(__name__)
 # Refresh tokens that expire within this window
 REFRESH_BUFFER = timedelta(minutes=5)
 
+PROVIDER_TOKEN_URLS = {
+    "commcare": "https://www.commcarehq.org/oauth/token/",
+    "commcare_connect": "https://connect.dimagi.com/o/token/",
+}
+
 
 class TokenRefreshError(Exception):
     """Raised when token refresh fails."""

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 import logging
 
-from allauth.socialaccount.models import SocialToken
 from asgiref.sync import sync_to_async
 from django.core.cache import cache
 from django.http import JsonResponse
@@ -14,6 +13,7 @@ from django.views.decorators.http import require_http_methods
 
 from apps.users.decorators import async_login_required
 from apps.users.models import Tenant, TenantMembership
+from apps.users.services.credential_resolver import get_social_token
 from apps.users.services.tenant_verification import (
     CommCareVerificationError,
     verify_commcare_credential,
@@ -24,25 +24,9 @@ TENANT_REFRESH_TTL = 3600  # seconds (1 hour)
 logger = logging.getLogger(__name__)
 
 
-def _get_commcare_token(user) -> str | None:
-    """Return the user's CommCare OAuth access token, or None."""
-    token = (
-        SocialToken.objects.filter(
-            account__user=user,
-            account__provider__startswith="commcare",
-        )
-        .exclude(account__provider__startswith="commcare_connect")
-        .first()
-    )
-    return token.token if token else None
-
-
-def _get_connect_token(user) -> str | None:
-    """Return the user's Connect OAuth access token, or None."""
-    token = SocialToken.objects.filter(
-        account__user=user,
-        account__provider="commcare_connect",
-    ).first()
+def _get_token_value(user, provider: str) -> str | None:
+    """Return the user's OAuth access token string for *provider*, or None."""
+    token = get_social_token(user, provider)
     return token.token if token else None
 
 
@@ -59,7 +43,7 @@ async def tenant_list_view(request):
     # Refresh domains from CommCare if the user has an OAuth token
     commcare_cache_key = f"tenant_refresh:{user.id}:commcare"
     if not await cache.aget(commcare_cache_key):
-        access_token = await sync_to_async(_get_commcare_token)(user)
+        access_token = await sync_to_async(_get_token_value)(user, "commcare")
         if access_token:
             try:
                 from apps.users.services.tenant_resolution import resolve_commcare_domains
@@ -72,7 +56,7 @@ async def tenant_list_view(request):
     # Refresh opportunities from Connect if the user has a Connect OAuth token
     connect_cache_key = f"tenant_refresh:{user.id}:commcare_connect"
     if not await cache.aget(connect_cache_key):
-        connect_token = await sync_to_async(_get_connect_token)(user)
+        connect_token = await sync_to_async(_get_token_value)(user, "commcare_connect")
         if connect_token:
             try:
                 from apps.users.services.tenant_resolution import resolve_connect_opportunities
@@ -326,7 +310,7 @@ async def tenant_ensure_view(request):
         )
     except TenantMembership.DoesNotExist:
         if provider == "commcare_connect":
-            connect_token = await sync_to_async(_get_connect_token)(user)
+            connect_token = await sync_to_async(_get_token_value)(user, "commcare_connect")
             if not connect_token:
                 return JsonResponse(
                     {"error": "No Connect OAuth token. Please log in with Connect first."},

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -31,12 +31,7 @@ from django.core.exceptions import ValidationError as _ValidationError
 from mcp.server.fastmcp import Context, FastMCP
 from mcp.server.transport_security import TransportSecuritySettings
 
-from apps.users.auth_views import PROVIDER_TOKEN_URLS
-from apps.users.services.token_refresh import (
-    TokenRefreshError,
-    refresh_oauth_token,
-    token_needs_refresh,
-)
+from apps.users.services.credential_resolver import aresolve_credential
 from apps.workspaces.models import (
     MaterializationRun,
     SchemaState,
@@ -469,23 +464,6 @@ async def cancel_materialization(run_id: str) -> dict:
         return tc["result"]
 
 
-def _resolve_oauth_credential(token_obj, provider: str) -> dict:
-    """Build an OAuth credential dict, refreshing the token if expired."""
-    token_value = token_obj.token
-
-    if token_needs_refresh(token_obj.expires_at):
-        token_url = PROVIDER_TOKEN_URLS.get(provider)
-        if token_url and token_obj.token_secret:
-            try:
-                token_value = refresh_oauth_token(token_obj, token_url)
-            except TokenRefreshError:
-                logger.warning(
-                    "Token refresh failed for provider %s, using existing token", provider
-                )
-
-    return {"type": "oauth", "value": token_value}
-
-
 async def _materialize_tenant(
     tm,
     pipeline_config,
@@ -496,57 +474,15 @@ async def _materialize_tenant(
     Resolves credentials, builds a progress callback, and executes the pipeline.
     Returns the pipeline result dict on success, or raises on failure.
     """
-    from apps.users.models import TenantCredential
     from mcp_server.loaders.commcare_base import CommCareAuthError
     from mcp_server.loaders.connect_base import ConnectAuthError
 
     tenant_id = tm.tenant.external_id
 
     # ── Resolve credential ────────────────────────────────────────────────
-    try:
-        cred_obj = await TenantCredential.objects.select_related("tenant_membership").aget(
-            tenant_membership=tm
-        )
-    except TenantCredential.DoesNotExist:
+    credential = await aresolve_credential(tm)
+    if credential is None:
         return error_response("AUTH_TOKEN_MISSING", "No credential configured for this tenant")
-
-    if cred_obj.credential_type == TenantCredential.API_KEY:
-        from apps.users.adapters import decrypt_credential
-
-        try:
-            decrypted = await sync_to_async(decrypt_credential)(cred_obj.encrypted_credential)
-        except Exception:
-            logger.exception("Failed to decrypt API key for tenant %s", tenant_id)
-            return error_response("AUTH_TOKEN_MISSING", "Failed to decrypt API key")
-        credential = {"type": "api_key", "value": decrypted}
-    else:
-        from allauth.socialaccount.models import SocialToken
-
-        if tm.tenant.provider == "commcare_connect":
-            token_obj = (
-                await SocialToken.objects.select_related("app")
-                .filter(
-                    account__user=tm.user,
-                    account__provider__startswith="commcare_connect",
-                )
-                .afirst()
-            )
-        else:
-            token_obj = (
-                await SocialToken.objects.select_related("app")
-                .filter(
-                    account__user=tm.user,
-                    account__provider__startswith="commcare",
-                )
-                .exclude(account__provider__startswith="commcare_connect")
-                .afirst()
-            )
-        if not token_obj:
-            return error_response(
-                "AUTH_TOKEN_MISSING",
-                f"No OAuth token found for provider '{tm.tenant.provider}'",
-            )
-        credential = await sync_to_async(_resolve_oauth_credential)(token_obj, tm.tenant.provider)
 
     # ── Build progress callback ───────────────────────────────────────────
     progress_callback = None

--- a/tests/test_mcp_token_refresh.py
+++ b/tests/test_mcp_token_refresh.py
@@ -1,4 +1,4 @@
-"""Test that MCP server refreshes expired OAuth tokens before materialization."""
+"""Test that credential resolution refreshes expired OAuth tokens."""
 
 from datetime import timedelta
 from unittest.mock import MagicMock, patch
@@ -8,42 +8,61 @@ from django.utils import timezone
 
 
 @pytest.mark.django_db
-class TestMCPTokenRefresh:
+class TestCredentialResolverTokenRefresh:
     def test_expired_token_is_refreshed(self):
-        from mcp_server.server import _resolve_oauth_credential
+        from apps.users.services.credential_resolver import _resolve_oauth_credential
+
         mock_token = MagicMock()
         mock_token.token = "old-expired-token"
         mock_token.token_secret = "refresh-token"
         mock_token.expires_at = timezone.now() - timedelta(hours=1)
         mock_token.app = MagicMock()
 
-        with patch("mcp_server.server.token_needs_refresh", return_value=True) as mock_needs, \
-             patch("mcp_server.server.refresh_oauth_token", return_value="new-fresh-token") as mock_refresh:
+        with (
+            patch(
+                "apps.users.services.credential_resolver.token_needs_refresh", return_value=True
+            ) as mock_needs,
+            patch(
+                "apps.users.services.credential_resolver.refresh_oauth_token",
+                return_value="new-fresh-token",
+            ) as mock_refresh,
+        ):
             result = _resolve_oauth_credential(mock_token, "commcare")
             mock_needs.assert_called_once_with(mock_token.expires_at)
             mock_refresh.assert_called_once()
             assert result["value"] == "new-fresh-token"
 
     def test_valid_token_not_refreshed(self):
-        from mcp_server.server import _resolve_oauth_credential
+        from apps.users.services.credential_resolver import _resolve_oauth_credential
+
         mock_token = MagicMock()
         mock_token.token = "still-valid-token"
         mock_token.expires_at = timezone.now() + timedelta(hours=1)
 
-        with patch("mcp_server.server.token_needs_refresh", return_value=False), \
-             patch("mcp_server.server.refresh_oauth_token") as mock_refresh:
+        with (
+            patch(
+                "apps.users.services.credential_resolver.token_needs_refresh", return_value=False
+            ),
+            patch("apps.users.services.credential_resolver.refresh_oauth_token") as mock_refresh,
+        ):
             result = _resolve_oauth_credential(mock_token, "commcare")
             mock_refresh.assert_not_called()
             assert result["value"] == "still-valid-token"
 
     def test_refresh_failure_returns_original_token(self):
+        from apps.users.services.credential_resolver import _resolve_oauth_credential
         from apps.users.services.token_refresh import TokenRefreshError
-        from mcp_server.server import _resolve_oauth_credential
+
         mock_token = MagicMock()
         mock_token.token = "maybe-still-works"
         mock_token.expires_at = timezone.now() - timedelta(minutes=1)
 
-        with patch("mcp_server.server.token_needs_refresh", return_value=True), \
-             patch("mcp_server.server.refresh_oauth_token", side_effect=TokenRefreshError("fail")):
+        with (
+            patch("apps.users.services.credential_resolver.token_needs_refresh", return_value=True),
+            patch(
+                "apps.users.services.credential_resolver.refresh_oauth_token",
+                side_effect=TokenRefreshError("fail"),
+            ),
+        ):
             result = _resolve_oauth_credential(mock_token, "commcare")
             assert result["value"] == "maybe-still-works"


### PR DESCRIPTION
## Summary

- Extract shared `get_social_token(user, provider)` and `aresolve_credential(membership)` helpers into `credential_resolver.py`, eliminating 3 copies of the provider-branching SocialToken query and 2 copies of the full credential resolution flow
- Move `PROVIDER_TOKEN_URLS` from `auth_views.py` to `token_refresh.py` to break a circular import
- Replace ~50 lines of inline credential resolution in `mcp_server/server.py` with a single `await aresolve_credential(tm)` call
- Replace `_get_commcare_token`/`_get_connect_token` in `views.py` with a single `_get_token_value` helper backed by `get_social_token`

## Test plan

- [x] All 816 tests pass (0 failures)
- [x] ruff check + ruff format pass on all changed files
- [x] Updated `test_mcp_token_refresh.py` to import from new location — same coverage, same structure
- [ ] Verify credential resolution works end-to-end for OAuth and API key tenants

🤖 Generated with [Claude Code](https://claude.com/claude-code)