### PR TITLE
fix(workspaces): replace DROP OWNED BY with explicit REVOKE in role teardown

### DIFF
--- a/apps/workspaces/services/schema_manager.py
+++ b/apps/workspaces/services/schema_manager.py
@@ -167,6 +167,11 @@ class SchemaManager:
 
         Only performs the physical DROP SCHEMA — callers are responsible for
         updating the model state (EXPIRED or FAILED) after this returns.
+
+        Role cleanup is best-effort: once DROP SCHEMA has succeeded the schema
+        is gone, so a later failure in ``_drop_readonly_role`` must not surface
+        as an exception (callers would otherwise incorrectly flip the record
+        back to ACTIVE). A dangling role is logged for operator follow-up.
         """
         conn = get_managed_db_connection()
         try:
@@ -176,7 +181,14 @@ class SchemaManager:
                     psycopg.sql.Identifier(tenant_schema.schema_name)
                 )
             )
-            self._drop_readonly_role(cursor, tenant_schema.schema_name)
+            try:
+                self._drop_readonly_role(cursor, tenant_schema.schema_name)
+            except Exception:
+                logger.exception(
+                    "teardown: dropping readonly role for schema '%s' failed; "
+                    "physical schema was dropped, role may be dangling",
+                    tenant_schema.schema_name,
+                )
             cursor.close()
         finally:
             conn.close()
@@ -360,7 +372,10 @@ class SchemaManager:
         return vs
 
     def teardown_view_schema(self, view_schema: WorkspaceViewSchema) -> None:
-        """Drop the physical PostgreSQL schema for a WorkspaceViewSchema."""
+        """Drop the physical PostgreSQL schema for a WorkspaceViewSchema.
+
+        Role cleanup is best-effort — see ``teardown`` for rationale.
+        """
         conn = get_managed_db_connection()
         try:
             cursor = conn.cursor()
@@ -369,13 +384,23 @@ class SchemaManager:
                     psycopg.sql.Identifier(view_schema.schema_name)
                 )
             )
-            self._drop_readonly_role(cursor, view_schema.schema_name)
+            try:
+                self._drop_readonly_role(cursor, view_schema.schema_name)
+            except Exception:
+                logger.exception(
+                    "teardown_view_schema: dropping readonly role for '%s' failed; "
+                    "physical schema was dropped, role may be dangling",
+                    view_schema.schema_name,
+                )
             cursor.close()
         finally:
             conn.close()
 
     async def ateardown(self, tenant_schema: TenantSchema) -> None:
-        """Async version of teardown — drop a tenant's schema from the managed database."""
+        """Async version of teardown — drop a tenant's schema from the managed database.
+
+        Role cleanup is best-effort — see ``teardown`` for rationale.
+        """
         async with await aget_managed_db_connection() as conn:
             async with conn.cursor() as cursor:
                 await cursor.execute(
@@ -383,10 +408,20 @@ class SchemaManager:
                         psycopg.sql.Identifier(tenant_schema.schema_name)
                     )
                 )
-                await self._adrop_readonly_role(cursor, tenant_schema.schema_name)
+                try:
+                    await self._adrop_readonly_role(cursor, tenant_schema.schema_name)
+                except Exception:
+                    logger.exception(
+                        "ateardown: dropping readonly role for schema '%s' failed; "
+                        "physical schema was dropped, role may be dangling",
+                        tenant_schema.schema_name,
+                    )
 
     async def ateardown_view_schema(self, view_schema: WorkspaceViewSchema) -> None:
-        """Async version of teardown_view_schema — drop the physical PostgreSQL schema."""
+        """Async version of teardown_view_schema — drop the physical PostgreSQL schema.
+
+        Role cleanup is best-effort — see ``teardown`` for rationale.
+        """
         async with await aget_managed_db_connection() as conn:
             async with conn.cursor() as cursor:
                 await cursor.execute(
@@ -394,7 +429,25 @@ class SchemaManager:
                         psycopg.sql.Identifier(view_schema.schema_name)
                     )
                 )
