### PR TITLE
feat(workspaces): show provider context in workspace display name

### DIFF
--- a/apps/users/models.py
+++ b/apps/users/models.py
@@ -89,8 +89,9 @@ PROVIDER_CHOICES = [
 # Fields available: {name} (workspace name), plus any field on the source Tenant
 # (e.g. {canonical_name}, {external_id}, {provider}).
 PROVIDER_DISPLAY_TEMPLATES: dict[str, str] = {
-    "commcare": "{name}",
-    "commcare_connect": "{name} (Opp {external_id})",
+    "commcare": "[CC] {name}",
+    "commcare_connect": "[CCC] {name} (Opp {external_id})",
+    "ocs": "[OCS] {name} (Bot {external_id})",
 }
 
 

--- a/apps/users/models.py
+++ b/apps/users/models.py
@@ -85,6 +85,14 @@ PROVIDER_CHOICES = [
     ("commcare_connect", "CommCare Connect"),
 ]
 
+# Per-provider templates applied to a workspace's stored name to produce a display name.
+# Fields available: {name} (workspace name), plus any field on the source Tenant
+# (e.g. {canonical_name}, {external_id}, {provider}).
+PROVIDER_DISPLAY_TEMPLATES: dict[str, str] = {
+    "commcare": "{name}",
+    "commcare_connect": "{name} (Opp {external_id})",
+}
+
 
 class Tenant(models.Model):
     """Canonical tenant identity record, created only after provider verification."""
@@ -105,6 +113,25 @@ class Tenant(models.Model):
 
     def __str__(self):
         return f"{self.provider}:{self.external_id} ({self.canonical_name})"
+
+    def format_display_name(self, workspace_name: str) -> str:
+        """Apply this tenant's provider template to ``workspace_name``.
+
+        Falls back to ``workspace_name`` unchanged if the provider has no
+        template or the template references a field we can't resolve.
+        """
+        template = PROVIDER_DISPLAY_TEMPLATES.get(self.provider)
+        if not template:
+            return workspace_name
+        try:
+            return template.format(
+                name=workspace_name,
+                canonical_name=self.canonical_name,
+                external_id=self.external_id,
+                provider=self.provider,
+            )
+        except (KeyError, IndexError):
+            return workspace_name
 
 
 class TenantMembership(models.Model):

--- a/apps/workspaces/api/workspace_views.py
+++ b/apps/workspaces/api/workspace_views.py
@@ -46,26 +46,19 @@ class WorkspaceListView(APIView):
         )
         results = []
         for m in memberships:
-            workspace_tenants = list(m.workspace.workspace_tenants.all())
             tenants = [
                 {
                     "id": str(wt.tenant.id),
                     "tenant_name": wt.tenant.canonical_name,
                     "provider": wt.tenant.provider,
                 }
-                for wt in workspace_tenants
+                for wt in m.workspace.workspace_tenants.all()
             ]
