### PR TITLE
Replace sync psycopg with async psycopg.AsyncConnection (Phase 3)

### DIFF
--- a/apps/agents/graph/base.py
+++ b/apps/agents/graph/base.py
@@ -25,7 +25,6 @@ import logging
 import time
 from typing import TYPE_CHECKING, Any, Literal
 
-from asgiref.sync import sync_to_async
 from langchain_anthropic import ChatAnthropic
 from langchain_core.messages import SystemMessage
 from langgraph.graph import END, StateGraph
@@ -180,11 +179,9 @@ async def _fetch_schema_context(tenant, user) -> str:
     terminal_assets = await aget_terminal_assets(tenant_ids=[tenant.id])
 
     if terminal_assets:
-        tables = await sync_to_async(transformation_aware_list_tables)(
-            ts, pipeline_config, tenant_ids=[tenant.id]
-        )
+        tables = await transformation_aware_list_tables(ts, pipeline_config, tenant_ids=[tenant.id])
     else:
-        tables = await sync_to_async(pipeline_list_tables)(ts, pipeline_config)
+        tables = await pipeline_list_tables(ts, pipeline_config)
 
     if not tables:
         return "Data is loaded but no tables are available yet. The materialization may still be completing."
@@ -202,9 +199,7 @@ async def _fetch_schema_context(tenant, user) -> str:
 
         column_map: dict[str, list[dict]] = {}
         for t in tables:
-            detail = await sync_to_async(pipeline_describe_table)(
-                t["name"], ctx, tenant_metadata, pipeline_config
-            )
+            detail = await pipeline_describe_table(t["name"], ctx, tenant_metadata, pipeline_config)
             if detail:
                 column_map[t["name"]] = detail.get("columns", [])
 

--- a/apps/workspaces/services/schema_manager.py
+++ b/apps/workspaces/services/schema_manager.py
@@ -32,6 +32,14 @@ def get_managed_db_connection():
     return psycopg.connect(url, autocommit=True)
 
 
+async def aget_managed_db_connection():
+    """Get an async psycopg connection to the managed database."""
+    url = settings.MANAGED_DATABASE_URL
+    if not url:
+        raise RuntimeError("MANAGED_DATABASE_URL is not configured")
+    return await psycopg.AsyncConnection.connect(url, autocommit=True)
+
+
 class SchemaManager:
     """Creates and manages tenant schemas in the managed database."""
 
@@ -365,6 +373,41 @@ class SchemaManager:
             cursor.close()
         finally:
             conn.close()