-                await self._adrop_readonly_role(cursor, view_schema.schema_name)
+                try:
+                    await self._adrop_readonly_role(cursor, view_schema.schema_name)
+                except Exception:
+                    logger.exception(
+                        "ateardown_view_schema: dropping readonly role for '%s' failed; "
+                        "physical schema was dropped, role may be dangling",
+                        view_schema.schema_name,
+                    )
+
+    # SQL used by both sync and async role-teardown paths. Finds schemas on
+    # which the role holds direct ACL entries — schema-level grants (e.g.
+    # USAGE on constituent tenant schemas for view-schema _ro roles) are the
+    # only ones that survive DROP SCHEMA CASCADE and block DROP ROLE.
+    _SCHEMAS_WITH_ROLE_GRANTS_SQL = """
+        SELECT DISTINCT n.nspname
+        FROM pg_namespace n, aclexplode(n.nspacl) AS acl
+        JOIN pg_roles r ON r.oid = acl.grantee
+        WHERE r.rolname = %s
+    """
 
     async def _adrop_readonly_role(self, cursor, schema_name: str) -> None:
         """Async version of _drop_readonly_role."""
@@ -402,9 +455,21 @@ class SchemaManager:
         await cursor.execute("SELECT 1 FROM pg_roles WHERE rolname = %s", (role_name,))
         if not await cursor.fetchone():
             return
-        await cursor.execute(
-            psycopg.sql.SQL("DROP OWNED BY {}").format(psycopg.sql.Identifier(role_name))
-        )
+        await cursor.execute(self._SCHEMAS_WITH_ROLE_GRANTS_SQL, (role_name,))
+        schemas_with_grants = [row[0] for row in await cursor.fetchall()]
+        for schema in schemas_with_grants:
+            await cursor.execute(
+                psycopg.sql.SQL("REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA {} FROM {}").format(
+                    psycopg.sql.Identifier(schema),
+                    psycopg.sql.Identifier(role_name),
+                )
+            )
+            await cursor.execute(
+                psycopg.sql.SQL("REVOKE ALL PRIVILEGES ON SCHEMA {} FROM {}").format(
+                    psycopg.sql.Identifier(schema),
+                    psycopg.sql.Identifier(role_name),
+                )
+            )
         await cursor.execute(
             psycopg.sql.SQL("DROP ROLE IF EXISTS {}").format(psycopg.sql.Identifier(role_name))
         )
@@ -412,24 +477,37 @@ class SchemaManager:
     def _drop_readonly_role(self, cursor, schema_name: str) -> None:
         """Drop the read-only PostgreSQL role for a schema.
 
-        Issues DROP OWNED BY first to revoke all privileges the role holds
-        (including cross-schema grants from view schema roles), then drops
-        the role itself.
+        Explicitly revokes grants the role still holds (schema-scoped ACLs on
+        other schemas — e.g. view-schema roles' USAGE/SELECT on constituent
+        tenant schemas) and then drops the role.
+
+        We avoid ``DROP OWNED BY`` because it requires the executing role to
+        have privileges of the target role (inheritable grant or SET ROLE
+        capability) — a prerequisite Scout's managed-DB user does not reliably
+        hold for roles created earlier or by a different operator. Explicit
+        REVOKE works as long as the current user is the grantor (which it is,
+        since it issued the original GRANTs in ``_create_readonly_role`` and
+        ``build_view_schema``).
         """
         role_name = readonly_role_name(schema_name)
-        # Check if role exists before DROP OWNED BY (which errors on missing roles)
         cursor.execute("SELECT 1 FROM pg_roles WHERE rolname = %s", (role_name,))
         if not cursor.fetchone():
             return