-            first_tenant = workspace_tenants[0].tenant if workspace_tenants else None
-            display_name = (
-                first_tenant.format_display_name(m.workspace.name)
-                if first_tenant
-                else m.workspace.name
-            )
             results.append(
                 {
                     "id": str(m.workspace.id),
                     "name": m.workspace.name,
-                    "display_name": display_name,
+                    "display_name": m.workspace.display_name,
                     "is_auto_created": m.workspace.is_auto_created,
                     "role": m.role,
                     "tenants": tenants,

--- a/apps/workspaces/api/workspace_views.py
+++ b/apps/workspaces/api/workspace_views.py
@@ -46,18 +46,26 @@ class WorkspaceListView(APIView):
         )
         results = []
         for m in memberships:
+            workspace_tenants = list(m.workspace.workspace_tenants.all())
             tenants = [
                 {
                     "id": str(wt.tenant.id),
                     "tenant_name": wt.tenant.canonical_name,
                     "provider": wt.tenant.provider,
                 }
-                for wt in m.workspace.workspace_tenants.all()
+                for wt in workspace_tenants
             ]
+            first_tenant = workspace_tenants[0].tenant if workspace_tenants else None
+            display_name = (
+                first_tenant.format_display_name(m.workspace.name)
+                if first_tenant
+                else m.workspace.name
+            )
             results.append(
                 {
                     "id": str(m.workspace.id),
                     "name": m.workspace.name,
+                    "display_name": display_name,
                     "is_auto_created": m.workspace.is_auto_created,
                     "role": m.role,
                     "tenants": tenants,
@@ -94,8 +102,11 @@ class WorkspaceListView(APIView):
             created_by=request.user,
         )
         tenants = []
+        first_tenant = None
         for tenant in Tenant.objects.filter(id__in=tenant_ids):
             WorkspaceTenant.objects.create(workspace=workspace, tenant=tenant)
+            if first_tenant is None:
+                first_tenant = tenant
             tenants.append(
                 {
                     "id": str(tenant.id),
@@ -110,10 +121,14 @@ class WorkspaceListView(APIView):
             role=WorkspaceRole.MANAGE,
         )
 
+        display_name = (
+            first_tenant.format_display_name(workspace.name) if first_tenant else workspace.name
+        )
         return Response(
             {
                 "id": str(workspace.id),
                 "name": workspace.name,
+                "display_name": display_name,
                 "is_auto_created": workspace.is_auto_created,
                 "role": WorkspaceRole.MANAGE,
                 "tenants": tenants,
@@ -162,10 +177,15 @@ class WorkspaceDetailView(APIView):
             except WorkspaceViewSchema.DoesNotExist:
                 schema_status = "provisioning"
 
+        first_tenant = tenants[0] if tenants else None
+        display_name = (
+            first_tenant.format_display_name(workspace.name) if first_tenant else workspace.name
+        )
         return Response(
             {
                 "id": str(workspace.id),
                 "name": workspace.name,
+                "display_name": display_name,
                 "is_auto_created": workspace.is_auto_created,
                 "role": membership.role,
                 "system_prompt": workspace.system_prompt,
@@ -200,7 +220,13 @@ class WorkspaceDetailView(APIView):
             workspace.system_prompt = system_prompt
 
         workspace.save(update_fields=["name", "system_prompt", "updated_at"])
-        return Response({"id": str(workspace.id), "name": workspace.name})
+        return Response(
+            {
+                "id": str(workspace.id),
+                "name": workspace.name,
+                "display_name": workspace.display_name,
+            }
+        )
 
     def delete(self, request, workspace_id):
         workspace, membership, err = resolve_workspace(request, workspace_id)

--- a/apps/workspaces/models.py
+++ b/apps/workspaces/models.py
@@ -132,6 +132,14 @@ class Workspace(models.Model):
         return self.tenants.first()
 
     @property
+    def display_name(self) -> str:
+        """Human-facing label: the stored name formatted by the tenant's provider template."""
+        t = self.tenant
+        if t is None:
+            return self.name
+        return t.format_display_name(self.name)
+
+    @property
     def external_tenant_id(self):
         """Compatibility shim: returns the external_id of the first tenant."""
         t = self.tenant

--- a/frontend/src/api/workspaces.ts
+++ b/frontend/src/api/workspaces.ts
@@ -14,6 +14,7 @@ export interface WorkspaceListTenant {
 export interface WorkspaceListItem {
   id: string
   name: string
+  display_name: string
   is_auto_created: boolean
   role: "read" | "read_write" | "manage"
   tenants: WorkspaceListTenant[]
@@ -24,6 +25,7 @@ export interface WorkspaceListItem {
 export interface WorkspaceDetail {
   id: string
   name: string
+  display_name: string
   is_auto_created: boolean
   role: "read" | "read_write" | "manage"
   system_prompt: string
@@ -65,7 +67,10 @@ export const workspaceApi = {
     }),
 
   update: (workspaceId: string, body: { name?: string; system_prompt?: string }) =>
-    api.patch<{ id: string; name: string }>(`/api/workspaces/${workspaceId}/`, body),
+    api.patch<{ id: string; name: string; display_name: string }>(
+      `/api/workspaces/${workspaceId}/`,
+      body,
+    ),
 
   delete: (workspaceId: string) =>
     api.delete<void>(`/api/workspaces/${workspaceId}/`),

--- a/frontend/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/Sidebar/Sidebar.tsx
@@ -75,7 +75,7 @@ export function Sidebar() {
               data-testid="domain-selector"
             >
               <span className="truncate">
-                {domains.find((d) => d.id === activeDomainId)?.name ?? "Select workspace"}
+                {domains.find((d) => d.id === activeDomainId)?.display_name ?? "Select workspace"}
               </span>
               <ChevronDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
             </Button>
@@ -97,7 +97,7 @@ export function Sidebar() {
             {/* Scrollable workspace list */}
             <div className="max-h-60 overflow-y-auto p-1">
               {domains
-                .filter((d) => !wsSearch || d.name.toLowerCase().includes(wsSearch.toLowerCase()))
+                .filter((d) => !wsSearch || d.display_name.toLowerCase().includes(wsSearch.toLowerCase()))
                 .map((d) => (
                   <button
                     key={d.id}
@@ -107,12 +107,12 @@ export function Sidebar() {
                       d.id === activeDomainId ? "font-medium bg-accent" : ""
                     }`}
                   >
-                    {d.name}
+                    {d.display_name}
                   </button>
                 ))}
               {domains.length > 0 &&
                 wsSearch &&
-                !domains.some((d) => d.name.toLowerCase().includes(wsSearch.toLowerCase())) && (
+                !domains.some((d) => d.display_name.toLowerCase().includes(wsSearch.toLowerCase())) && (
                   <p className="px-2 py-4 text-center text-sm text-muted-foreground">
                     No workspaces match.
                   </p>

--- a/frontend/src/pages/WorkspaceDetailPage/WorkspaceDetailPage.tsx
+++ b/frontend/src/pages/WorkspaceDetailPage/WorkspaceDetailPage.tsx
@@ -536,7 +536,7 @@ export function WorkspaceDetailPage() {
         </Link>
         <div className="flex items-center gap-3">
           <h1 className="text-2xl font-semibold" data-testid="workspace-name">
-            {workspace.name}
+            {workspace.display_name}
           </h1>
           <RoleBadge role={workspace.role} />
         </div>

--- a/frontend/src/pages/WorkspacesPage/WorkspacesPage.tsx
+++ b/frontend/src/pages/WorkspacesPage/WorkspacesPage.tsx
@@ -53,7 +53,7 @@ function WorkspaceRow({ workspace, onClick }: { workspace: TenantMembership; onC
       className="flex w-full items-center justify-between rounded-lg border bg-card px-4 py-3 text-left transition-colors hover:bg-accent"
     >
       <div className="min-w-0 flex-1">
-        <div className="font-medium">{workspace.name}</div>
+        <div className="font-medium">{workspace.display_name}</div>
         <div className="mt-1 flex items-center gap-3 text-xs text-muted-foreground">
           <span className="flex items-center gap-1">
             <Users className="h-3 w-3" />
@@ -142,7 +142,7 @@ export function WorkspacesPage() {
   const filtered = useMemo(() => {
     const lowerSearch = search.toLowerCase()
     return domains.filter((ws) => {
-      if (lowerSearch && !ws.name.toLowerCase().includes(lowerSearch)) return false
+      if (lowerSearch && !ws.display_name.toLowerCase().includes(lowerSearch)) return false
       if (activeFilters.role && ws.role !== activeFilters.role) return false
       if (activeFilters.provider) {
         const tenants = ws.tenants ?? []

--- a/tests/test_workspace_models.py
+++ b/tests/test_workspace_models.py
@@ -3,6 +3,7 @@
 import pytest
 from django.db.utils import IntegrityError
 
+from apps.users.models import Tenant
 from apps.workspaces.models import Workspace, WorkspaceMembership, WorkspaceRole, WorkspaceTenant
 
 
@@ -42,3 +43,42 @@ def test_workspace_tenant_str_uniqueness(workspace, tenant, user):
     with pytest.raises(IntegrityError):
         WorkspaceTenant.objects.create(workspace=ws2, tenant=tenant)
         WorkspaceTenant.objects.create(workspace=ws2, tenant=tenant)
+
+
+@pytest.mark.django_db
+def test_display_name_for_connect_workspace_includes_opp_id(user):
+    """Connect provider template renders "{name} (Opp {external_id})"."""
+    connect_tenant = Tenant.objects.create(
+        provider="commcare_connect",
+        external_id="opp-42",
+        canonical_name="Malaria Campaign",
+    )
+    ws = Workspace.objects.create(name="Malaria Campaign", created_by=user)
+    WorkspaceTenant.objects.create(workspace=ws, tenant=connect_tenant)
+
+    assert ws.display_name == "Malaria Campaign (Opp opp-42)"
+
+
+@pytest.mark.django_db
+def test_display_name_for_commcare_workspace_is_plain_name(workspace):
+    """CommCare provider template is just "{name}" — no added context."""
+    assert workspace.display_name == workspace.name
+
+
+@pytest.mark.django_db
+def test_display_name_without_tenant_falls_back_to_name(user):
+    """A workspace with no tenants returns its raw name."""
+    ws = Workspace.objects.create(name="Tenantless", created_by=user)
+    assert ws.display_name == "Tenantless"
+
+
+@pytest.mark.django_db
+def test_display_name_with_unknown_provider_falls_back_to_name(user):
+    """A provider without a template entry falls back to the raw name."""
+    # Bypass choices validation to simulate a provider with no template entry.
+    tenant = Tenant(provider="future-provider", external_id="abc", canonical_name="Future")
+    tenant.save()
+    ws = Workspace.objects.create(name="Mystery", created_by=user)
+    WorkspaceTenant.objects.create(workspace=ws, tenant=tenant)
+
+    assert ws.display_name == "Mystery"

--- a/tests/test_workspace_models.py
+++ b/tests/test_workspace_models.py
@@ -60,9 +60,9 @@ def test_display_name_for_connect_workspace_includes_opp_id(user):
 
 
 @pytest.mark.django_db
-def test_display_name_for_commcare_workspace_is_plain_name(workspace):
-    """CommCare provider template is just "{name}" — no added context."""
-    assert workspace.display_name == workspace.name
+def test_display_name_for_commcare_workspace_includes_prefix(workspace):
+    """CommCare provider template renders."""
+    assert workspace.display_name == f"[CC] {workspace.name}"
 
 
 @pytest.mark.django_db

--- a/tests/test_workspace_models.py
+++ b/tests/test_workspace_models.py
@@ -47,7 +47,7 @@ def test_workspace_tenant_str_uniqueness(workspace, tenant, user):
 
 @pytest.mark.django_db
 def test_display_name_for_connect_workspace_includes_opp_id(user):
-    """Connect provider template renders "{name} (Opp {external_id})"."""
+    """Connect provider template renders."""
     connect_tenant = Tenant.objects.create(
         provider="commcare_connect",
         external_id="opp-42",
@@ -56,7 +56,7 @@ def test_display_name_for_connect_workspace_includes_opp_id(user):
     ws = Workspace.objects.create(name="Malaria Campaign", created_by=user)
     WorkspaceTenant.objects.create(workspace=ws, tenant=connect_tenant)
 
-    assert ws.display_name == "Malaria Campaign (Opp opp-42)"
+    assert ws.display_name == "[CCC] Malaria Campaign (Opp opp-42)"
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary
- Auto-created workspaces inherit `Tenant.canonical_name` as their name, so Connect workspaces with similar names are indistinguishable and the opportunity ID is hidden until you drill into settings.
- This PR adds a computed `Workspace.display_name` driven by a per-provider template. Connect surfaces `"<name> (Opp <external_id>)"`; CommCare stays `"<name>"`. Templates live in a single `PROVIDER_DISPLAY_TEMPLATES` dict next to `PROVIDER_CHOICES`, so adding a new provider is one line.
- `display_name` is a read-time property — no migration, no stored-state drift. The editable workspace name in settings keeps binding to `name`; only display locations switch to `display_name`.

## Changes
- `apps/users/models.py`: `PROVIDER_DISPLAY_TEMPLATES` and `Tenant.format_display_name()` (falls back to raw name on missing template or unresolved field).
- `apps/workspaces/models.py`: `Workspace.display_name` property using the first associated tenant.
- `apps/workspaces/api/workspace_views.py`: include `display_name` in list/detail/create/patch responses (reuses already-fetched tenant data — no extra queries on list).
- `frontend/src/api/workspaces.ts`: add `display_name` to `WorkspaceListItem` / `WorkspaceDetail` / patch response.
- Frontend render: sidebar selector + search (`Sidebar.tsx`), workspaces list row + search (`WorkspacesPage.tsx`), workspace detail header (`WorkspaceDetailPage.tsx:539`). Settings name editor stays on `workspace.name`.
- `tests/test_workspace_models.py`: Connect formatting, CommCare passthrough, no-tenant fallback, unknown-provider fallback.

## Test plan
- [x] `uv run pytest tests/` — 808 passed, 15 skipped
- [x] `uv run ruff check .` and `ruff format --check .` on touched files — clean
- [x] `bun run lint` — clean
- [x] `bun run build` (tsc + vite) — clean
- [ ] Manual smoke: verify Connect workspace label in the sidebar shows `"<name> (Opp <external_id>)"` and a CommCare workspace shows just the name

Note: re-opened as a same-repo PR (was dimagi-rad#149 from `jjackson:feat/...`). Fork PRs don't receive `ANTHROPIC_API_KEY` or an id-token, so the `auto-review` job can't run there.