+
+    async def ateardown(self, tenant_schema: TenantSchema) -> None:
+        """Async version of teardown — drop a tenant's schema from the managed database."""
+        async with await aget_managed_db_connection() as conn:
+            async with conn.cursor() as cursor:
+                await cursor.execute(
+                    psycopg.sql.SQL("DROP SCHEMA IF EXISTS {} CASCADE").format(
+                        psycopg.sql.Identifier(tenant_schema.schema_name)
+                    )
+                )
+                await self._adrop_readonly_role(cursor, tenant_schema.schema_name)
+
+    async def ateardown_view_schema(self, view_schema: WorkspaceViewSchema) -> None:
+        """Async version of teardown_view_schema — drop the physical PostgreSQL schema."""
+        async with await aget_managed_db_connection() as conn:
+            async with conn.cursor() as cursor:
+                await cursor.execute(
+                    psycopg.sql.SQL("DROP SCHEMA IF EXISTS {} CASCADE").format(
+                        psycopg.sql.Identifier(view_schema.schema_name)
+                    )
+                )
+                await self._adrop_readonly_role(cursor, view_schema.schema_name)
+
+    async def _adrop_readonly_role(self, cursor, schema_name: str) -> None:
+        """Async version of _drop_readonly_role."""
+        role_name = readonly_role_name(schema_name)
+        await cursor.execute("SELECT 1 FROM pg_roles WHERE rolname = %s", (role_name,))
+        if not await cursor.fetchone():
+            return
+        await cursor.execute(
+            psycopg.sql.SQL("DROP OWNED BY {}").format(psycopg.sql.Identifier(role_name))
+        )
+        await cursor.execute(
+            psycopg.sql.SQL("DROP ROLE IF EXISTS {}").format(psycopg.sql.Identifier(role_name))
+        )
 
     def _drop_readonly_role(self, cursor, schema_name: str) -> None:
         """Drop the read-only PostgreSQL role for a schema.

--- a/docs/plans/2026-04-14-async-conversion-remaining-phases.md
+++ b/docs/plans/2026-04-14-async-conversion-remaining-phases.md
@@ -1,0 +1,314 @@
+# Async Conversion — Remaining Phases
+
+> Continuation of Phase 1 (completed in PR #145). Documents the remaining
+> `sync_to_async` / `async_to_sync` call sites and the plan to eliminate them.
+
+**Current state after Phase 1:** 22 call sites removed. ~20 remain across 5 files.
+
+---
+
+## Phase 2: External HTTP — replace `requests` with `httpx`
+
+**Goal:** Replace the synchronous `requests` library with `httpx.AsyncClient` in
+all external API call sites so they run natively on the event loop instead of
+dispatching to a thread pool.
+
+**Dependency:** Add `httpx` to `pyproject.toml`.
+
+### 2a. Tenant verification (`apps/users/services/tenant_verification.py`)
+
+**Current:** `verify_commcare_credential` uses `requests.get()` to call the
+CommCare user_domains API. Callers in `apps/users/views.py:172,256` wrap it
+with `sync_to_async`.
+
+**Convert to:**
+
+```python
+import httpx
+
+async def verify_commcare_credential(domain: str, username: str, api_key: str) -> dict:
+    async with httpx.AsyncClient(timeout=15) as client:
+        resp = await client.get(
+            f"{COMMCARE_API_BASE}/api/user_domains/v1/",
+            headers={"Authorization": f"ApiKey {username}:{api_key}"},
+        )
+    # ... same validation logic, raise CommCareVerificationError on failure
+```
+
+Then remove `sync_to_async` wrappers at call sites (2 sites in `users/views.py`).
+
+**Effort:** Low — pure HTTP function, no ORM.
+
+### 2b. Tenant resolution (`apps/users/services/tenant_resolution.py`)
+
+**Current:** Three sync functions using `requests` + Django ORM:
+- `_fetch_all_domains(access_token)` — paginated `requests.get()` to CommCare API
+- `resolve_commcare_domains(user, access_token)` — calls `_fetch_all_domains` + ORM upserts
+- `resolve_connect_opportunities(user, access_token)` — `requests.get()` to Connect API + ORM upserts
+
+Callers in `apps/users/views.py:52,65,316` wrap with `sync_to_async`.
+
+**Convert to:**
+
+```python
+async def _afetch_all_domains(access_token: str) -> list[dict]:
+    async with httpx.AsyncClient(timeout=30) as client:
+        results = []
+        url = COMMCARE_DOMAIN_API
+        while url:
+            resp = await client.get(url, headers={"Authorization": f"Bearer {access_token}"})
+            # ... same pagination logic
+        return results
+
+async def aresolve_commcare_domains(user, access_token: str) -> list[TenantMembership]:
+    domains = await _afetch_all_domains(access_token)
+    memberships = []
+    for domain in domains:
+        tenant, _ = await Tenant.objects.aupdate_or_create(
+            provider="commcare", external_id=domain["domain_name"],
+            defaults={"canonical_name": domain["project_name"]},
+        )
+        tm, _ = await TenantMembership.objects.aget_or_create(user=user, tenant=tenant)
+        await TenantCredential.objects.aget_or_create(
+            tenant_membership=tm,
+            defaults={"credential_type": TenantCredential.OAUTH},
+        )
+        memberships.append(tm)
+    return memberships
+
+async def aresolve_connect_opportunities(user, access_token: str) -> list[TenantMembership]:
+    # Same pattern: httpx.AsyncClient + async ORM
+```
+
+Then remove `sync_to_async` wrappers at call sites (3 sites in `users/views.py`).
+
+Keep the sync versions for any non-async callers (e.g. management commands).
+
+**Effort:** Medium — HTTP + ORM combined, paginated loop.
+
+### 2c. Token refresh (`apps/users/services/token_refresh.py`)
+
+**Current:** `refresh_oauth_token` uses `requests.post()` + `social_token.save()`.
+Called via `_resolve_oauth_credential` in `credential_resolver.py:106`.
+
+**Convert to:**
+
+```python
+async def arefresh_oauth_token(social_token, token_url: str) -> str:
+    async with httpx.AsyncClient(timeout=30) as client:
+        response = await client.post(token_url, data={...})
+        response.raise_for_status()
+    data = response.json()
+    social_token.token = data["access_token"]
+    # ... update fields
+    await social_token.asave()
+    return social_token.token
+```
+
+Then convert `_resolve_oauth_credential` in `credential_resolver.py` to async,
+removing its `sync_to_async` wrapper.
+
+**Effort:** Medium — HTTP + ORM save + called from `aresolve_credential`.
+
+### 2d. Credential resolver (`apps/users/services/credential_resolver.py`)
+
+**Current:** `aresolve_credential` is already async but wraps `_resolve_oauth_credential`
+with `sync_to_async` because `refresh_oauth_token` uses sync `requests`.
+
+**After 2c:** Once `arefresh_oauth_token` exists, make `_resolve_oauth_credential`
+async too (rename to `_aresolve_oauth_credential`), removing the last `sync_to_async`
+in this file.
+
+**Effort:** Low — depends on 2c completing first.
+
+### 2e. `_create` with `transaction.atomic` (`apps/users/views.py:188-207`)
+
+**Current:** Inner function `_create()` uses `transaction.atomic()` for a
+get_or_create + update_or_create sequence, wrapped with `sync_to_async`.
+
+**Options:**
+1. **Keep as-is** — `transaction.atomic` doesn't have an async API in Django 5.2.
+   The `sync_to_async` wrapper is correct here.
+2. **Replace with individual async ORM calls** — `aget_or_create` + `aupdate_or_create`
+   without an explicit atomic block. Risk: non-atomic multi-step operation. The
+   get_or_create calls are idempotent so this is safe in practice.
+3. **Wait for Django async transactions** — expected in a future Django release.
+
+**Recommendation:** Option 2 — the operations are all idempotent upserts. No
+data integrity risk from removing the atomic wrapper.
+
+**Effort:** Low.
+
+### Phase 2 summary
+
+| Call site | File | Blocked by |
+|---|---|---|
+| `sync_to_async(verify_commcare_credential)` ×2 | `apps/users/views.py:172,256` | 2a |
+| `sync_to_async(resolve_commcare_domains)` | `apps/users/views.py:52` | 2b |
+| `sync_to_async(resolve_connect_opportunities)` ×2 | `apps/users/views.py:65,316` | 2b |
+| `sync_to_async(_resolve_oauth_credential)` | `credential_resolver.py:106` | 2c |
+| `sync_to_async(_create)` | `apps/users/views.py:207` | 2e |
+
+**Total:** 7 `sync_to_async` call sites removed. After Phase 2, `apps/users/`
+is fully async with zero `sync_to_async`.
+
+---
+
+## Phase 3: Psycopg async — managed database queries
+
+**Goal:** Migrate the MCP query service from `psycopg.connect()` (sync) to
+`psycopg.AsyncConnection` with an async connection pool. This unlocks all
+metadata service functions and the remaining `sync_to_async` calls in
+`mcp_server/` and `apps/agents/graph/base.py`.
+
+**Dependency:** None (psycopg 3 already supports async natively).
+
+### 3a. Query service (`mcp_server/services/query.py`)
+
+**Current:** `_execute_sync` and `_execute_sync_parameterized` use
+`psycopg.connect()` with sync cursors. Wrapped by `sync_to_async` at the two
+call sites in the same file (`execute_query`, `execute_internal_query`).
+
+**Convert to:**
+
+```python
+import psycopg
+
+async def _get_async_connection(ctx: QueryContext):
+    return await psycopg.AsyncConnection.connect(**ctx.connection_params, autocommit=True)
+
+async def _execute_async(ctx: QueryContext, sql: str, timeout_seconds: int) -> dict[str, Any]:
+    async with await _get_async_connection(ctx) as conn:
+        async with conn.cursor() as cursor:
+            await cursor.execute(psql.SQL("SET ROLE {}").format(psql.Identifier(ctx.readonly_role)))
+            try:
+                await cursor.execute(...)
+                # ... same logic
+            finally:
+                await cursor.execute("RESET ROLE")
+```
+
+Consider using `psycopg_pool.AsyncConnectionPool` for connection reuse.
+
+**Effort:** Medium — core query path, needs careful testing.
+
+### 3b. Metadata service (`mcp_server/services/metadata.py`)
+
+**Current:** `pipeline_describe_table`, `workspace_list_tables`, and
+`pipeline_get_metadata` call `_execute_sync_parameterized` directly (sync).
+`pipeline_list_tables` uses sync Django ORM.
+
+**After 3a:** Once the query functions are async:
+- `pipeline_describe_table` → calls async `_execute_async_parameterized`
+- `workspace_list_tables` → calls async `_execute_async_parameterized`
+- `pipeline_get_metadata` → calls the above two
+- `pipeline_list_tables` → convert ORM calls to async (`afirst()`, `async for`)
+
+Then convert `transformation_aware_list_tables` to async as well (it calls
+`pipeline_list_tables` + sync ORM).
+
+**Effort:** Medium — multiple functions, but each conversion is mechanical.
+
+### 3c. MCP server tool handlers (`mcp_server/server.py`)
+
+**Current:** Tool handlers wrap metadata functions with `sync_to_async`:
+
+| Line | Call |
+|---|---|
+| 101 | `sync_to_async(workspace_list_tables)(ctx)` |
+| 129 | `sync_to_async(pipeline_list_tables)(ts, pipeline_config)` |
+| 182 | `sync_to_async(pipeline_describe_table)(...)` |
+| 240 | `sync_to_async(pipeline_get_metadata)(...)` |
+| 732 | `sync_to_async(workspace_list_tables)(ctx)` |
+
+**After 3b:** Call the async metadata functions directly. Remove all
+`sync_to_async` wrappers.
+
+**Effort:** Low — just removing wrappers once metadata functions are async.
+
+### 3d. Agent graph schema context (`apps/agents/graph/base.py`)
+
+**Current:** `_fetch_schema_context` wraps metadata functions:
+
+| Line | Call |
+|---|---|
+| 183 | `sync_to_async(transformation_aware_list_tables)(...)` |
+| 187 | `sync_to_async(pipeline_list_tables)(...)` |
+| 205 | `sync_to_async(pipeline_describe_table)(...)` |
+
+**After 3b:** Call async versions directly. Remove `from asgiref.sync import sync_to_async`.
+
+**Effort:** Low.
+
+### 3e. SchemaManager DDL (`mcp_server/server.py:800,809`)
+
+**Current:** `teardown_schema` tool wraps `SchemaManager.teardown()` and
+`teardown_view_schema()` with `sync_to_async`. These use `psycopg.connect()`
+for DDL (CREATE/DROP SCHEMA).
+
+**Convert:** Make SchemaManager methods async using `psycopg.AsyncConnection`.
+
+**Priority:** Lowest — teardown runs infrequently, thread pool overhead is
+negligible for DDL operations.
+
+**Effort:** Medium — SchemaManager has multiple methods with psycopg usage.
+
+### 3f. Materializer (`mcp_server/server.py:506`)
+
+**Current:** `run_pipeline` is a massive sync orchestrator (HTTP + psycopg +
+dbt + progress callbacks). Wrapped with `sync_to_async` — runs in thread pool.
+
+**Recommendation:** Keep as-is. This is a long-running operation (minutes) that
+benefits from running in a dedicated thread. Converting it would require
+rewriting the entire materializer, all loaders, and the dbt runner. The
+thread pool is the correct pattern here.
+
+**Effort:** N/A — not recommended.
+
+### Phase 3 summary
+
+| Call site | File | Blocked by |
+|---|---|---|
+| `sync_to_async(_execute_sync)` | `query.py:142` | 3a |
+| `sync_to_async(_execute_sync_parameterized)` | `query.py:110` | 3a |
+| `sync_to_async(workspace_list_tables)` ×2 | `server.py:101,732` | 3b |
+| `sync_to_async(pipeline_list_tables)` | `server.py:129` | 3b |
+| `sync_to_async(pipeline_describe_table)` | `server.py:182` | 3b |
+| `sync_to_async(pipeline_get_metadata)` | `server.py:240` | 3b |
+| `sync_to_async(transformation_aware_list_tables)` | `graph/base.py:183` | 3b |
+| `sync_to_async(pipeline_list_tables)` | `graph/base.py:187` | 3b |
+| `sync_to_async(pipeline_describe_table)` | `graph/base.py:205` | 3b |
+| `sync_to_async(mgr.teardown_view_schema)` | `server.py:800` | 3e |
+| `sync_to_async(mgr.teardown)` | `server.py:809` | 3e |
+
+**Total:** 11 `sync_to_async` call sites removed. After Phase 3, `mcp_server/`
+and `apps/agents/graph/base.py` are fully async.
+
+---
+
+## Intentionally kept
+
+| Call site | File | Reason |
+|---|---|---|
+| `async_to_sync(self._build_graph)()` | `apps/recipes/services/runner.py:196` | Sync entry point (Celery/management command) calling async code. Correct pattern. |
+| `sync_to_async(run_pipeline)` | `mcp_server/server.py:506` | Long-running sync orchestrator. Thread pool is the right approach. |
+
+---
+
+## Phase ordering
+
+```
+Phase 2 (httpx)          Phase 3 (psycopg async)
+    │                         │
+    ├─ 2a: verification       ├─ 3a: query service
+    ├─ 2b: resolution         ├─ 3b: metadata service (depends on 3a)
+    ├─ 2c: token refresh      ├─ 3c: MCP server tools (depends on 3b)
+    ├─ 2d: credential resolver├─ 3d: agent graph (depends on 3b)
+    └─ 2e: atomic block       ├─ 3e: SchemaManager DDL (low priority)
+                              └─ 3f: materializer (keep as-is)
+```
+
+Phases 2 and 3 are independent and can be worked in parallel.
+
+After both phases: only 2 `sync_to_async`/`async_to_sync` calls remain in
+production code — `run_pipeline` (correct) and `RecipeRunner.execute` (correct).

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -98,7 +98,7 @@ async def list_tables(workspace_id: str = "") -> dict:
                 schema_name=ctx.schema_name, state=SchemaState.ACTIVE
             ).aexists()
             if is_view_schema:
-                tables = await sync_to_async(workspace_list_tables)(ctx)
+                tables = await workspace_list_tables(ctx)
                 tc["result"] = success_response(
                     {"tables": tables, "note": None},
                     schema=ctx.schema_name,
@@ -126,7 +126,7 @@ async def list_tables(workspace_id: str = "") -> dict:
         pipeline_name = last_run.pipeline if last_run else "commcare_sync"
         pipeline_config = get_registry().get(pipeline_name) or get_registry().get("commcare_sync")
 
-        tables = await sync_to_async(pipeline_list_tables)(ts, pipeline_config)
+        tables = await pipeline_list_tables(ts, pipeline_config)
 
         note = (
             "No completed materialization run found. Run run_materialization to load data."
@@ -179,9 +179,7 @@ async def describe_table(table_name: str, workspace_id: str = "") -> dict:
         pipeline_name = last_run.pipeline if last_run else "commcare_sync"
         pipeline_config = get_registry().get(pipeline_name) or get_registry().get("commcare_sync")
 
-        table = await sync_to_async(pipeline_describe_table)(
-            table_name, ctx, tenant_metadata, pipeline_config
-        )
+        table = await pipeline_describe_table(table_name, ctx, tenant_metadata, pipeline_config)
         if table is None:
             tc["result"] = error_response(
                 NOT_FOUND, f"Table '{table_name}' not found in schema '{ctx.schema_name}'"
@@ -237,9 +235,7 @@ async def get_metadata(workspace_id: str = "") -> dict:
             tenant_membership__tenant_id=ts.tenant_id
         ).afirst()
 
-        metadata = await sync_to_async(pipeline_get_metadata)(
-            ts, ctx, tenant_metadata, pipeline_config
-        )
+        metadata = await pipeline_get_metadata(ts, ctx, tenant_metadata, pipeline_config)
 
         tc["result"] = success_response(
             {
@@ -729,7 +725,7 @@ async def get_schema_status(workspace_id: str = "") -> dict:
 
         # List tables from the view schema via information_schema
         ctx = await _resolve_mcp_context(workspace_id)
-        tables = await sync_to_async(workspace_list_tables)(ctx)
+        tables = await workspace_list_tables(ctx)
 
         tc["result"] = success_response(
             {
@@ -760,8 +756,6 @@ async def teardown_schema(confirm: bool = False, workspace_id: str = "") -> dict
         confirm: Must be True to execute. Defaults to False as a safety guard.
         workspace_id: Workspace UUID (injected server-side by the agent graph).
     """