-        # DROP OWNED BY revokes all privileges granted TO this role (e.g. USAGE
-        # and SELECT on constituent tenant schemas for view schema roles). It does
-        # NOT drop or modify the tenant schemas themselves — only the grants that
-        # this specific role holds. Tenant schemas and their own _ro roles are
-        # unaffected. This is required because PostgreSQL refuses to DROP ROLE
-        # while the role still holds any privileges.
-        cursor.execute(
-            psycopg.sql.SQL("DROP OWNED BY {}").format(psycopg.sql.Identifier(role_name))
-        )
+        cursor.execute(self._SCHEMAS_WITH_ROLE_GRANTS_SQL, (role_name,))
+        schemas_with_grants = [row[0] for row in cursor.fetchall()]
+        for schema in schemas_with_grants:
+            cursor.execute(
+                psycopg.sql.SQL("REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA {} FROM {}").format(
+                    psycopg.sql.Identifier(schema),
+                    psycopg.sql.Identifier(role_name),
+                )
+            )
+            cursor.execute(
+                psycopg.sql.SQL("REVOKE ALL PRIVILEGES ON SCHEMA {} FROM {}").format(
+                    psycopg.sql.Identifier(schema),
+                    psycopg.sql.Identifier(role_name),
+                )
+            )
         cursor.execute(
             psycopg.sql.SQL("DROP ROLE IF EXISTS {}").format(psycopg.sql.Identifier(role_name))
         )

--- a/apps/workspaces/tasks.py
+++ b/apps/workspaces/tasks.py
@@ -188,7 +188,11 @@ def teardown_schema(schema_id: str) -> None:
     try:
         SchemaManager().teardown(schema)
     except Exception:
-        schema.state = SchemaState.ACTIVE  # rollback: physical schema still exists
+        # teardown() only raises when DROP SCHEMA itself fails — role-cleanup
+        # failures are logged and swallowed there — so reaching this branch
+        # means the physical schema is still present and the record should go
+        # back to ACTIVE rather than being stranded in TEARDOWN.
+        schema.state = SchemaState.ACTIVE
         schema.save(update_fields=["state"])
         raise
     try:

--- a/tests/test_schema_manager.py
+++ b/tests/test_schema_manager.py
@@ -1,5 +1,6 @@
 from unittest.mock import MagicMock, patch
 
+import psycopg.errors
 import psycopg.sql
 import pytest
 
@@ -121,6 +122,8 @@ class TestSchemaManagerRoleTeardown:
         mock_conn = MagicMock()
         mock_cursor = MagicMock()
         mock_conn.cursor.return_value = mock_cursor
