### PR TITLE
Move inline imports to module level

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,7 @@ Optional:
 ## Code style
 
 - **Python**: ruff (line-length=100, target py311, rules: E/F/I/UP/B)
+- **Imports**: Always at module level, never inside function bodies. Exceptions: optional dependencies guarded by `try/except ImportError`, and code that must run before `django.setup()`. When moving inline imports to module level, update any `mock.patch()` targets in tests to point at the consuming module (where the name is used), not the source module.
 - **Frontend**: ESLint with typescript-eslint + react-hooks plugin
 - **No Prettier** configured for frontend
 

--- a/apps/agents/tracing.py
+++ b/apps/agents/tracing.py
@@ -11,18 +11,19 @@ Langfuse v3 architecture:
 - propagate_attributes() is a context manager that stamps session_id/user_id onto
   every span created within its scope.
 """
+
 from __future__ import annotations
 
 import contextlib
 import logging
+
+from django.conf import settings
 
 logger = logging.getLogger(__name__)
 
 
 def _get_langfuse_settings() -> tuple[str, str, str]:
     """Return (secret_key, public_key, host) from Django settings."""
-    from django.conf import settings
-
     return (
         getattr(settings, "LANGFUSE_SECRET_KEY", ""),
         getattr(settings, "LANGFUSE_PUBLIC_KEY", ""),

--- a/apps/artifacts/views.py
+++ b/apps/artifacts/views.py
@@ -13,11 +13,14 @@ from decimal import Decimal
 from typing import Any
 from uuid import UUID
 
-from django.http import HttpRequest, HttpResponse, JsonResponse
+from django.db.models import Q
+from django.http import Http404, HttpRequest, HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404
 from django.views import View
 
+from apps.common.utils import creator_display_name
 from apps.users.decorators import LoginRequiredJsonMixin
+from apps.workspaces.models import TenantSchema
 from apps.workspaces.workspace_resolver import aresolve_workspace, resolve_workspace
 from mcp_server.context import load_tenant_context
 from mcp_server.services.query import execute_query
@@ -710,8 +713,6 @@ class ArtifactQueryDataView(View):
     """
 
     async def get(self, request: HttpRequest, workspace_id, artifact_id: str) -> JsonResponse:
-        from django.http import Http404
-
         user = await request.auser()
         if not user.is_authenticated:
             return JsonResponse({"error": "Authentication required"}, status=401)
@@ -748,8 +749,6 @@ class ArtifactQueryDataView(View):
             return JsonResponse({"queries": results, "static_data": artifact.data or {}})
 
         # Touch the schema to reset the inactivity TTL on user-initiated queries
-        from apps.workspaces.models import TenantSchema
-
         ts = await TenantSchema.objects.filter(schema_name=ctx.schema_name).afirst()
         if ts is not None:
             await ts.atouch()
@@ -796,16 +795,12 @@ class ArtifactListView(LoginRequiredJsonMixin, View):
         if err:
             return err
 
-        from django.db.models import Q
-
         search = request.GET.get("search", "").strip()
         queryset = Artifact.objects.filter(workspace=workspace)
         if search:
             queryset = queryset.filter(
                 Q(title__icontains=search) | Q(description__icontains=search)
             )