-    from asgiref.sync import sync_to_async
-
     from apps.workspaces.models import SchemaState, TenantSchema, WorkspaceViewSchema
     from apps.workspaces.services.schema_manager import SchemaManager
 
@@ -797,7 +791,7 @@ async def teardown_schema(confirm: bool = False, workspace_id: str = "") -> dict
             .afirst()
         )
         if vs:
-            await sync_to_async(mgr.teardown_view_schema)(vs)
+            await mgr.ateardown_view_schema(vs)
             dropped.append(vs.schema_name)
 
         # Tear down all tenant schemas for this workspace
@@ -806,7 +800,7 @@ async def teardown_schema(confirm: bool = False, workspace_id: str = "") -> dict
             tenant_id__in=tenant_ids,
         ).exclude(state=SchemaState.TEARDOWN):
             schema_name = ts.schema_name
-            await sync_to_async(mgr.teardown)(ts)
+            await mgr.ateardown(ts)
             dropped.append(schema_name)
 
         tc["result"] = success_response(

--- a/mcp_server/services/metadata.py
+++ b/mcp_server/services/metadata.py
@@ -14,7 +14,7 @@ from django.db import models
 
 from apps.workspaces.models import MaterializationRun
 from mcp_server.pipeline_registry import PipelineConfig
-from mcp_server.services.query import _execute_sync_parameterized
+from mcp_server.services.query import _execute_async_parameterized
 
 if TYPE_CHECKING:
     from apps.workspaces.models import TenantMetadata, TenantSchema
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def pipeline_list_tables(
+async def pipeline_list_tables(
     tenant_schema: TenantSchema,
     pipeline_config: PipelineConfig,
 ) -> list[dict]:
@@ -33,12 +33,12 @@ def pipeline_list_tables(
     Each entry includes name, type, description, row_count, and materialized_at.
     """
     run = (
-        MaterializationRun.objects.filter(
+        await MaterializationRun.objects.filter(
             tenant_schema=tenant_schema,
             state=MaterializationRun.RunState.COMPLETED,
         )
         .order_by("-completed_at")
-        .first()
+        .afirst()
     )
     if run is None:
         return []
@@ -74,13 +74,13 @@ def pipeline_list_tables(
     return tables
 
 
-def workspace_list_tables(ctx: QueryContext) -> list[dict]:
+async def workspace_list_tables(ctx: QueryContext) -> list[dict]:
     """Return table list for a workspace view schema by querying information_schema directly.
 
     Used when the schema is a WorkspaceViewSchema (namespaced views) rather than a
     TenantSchema backed by a MaterializationRun. Returns one entry per view found.
     """
-    result = _execute_sync_parameterized(
+    result = await _execute_async_parameterized(
         ctx,
         "SELECT table_name FROM information_schema.tables "
         "WHERE table_schema = %s AND table_type = 'VIEW' "
@@ -100,7 +100,7 @@ def workspace_list_tables(ctx: QueryContext) -> list[dict]:
     ]
 
 
-def pipeline_describe_table(
+async def pipeline_describe_table(
     table_name: str,
     ctx: QueryContext,
     tenant_metadata: TenantMetadata | None,
@@ -111,7 +111,7 @@ def pipeline_describe_table(
     Returns None if the table does not exist in information_schema.
     JSONB columns (properties, form_data) receive descriptions derived from TenantMetadata.
     """
-    result = _execute_sync_parameterized(
+    result = await _execute_async_parameterized(
         ctx,
         "SELECT column_name, data_type, is_nullable, column_default "
         "FROM information_schema.columns "
@@ -181,7 +181,7 @@ def _build_jsonb_annotations(
     return {}
 
 
-def transformation_aware_list_tables(
+async def transformation_aware_list_tables(
     tenant_schema: TenantSchema,
     pipeline_config: PipelineConfig,
     tenant_ids: list,
@@ -193,13 +193,13 @@ def transformation_aware_list_tables(
     replace their upstream tables in the listing. Otherwise falls back
     to the standard pipeline_list_tables behavior.
     """
-    from apps.transformations.services.lineage import get_terminal_assets
+    from apps.transformations.services.lineage import aget_terminal_assets
 
-    terminal_assets = get_terminal_assets(tenant_ids, workspace_id)
+    terminal_assets = await aget_terminal_assets(tenant_ids, workspace_id)
 
     if not terminal_assets:
         # No transformation assets — use existing pipeline-based listing
-        return pipeline_list_tables(tenant_schema, pipeline_config)
+        return await pipeline_list_tables(tenant_schema, pipeline_config)
 
     # Build set of replaced table names (walk replaces chains, scoped to
     # visible assets to prevent cross-tenant information disclosure).
@@ -215,14 +215,14 @@ def transformation_aware_list_tables(
         visited = set()
         while next_id and next_id not in visited:
             visited.add(next_id)
-            upstream = _TA.objects.filter(visible_q, id=next_id).first()
+            upstream = await _TA.objects.filter(visible_q, id=next_id).afirst()
             if upstream is None:
                 break
             replaced_names.add(upstream.name)
             next_id = upstream.replaces_id
 
     # Start with raw tables, excluding replaced ones and terminal asset names
-    raw_tables = pipeline_list_tables(tenant_schema, pipeline_config)
+    raw_tables = await pipeline_list_tables(tenant_schema, pipeline_config)
     terminal_names = {asset.name for asset in terminal_assets}
     result = [
         t for t in raw_tables if t["name"] not in replaced_names and t["name"] not in terminal_names
@@ -243,7 +243,7 @@ def transformation_aware_list_tables(
     return result
 
 
-def pipeline_get_metadata(
+async def pipeline_get_metadata(
     tenant_schema: TenantSchema,
     ctx: QueryContext,
     tenant_metadata: TenantMetadata | None,
@@ -253,13 +253,13 @@ def pipeline_get_metadata(
 
     Returns {"tables": {}, "relationships": []} if no completed run exists.
     """
-    tables_list = pipeline_list_tables(tenant_schema, pipeline_config)
+    tables_list = await pipeline_list_tables(tenant_schema, pipeline_config)
     if not tables_list:
         return {"tables": {}, "relationships": []}
 
     tables = {}
     for t in tables_list:
-        detail = pipeline_describe_table(t["name"], ctx, tenant_metadata, pipeline_config)
+        detail = await pipeline_describe_table(t["name"], ctx, tenant_metadata, pipeline_config)
         if detail:
             tables[t["name"]] = detail
 

--- a/mcp_server/services/query.py
+++ b/mcp_server/services/query.py
@@ -9,7 +9,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from asgiref.sync import sync_to_async
+import psycopg
+from psycopg import sql as psql
 
 from mcp_server.context import QueryContext
 from mcp_server.envelope import (
@@ -33,34 +34,26 @@ def _build_validator(ctx: QueryContext) -> SQLValidator:
     )
 
 
-def _get_connection(ctx: QueryContext):
-    """Create a psycopg connection from context params."""
-    import psycopg
-
-    return psycopg.connect(**ctx.connection_params, autocommit=True)
-
-
-def _execute_sync(ctx: QueryContext, sql: str, timeout_seconds: int) -> dict[str, Any]:
-    """Run a SQL query synchronously under the tenant's read-only role."""
-    from psycopg import sql as psql
-
-    with _get_connection(ctx) as conn:
-        cursor = conn.cursor()
-        try:
-            cursor.execute(psql.SQL("SET ROLE {}").format(psql.Identifier(ctx.readonly_role)))
+async def _execute_async(ctx: QueryContext, sql: str, timeout_seconds: int) -> dict[str, Any]:
+    """Run a SQL query asynchronously under the tenant's read-only role."""
+    async with await psycopg.AsyncConnection.connect(
+        **ctx.connection_params, autocommit=True
+    ) as conn:
+        async with conn.cursor() as cursor:
+            await cursor.execute(psql.SQL("SET ROLE {}").format(psql.Identifier(ctx.readonly_role)))
             try:
-                cursor.execute(
+                await cursor.execute(
                     psql.SQL("SET search_path TO {}").format(psql.Identifier(ctx.schema_name))
                 )
-                cursor.execute(f"SET statement_timeout TO '{timeout_seconds}s'")
-                cursor.execute(sql)
+                await cursor.execute(f"SET statement_timeout TO '{timeout_seconds}s'")
+                await cursor.execute(sql)
 
                 columns: list[str] = []
                 rows: list[list[Any]] = []
 
                 if cursor.description:
                     columns = [desc[0] for desc in cursor.description]
-                    rows = [list(row) for row in cursor.fetchall()]
+                    rows = [list(row) for row in await cursor.fetchall()]
 
                 return {
                     "columns": columns,
@@ -68,48 +61,41 @@ def _execute_sync(ctx: QueryContext, sql: str, timeout_seconds: int) -> dict[str
                     "row_count": len(rows),
                 }
             finally:
-                cursor.execute("RESET ROLE")
-        finally:
-            cursor.close()
+                await cursor.execute("RESET ROLE")
 
 
-def _execute_sync_parameterized(
+async def _execute_async_parameterized(
     ctx: QueryContext, sql: str, params: tuple, timeout_seconds: int
 ) -> dict[str, Any]:
-    """Run a parameterized SQL query synchronously. No validation or LIMIT injection."""
-    from psycopg import sql as psql
-
-    with _get_connection(ctx) as conn:
-        cursor = conn.cursor()
-        try:
-            cursor.execute(
+    """Run a parameterized SQL query asynchronously. No validation or LIMIT injection."""
+    async with await psycopg.AsyncConnection.connect(
+        **ctx.connection_params, autocommit=True
+    ) as conn:
+        async with conn.cursor() as cursor:
+            await cursor.execute(
                 psql.SQL("SET search_path TO {}").format(psql.Identifier(ctx.schema_name))
             )
-            cursor.execute(f"SET statement_timeout TO '{timeout_seconds}s'")
-            cursor.execute(sql, params)
+            await cursor.execute(f"SET statement_timeout TO '{timeout_seconds}s'")
+            await cursor.execute(sql, params)
 
             columns: list[str] = []
             rows: list[list[Any]] = []
 
             if cursor.description:
                 columns = [desc[0] for desc in cursor.description]
-                rows = [list(row) for row in cursor.fetchall()]
+                rows = [list(row) for row in await cursor.fetchall()]
 
             return {
                 "columns": columns,
                 "rows": rows,
                 "row_count": len(rows),
             }
-        finally:
-            cursor.close()
 
 
 async def execute_internal_query(ctx: QueryContext, sql: str, params: tuple = ()) -> dict[str, Any]:
     """Execute a trusted internal query, bypassing SQL validation."""
     try:
-        return await sync_to_async(_execute_sync_parameterized)(
-            ctx, sql, params, ctx.max_query_timeout_seconds
-        )
+        return await _execute_async_parameterized(ctx, sql, params, ctx.max_query_timeout_seconds)
     except Exception as e:
         code, message = _classify_error(e)
         logger.error("Internal query error: %s", message, exc_info=True)
@@ -139,9 +125,7 @@ async def execute_query(ctx: QueryContext, sql: str) -> dict[str, Any]:
             truncated = True
 
     try:
-        result = await sync_to_async(_execute_sync)(
-            ctx, sql_executed, ctx.max_query_timeout_seconds
-        )
+        result = await _execute_async(ctx, sql_executed, ctx.max_query_timeout_seconds)
     except Exception as e:
         code, message = _classify_error(e)
         logger.error("Query error for tenant %s: %s", ctx.tenant_id, message, exc_info=True)

--- a/tests/agents/test_schema_context.py
+++ b/tests/agents/test_schema_context.py
@@ -80,7 +80,10 @@ async def test_fetch_schema_context_active_compact(mock_tenant, mock_user):
     with (
         patch("apps.agents.graph.base.TenantSchema") as MockTS,
         patch("apps.agents.graph.base.get_registry") as mock_registry,
-        patch("apps.agents.graph.base.sync_to_async") as mock_s2a,
+        patch(
+            "apps.agents.graph.base.pipeline_list_tables",
+            new=AsyncMock(return_value=mock_tables),
+        ),
         patch("apps.agents.graph.base._render_full_schema") as mock_full,
         patch(
             "apps.transformations.services.lineage.aget_terminal_assets",
@@ -89,10 +92,6 @@ async def test_fetch_schema_context_active_compact(mock_tenant, mock_user):
     ):
         MockTS.objects.filter.return_value.afirst = AsyncMock(return_value=mock_ts)
         mock_registry.return_value.get.return_value = MagicMock()
-        # sync_to_async calls: 1) pipeline_list_tables
-        mock_s2a.side_effect = [
-            AsyncMock(return_value=mock_tables),  # pipeline_list_tables
-        ]
         mock_full.return_value = big_column_text  # triggers fallback
 
         result = await _fetch_schema_context(mock_tenant, mock_user)
@@ -128,7 +127,14 @@ async def test_fetch_schema_context_active_full(mock_tenant, mock_user):
     with (
         patch("apps.agents.graph.base.TenantSchema") as MockTS,
         patch("apps.agents.graph.base.get_registry") as mock_registry,
-        patch("apps.agents.graph.base.sync_to_async") as mock_s2a,
+        patch(
+            "apps.agents.graph.base.pipeline_list_tables",
+            new=AsyncMock(return_value=mock_tables),
+        ),
+        patch(
+            "apps.agents.graph.base.pipeline_describe_table",
+            new=AsyncMock(return_value={"columns": [{"name": "case_id", "type": "text"}]}),
+        ),
         patch("apps.agents.graph.base._render_full_schema") as mock_full,
         patch(
             "apps.agents.graph.base.load_tenant_context", new=AsyncMock(return_value=MagicMock())
@@ -141,11 +147,6 @@ async def test_fetch_schema_context_active_full(mock_tenant, mock_user):
     ):
         MockTS.objects.filter.return_value.afirst = AsyncMock(return_value=mock_ts)
         mock_registry.return_value.get.return_value = MagicMock()
-        # sync_to_async calls: 1) pipeline_list_tables, 2) describe_table
-        mock_s2a.side_effect = [
-            AsyncMock(return_value=mock_tables),  # pipeline_list_tables
-            AsyncMock(return_value={"columns": [{"name": "case_id", "type": "text"}]}),
-        ]
         mock_full.return_value = small_column_text
         MockTM.objects.filter.return_value.afirst = AsyncMock(return_value=None)
 
@@ -167,7 +168,10 @@ async def test_fetch_schema_context_no_get_schema_status_instruction(mock_tenant
     with (
         patch("apps.agents.graph.base.TenantSchema") as MockTS,
         patch("apps.agents.graph.base.get_registry") as mock_registry,
-        patch("apps.agents.graph.base.sync_to_async") as mock_s2a,
+        patch(
+            "apps.agents.graph.base.pipeline_list_tables",
+            new=AsyncMock(return_value=[]),
+        ),
         patch("apps.agents.graph.base._render_full_schema") as mock_full,
         patch(
             "apps.transformations.services.lineage.aget_terminal_assets",
@@ -176,9 +180,6 @@ async def test_fetch_schema_context_no_get_schema_status_instruction(mock_tenant
     ):
         MockTS.objects.filter.return_value.afirst = AsyncMock(return_value=mock_ts)
         mock_registry.return_value.get.return_value = MagicMock()
-        mock_s2a.side_effect = [
-            AsyncMock(return_value=[]),  # pipeline_list_tables
-        ]
         mock_full.return_value = ""
 
         result = await _fetch_schema_context(mock_tenant, mock_user)
@@ -211,7 +212,10 @@ async def test_build_system_prompt_no_schema_status_call():
         patch("apps.agents.graph.base.KnowledgeRetriever") as MockKR,
         patch("apps.agents.graph.base.TenantSchema") as MockTS,
         patch("apps.agents.graph.base.get_registry") as mock_reg,
-        patch("apps.agents.graph.base.sync_to_async") as mock_s2a,
+        patch(
+            "apps.agents.graph.base.pipeline_list_tables",
+            new=AsyncMock(return_value=[]),
+        ),
         patch("apps.agents.graph.base._render_full_schema") as mock_full,
         patch(
             "apps.transformations.services.lineage.aget_terminal_assets",
@@ -221,7 +225,6 @@ async def test_build_system_prompt_no_schema_status_call():
         MockKR.return_value.retrieve = AsyncMock(return_value="")
         MockTS.objects.filter.return_value.afirst = AsyncMock(return_value=mock_ts)
         mock_reg.return_value.get.return_value = MagicMock()
-        mock_s2a.return_value = AsyncMock(return_value=[])
         mock_full.return_value = ""
 
         prompt = await _build_system_prompt(mock_workspace, MagicMock())

--- a/tests/test_lineage.py
+++ b/tests/test_lineage.py
@@ -1,8 +1,9 @@
 """Tests for lineage resolution and transformation-aware metadata (Milestone 6)."""
 
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
+from asgiref.sync import sync_to_async
 
 from apps.transformations.models import TransformationAsset, TransformationScope
 from apps.transformations.services.lineage import get_lineage_chain, get_terminal_assets
@@ -251,17 +252,19 @@ def test_lineage_cycle_guard(tenant):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.django_db
-def test_transformation_aware_no_assets_fallback(tenant):
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_transformation_aware_no_assets_fallback(tenant):
     """No transformation assets → falls back to pipeline_list_tables."""
     from mcp_server.services.metadata import transformation_aware_list_tables
 
     mock_tables = [{"name": "raw_cases", "type": "table", "description": "", "row_count": 10}]
 
     with patch(
-        "mcp_server.services.metadata.pipeline_list_tables", return_value=mock_tables
+        "mcp_server.services.metadata.pipeline_list_tables",
+        new=AsyncMock(return_value=mock_tables),
     ) as mock_plt:
-        result = transformation_aware_list_tables(
+        result = await transformation_aware_list_tables(
             tenant_schema=None,  # not used when mocked
             pipeline_config=None,
             tenant_ids=[tenant.id],
@@ -270,19 +273,20 @@ def test_transformation_aware_no_assets_fallback(tenant):
     assert result == mock_tables
 
 
-@pytest.mark.django_db
-def test_transformation_aware_terminal_replaces_raw(tenant):
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_transformation_aware_terminal_replaces_raw(tenant):
     """Terminal asset replacing a raw table: raw table excluded, terminal included."""
     from mcp_server.services.metadata import transformation_aware_list_tables
 
-    raw_asset = TransformationAsset.objects.create(
+    raw_asset = await sync_to_async(TransformationAsset.objects.create)(
         name="stg_case_patient",
         scope=TransformationScope.SYSTEM,
         tenant=tenant,
         sql_content="SELECT * FROM raw_cases",
         description="Staging cases",
     )
-    TransformationAsset.objects.create(
+    await sync_to_async(TransformationAsset.objects.create)(
         name="cases_clean",
         scope=TransformationScope.TENANT,
         tenant=tenant,
@@ -296,8 +300,11 @@ def test_transformation_aware_terminal_replaces_raw(tenant):
         {"name": "raw_forms", "type": "table", "description": "Forms", "row_count": 50},
     ]
 
-    with patch("mcp_server.services.metadata.pipeline_list_tables", return_value=mock_raw_tables):
-        result = transformation_aware_list_tables(
+    with patch(
+        "mcp_server.services.metadata.pipeline_list_tables",
+        new=AsyncMock(return_value=mock_raw_tables),
+    ):
+        result = await transformation_aware_list_tables(
             tenant_schema=None,
             pipeline_config=None,
             tenant_ids=[tenant.id],
@@ -313,12 +320,13 @@ def test_transformation_aware_terminal_replaces_raw(tenant):
     assert "raw_forms" in names
 
 
-@pytest.mark.django_db
-def test_transformation_aware_mixed(tenant):
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_transformation_aware_mixed(tenant):
     """Mix: some raw tables have no replacing asset → they appear alongside terminals."""
     from mcp_server.services.metadata import transformation_aware_list_tables
 
-    TransformationAsset.objects.create(
+    await sync_to_async(TransformationAsset.objects.create)(
         name="stg_form_reg",
         scope=TransformationScope.SYSTEM,
         tenant=tenant,
@@ -331,8 +339,11 @@ def test_transformation_aware_mixed(tenant):
         {"name": "raw_forms", "type": "table", "description": "Forms", "row_count": 50},
     ]
 
-    with patch("mcp_server.services.metadata.pipeline_list_tables", return_value=mock_raw_tables):
-        result = transformation_aware_list_tables(
+    with patch(
+        "mcp_server.services.metadata.pipeline_list_tables",
+        new=AsyncMock(return_value=mock_raw_tables),
+    ):
+        result = await transformation_aware_list_tables(
             tenant_schema=None,
             pipeline_config=None,
             tenant_ids=[tenant.id],
@@ -345,12 +356,13 @@ def test_transformation_aware_mixed(tenant):
     assert "raw_forms" in names
 
 
-@pytest.mark.django_db
-def test_transformation_aware_no_duplicates(tenant):
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_transformation_aware_no_duplicates(tenant):
     """Terminal asset whose name matches a pipeline table should not produce duplicates."""
     from mcp_server.services.metadata import transformation_aware_list_tables
 
-    TransformationAsset.objects.create(
+    await sync_to_async(TransformationAsset.objects.create)(
         name="stg_cases",
         scope=TransformationScope.SYSTEM,
         tenant=tenant,
@@ -363,8 +375,11 @@ def test_transformation_aware_no_duplicates(tenant):
         {"name": "stg_cases", "type": "table", "description": "Staged", "row_count": 80},
     ]
 
-    with patch("mcp_server.services.metadata.pipeline_list_tables", return_value=mock_raw_tables):
-        result = transformation_aware_list_tables(
+    with patch(
+        "mcp_server.services.metadata.pipeline_list_tables",
+        new=AsyncMock(return_value=mock_raw_tables),
+    ):
+        result = await transformation_aware_list_tables(
             tenant_schema=None,
             pipeline_config=None,
             tenant_ids=[tenant.id],

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -127,7 +127,7 @@ class TestExecuteQuery:
         assert "not allowed" in result["error"]["message"].lower()
 
     @pytest.mark.asyncio
-    @patch("mcp_server.services.query._execute_sync")
+    @patch("mcp_server.services.query._execute_async")
     async def test_successful_query(self, mock_exec, project_context):
         mock_exec.return_value = {
             "columns": ["id", "name"],
@@ -145,7 +145,7 @@ class TestExecuteQuery:
         assert "users" in result["tables_accessed"]
 
     @pytest.mark.asyncio
-    @patch("mcp_server.services.query._execute_sync")
+    @patch("mcp_server.services.query._execute_async")
     async def test_truncation_detected(self, mock_exec, project_context):
         """When row_count equals max_limit, truncated should be True."""
         mock_exec.return_value = {
@@ -157,7 +157,7 @@ class TestExecuteQuery:
         assert result["truncated"] is True
 
     @pytest.mark.asyncio
-    @patch("mcp_server.services.query._execute_sync")
+    @patch("mcp_server.services.query._execute_async")
     async def test_limit_injected(self, mock_exec, project_context):
         mock_exec.return_value = {
             "columns": ["id"],
@@ -168,7 +168,7 @@ class TestExecuteQuery:
         assert "LIMIT" in result["sql_executed"].upper()
 
     @pytest.mark.asyncio
-    @patch("mcp_server.services.query._execute_sync")
+    @patch("mcp_server.services.query._execute_async")
     async def test_timeout_error(self, mock_exec, project_context):
         import psycopg.errors
 
@@ -178,7 +178,7 @@ class TestExecuteQuery:
         assert result["error"]["code"] == QUERY_TIMEOUT
 
     @pytest.mark.asyncio
-    @patch("mcp_server.services.query._execute_sync")
+    @patch("mcp_server.services.query._execute_async")
     async def test_connection_error(self, mock_exec, project_context):
         import psycopg
 
@@ -188,7 +188,7 @@ class TestExecuteQuery:
         assert result["error"]["code"] == CONNECTION_ERROR
 
     @pytest.mark.asyncio
-    @patch("mcp_server.services.query._execute_sync")
+    @patch("mcp_server.services.query._execute_async")
     async def test_unexpected_error(self, mock_exec, project_context):
         mock_exec.side_effect = RuntimeError("boom")
         result = await execute_query(project_context, "SELECT * FROM users")

--- a/tests/test_mcp_tenant_tools.py
+++ b/tests/test_mcp_tenant_tools.py
@@ -60,7 +60,7 @@ def tenant_context(tenant_id, schema_name):
 class TestExecuteInternalQuery:
     """Test that execute_internal_query bypasses validation and passes params."""
 
-    @patch("mcp_server.services.query._execute_sync_parameterized")
+    @patch("mcp_server.services.query._execute_async_parameterized")
     async def test_passes_sql_and_params(self, mock_exec, tenant_context):
         from mcp_server.services.query import execute_internal_query
 
@@ -78,7 +78,7 @@ class TestExecuteInternalQuery:
         assert result["row_count"] == 1
         assert result["rows"] == [["cases"]]
 
-    @patch("mcp_server.services.query._execute_sync_parameterized")
+    @patch("mcp_server.services.query._execute_async_parameterized")
     async def test_does_not_validate_sql(self, mock_exec, tenant_context):
         """Internal queries should NOT go through the SQL validator."""
         from mcp_server.services.query import execute_internal_query
@@ -92,7 +92,7 @@ class TestExecuteInternalQuery:
         assert "error" not in result
         mock_exec.assert_called_once()
 
-    @patch("mcp_server.services.query._execute_sync_parameterized")
+    @patch("mcp_server.services.query._execute_async_parameterized")
     async def test_does_not_inject_limit(self, mock_exec, tenant_context):
         """Internal queries should NOT have LIMIT injected."""
         from mcp_server.services.query import execute_internal_query
@@ -102,11 +102,11 @@ class TestExecuteInternalQuery:
         sql = "SELECT table_name FROM information_schema.tables WHERE table_schema = %s"
         await execute_internal_query(tenant_context, sql, ("test_domain",))
 
-        # The SQL passed to _execute_sync_parameterized should be unchanged
+        # The SQL passed to _execute_async_parameterized should be unchanged
         called_sql = mock_exec.call_args[0][1]
         assert "LIMIT" not in called_sql.upper()
 
-    @patch("mcp_server.services.query._execute_sync_parameterized")
+    @patch("mcp_server.services.query._execute_async_parameterized")
     async def test_returns_error_envelope_on_exception(self, mock_exec, tenant_context):
         from mcp_server.services.query import execute_internal_query
 
@@ -118,27 +118,39 @@ class TestExecuteInternalQuery:
 
 
 # ---------------------------------------------------------------------------
-# _execute_sync_parameterized
+# _execute_async_parameterized
 # ---------------------------------------------------------------------------
 
 
-class TestExecuteSyncParameterized:
-    """Test the low-level sync execution function."""
+def _make_async_conn(mock_cursor):
+    """Build a mock that mimics psycopg.AsyncConnection for async with patterns."""
+    mock_conn = MagicMock()
+    mock_cursor.__aenter__ = AsyncMock(return_value=mock_cursor)
+    mock_cursor.__aexit__ = AsyncMock(return_value=False)
+    mock_conn.cursor.return_value = mock_cursor
+    mock_conn.__aenter__ = AsyncMock(return_value=mock_conn)
+    mock_conn.__aexit__ = AsyncMock(return_value=False)
+    return mock_conn
 
-    def test_sets_search_path_and_executes_with_params(self, tenant_context):
-        from mcp_server.services.query import _execute_sync_parameterized
 
-        mock_cursor = MagicMock()
+class TestExecuteAsyncParameterized:
+    """Test the low-level async execution function."""
+
+    @pytest.mark.asyncio
+    async def test_sets_search_path_and_executes_with_params(self, tenant_context):
+        from mcp_server.services.query import _execute_async_parameterized
+
+        mock_cursor = AsyncMock()
         mock_cursor.description = [("table_name",), ("table_type",)]
         mock_cursor.fetchall.return_value = [("cases", "BASE TABLE")]
 
-        mock_conn = MagicMock()
-        mock_conn.cursor.return_value = mock_cursor
-        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
-        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_conn = _make_async_conn(mock_cursor)
 
-        with patch("mcp_server.services.query._get_connection", return_value=mock_conn):
-            result = _execute_sync_parameterized(
+        with patch(
+            "psycopg.AsyncConnection.connect",
+            new=AsyncMock(return_value=mock_conn),
+        ):
+            result = await _execute_async_parameterized(
                 tenant_context,
                 "SELECT table_name, table_type FROM information_schema.tables "
                 "WHERE table_schema = %s",
@@ -161,20 +173,21 @@ class TestExecuteSyncParameterized:
             "row_count": 1,
         }
 
-    def test_returns_empty_rows_when_no_data(self, tenant_context):
-        from mcp_server.services.query import _execute_sync_parameterized
+    @pytest.mark.asyncio
+    async def test_returns_empty_rows_when_no_data(self, tenant_context):
+        from mcp_server.services.query import _execute_async_parameterized
 
-        mock_cursor = MagicMock()
+        mock_cursor = AsyncMock()
         mock_cursor.description = [("table_name",), ("table_type",)]
         mock_cursor.fetchall.return_value = []
 
-        mock_conn = MagicMock()
-        mock_conn.cursor.return_value = mock_cursor
-        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
-        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_conn = _make_async_conn(mock_cursor)
 
-        with patch("mcp_server.services.query._get_connection", return_value=mock_conn):
-            result = _execute_sync_parameterized(
+        with patch(
+            "psycopg.AsyncConnection.connect",
+            new=AsyncMock(return_value=mock_conn),
+        ):
+            result = await _execute_async_parameterized(
                 tenant_context,
                 "SELECT table_name FROM information_schema.tables WHERE table_schema = %s",
                 ("nonexistent_schema",),
@@ -792,9 +805,9 @@ class TestCancelMaterialization:
 # ---------------------------------------------------------------------------
 
 
-class TestExecuteSyncIntegration:
+class TestExecuteAsyncIntegration:
     """
-    End-to-end tests for _execute_sync and _execute_sync_parameterized against
+    End-to-end tests for _execute_async and _execute_async_parameterized against
     a real PostgreSQL server.  These catch driver-level regressions (e.g. SET
     statement_timeout failing with psycopg3's server-side parameters) that
     mock-based tests can't detect.
@@ -843,7 +856,7 @@ class TestExecuteSyncIntegration:
                     VALUES ('alpha', 1), ('beta', 2), ('gamma', 3)
                     """
                 )
-                # Create the read-only role required by _execute_sync SET ROLE
+                # Create the read-only role required by _execute_async SET ROLE
                 cur.execute(f'CREATE ROLE "{self.ro_role}"')
                 cur.execute(f'GRANT USAGE ON SCHEMA "{self.schema}" TO "{self.ro_role}"')
                 cur.execute(
@@ -873,36 +886,42 @@ class TestExecuteSyncIntegration:
             connection_params=self.connection_params,
         )
 
-    def test_returns_rows(self):
-        from mcp_server.services.query import _execute_sync
+    @pytest.mark.asyncio
+    async def test_returns_rows(self):
+        from mcp_server.services.query import _execute_async
 
-        result = _execute_sync(self._ctx(), "SELECT name, value FROM items ORDER BY value", 30)
+        result = await _execute_async(
+            self._ctx(), "SELECT name, value FROM items ORDER BY value", 30
+        )
 
         assert result["columns"] == ["name", "value"]
         assert result["rows"] == [["alpha", 1], ["beta", 2], ["gamma", 3]]
         assert result["row_count"] == 3
 
-    def test_statement_timeout_does_not_use_server_side_param(self):
+    @pytest.mark.asyncio
+    async def test_statement_timeout_does_not_use_server_side_param(self):
         """Regression: SET statement_timeout TO $1 raises SyntaxError in psycopg3."""
-        from mcp_server.services.query import _execute_sync
+        from mcp_server.services.query import _execute_async
 
         # Would raise psycopg.errors.SyntaxError before the fix
-        result = _execute_sync(self._ctx(), "SELECT 1 AS n", 30)
+        result = await _execute_async(self._ctx(), "SELECT 1 AS n", 30)
         assert result["row_count"] == 1
 
-    def test_empty_result(self):
-        from mcp_server.services.query import _execute_sync
+    @pytest.mark.asyncio
+    async def test_empty_result(self):
+        from mcp_server.services.query import _execute_async
 
-        result = _execute_sync(self._ctx(), "SELECT name FROM items WHERE value > 9999", 30)
+        result = await _execute_async(self._ctx(), "SELECT name FROM items WHERE value > 9999", 30)
 
         assert result["columns"] == ["name"]
         assert result["rows"] == []
         assert result["row_count"] == 0
 
-    def test_parameterized_filters_rows(self):
-        from mcp_server.services.query import _execute_sync_parameterized
+    @pytest.mark.asyncio
+    async def test_parameterized_filters_rows(self):
+        from mcp_server.services.query import _execute_async_parameterized
 
-        result = _execute_sync_parameterized(
+        result = await _execute_async_parameterized(
             self._ctx(),
             "SELECT name, value FROM items WHERE value > %s ORDER BY value",
             (1,),
@@ -913,12 +932,13 @@ class TestExecuteSyncIntegration:
         assert result["rows"] == [["beta", 2], ["gamma", 3]]
         assert result["row_count"] == 2
 
-    def test_search_path_is_applied(self):
+    @pytest.mark.asyncio
+    async def test_search_path_is_applied(self):
         """Unqualified table name resolves because search_path is set to the schema."""
-        from mcp_server.services.query import _execute_sync
+        from mcp_server.services.query import _execute_async
 
         # No schema qualifier — relies on SET search_path TO working correctly
-        result = _execute_sync(self._ctx(), "SELECT count(*) AS n FROM items", 30)
+        result = await _execute_async(self._ctx(), "SELECT count(*) AS n FROM items", 30)
 
         assert result["row_count"] == 1
         assert result["rows"][0][0] == 3

--- a/tests/test_metadata_service.py
+++ b/tests/test_metadata_service.py
@@ -1,7 +1,9 @@
 """Tests for mcp_server/services/metadata.py."""
 
 from datetime import UTC, datetime
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 
 def _make_pipeline_config(sources=None, dbt_models=None, relationships=None):
@@ -33,7 +35,8 @@ def _set_dbt_models(config, models):
 
 
 class TestPipelineListTables:
-    def test_returns_empty_when_no_completed_run(self):
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_no_completed_run(self):
         from mcp_server.services.metadata import pipeline_list_tables
 
         mock_ts = MagicMock()
@@ -41,13 +44,15 @@ class TestPipelineListTables:
 
         with patch("mcp_server.services.metadata.MaterializationRun") as mock_run_cls:
             mock_run_cls.RunState.COMPLETED = "completed"
-            mock_run_cls.objects.filter.return_value.order_by.return_value.first.return_value = None
+            qs = mock_run_cls.objects.filter.return_value.order_by.return_value
+            qs.afirst = AsyncMock(return_value=None)
 
-            result = pipeline_list_tables(mock_ts, pipeline_config)
+            result = await pipeline_list_tables(mock_ts, pipeline_config)
 
         assert result == []
 
-    def test_returns_table_entries_from_completed_run(self):
+    @pytest.mark.asyncio
+    async def test_returns_table_entries_from_completed_run(self):
         from mcp_server.services.metadata import pipeline_list_tables
 
         mock_ts = MagicMock()
@@ -67,11 +72,10 @@ class TestPipelineListTables:
 
         with patch("mcp_server.services.metadata.MaterializationRun") as mock_run_cls:
             mock_run_cls.RunState.COMPLETED = "completed"
-            mock_run_cls.objects.filter.return_value.order_by.return_value.first.return_value = (
-                mock_run
-            )
+            qs = mock_run_cls.objects.filter.return_value.order_by.return_value
+            qs.afirst = AsyncMock(return_value=mock_run)
 
-            result = pipeline_list_tables(mock_ts, pipeline_config)
+            result = await pipeline_list_tables(mock_ts, pipeline_config)
 
         assert len(result) == 2
         cases = next(t for t in result if t["name"] == "raw_cases")
@@ -80,7 +84,8 @@ class TestPipelineListTables:
         assert cases["materialized_at"] == completed_at.isoformat()
         assert cases["type"] == "table"
 
-    def test_includes_dbt_models_with_null_row_count(self):
+    @pytest.mark.asyncio
+    async def test_includes_dbt_models_with_null_row_count(self):
         from mcp_server.services.metadata import pipeline_list_tables
 
         mock_ts = MagicMock()
@@ -94,11 +99,10 @@ class TestPipelineListTables:
 
         with patch("mcp_server.services.metadata.MaterializationRun") as mock_run_cls:
             mock_run_cls.RunState.COMPLETED = "completed"
-            mock_run_cls.objects.filter.return_value.order_by.return_value.first.return_value = (
-                mock_run
-            )
+            qs = mock_run_cls.objects.filter.return_value.order_by.return_value
+            qs.afirst = AsyncMock(return_value=mock_run)
 
-            result = pipeline_list_tables(mock_ts, pipeline_config)
+            result = await pipeline_list_tables(mock_ts, pipeline_config)
 
         names = [t["name"] for t in result]
         assert "stg_cases" in names
@@ -120,34 +124,42 @@ class TestPipelineDescribeTable:
             connection_params={},
         )
 
-    def test_returns_none_when_table_not_found(self):
+    @pytest.mark.asyncio
+    async def test_returns_none_when_table_not_found(self):
         from mcp_server.services.metadata import pipeline_describe_table
 
         ctx = self._make_ctx()
         pipeline_config = _make_pipeline_config()
 
-        with patch("mcp_server.services.metadata._execute_sync_parameterized") as mock_exec:
-            mock_exec.return_value = {"columns": [], "rows": [], "row_count": 0}
-            result = pipeline_describe_table("nonexistent", ctx, None, pipeline_config)
+        with patch(
+            "mcp_server.services.metadata._execute_async_parameterized",
+            new=AsyncMock(return_value={"columns": [], "rows": [], "row_count": 0}),
+        ):
+            result = await pipeline_describe_table("nonexistent", ctx, None, pipeline_config)
 
         assert result is None
 
-    def test_returns_column_structure(self):
+    @pytest.mark.asyncio
+    async def test_returns_column_structure(self):
         from mcp_server.services.metadata import pipeline_describe_table
 
         ctx = self._make_ctx()
         pipeline_config = _make_pipeline_config(sources=[("cases", "CommCare case records")])
 
-        with patch("mcp_server.services.metadata._execute_sync_parameterized") as mock_exec:
-            mock_exec.return_value = {
-                "columns": ["column_name", "data_type", "is_nullable", "column_default"],
-                "rows": [
-                    ["case_id", "text", "NO", None],
-                    ["case_type", "text", "YES", None],
-                ],
-                "row_count": 2,
-            }
-            result = pipeline_describe_table("raw_cases", ctx, None, pipeline_config)
+        with patch(
+            "mcp_server.services.metadata._execute_async_parameterized",
+            new=AsyncMock(
+                return_value={
+                    "columns": ["column_name", "data_type", "is_nullable", "column_default"],
+                    "rows": [
+                        ["case_id", "text", "NO", None],
+                        ["case_type", "text", "YES", None],
+                    ],
+                    "row_count": 2,
+                }
+            ),
+        ):
+            result = await pipeline_describe_table("raw_cases", ctx, None, pipeline_config)
 
         assert result is not None
         assert result["name"] == "raw_cases"
@@ -161,7 +173,8 @@ class TestPipelineDescribeTable:
             "description": "",
         }
 
-    def test_annotates_properties_column_with_case_types(self):
+    @pytest.mark.asyncio
+    async def test_annotates_properties_column_with_case_types(self):
         from mcp_server.services.metadata import pipeline_describe_table
 
         ctx = self._make_ctx()
@@ -175,20 +188,27 @@ class TestPipelineDescribeTable:
             ]
         }
 
-        with patch("mcp_server.services.metadata._execute_sync_parameterized") as mock_exec:
-            mock_exec.return_value = {
-                "columns": ["column_name", "data_type", "is_nullable", "column_default"],
-                "rows": [["properties", "jsonb", "YES", "'{}'::jsonb"]],
-                "row_count": 1,
-            }
-            result = pipeline_describe_table("raw_cases", ctx, mock_tenant_metadata, pipeline_config)
+        with patch(
+            "mcp_server.services.metadata._execute_async_parameterized",
+            new=AsyncMock(
+                return_value={
+                    "columns": ["column_name", "data_type", "is_nullable", "column_default"],
+                    "rows": [["properties", "jsonb", "YES", "'{}'::jsonb"]],
+                    "row_count": 1,
+                }
+            ),
+        ):
+            result = await pipeline_describe_table(
+                "raw_cases", ctx, mock_tenant_metadata, pipeline_config
+            )
 
         col = result["columns"][0]
         assert "pregnancy" in col["description"]
         assert "child" in col["description"]
         assert col["description"].startswith("Contains case properties")
 
-    def test_annotates_form_data_column_with_form_names(self):
+    @pytest.mark.asyncio
+    async def test_annotates_form_data_column_with_form_names(self):
         from mcp_server.services.metadata import pipeline_describe_table
 
         ctx = self._make_ctx()
@@ -202,32 +222,43 @@ class TestPipelineDescribeTable:
             }
         }
 
-        with patch("mcp_server.services.metadata._execute_sync_parameterized") as mock_exec:
-            mock_exec.return_value = {
-                "columns": ["column_name", "data_type", "is_nullable", "column_default"],
-                "rows": [["form_data", "jsonb", "YES", "'{}'::jsonb"]],
-                "row_count": 1,
-            }
-            result = pipeline_describe_table("raw_forms", ctx, mock_tenant_metadata, pipeline_config)
+        with patch(
+            "mcp_server.services.metadata._execute_async_parameterized",
+            new=AsyncMock(
+                return_value={
+                    "columns": ["column_name", "data_type", "is_nullable", "column_default"],
+                    "rows": [["form_data", "jsonb", "YES", "'{}'::jsonb"]],
+                    "row_count": 1,
+                }
+            ),
+        ):
+            result = await pipeline_describe_table(
+                "raw_forms", ctx, mock_tenant_metadata, pipeline_config
+            )
 
         col = result["columns"][0]
         assert "ANC Registration" in col["description"]
         assert "Child Visit" in col["description"]
         assert col["description"].startswith("Contains form submission data")
 
-    def test_graceful_when_tenant_metadata_is_none(self):
+    @pytest.mark.asyncio
+    async def test_graceful_when_tenant_metadata_is_none(self):
         from mcp_server.services.metadata import pipeline_describe_table
 
         ctx = self._make_ctx()
         pipeline_config = _make_pipeline_config(sources=[("cases", "Cases")])
 
-        with patch("mcp_server.services.metadata._execute_sync_parameterized") as mock_exec:
-            mock_exec.return_value = {
-                "columns": ["column_name", "data_type", "is_nullable", "column_default"],
-                "rows": [["properties", "jsonb", "YES", None]],
-                "row_count": 1,
-            }
-            result = pipeline_describe_table("raw_cases", ctx, None, pipeline_config)
+        with patch(
+            "mcp_server.services.metadata._execute_async_parameterized",
+            new=AsyncMock(
+                return_value={
+                    "columns": ["column_name", "data_type", "is_nullable", "column_default"],
+                    "rows": [["properties", "jsonb", "YES", None]],
+                    "row_count": 1,
+                }
+            ),
+        ):
+            result = await pipeline_describe_table("raw_cases", ctx, None, pipeline_config)
 
         assert result is not None
         assert result["columns"][0]["description"] == ""
@@ -245,7 +276,8 @@ class TestPipelineGetMetadata:
             connection_params={},
         )
 
-    def test_returns_empty_when_no_completed_run(self):
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_no_completed_run(self):
         from mcp_server.services.metadata import pipeline_get_metadata
 
         ctx = self._make_ctx()
@@ -254,13 +286,15 @@ class TestPipelineGetMetadata:
 
         with patch("mcp_server.services.metadata.MaterializationRun") as mock_run_cls:
             mock_run_cls.RunState.COMPLETED = "completed"
-            mock_run_cls.objects.filter.return_value.order_by.return_value.first.return_value = None
+            qs = mock_run_cls.objects.filter.return_value.order_by.return_value
+            qs.afirst = AsyncMock(return_value=None)
 
-            result = pipeline_get_metadata(mock_ts, ctx, None, pipeline_config)
+            result = await pipeline_get_metadata(mock_ts, ctx, None, pipeline_config)
 
         assert result == {"tables": {}, "relationships": []}
 
-    def test_includes_relationships_from_pipeline_config(self):
+    @pytest.mark.asyncio
+    async def test_includes_relationships_from_pipeline_config(self):
         from mcp_server.services.metadata import pipeline_get_metadata
 
         ctx = self._make_ctx()
@@ -285,18 +319,21 @@ class TestPipelineGetMetadata:
 
         with (
             patch("mcp_server.services.metadata.MaterializationRun") as mock_run_cls,
-            patch("mcp_server.services.metadata._execute_sync_parameterized") as mock_exec,
+            patch(
+                "mcp_server.services.metadata._execute_async_parameterized",
+                new=AsyncMock(
+                    return_value={
+                        "rows": [["case_id", "text", "NO", None]],
+                        "row_count": 1,
+                    }
+                ),
+            ),
         ):
             mock_run_cls.RunState.COMPLETED = "completed"
-            mock_run_cls.objects.filter.return_value.order_by.return_value.first.return_value = (
-                mock_run
-            )
-            mock_exec.return_value = {
-                "rows": [["case_id", "text", "NO", None]],
-                "row_count": 1,
-            }
+            qs = mock_run_cls.objects.filter.return_value.order_by.return_value
+            qs.afirst = AsyncMock(return_value=mock_run)
 
-            result = pipeline_get_metadata(mock_ts, ctx, None, pipeline_config)
+            result = await pipeline_get_metadata(mock_ts, ctx, None, pipeline_config)
 
         assert "raw_cases" in result["tables"]
         assert len(result["relationships"]) == 1

--- a/tests/test_query_role_isolation.py
+++ b/tests/test_query_role_isolation.py
@@ -1,9 +1,10 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import psycopg.errors
+import pytest
 
 from mcp_server.context import QueryContext
-from mcp_server.services.query import _classify_error, _execute_sync
+from mcp_server.services.query import _classify_error, _execute_async
 
 
 class TestQueryContextReadonlyRole:
@@ -24,6 +25,17 @@ class TestQueryContextReadonlyRole:
         assert ctx.readonly_role == "ws_abc1234def56789_ro"
 
 
+def _make_async_conn(mock_cursor):
+    """Build a mock that mimics psycopg.AsyncConnection for async with patterns."""
+    mock_conn = MagicMock()
+    mock_cursor.__aenter__ = AsyncMock(return_value=mock_cursor)
+    mock_cursor.__aexit__ = AsyncMock(return_value=False)
+    mock_conn.cursor.return_value = mock_cursor
+    mock_conn.__aenter__ = AsyncMock(return_value=mock_conn)
+    mock_conn.__aexit__ = AsyncMock(return_value=False)
+    return mock_conn
+
+
 class TestSetRoleIsolation:
     def _make_ctx(self, schema_name="test_domain"):
         return QueryContext(
@@ -32,19 +44,20 @@ class TestSetRoleIsolation:
             connection_params={"host": "localhost"},
         )
 
-    @patch("mcp_server.services.query._get_connection")
-    def test_execute_sync_sets_and_resets_role(self, mock_get_conn):
-        mock_conn = MagicMock()
-        mock_cursor = MagicMock()
+    @pytest.mark.asyncio
+    async def test_execute_async_sets_and_resets_role(self):
+        mock_cursor = AsyncMock()
         mock_cursor.description = [("col1",)]
         mock_cursor.fetchall.return_value = [("val1",)]
-        mock_conn.cursor.return_value = mock_cursor
-        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
-        mock_conn.__exit__ = MagicMock(return_value=False)
-        mock_get_conn.return_value = mock_conn
 
-        ctx = self._make_ctx()
-        _execute_sync(ctx, "SELECT 1", 30)
+        mock_conn = _make_async_conn(mock_cursor)
+
+        with patch(
+            "psycopg.AsyncConnection.connect",
+            new=AsyncMock(return_value=mock_conn),
+        ):
+            ctx = self._make_ctx()
+            await _execute_async(ctx, "SELECT 1", 30)
 
         execute_calls = mock_cursor.execute.call_args_list
         # First call should be SET ROLE
@@ -55,10 +68,9 @@ class TestSetRoleIsolation:
         last_call_str = str(execute_calls[-1])
         assert "RESET ROLE" in last_call_str
 
-    @patch("mcp_server.services.query._get_connection")
-    def test_reset_role_on_query_error(self, mock_get_conn):
-        mock_conn = MagicMock()
-        mock_cursor = MagicMock()
+    @pytest.mark.asyncio
+    async def test_reset_role_on_query_error(self):
+        mock_cursor = AsyncMock()
         mock_cursor.execute.side_effect = [
             None,  # SET ROLE succeeds
             None,  # SET search_path succeeds
@@ -66,16 +78,18 @@ class TestSetRoleIsolation:
             Exception("query failed"),  # actual query fails
             None,  # RESET ROLE succeeds
         ]
-        mock_conn.cursor.return_value = mock_cursor
-        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
-        mock_conn.__exit__ = MagicMock(return_value=False)
-        mock_get_conn.return_value = mock_conn
 
-        ctx = self._make_ctx()
-        try:
-            _execute_sync(ctx, "SELECT bad", 30)
-        except Exception:
-            pass
+        mock_conn = _make_async_conn(mock_cursor)
+
+        with patch(
+            "psycopg.AsyncConnection.connect",
+            new=AsyncMock(return_value=mock_conn),
+        ):
+            ctx = self._make_ctx()
+            try:
+                await _execute_async(ctx, "SELECT bad", 30)
+            except Exception:
+                pass
 
         # RESET ROLE should still have been called
         last_call_str = str(mock_cursor.execute.call_args_list[-1])


### PR DESCRIPTION
## Summary

- Migrate MCP query service (`query.py`) from sync `psycopg.connect()` to `psycopg.AsyncConnection.connect()` with async cursors
- Convert all metadata service functions (`metadata.py`) to native async, using async ORM and async query functions
- Remove 11 `sync_to_async` call sites across `server.py`, `base.py`, `query.py`, `metadata.py`, and `schema_manager.py`
- Add async `ateardown()` and `ateardown_view_schema()` methods to `SchemaManager`
- `sync_to_async(run_pipeline)` intentionally kept — long-running sync orchestrator benefits from thread pool

Phase 3 of the [async conversion plan](docs/plans/2026-04-14-async-conversion-remaining-phases.md). After this, `mcp_server/` and `apps/agents/graph/base.py` are fully async with zero `sync_to_async` (except the intentionally kept `run_pipeline`).

## Test plan

- [x] All 816 tests pass (0 failures)
- [x] `ruff check` and `ruff format` clean
- [x] Integration tests (`TestExecuteAsyncIntegration`) verify real PostgreSQL async driver behavior
- [ ] Manual: run `honcho -f Procfile.dev start` and verify MCP tools (list_tables, describe_table, query, get_metadata) work end-to-end
- [ ] Manual: verify teardown_schema works via agent chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)