+        mock_cursor.fetchone.return_value = (1,)  # role exists
+        mock_cursor.fetchall.return_value = []  # no schemas with residual grants
 
         with patch(
             "apps.workspaces.services.schema_manager.get_managed_db_connection",
@@ -131,7 +134,6 @@ class TestSchemaManagerRoleTeardown:
 
         role_name = readonly_role_name(ts.schema_name)
         calls = [str(c) for c in mock_cursor.execute.call_args_list]
-        assert any("DROP OWNED BY" in c and role_name in c for c in calls)
         assert any("DROP ROLE IF EXISTS" in c and role_name in c for c in calls)
 
     def test_teardown_view_schema_drops_readonly_role(self, workspace):
@@ -146,6 +148,8 @@ class TestSchemaManagerRoleTeardown:
         mock_conn = MagicMock()
         mock_cursor = MagicMock()
         mock_conn.cursor.return_value = mock_cursor
+        mock_cursor.fetchone.return_value = (1,)  # role exists
+        mock_cursor.fetchall.return_value = []  # no cross-schema grants
 
         with patch(
             "apps.workspaces.services.schema_manager.get_managed_db_connection",
@@ -156,8 +160,157 @@ class TestSchemaManagerRoleTeardown:
 
         role_name = readonly_role_name(vs.schema_name)
         calls = [str(c) for c in mock_cursor.execute.call_args_list]
-        assert any("DROP OWNED BY" in c and role_name in c for c in calls)
         assert any("DROP ROLE IF EXISTS" in c and role_name in c for c in calls)
+
+    def test_drop_readonly_role_does_not_use_drop_owned_by(self, tenant_membership):
+        """DROP OWNED BY requires membership in the target role, which a non-superuser
+        creator may not have. Use explicit REVOKE instead."""
+        from apps.workspaces.models import TenantSchema
+
+        ts = TenantSchema.objects.create(
+            tenant=tenant_membership.tenant,
+            schema_name="test_domain",
+            state="active",
+        )
+
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.cursor.return_value = mock_cursor
+        mock_cursor.fetchone.return_value = (1,)
+        mock_cursor.fetchall.return_value = []
+
+        with patch(
+            "apps.workspaces.services.schema_manager.get_managed_db_connection",
+            return_value=mock_conn,
+        ):
+            SchemaManager().teardown(ts)
+
+        calls = [str(c) for c in mock_cursor.execute.call_args_list]
+        assert not any("DROP OWNED BY" in c for c in calls), (
+            "DROP OWNED BY should not be emitted; it requires role membership"
+        )
+
+    def test_drop_readonly_role_revokes_cross_schema_grants(self, workspace):
+        """View-schema _ro roles hold USAGE/SELECT on constituent tenant schemas that
+        survive DROP SCHEMA CASCADE. _drop_readonly_role must revoke those explicitly."""
+        from apps.workspaces.models import WorkspaceViewSchema
+
+        vs = WorkspaceViewSchema.objects.create(
+            workspace=workspace,
+            schema_name="ws_abc1234def56789",
+            state="active",
+        )
+
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.cursor.return_value = mock_cursor
+        mock_cursor.fetchone.return_value = (1,)  # role exists
+        # Simulate: role holds grants on two tenant schemas
+        mock_cursor.fetchall.return_value = [("tenant_alpha",), ("tenant_beta",)]
+
+        with patch(
+            "apps.workspaces.services.schema_manager.get_managed_db_connection",
+            return_value=mock_conn,
+        ):
+            SchemaManager().teardown_view_schema(vs)
+
+        role_name = readonly_role_name(vs.schema_name)
+        calls = [str(c) for c in mock_cursor.execute.call_args_list]
+        for schema in ("tenant_alpha", "tenant_beta"):
+            assert any(
+                "REVOKE" in c and "SCHEMA" in c and schema in c and role_name in c for c in calls
+            ), f"Expected REVOKE on schema {schema} from {role_name}"
+            assert any(
+                "REVOKE" in c and "ALL TABLES IN SCHEMA" in c and schema in c and role_name in c
+                for c in calls
+            ), f"Expected REVOKE ALL TABLES in {schema} from {role_name}"
+
+    def test_drop_readonly_role_is_noop_when_role_missing(self, tenant_membership):
+        from apps.workspaces.models import TenantSchema
+
+        ts = TenantSchema.objects.create(
+            tenant=tenant_membership.tenant,
+            schema_name="test_domain",
+            state="active",
+        )
+
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.cursor.return_value = mock_cursor
+        mock_cursor.fetchone.return_value = None  # role does not exist
+
+        with patch(
+            "apps.workspaces.services.schema_manager.get_managed_db_connection",
+            return_value=mock_conn,
+        ):
+            SchemaManager().teardown(ts)
+
+        calls = [str(c) for c in mock_cursor.execute.call_args_list]
+        role_name = readonly_role_name(ts.schema_name)
+        # DROP SCHEMA still emitted; role commands skipped
+        assert any("DROP SCHEMA" in c for c in calls)
+        assert not any("DROP ROLE" in c and role_name in c for c in calls)
+        assert not any("REVOKE" in c and role_name in c for c in calls)
+
+    def test_teardown_tolerates_role_cleanup_failure(self, tenant_membership):
+        """If DROP SCHEMA succeeds but role cleanup raises, teardown() should log and
+        return successfully — the physical schema is already gone, so failing here
+        would make callers incorrectly flip state back to ACTIVE."""
+        from apps.workspaces.models import TenantSchema
+
+        ts = TenantSchema.objects.create(
+            tenant=tenant_membership.tenant,
+            schema_name="test_domain",
+            state="active",
+        )
+
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.cursor.return_value = mock_cursor
+
+        # DROP SCHEMA succeeds. Role cleanup queries raise.
+        drop_schema_seen = {"v": False}
+
+        def execute(stmt, *args, **kwargs):
+            s = str(stmt)
+            if "DROP SCHEMA" in s:
+                drop_schema_seen["v"] = True
+                return None
+            # Every role-related query raises InsufficientPrivilege
+            raise psycopg.errors.InsufficientPrivilege("permission denied")
+
+        mock_cursor.execute.side_effect = execute
+
+        with patch(
+            "apps.workspaces.services.schema_manager.get_managed_db_connection",
+            return_value=mock_conn,
+        ):
+            SchemaManager().teardown(ts)
+
+        assert drop_schema_seen["v"], "DROP SCHEMA must be attempted before role cleanup"
+
+    def test_teardown_reraises_when_drop_schema_fails(self, tenant_membership):
+        """If DROP SCHEMA itself fails, teardown() must re-raise so the caller can
+        roll the record state back to ACTIVE."""
+        from apps.workspaces.models import TenantSchema
+
+        ts = TenantSchema.objects.create(
+            tenant=tenant_membership.tenant,
+            schema_name="test_domain",
+            state="active",
+        )
+
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.cursor.return_value = mock_cursor
+        mock_cursor.execute.side_effect = RuntimeError("boom")
+
+        with patch(
+            "apps.workspaces.services.schema_manager.get_managed_db_connection",
+            return_value=mock_conn,
+        ):
+            with pytest.raises(RuntimeError):
+                SchemaManager().teardown(ts)
 
 
 @pytest.mark.django_db
@@ -203,6 +356,106 @@ class TestViewSchemaRoleCreation:
         )
         # Should grant USAGE on constituent tenant schema
         assert any("GRANT USAGE ON SCHEMA" in c and ts.schema_name in c for c in calls)
+
+
+class _AsyncCursor:
+    """Minimal async cursor double for testing ateardown paths."""
+
+    def __init__(self, fetchone_value=(1,), fetchall_value=()):
+        self.executed: list[str] = []
+        self._fetchone = fetchone_value
+        self._fetchall = list(fetchall_value)
+        self.execute_side_effect = None
+
+    async def execute(self, stmt, params=None):
+        s = str(stmt)
+        self.executed.append(s)
+        if self.execute_side_effect is not None:
+            raise self.execute_side_effect
+
+    async def fetchone(self):
+        return self._fetchone
+
+    async def fetchall(self):
+        return self._fetchall
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _AsyncConn:
+    def __init__(self, cursor):
+        self._cursor = cursor
+
+    def cursor(self):
+        return self._cursor
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+@pytest.mark.django_db(transaction=True)
+class TestSchemaManagerAsyncTeardown:
+    @pytest.mark.asyncio
+    async def test_ateardown_does_not_use_drop_owned_by(self, tenant_membership):
+        from apps.workspaces.models import TenantSchema
+
+        ts = await TenantSchema.objects.acreate(
+            tenant=tenant_membership.tenant,
+            schema_name="test_async_schema",
+            state="active",
+        )
+
+        cursor = _AsyncCursor(fetchone_value=(1,), fetchall_value=[])
+
+        async def _aconn():
+            return _AsyncConn(cursor)
+
+        with patch(
+            "apps.workspaces.services.schema_manager.aget_managed_db_connection",
+            side_effect=_aconn,
+        ):
+            await SchemaManager().ateardown(ts)
+
+        assert not any("DROP OWNED BY" in s for s in cursor.executed)
+        role_name = readonly_role_name(ts.schema_name)
+        assert any("DROP ROLE IF EXISTS" in s and role_name in s for s in cursor.executed)
+
+    @pytest.mark.asyncio
+    async def test_ateardown_revokes_cross_schema_grants(self, workspace):
+        from apps.workspaces.models import WorkspaceViewSchema
+
+        vs = await WorkspaceViewSchema.objects.acreate(
+            workspace=workspace,
+            schema_name="ws_aaaa1111bbbb2222",
+            state="active",
+        )
+
+        cursor = _AsyncCursor(
+            fetchone_value=(1,),
+            fetchall_value=[("tenant_gamma",)],
+        )
+
+        async def _aconn():
+            return _AsyncConn(cursor)
+
+        with patch(
+            "apps.workspaces.services.schema_manager.aget_managed_db_connection",
+            side_effect=_aconn,
+        ):
+            await SchemaManager().ateardown_view_schema(vs)
+
+        role_name = readonly_role_name(vs.schema_name)
+        assert any(
+            "REVOKE" in s and "SCHEMA" in s and "tenant_gamma" in s and role_name in s
+            for s in cursor.executed
+        )
 
 
 class TestReadonlyRoleName:

--- a/tests/test_schema_manager.py
+++ b/tests/test_schema_manager.py
@@ -4,7 +4,7 @@ import psycopg.errors
 import psycopg.sql
 import pytest
 
-from apps.workspaces.models import TenantSchema
+from apps.workspaces.models import TenantSchema, WorkspaceViewSchema
 from apps.workspaces.services.schema_manager import SchemaManager, readonly_role_name
 
 
@@ -88,8 +88,6 @@ class TestSchemaManagerRoleCreation:
         mock_conn.cursor.return_value = mock_cursor
         mock_cursor.fetchone.return_value = None  # role doesn't exist yet
 
-        from apps.workspaces.models import TenantSchema
-
         ts = TenantSchema.objects.create(
             tenant=tenant_membership.tenant,
             schema_name="test_domain_r1a2b3c4",
@@ -111,8 +109,6 @@ class TestSchemaManagerRoleCreation:
 @pytest.mark.django_db
 class TestSchemaManagerRoleTeardown:
     def test_teardown_drops_readonly_role(self, tenant_membership):
-        from apps.workspaces.models import TenantSchema
-
         ts = TenantSchema.objects.create(
             tenant=tenant_membership.tenant,
             schema_name="test_domain",
@@ -137,8 +133,6 @@ class TestSchemaManagerRoleTeardown:
         assert any("DROP ROLE IF EXISTS" in c and role_name in c for c in calls)
 
     def test_teardown_view_schema_drops_readonly_role(self, workspace):
-        from apps.workspaces.models import WorkspaceViewSchema
-
         vs = WorkspaceViewSchema.objects.create(
             workspace=workspace,
             schema_name="ws_abc1234def56789",
@@ -165,8 +159,6 @@ class TestSchemaManagerRoleTeardown:
     def test_drop_readonly_role_does_not_use_drop_owned_by(self, tenant_membership):
         """DROP OWNED BY requires membership in the target role, which a non-superuser
         creator may not have. Use explicit REVOKE instead."""
-        from apps.workspaces.models import TenantSchema
-
         ts = TenantSchema.objects.create(
             tenant=tenant_membership.tenant,
             schema_name="test_domain",
@@ -193,8 +185,6 @@ class TestSchemaManagerRoleTeardown:
     def test_drop_readonly_role_revokes_cross_schema_grants(self, workspace):
         """View-schema _ro roles hold USAGE/SELECT on constituent tenant schemas that
         survive DROP SCHEMA CASCADE. _drop_readonly_role must revoke those explicitly."""
-        from apps.workspaces.models import WorkspaceViewSchema
-
         vs = WorkspaceViewSchema.objects.create(
             workspace=workspace,
             schema_name="ws_abc1234def56789",
@@ -226,8 +216,6 @@ class TestSchemaManagerRoleTeardown:
             ), f"Expected REVOKE ALL TABLES in {schema} from {role_name}"
 
     def test_drop_readonly_role_is_noop_when_role_missing(self, tenant_membership):
-        from apps.workspaces.models import TenantSchema
-
         ts = TenantSchema.objects.create(
             tenant=tenant_membership.tenant,
             schema_name="test_domain",
@@ -256,8 +244,6 @@ class TestSchemaManagerRoleTeardown:
         """If DROP SCHEMA succeeds but role cleanup raises, teardown() should log and
         return successfully — the physical schema is already gone, so failing here
         would make callers incorrectly flip state back to ACTIVE."""
-        from apps.workspaces.models import TenantSchema
-
         ts = TenantSchema.objects.create(
             tenant=tenant_membership.tenant,
             schema_name="test_domain",
@@ -292,8 +278,6 @@ class TestSchemaManagerRoleTeardown:
     def test_teardown_reraises_when_drop_schema_fails(self, tenant_membership):
         """If DROP SCHEMA itself fails, teardown() must re-raise so the caller can
         roll the record state back to ACTIVE."""
-        from apps.workspaces.models import TenantSchema
-
         ts = TenantSchema.objects.create(
             tenant=tenant_membership.tenant,
             schema_name="test_domain",
@@ -318,8 +302,6 @@ class TestViewSchemaRoleCreation:
     def test_build_view_schema_creates_readonly_role_with_tenant_grants(
         self, workspace, tenant_membership
     ):
-        from apps.workspaces.models import TenantSchema
-
         ts = TenantSchema.objects.create(
             tenant=tenant_membership.tenant,
             schema_name="test_domain",
@@ -404,8 +386,6 @@ class _AsyncConn:
 class TestSchemaManagerAsyncTeardown:
     @pytest.mark.asyncio
     async def test_ateardown_does_not_use_drop_owned_by(self, tenant_membership):
-        from apps.workspaces.models import TenantSchema
-
         ts = await TenantSchema.objects.acreate(
             tenant=tenant_membership.tenant,
             schema_name="test_async_schema",
@@ -429,8 +409,6 @@ class TestSchemaManagerAsyncTeardown:
 
     @pytest.mark.asyncio
     async def test_ateardown_revokes_cross_schema_grants(self, workspace):
-        from apps.workspaces.models import WorkspaceViewSchema
-
         vs = await WorkspaceViewSchema.objects.acreate(
             workspace=workspace,
             schema_name="ws_aaaa1111bbbb2222",


### PR DESCRIPTION
## Summary
- Replaces `DROP OWNED BY` in `_drop_readonly_role` / `_adrop_readonly_role` with an enumeration of schemas where the role holds direct ACL entries (via `pg_namespace.nspacl` + `aclexplode`) followed by explicit `REVOKE ALL PRIVILEGES ON SCHEMA / ON ALL TABLES IN SCHEMA`, then `DROP ROLE IF EXISTS`. The current user is always the original grantor, so REVOKE succeeds without needing membership in the target role.
- Makes role cleanup best-effort in `teardown` / `teardown_view_schema` / `ateardown` / `ateardown_view_schema` — once `DROP SCHEMA CASCADE` has committed the physical schema is gone, so a later role-cleanup failure is logged and swallowed rather than propagated. This also makes the `teardown_schema` Celery task's rollback-to-ACTIVE semantically correct again: it now only triggers when `DROP SCHEMA` itself failed.

## Why
Sentry [SCOUT-DJANGO-2](https://dimagi.sentry.io/issues/7429950607/) fired 8 times on 2026-04-21 during the periodic `expire_inactive_schemas` run with `InsufficientPrivilege: permission denied to drop objects — Only roles with privileges of role \"<tenant>_ro\" may drop objects owned by it`. Postgres's `DROP OWNED BY` requires the executing session to have privileges of the target role (inheritable grant or SET ROLE capability), which Scout's managed-DB user doesn't reliably hold for roles created earlier or by a different operator. Secondary symptom: task rollback was flipping records back to ACTIVE even though `DROP SCHEMA CASCADE` had already succeeded, masking the failure as \"schema still exists.\"

## Test plan
- [x] New tests in `tests/test_schema_manager.py`:
  - `test_drop_readonly_role_does_not_use_drop_owned_by` — negative assertion
  - `test_drop_readonly_role_revokes_cross_schema_grants` — view-role REVOKE on constituent tenant schemas
  - `test_drop_readonly_role_is_noop_when_role_missing`
  - `test_teardown_tolerates_role_cleanup_failure` — teardown returns cleanly when role cleanup raises after DROP SCHEMA succeeds
  - `test_teardown_reraises_when_drop_schema_fails` — DROP SCHEMA failure still propagates so task rollback fires
  - `test_ateardown_does_not_use_drop_owned_by` / `test_ateardown_revokes_cross_schema_grants` — async parity
- [x] Full backend suite: `uv run pytest` — 847 passed, 8 skipped
- [x] `uv run ruff check` + `uv run ruff format --check` pass

## Follow-up (not in this PR)
Prod still has 8 dangling `_ro` roles from the failed teardowns (`t_146_ro`, `dsa_summit_2016_ro`, `sma_test_ro`, `onborading_ro`, `t_589_ro`, `nile_special_ro`, `t_802_ro`, `skelly_ro`). They're harmless but occupy their names. Options for cleanup: a one-off psql session as the original grantor, or a small management command reusing the explicit-REVOKE path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)