### PR TITLE
fix(embed): keep CSP frame-ancestors on /embed/ SPA fallback

### DIFF
--- a/frontend/nginx.prod-kamal.conf
+++ b/frontend/nginx.prod-kamal.conf
@@ -26,10 +26,28 @@ server {
     # (substituted by the nginx image's envsubst entrypoint at container start).
     # When EMBED_ALLOWED_ORIGINS is empty the policy collapses to 'self',
     # matching SAMEORIGIN behavior — so this is a safe default for every deploy.
+    #
+    # SPA fallback uses a named location (@embed_index) instead of falling
+    # through to /index.html. A try_files fallback to /index.html triggers an
+    # internal redirect that re-runs location matching against `location /`,
+    # which would replace these embed-specific headers with X-Frame-Options:
+    # SAMEORIGIN. The named location keeps the response in the embed context.
     location /embed/ {
-        try_files $uri $uri/ /index.html;
+        try_files $uri $uri/ @embed_index;
         # Re-declare headers — nginx add_header does not inherit when a location
         # block defines its own. X-Frame-Options is intentionally omitted.
+        add_header X-Content-Type-Options nosniff always;
+        add_header Referrer-Policy strict-origin-when-cross-origin always;
+        add_header Permissions-Policy "camera=(), microphone=()" always;
+        add_header Content-Security-Policy "frame-ancestors 'self' ${EMBED_ALLOWED_ORIGINS}" always;
+    }
+
+    location @embed_index {
+        # Serve the SPA shell for any /embed/* path that doesn't match a real
+        # file. `rewrite ... break` rewrites within this location instead of
+        # doing an internal redirect, so the embed headers below are what the
+        # client receives.
+        rewrite ^ /index.html break;
         add_header X-Content-Type-Options nosniff always;
         add_header Referrer-Policy strict-origin-when-cross-origin always;
         add_header Permissions-Policy "camera=(), microphone=()" always;


### PR DESCRIPTION
## Summary

PR #153 set `Content-Security-Policy: frame-ancestors` and dropped `X-Frame-Options` on `location /embed/`, but the SPA fallback used `try_files $uri $uri/ /index.html` — and the trailing `/index.html` argument is a URI, which triggers an internal redirect that re-runs location matching against `location /`. The request is then served by `location /`, with its `X-Frame-Options: SAMEORIGIN` header — and the embed headers never reach the client.

In production today, every `/embed/*` response on `scout.dimagi.com` carries `X-Frame-Options: SAMEORIGIN` and no CSP, so the iframe at `labs.connect.dimagi.com/labs/scout-prod/` is still refused.

This PR routes the SPA fallback through a named location (`@embed_index`) and serves `/index.html` via `rewrite ^ /index.html break;`. `break` rewrites within the current location instead of doing an internal redirect, so the embed-specific headers stay attached to the response. `add_header` is not inherited into named locations, so the directives are repeated.

## Verification

Live state before fix (`curl -I https://scout.dimagi.com/embed/`):

```
x-frame-options: SAMEORIGIN
(no content-security-policy header)
```

Rendered the template through envsubst with `EMBED_ALLOWED_ORIGINS=https://labs.connect.dimagi.com` — both the `/embed/` location and the new `@embed_index` named location include:

```
add_header Content-Security-Policy "frame-ancestors 'self' https://labs.connect.dimagi.com" always;
```

…and `X-Frame-Options` is absent in both blocks.

Wasn't able to run `nginx -t` or a full container locally (no Docker daemon available), so the post-deploy verification below is what catches a config-syntax mistake.

## Test plan

- [ ] Deploy and confirm `curl -I https://scout.dimagi.com/embed/` returns `Content-Security-Policy: frame-ancestors 'self' https://labs.connect.dimagi.com` and **no** `X-Frame-Options` header
- [ ] Same for a virtual SPA path like `/embed/foo`
- [ ] Confirm `/` and other routes still return `X-Frame-Options: SAMEORIGIN` (defense-in-depth for non-embed paths)
- [ ] Load `https://labs.connect.dimagi.com/labs/scout-prod/` and confirm the iframe renders, OAuth login completes, and tenant switching flows through

🤖 Generated with [Claude Code](https://claude.com/claude-code)