### PR TITLE
fix(workspaces): wrap async pipeline_list_tables in async_to_sync

### DIFF
--- a/apps/workspaces/api/views.py
+++ b/apps/workspaces/api/views.py
@@ -4,6 +4,7 @@ API views for data dictionary and workspace schema management.
 
 import logging
 
+from asgiref.sync import async_to_sync
 from django.db import transaction
 from rest_framework import status
 from rest_framework.permissions import IsAuthenticated
@@ -263,7 +264,7 @@ class DataDictionaryView(APIView):
 
         tables_list = [
             t
-            for t in pipeline_list_tables(tenant_schema, pipeline_config)
+            for t in async_to_sync(pipeline_list_tables)(tenant_schema, pipeline_config)
             if not t["name"].startswith("stg_")
         ]
         if not tables_list:
@@ -433,7 +434,9 @@ class TableDetailView(APIView):
         pipeline_name = last_run.pipeline if last_run else "commcare_sync"
         pipeline_config = get_registry().get(pipeline_name) or get_registry().get("commcare_sync")
 
-        known = {t["name"] for t in pipeline_list_tables(tenant_schema, pipeline_config)}
+        known = {
+            t["name"] for t in async_to_sync(pipeline_list_tables)(tenant_schema, pipeline_config)
+        }
         if table_name not in known:
             return None
 


### PR DESCRIPTION
## Summary
- `pipeline_list_tables` became async in PR #146 but two sync DRF call sites in `apps/workspaces/api/views.py` were not updated, producing `TypeError: 'coroutine' object is not iterable` on `GET /api/workspaces/<id>/data-dictionary/`
- Wrap both call sites (`DataDictionaryView._get_from_pipeline`, `TableDetailView._get_pipeline_table`) with `async_to_sync` since DRF `APIView` stays sync per project conventions

## Test plan
- [x] Existing tests pass: `uv run pytest tests/test_schema_unavailable_503.py tests/test_explicit_workspace_context.py`
- [ ] Manual: load data dictionary page in dev and confirm 200 response

🤖 Generated with [Claude Code](https://claude.com/claude-code)