-
-        from apps.common.utils import creator_display_name
 
         results = [
             {

--- a/apps/chat/checkpointer.py
+++ b/apps/chat/checkpointer.py
@@ -2,6 +2,11 @@
 
 import logging
 
+from django.conf import settings
+from langgraph.checkpoint.memory import MemorySaver
+from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
+from psycopg_pool import AsyncConnectionPool
+
 from apps.agents.memory.checkpointer import get_database_url
 
 logger = logging.getLogger(__name__)
@@ -16,9 +21,6 @@ async def ensure_checkpointer(*, force_new: bool = False):
         return _checkpointer
 
     try:
-        from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
-        from psycopg_pool import AsyncConnectionPool
-
         database_url = get_database_url()
 
         if _pool is not None:
@@ -39,11 +41,7 @@ async def ensure_checkpointer(*, force_new: bool = False):
         await _checkpointer.setup()
         logger.info("PostgreSQL checkpointer initialized")
     except Exception as e:
-        from django.conf import settings
-
         if settings.DEBUG:
-            from langgraph.checkpoint.memory import MemorySaver
-
             logger.warning(
                 "PostgreSQL checkpointer unavailable, using MemorySaver (DEBUG only): %s", e
             )

--- a/apps/recipes/services/runner.py
+++ b/apps/recipes/services/runner.py
@@ -7,15 +7,19 @@ sending it to the agent, and collecting results.
 
 from __future__ import annotations
 
+import json
 import logging
 import uuid
 from typing import TYPE_CHECKING, Any
 
+from asgiref.sync import async_to_sync
 from django.utils import timezone
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 
 from apps.agents.graph.base import build_agent_graph
 from apps.recipes.models import Recipe, RecipeRun, RecipeRunStatus
+from apps.users.models import TenantMembership
+from apps.workspaces.models import WorkspaceTenant
 
 if TYPE_CHECKING:
     from langgraph.graph.state import CompiledStateGraph
@@ -99,9 +103,6 @@ class RecipeRunner:
             return self._provided_graph
 
         if self._graph is None:
-            from apps.users.models import TenantMembership
-            from apps.workspaces.models import WorkspaceTenant
-
             workspace_tenant = (
                 await WorkspaceTenant.objects.select_related("tenant")
                 .filter(workspace=self.recipe.workspace)
@@ -173,8 +174,6 @@ class RecipeRunner:
             if isinstance(msg, ToolMessage):
                 if msg.name in ("create_artifact", "update_artifact"):
                     try:
-                        import json
-
                         content = msg.content
                         if isinstance(content, str):
                             result = json.loads(content)
@@ -187,8 +186,6 @@ class RecipeRunner:
 
     def execute(self) -> RecipeRun:
         """Execute the recipe and return the RecipeRun record."""
-        from asgiref.sync import async_to_sync
-
         self.validate_variables()
 
         self._run = self._create_run_record()
@@ -302,10 +299,12 @@ class RecipeRunner:
         try:
             workspace = self.recipe.workspace
             # Fetch tenant info asynchronously to avoid sync query in async context
-            from apps.workspaces.models import WorkspaceTenant as _WT
-
-            _wt = await _WT.objects.select_related("tenant").filter(workspace=workspace).afirst()
-            _tenant = _wt.tenant if _wt else None
+            wt = (
+                await WorkspaceTenant.objects.select_related("tenant")
+                .filter(workspace=workspace)
+                .afirst()
+            )
+            _tenant = wt.tenant if wt else None
             initial_state = {
                 "messages": [HumanMessage(content=prompt)],
                 "tenant_id": _tenant.external_id if _tenant else "",

--- a/apps/transformations/views.py
+++ b/apps/transformations/views.py
@@ -5,7 +5,8 @@ from rest_framework.exceptions import PermissionDenied
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
-from apps.workspaces.models import WorkspaceRole
+from apps.users.models import Tenant
+from apps.workspaces.models import TenantSchema, Workspace, WorkspaceRole
 
 from .models import TransformationAsset, TransformationRun, TransformationScope
 from .serializers import (
@@ -13,6 +14,8 @@ from .serializers import (
     TransformationAssetSerializer,
     TransformationRunSerializer,
 )
+from .services.executor import run_transformation_pipeline
+from .services.lineage import get_lineage_chain
 
 
 class TransformationAssetViewSet(viewsets.ModelViewSet):
@@ -59,17 +62,13 @@ class TransformationAssetViewSet(viewsets.ModelViewSet):
         if serializer.instance.scope == TransformationScope.SYSTEM:
             raise PermissionDenied("System assets cannot be modified.")
         instance = serializer.instance
-        self._check_write_permission(
-            {"workspace": instance.workspace, "tenant": instance.tenant}
-        )
+        self._check_write_permission({"workspace": instance.workspace, "tenant": instance.tenant})
         serializer.save()
 
     def perform_destroy(self, instance):
         if instance.scope == TransformationScope.SYSTEM:
             raise PermissionDenied("System assets cannot be deleted.")
-        self._check_write_permission(
-            {"workspace": instance.workspace, "tenant": instance.tenant}
-        )
+        self._check_write_permission({"workspace": instance.workspace, "tenant": instance.tenant})
         instance.delete()
 
     def _check_write_permission(self, data):
@@ -85,15 +84,11 @@ class TransformationAssetViewSet(viewsets.ModelViewSet):
                 role__in=[WorkspaceRole.READ_WRITE, WorkspaceRole.MANAGE],
             ).exists()
             if not has_write:
-                raise PermissionDenied(
-                    "You need read_write or manage role on this workspace."
-                )
+                raise PermissionDenied("You need read_write or manage role on this workspace.")
 
     @action(detail=True, methods=["get"])
     def lineage(self, request, pk=None):
         """GET /api/transformations/assets/{id}/lineage/"""
-        from .services.lineage import get_lineage_chain
-
         asset = self.get_object()
         tenant_ids = list(request.user.tenant_memberships.values_list("tenant_id", flat=True))
         workspace_id = asset.workspace_id
@@ -130,11 +125,6 @@ class TransformationRunViewSet(viewsets.ReadOnlyModelViewSet):
         Body: {"tenant_id": "...", "workspace_id": "..." (optional)}
         Triggers a transformation run synchronously.
         """
-        from apps.users.models import Tenant
-        from apps.workspaces.models import TenantSchema
-
-        from .services.executor import run_transformation_pipeline
-
         tenant_id = request.data.get("tenant_id")
         if not tenant_id:
             return Response({"error": "tenant_id is required"}, status=status.HTTP_400_BAD_REQUEST)
@@ -158,17 +148,13 @@ class TransformationRunViewSet(viewsets.ReadOnlyModelViewSet):
         workspace = None
         workspace_id = request.data.get("workspace_id")
         if workspace_id:
-            from apps.workspaces.models import Workspace
-
             workspace = Workspace.objects.filter(
                 id=workspace_id,
                 memberships__user=request.user,
                 memberships__role__in=[WorkspaceRole.READ_WRITE, WorkspaceRole.MANAGE],
             ).first()
             if not workspace:
-                raise PermissionDenied(
-                    "Workspace not found or you are not a member."
-                )
+                raise PermissionDenied("Workspace not found or you are not a member.")
 
         run = run_transformation_pipeline(
             tenant=tenant,

--- a/apps/users/adapters.py
+++ b/apps/users/adapters.py
@@ -11,7 +11,8 @@ from __future__ import annotations
 import logging
 
 from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
-from cryptography.fernet import Fernet
+from allauth.socialaccount.models import SocialToken
+from cryptography.fernet import Fernet, InvalidToken
 from django.conf import settings
 
 logger = logging.getLogger(__name__)
@@ -37,8 +38,6 @@ class EncryptingSocialAccountAdapter(DefaultSocialAccountAdapter):
         """Decrypt a token string. Returns empty string for empty or unreadable input."""
         if not ciphertext:
             return ""
-        from cryptography.fernet import InvalidToken
-
         f = self._get_fernet()
         try:
             return f.decrypt(ciphertext.encode()).decode()
@@ -48,8 +47,6 @@ class EncryptingSocialAccountAdapter(DefaultSocialAccountAdapter):
 
     def serialize_instance(self, instance):
         """Encrypt token fields before serialization (storage)."""
-        from allauth.socialaccount.models import SocialToken
-
         data = super().serialize_instance(instance)
         if isinstance(instance, SocialToken):
             if data.get("token"):
@@ -60,8 +57,6 @@ class EncryptingSocialAccountAdapter(DefaultSocialAccountAdapter):
 
     def deserialize_instance(self, model, data):
         """Decrypt token fields after deserialization (retrieval)."""
-        from allauth.socialaccount.models import SocialToken
-
         if model is SocialToken:
             data = dict(data)  # don't mutate the original
             if data.get("token"):
@@ -73,8 +68,6 @@ class EncryptingSocialAccountAdapter(DefaultSocialAccountAdapter):
 
 def encrypt_credential(plaintext: str) -> str:
     """Fernet-encrypt a credential string using DB_CREDENTIAL_KEY."""
-    from django.conf import settings
-
     key = settings.DB_CREDENTIAL_KEY
     if not key:
         raise ValueError("DB_CREDENTIAL_KEY is not set in settings")
@@ -84,8 +77,6 @@ def encrypt_credential(plaintext: str) -> str:
 
 def decrypt_credential(ciphertext: str) -> str:
     """Fernet-decrypt a credential string using DB_CREDENTIAL_KEY."""
-    from django.conf import settings
-
     key = settings.DB_CREDENTIAL_KEY
     if not key:
         raise ValueError("DB_CREDENTIAL_KEY is not set in settings")

--- a/apps/users/services/credential_resolver.py
+++ b/apps/users/services/credential_resolver.py
@@ -6,6 +6,8 @@ import logging
 
 from allauth.socialaccount.models import SocialToken
 
+from apps.users.adapters import decrypt_credential
+from apps.users.models import TenantCredential
 from apps.users.services.token_refresh import (
     PROVIDER_TOKEN_URLS,
     TokenRefreshError,
@@ -53,16 +55,12 @@ def resolve_credential(membership) -> dict | None:
     ``value`` (the decrypted key or OAuth token string), or ``None`` if no
     usable credential is found.
     """
-    from apps.users.models import TenantCredential
-
     try:
         cred_obj = TenantCredential.objects.get(tenant_membership=membership)
     except TenantCredential.DoesNotExist:
         return None
 
     if cred_obj.credential_type == TenantCredential.API_KEY:
-        from apps.users.adapters import decrypt_credential
-
         try:
             decrypted = decrypt_credential(cred_obj.encrypted_credential)
             return {"type": "api_key", "value": decrypted}
@@ -83,8 +81,6 @@ async def aresolve_credential(membership) -> dict | None:
     ``None``.  For OAuth tokens, attempts a refresh when the token is near
     expiry.
     """
-    from apps.users.models import TenantCredential
-
     try:
         cred_obj = await TenantCredential.objects.select_related("tenant_membership").aget(
             tenant_membership=membership
@@ -93,8 +89,6 @@ async def aresolve_credential(membership) -> dict | None:
         return None
 
     if cred_obj.credential_type == TenantCredential.API_KEY:
-        from apps.users.adapters import decrypt_credential
-
         try:
             decrypted = decrypt_credential(cred_obj.encrypted_credential)
             return {"type": "api_key", "value": decrypted}

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -10,12 +10,18 @@ from django.http import JsonResponse
 from django.utils import timezone
 from django.views.decorators.http import require_http_methods
 
+from apps.users.adapters import encrypt_credential
 from apps.users.decorators import async_login_required
-from apps.users.models import Tenant, TenantMembership
+from apps.users.models import Tenant, TenantCredential, TenantMembership
+from apps.users.services.tenant_resolution import (
+    resolve_commcare_domains,
+    resolve_connect_opportunities,
+)
 from apps.users.services.tenant_verification import (
     CommCareVerificationError,
     verify_commcare_credential,
 )
+from apps.workspaces.models import Workspace
 
 TENANT_REFRESH_TTL = 3600  # seconds (1 hour)
 
@@ -46,8 +52,6 @@ async def tenant_list_view(request):
         access_token = await _aget_token_value(user, "commcare")
         if access_token:
             try:
-                from apps.users.services.tenant_resolution import resolve_commcare_domains
-
                 await resolve_commcare_domains(user, access_token)
                 await cache.aset(commcare_cache_key, True, TENANT_REFRESH_TTL)
             except Exception:
@@ -59,8 +63,6 @@ async def tenant_list_view(request):
         connect_token = await _aget_token_value(user, "commcare_connect")
         if connect_token:
             try:
-                from apps.users.services.tenant_resolution import resolve_connect_opportunities
-
                 await resolve_connect_opportunities(user, connect_token)
                 await cache.aset(connect_cache_key, True, TENANT_REFRESH_TTL)
             except Exception:
@@ -172,9 +174,6 @@ async def tenant_credential_list_view(request):
     except CommCareVerificationError as e:
         return JsonResponse({"error": str(e)}, status=400)
 
-    from apps.users.adapters import encrypt_credential
-    from apps.users.models import TenantCredential
-
     try:
         encrypted = encrypt_credential(credential)
     except ValueError as e:
@@ -249,8 +248,6 @@ async def tenant_credential_detail_view(request, membership_id):
     except CommCareVerificationError as e:
         return JsonResponse({"error": str(e)}, status=400)
 
-    from apps.users.adapters import encrypt_credential
-
     try:
         encrypted = encrypt_credential(credential)
     except ValueError as e:
@@ -299,10 +296,6 @@ async def tenant_ensure_view(request):
 
             # Resolve the user's actual opportunities from the Connect API
             # to verify they have access to the requested tenant_id.
-            from apps.users.services.tenant_resolution import (
-                resolve_connect_opportunities,
-            )
-
             memberships = await resolve_connect_opportunities(user, connect_token)
             tm = next((m for m in memberships if m.tenant.external_id == tenant_id), None)
             if tm is None:
@@ -317,8 +310,6 @@ async def tenant_ensure_view(request):
     await tm.asave(update_fields=["last_selected_at"])
 
     # Find the auto-created workspace for this tenant
-    from apps.workspaces.models import Workspace
-
     workspace = await Workspace.objects.filter(
         workspace_tenants__tenant=tm.tenant,
         memberships__user=user,

--- a/apps/workspaces/api/views.py
+++ b/apps/workspaces/api/views.py
@@ -10,11 +10,20 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from apps.knowledge.models import TableKnowledge
 from apps.users.models import TenantMembership
-from apps.workspaces.models import SchemaState, TenantSchema, WorkspaceRole
-from apps.workspaces.services.schema_manager import SchemaManager
+from apps.workspaces.models import (
+    MaterializationRun,
+    SchemaState,
+    TenantMetadata,
+    TenantSchema,
+    WorkspaceRole,
+)
+from apps.workspaces.services.schema_manager import SchemaManager, get_managed_db_connection
 from apps.workspaces.tasks import refresh_tenant_schema
 from apps.workspaces.workspace_resolver import resolve_workspace_drf as resolve_workspace
+from mcp_server.pipeline_registry import get_registry
+from mcp_server.services.metadata import pipeline_list_tables
 
 logger = logging.getLogger(__name__)
 
@@ -66,8 +75,6 @@ def _get_all_columns(schema_name: str) -> dict[str, list[dict]]:
     Returns a mapping of table_name → list of column dicts.
     Returns an empty dict on any connection error.
     """
-    from apps.workspaces.services.schema_manager import get_managed_db_connection
-
     try:
         conn = get_managed_db_connection()
         try:
@@ -105,8 +112,6 @@ def _get_table_columns(schema_name: str, table_name: str) -> list[dict]:
 
     Returns an empty list on any connection error or if the table doesn't exist.
     """
-    from apps.workspaces.services.schema_manager import get_managed_db_connection
-
     try:
         conn = get_managed_db_connection()
         try:
@@ -187,8 +192,6 @@ def _build_source_metadata(table_name: str, tenant_metadata) -> dict | None:
 
 def _get_tenant_metadata(tenant):
     """Return TenantMetadata for any membership in the given tenant, or None."""
-    from apps.workspaces.models import TenantMetadata
-
     return TenantMetadata.objects.filter(tenant_membership__tenant=tenant).first()
 
 
@@ -211,8 +214,6 @@ def _serialize_annotation(tk):
 
 def _get_annotation(workspace, table_name):
     """Return serialized TableKnowledge annotation for a table, or None."""
-    from apps.knowledge.models import TableKnowledge
-
     try:
         tk = TableKnowledge.objects.get(workspace=workspace, table_name=table_name)
         return _serialize_annotation(tk)
@@ -248,10 +249,6 @@ class DataDictionaryView(APIView):
         return self._get_from_pipeline(workspace, tenant_schema)
 
     def _get_from_pipeline(self, workspace, tenant_schema):
-        from apps.workspaces.models import MaterializationRun
-        from mcp_server.pipeline_registry import get_registry
-        from mcp_server.services.metadata import pipeline_list_tables
-
         last_run = (
             MaterializationRun.objects.filter(
                 tenant_schema=tenant_schema,
@@ -424,9 +421,6 @@ class TableDetailView(APIView):
         """Return table data from pipeline models, or None if not found or hidden."""
         if table_name.startswith("stg_"):
             return None
-        from apps.workspaces.models import MaterializationRun
-        from mcp_server.pipeline_registry import get_registry
-        from mcp_server.services.metadata import pipeline_list_tables
 
         last_run = (
             MaterializationRun.objects.filter(
@@ -493,8 +487,6 @@ class TableDetailView(APIView):
         table_data = self._get_table_data(workspace, workspace.tenant, qualified_name)
         if table_data is None:
             return Response({"error": "Table not found."}, status=status.HTTP_404_NOT_FOUND)
-
-        from apps.knowledge.models import TableKnowledge
 
         data = request.data
 

--- a/apps/workspaces/models.py
+++ b/apps/workspaces/models.py
@@ -8,6 +8,7 @@ import uuid
 
 from django.conf import settings
 from django.db import models
+from django.utils import timezone
 from django_pydantic_field import SchemaField
 
 
@@ -46,15 +47,11 @@ class TenantSchema(models.Model):
 
     def touch(self):
         """Call this on user-initiated actions to reset the inactivity TTL."""
-        from django.utils import timezone
-
         self.last_accessed_at = timezone.now()
         self.save(update_fields=["last_accessed_at"])
 
     async def atouch(self):
         """Async version of touch() — reset the inactivity TTL."""
-        from django.utils import timezone
-
         self.last_accessed_at = timezone.now()
         await self.asave(update_fields=["last_accessed_at"])
 
@@ -219,15 +216,11 @@ class WorkspaceViewSchema(models.Model):
 
     def touch(self):
         """Reset the inactivity TTL for this view schema."""
-        from django.utils import timezone
-
         self.last_accessed_at = timezone.now()
         self.save(update_fields=["last_accessed_at"])
 
     async def atouch(self):
         """Async version of touch() — reset the inactivity TTL."""
-        from django.utils import timezone
-
         self.last_accessed_at = timezone.now()
         await self.asave(update_fields=["last_accessed_at"])
 

--- a/apps/workspaces/tasks.py
+++ b/apps/workspaces/tasks.py
@@ -7,8 +7,12 @@ from celery import shared_task
 from django.conf import settings
 from django.utils import timezone
 
+from apps.users.models import TenantMembership
 from apps.users.services.credential_resolver import resolve_credential
+from apps.workspaces.models import SchemaState, TenantSchema, Workspace, WorkspaceViewSchema
 from apps.workspaces.services.schema_manager import SchemaManager
+from mcp_server.pipeline_registry import get_registry
+from mcp_server.services.materializer import run_pipeline
 
 logger = logging.getLogger(__name__)
 
@@ -20,10 +24,6 @@ def refresh_tenant_schema(schema_id: str, membership_id: str) -> dict:
     On success: marks state=ACTIVE, schedules teardown of old active schemas.
     On failure: drops the new schema, marks state=FAILED.
     """
-    from apps.users.models import TenantMembership
-    from apps.workspaces.models import SchemaState, TenantSchema
-    from apps.workspaces.services.schema_manager import SchemaManager
-
     try:
         new_schema = TenantSchema.objects.select_related("tenant").get(id=schema_id)
     except TenantSchema.DoesNotExist:
@@ -53,9 +53,6 @@ def refresh_tenant_schema(schema_id: str, membership_id: str) -> dict:
         return {"error": "No credential available"}
 
     try:
-        from mcp_server.pipeline_registry import get_registry
-        from mcp_server.services.materializer import run_pipeline
-
         registry = get_registry()
         provider_pipeline_map = {p.provider: p.name for p in registry.list()}
         pipeline_name = provider_pipeline_map.get(membership.tenant.provider)
@@ -90,8 +87,6 @@ def refresh_tenant_schema(schema_id: str, membership_id: str) -> dict:
 
 def _drop_schema_and_fail(schema) -> None:
     """Drop the physical schema and mark the record as FAILED."""
-    from apps.workspaces.models import SchemaState
-
     try:
         SchemaManager().teardown(schema)
     except Exception:
@@ -107,8 +102,6 @@ def expire_inactive_schemas() -> None:
     Handles both TenantSchema and WorkspaceViewSchema records.
     Schemas with null last_accessed_at are never auto-expired.
     """
-    from apps.workspaces.models import SchemaState, TenantSchema, WorkspaceViewSchema
-
     cutoff = timezone.now() - timedelta(hours=settings.SCHEMA_TTL_HOURS)
 
     # Expire stale tenant schemas
@@ -139,8 +132,6 @@ def rebuild_workspace_view_schema(workspace_id: str) -> dict:
     On success: marks WorkspaceViewSchema.state = ACTIVE.
     On failure: marks state = FAILED and returns an error dict.
     """
-    from apps.workspaces.models import Workspace
-
     try:
         workspace = Workspace.objects.prefetch_related("tenants").get(id=workspace_id)
     except Workspace.DoesNotExist:
@@ -167,8 +158,6 @@ def rebuild_workspace_view_schema(workspace_id: str) -> dict:
 @shared_task
 def teardown_view_schema_task(view_schema_id: str) -> None:
     """Drop the physical PostgreSQL schema for a WorkspaceViewSchema and mark EXPIRED."""
-    from apps.workspaces.models import SchemaState, WorkspaceViewSchema
-
     try:
         vs = WorkspaceViewSchema.objects.get(id=view_schema_id)
     except WorkspaceViewSchema.DoesNotExist:
@@ -190,9 +179,6 @@ def teardown_view_schema_task(view_schema_id: str) -> None:
 @shared_task
 def teardown_schema(schema_id: str) -> None:
     """Drop a tenant schema in the managed database and mark it EXPIRED."""
-    from apps.workspaces.models import SchemaState, TenantSchema
-    from apps.workspaces.services.schema_manager import SchemaManager
-
     try:
         schema = TenantSchema.objects.get(id=schema_id)
     except TenantSchema.DoesNotExist:

--- a/mcp_server/context.py
+++ b/mcp_server/context.py
@@ -10,6 +10,10 @@ from dataclasses import dataclass
 from typing import Any
 from urllib.parse import parse_qs, unquote, urlparse
 
+from django.conf import settings
+
+from apps.workspaces.models import SchemaState, TenantSchema, Workspace, WorkspaceViewSchema
+
 
 @dataclass(frozen=True)
 class QueryContext:
@@ -49,10 +53,6 @@ async def load_tenant_context(tenant_id: str) -> QueryContext:
 
     Raises ValueError if the tenant schema is not found or not active.
     """
-    from django.conf import settings
-
-    from apps.workspaces.models import SchemaState, TenantSchema
-
     ts = await TenantSchema.objects.filter(
         tenant__external_id=tenant_id,
         state__in=[SchemaState.ACTIVE, SchemaState.MATERIALIZING],
@@ -89,10 +89,6 @@ async def load_workspace_context(workspace_id: str) -> QueryContext:
     Raises ValueError if the workspace has no tenants, or if multi-tenant and
     no active WorkspaceViewSchema exists.
     """
-    from django.conf import settings
-
-    from apps.workspaces.models import SchemaState, Workspace, WorkspaceViewSchema
-
     try:
         workspace = await Workspace.objects.aget(id=workspace_id)
     except Workspace.DoesNotExist:

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -31,14 +31,19 @@ from django.core.exceptions import ValidationError as _ValidationError
 from mcp.server.fastmcp import Context, FastMCP
 from mcp.server.transport_security import TransportSecuritySettings
 
+from apps.transformations.services.lineage import aget_lineage_chain
+from apps.users.models import TenantMembership
 from apps.users.services.credential_resolver import aresolve_credential
 from apps.workspaces.models import (
     MaterializationRun,
     SchemaState,
     TenantMetadata,
     TenantSchema,
+    Workspace,
+    WorkspaceTenant,
     WorkspaceViewSchema,
 )
+from apps.workspaces.services.schema_manager import SchemaManager
 from mcp_server.context import load_workspace_context
 from mcp_server.envelope import (
     AUTH_TOKEN_EXPIRED,
@@ -49,6 +54,8 @@ from mcp_server.envelope import (
     success_response,
     tool_context,
 )
+from mcp_server.loaders.commcare_base import CommCareAuthError
+from mcp_server.loaders.connect_base import ConnectAuthError
 from mcp_server.pipeline_registry import get_registry
 from mcp_server.services.materializer import run_pipeline
 from mcp_server.services.metadata import (
@@ -263,9 +270,6 @@ async def get_lineage(model_name: str, workspace_id: str = "") -> dict:
         model_name: Name of the model to trace lineage for.
         workspace_id: Workspace UUID (injected server-side by the agent graph).
     """
-    from apps.transformations.services.lineage import aget_lineage_chain
-    from apps.workspaces.models import Workspace
-
     async with tool_context("get_lineage", workspace_id, model_name=model_name) as tc:
         if not workspace_id:
             tc["result"] = error_response(VALIDATION_ERROR, "workspace_id is required")
@@ -470,9 +474,6 @@ async def _materialize_tenant(
     Resolves credentials, builds a progress callback, and executes the pipeline.
     Returns the pipeline result dict on success, or raises on failure.
     """
-    from mcp_server.loaders.commcare_base import CommCareAuthError
-    from mcp_server.loaders.connect_base import ConnectAuthError
-
     tenant_id = tm.tenant.external_id
 
     # ── Resolve credential ────────────────────────────────────────────────
@@ -510,9 +511,6 @@ async def _materialize_tenant(
 
 async def _resolve_workspace_memberships(workspace_id, user_id):
     """Resolve TenantMemberships for all tenants in a workspace."""
-    from apps.users.models import TenantMembership
-    from apps.workspaces.models import Workspace, WorkspaceTenant
-
     workspace = await Workspace.objects.filter(id=workspace_id).afirst()
     if workspace is None:
         return None, f"Workspace '{workspace_id}' not found"
@@ -619,14 +617,6 @@ async def get_schema_status(workspace_id: str = "") -> dict:
     Args:
         workspace_id: Workspace UUID (injected server-side by the agent graph).
     """
-    from apps.workspaces.models import (
-        MaterializationRun,
-        SchemaState,
-        TenantSchema,
-        Workspace,
-        WorkspaceViewSchema,
-    )
-
     async with tool_context("get_schema_status", workspace_id) as tc:
         if not workspace_id:
             tc["result"] = error_response(VALIDATION_ERROR, "workspace_id is required")
@@ -756,9 +746,6 @@ async def teardown_schema(confirm: bool = False, workspace_id: str = "") -> dict
         confirm: Must be True to execute. Defaults to False as a safety guard.
         workspace_id: Workspace UUID (injected server-side by the agent graph).
     """
-    from apps.workspaces.models import SchemaState, TenantSchema, WorkspaceViewSchema
-    from apps.workspaces.services.schema_manager import SchemaManager
-
     async with tool_context("teardown_schema", workspace_id, confirm=confirm) as tc:
         if not confirm:
             tc["result"] = error_response(
@@ -771,8 +758,6 @@ async def teardown_schema(confirm: bool = False, workspace_id: str = "") -> dict
         if not workspace_id:
             tc["result"] = error_response(VALIDATION_ERROR, "workspace_id is required")
             return tc["result"]
-
-        from apps.workspaces.models import Workspace
 
         workspace = await Workspace.objects.filter(id=workspace_id).afirst()
         if workspace is None:

--- a/mcp_server/services/materializer.py
+++ b/mcp_server/services/materializer.py
@@ -21,8 +21,12 @@ from collections.abc import Callable, Iterator
 from datetime import UTC, datetime
 from typing import Any
 
+from django.utils import timezone
 from psycopg import sql as psql
 
+from apps.transformations.models import TransformationAsset
+from apps.transformations.services.commcare_staging import upsert_system_assets
+from apps.transformations.services.executor import run_transformation_pipeline
 from apps.workspaces.models import MaterializationRun, TenantMetadata
 from apps.workspaces.services.schema_manager import SchemaManager, get_managed_db_connection
 from mcp_server.loaders.commcare_cases import CommCareCaseLoader
@@ -36,7 +40,7 @@ from mcp_server.loaders.connect_metadata import ConnectMetadataLoader
 from mcp_server.loaders.connect_payments import ConnectPaymentLoader
 from mcp_server.loaders.connect_users import ConnectUserLoader
 from mcp_server.loaders.connect_visits import ConnectVisitLoader
-from mcp_server.pipeline_registry import PipelineConfig
+from mcp_server.pipeline_registry import PipelineConfig, get_registry
 
 logger = logging.getLogger(__name__)
 
@@ -97,8 +101,6 @@ def run_pipeline(
         # has already stored metadata, and load can proceed without assets.
         if pipeline.provider == "commcare":
             try:
-                from apps.transformations.services.commcare_staging import upsert_system_assets
-
                 tenant_meta = TenantMetadata.objects.filter(
                     tenant_membership=tenant_membership
                 ).first()
@@ -156,8 +158,6 @@ def run_pipeline(
     transform_result: dict = {}
 
     # Check if there are any TransformationAssets to execute
-    from apps.transformations.models import TransformationAsset
-
     has_assets = TransformationAsset.objects.filter(tenant=tenant_membership.tenant).exists()
     if has_assets:
         report("Running transforms...")
@@ -225,8 +225,6 @@ def _run_discover_phase(
     tenant_membership: Any, credential: dict[str, str], pipeline: PipelineConfig
 ) -> None:
     """Fetch provider metadata and upsert into TenantMetadata."""
-    from django.utils import timezone
-
     if not pipeline.has_metadata_discovery:
         return
 
@@ -297,8 +295,6 @@ def _load_connect_source(
 
 def _run_transform_phase(pipeline: PipelineConfig, schema_name: str, tenant=None) -> dict:
     """Run the three-stage transformation pipeline using TransformationAsset records."""
-    from apps.transformations.services.executor import run_transformation_pipeline
-
     run = run_transformation_pipeline(
         tenant=tenant,
         schema_name=schema_name,
@@ -973,8 +969,6 @@ def _write_connect_completed_modules(
 
 def run_commcare_sync(tenant_membership: Any, credential: dict[str, str]) -> dict:
     """Legacy entry point — delegates to run_pipeline with the default registry."""
-    from mcp_server.pipeline_registry import get_registry
-
     pipeline = get_registry().get("commcare_sync")
     if pipeline is None:
         raise ValueError("commcare_sync pipeline not found in registry")

--- a/mcp_server/services/metadata.py
+++ b/mcp_server/services/metadata.py
@@ -12,6 +12,8 @@ from typing import TYPE_CHECKING, Any
 
 from django.db import models
 
+from apps.transformations.models import TransformationAsset
+from apps.transformations.services.lineage import aget_terminal_assets
 from apps.workspaces.models import MaterializationRun
 from mcp_server.pipeline_registry import PipelineConfig
 from mcp_server.services.query import _execute_async_parameterized
@@ -193,8 +195,6 @@ async def transformation_aware_list_tables(
     replace their upstream tables in the listing. Otherwise falls back
     to the standard pipeline_list_tables behavior.
     """
-    from apps.transformations.services.lineage import aget_terminal_assets
-
     terminal_assets = await aget_terminal_assets(tenant_ids, workspace_id)
 
     if not terminal_assets:
@@ -203,8 +203,6 @@ async def transformation_aware_list_tables(
 
     # Build set of replaced table names (walk replaces chains, scoped to
     # visible assets to prevent cross-tenant information disclosure).
-    from apps.transformations.models import TransformationAsset as _TA
-
     visible_q = models.Q(tenant_id__in=tenant_ids)
     if workspace_id:
         visible_q = visible_q | models.Q(workspace_id=workspace_id)
@@ -215,7 +213,7 @@ async def transformation_aware_list_tables(
         visited = set()
         while next_id and next_id not in visited:
             visited.add(next_id)
-            upstream = await _TA.objects.filter(visible_q, id=next_id).afirst()
+            upstream = await TransformationAsset.objects.filter(visible_q, id=next_id).afirst()
             if upstream is None:
                 break
             replaced_names.add(upstream.name)

--- a/mcp_server/services/query.py
+++ b/mcp_server/services/query.py
@@ -10,6 +10,7 @@ import logging
 from typing import Any
 
 import psycopg
+import psycopg.errors
 from psycopg import sql as psql
 
 from mcp_server.context import QueryContext
@@ -146,9 +147,6 @@ async def execute_query(ctx: QueryContext, sql: str) -> dict[str, Any]:
 
 def _classify_error(exc: Exception) -> tuple[str, str]:
     """Classify a database exception into an error code and user-safe message."""
-    import psycopg
-    import psycopg.errors
-
     if isinstance(exc, psycopg.errors.QueryCanceled):
         return QUERY_TIMEOUT, "Query timed out. Consider adding filters or limiting the data range."
 

--- a/tests/test_materializer.py
+++ b/tests/test_materializer.py
@@ -45,7 +45,7 @@ class TestRunPipeline:
             patch("mcp_server.services.materializer.CommCareMetadataLoader") as mock_meta,
             patch("mcp_server.services.materializer.CommCareCaseLoader") as mock_cases,
             patch("mcp_server.services.materializer.get_managed_db_connection") as mock_conn,
-            patch("apps.transformations.models.TransformationAsset") as mock_asset_cls,
+            patch("mcp_server.services.materializer.TransformationAsset") as mock_asset_cls,
         ):
             schema = self._make_schema()
             mock_mgr.return_value.provision.return_value = schema
@@ -93,7 +93,7 @@ class TestRunPipeline:
             patch("mcp_server.services.materializer.CommCareMetadataLoader") as mock_meta,
             patch("mcp_server.services.materializer.CommCareCaseLoader") as mock_cases,
             patch("mcp_server.services.materializer.get_managed_db_connection") as mock_conn,
-            patch("apps.transformations.models.TransformationAsset") as mock_asset_cls,
+            patch("mcp_server.services.materializer.TransformationAsset") as mock_asset_cls,
         ):
             schema = self._make_schema()
             mock_mgr.return_value.provision.return_value = schema
@@ -146,7 +146,7 @@ class TestRunPipeline:
             patch("mcp_server.services.materializer.TenantMetadata") as mock_meta_model,
             patch("mcp_server.services.materializer.CommCareMetadataLoader") as mock_meta_loader,
             patch("mcp_server.services.materializer.get_managed_db_connection") as mock_conn,
-            patch("apps.transformations.models.TransformationAsset") as mock_asset_cls,
+            patch("mcp_server.services.materializer.TransformationAsset") as mock_asset_cls,
         ):
             schema = self._make_schema()
             mock_mgr.return_value.provision.return_value = schema
@@ -180,7 +180,7 @@ class TestRunPipeline:
             patch("mcp_server.services.materializer.TenantMetadata"),
             patch("mcp_server.services.materializer.CommCareMetadataLoader") as mock_meta,
             patch("mcp_server.services.materializer.get_managed_db_connection") as mock_conn,
-            patch("apps.transformations.models.TransformationAsset") as mock_asset_cls,
+            patch("mcp_server.services.materializer.TransformationAsset") as mock_asset_cls,
             patch("mcp_server.services.materializer._run_transform_phase") as mock_transform,
         ):
             schema = self._make_schema()

--- a/tests/test_refresh_task.py
+++ b/tests/test_refresh_task.py
@@ -62,10 +62,10 @@ def test_refresh_task_marks_schema_active_on_success(provisioning_schema, tenant
             return_value={"type": "api_key", "value": "tok"},
         ),
         patch(
-            "mcp_server.pipeline_registry.get_registry",
+            "apps.workspaces.tasks.get_registry",
             return_value=_mock_registry(),
         ),
-        patch("mcp_server.services.materializer.run_pipeline"),
+        patch("apps.workspaces.tasks.run_pipeline"),
     ):
         from apps.workspaces.tasks import refresh_tenant_schema
 
@@ -91,10 +91,10 @@ def test_refresh_task_schedules_old_schema_teardown(
             return_value={"type": "api_key", "value": "tok"},
         ),
         patch(
-            "mcp_server.pipeline_registry.get_registry",
+            "apps.workspaces.tasks.get_registry",
             return_value=_mock_registry(),
         ),
-        patch("mcp_server.services.materializer.run_pipeline"),
+        patch("apps.workspaces.tasks.run_pipeline"),
         patch("apps.workspaces.tasks.teardown_schema.apply_async") as mock_apply_async,
     ):
         from apps.workspaces.tasks import refresh_tenant_schema
@@ -156,11 +156,11 @@ def test_refresh_task_marks_failed_on_materialization_error(
             return_value={"type": "api_key", "value": "tok"},
         ),
         patch(
-            "mcp_server.pipeline_registry.get_registry",
+            "apps.workspaces.tasks.get_registry",
             return_value=_mock_registry(),
         ),
         patch(
-            "mcp_server.services.materializer.run_pipeline",
+            "apps.workspaces.tasks.run_pipeline",
             side_effect=RuntimeError("Pipeline exploded"),
         ),
         patch("apps.workspaces.services.schema_manager.SchemaManager.teardown"),

--- a/tests/test_schema_ttl_task.py
+++ b/tests/test_schema_ttl_task.py
@@ -63,7 +63,7 @@ def test_schema_with_null_last_accessed_is_not_expired(active_schema):
 
 @pytest.mark.django_db
 def test_teardown_schema_marks_expired_on_success(active_schema):
-    patch_target = "apps.workspaces.services.schema_manager.SchemaManager"
+    patch_target = "apps.workspaces.tasks.SchemaManager"
     with patch(patch_target) as MockManager:
         MockManager.return_value.teardown.return_value = None
         from apps.workspaces.tasks import teardown_schema
@@ -79,7 +79,7 @@ def test_teardown_schema_rolls_back_to_active_on_failure(active_schema):
     active_schema.state = SchemaState.TEARDOWN
     active_schema.save(update_fields=["state"])
 
-    patch_target = "apps.workspaces.services.schema_manager.SchemaManager"
+    patch_target = "apps.workspaces.tasks.SchemaManager"
     with patch(patch_target) as MockManager:
         MockManager.return_value.teardown.side_effect = RuntimeError("DB error")
         from apps.workspaces.tasks import teardown_schema

--- a/tests/test_tenant_ensure_api.py
+++ b/tests/test_tenant_ensure_api.py
@@ -39,7 +39,7 @@ class TestTenantEnsureAPI:
         client.force_login(user)
 
         with patch(
-            "apps.users.services.tenant_resolution.resolve_connect_opportunities",
+            "apps.users.views.resolve_connect_opportunities",
             new=AsyncMock(return_value=[tm_obj]),
         ):
             response = client.post(
@@ -75,7 +75,7 @@ class TestTenantEnsureAPI:
         client.force_login(user)
 
         with patch(
-            "apps.users.services.tenant_resolution.resolve_connect_opportunities",
+            "apps.users.views.resolve_connect_opportunities",
             new=AsyncMock(return_value=[other_tm]),
         ):
             response = client.post(


### PR DESCRIPTION
## Summary

- Moved ~80 inline imports to module level across 17 production files in `apps/` and `mcp_server/`
- Removed duplicate imports (e.g. `SchemaManager` imported both at module level and inline in `tasks.py`)
- Updated `mock.patch()` targets in 4 test files to point at consuming modules instead of source modules
- Added import convention to CLAUDE.md code style section

## Details

**Intentionally left inline:**
- `langfuse` imports in `apps/agents/tracing.py` (optional dependency, guarded by `try/except`)
- `django.conf.settings` in `mcp_server/loaders/connect_base.py` (guarded by `try/except ImportError` for non-Django use)
- `import django` in `mcp_server/server.py:_setup_django()` (must run before `django.setup()`)

## Test plan

- [x] `ruff check` passes (no F401/F811/I001 errors)
- [x] `ruff format` passes
- [x] Full test suite passes (811 passed, 8 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)