### PR TITLE
fix(commcare): follow meta.next for TastyPie API pagination

### DIFF
--- a/mcp_server/loaders/commcare_forms.py
+++ b/mcp_server/loaders/commcare_forms.py
@@ -66,7 +66,9 @@ class CommCareFormLoader(CommCareBaseLoader):
                     self.domain,
                 )
                 yield forms, page_total
-            url = data.get("next")
+            url = data.get("meta", {}).get("next")
+            if url and url.startswith("/"):
+                url = f"{_BASE_URL}{url}"
             params = {}
 
     def load(self) -> list[dict]:

--- a/mcp_server/loaders/commcare_metadata.py
+++ b/mcp_server/loaders/commcare_metadata.py
@@ -51,7 +51,9 @@ class CommCareMetadataLoader(CommCareBaseLoader):
         while url:
             data = self._get(url, params=params).json()
             apps.extend(data.get("objects", []))
-            url = data.get("next")
+            url = data.get("meta", {}).get("next")
+            if url and url.startswith("/"):
+                url = f"{_BASE_URL}{url}"
             params = {}
         return apps
 

--- a/tests/test_commcare_forms_loader.py
+++ b/tests/test_commcare_forms_loader.py
@@ -21,8 +21,7 @@ class TestCommCareFormLoader:
         mock_resp = MagicMock()
         mock_resp.status_code = 200
         mock_resp.json.return_value = {
-            "next": None,
-            "meta": {"total_count": 2},
+            "meta": {"total_count": 2, "next": None},
             "objects": [
                 {
                     "id": "f1",
@@ -48,15 +47,16 @@ class TestCommCareFormLoader:
         page1 = MagicMock()
         page1.status_code = 200
         page1.json.return_value = {
-            "next": "https://www.commcarehq.org/a/dimagi/api/v0.5/form/?cursor=x",
-            "meta": {"total_count": 3},
+            "meta": {
+                "total_count": 3,
+                "next": "/a/dimagi/api/v0.5/form/?offset=2&limit=2",
+            },
             "objects": [{"id": "f1", "form": {}}, {"id": "f2", "form": {}}],
         }
         page2 = MagicMock()
         page2.status_code = 200
         page2.json.return_value = {
-            "next": None,
-            "meta": {"total_count": 3},
+            "meta": {"total_count": 3, "next": None},
             "objects": [{"id": "f3", "form": {}}],
         }
 
@@ -73,12 +73,15 @@ class TestCommCareFormLoader:
         page1 = MagicMock()
         page1.status_code = 200
         page1.json.return_value = {
-            "next": "https://www.commcarehq.org/a/dimagi/api/v0.5/form/?cursor=x",
+            "meta": {"next": "/a/dimagi/api/v0.5/form/?offset=2&limit=2"},
             "objects": [{"id": "f1", "form": {}}, {"id": "f2", "form": {}}],
         }
         page2 = MagicMock()
         page2.status_code = 200
-        page2.json.return_value = {"next": None, "objects": [{"id": "f3", "form": {}}]}
+        page2.json.return_value = {
+            "meta": {"next": None},
+            "objects": [{"id": "f3", "form": {}}],
+        }
 
         with _mock_session([page1, page2]):
             pages = list(
@@ -93,6 +96,49 @@ class TestCommCareFormLoader:
         assert len(pages[0][0]) == 2
         assert len(pages[1][0]) == 1
         assert pages[0][1] is None and pages[1][1] is None
+
+    def test_follows_meta_next_url_across_pages(self):
+        """Regression test: pagination must follow ``meta.next``, not a top-level
+        ``next`` key. The CommCare HQ v0.5 form API uses TastyPie envelope
+        format which nests pagination links inside ``meta``. Reading
+        ``data["next"]`` always returns ``None`` and silently truncates the
+        result set to the first page (1000 records).
+        """
+        from mcp_server.loaders.commcare_forms import CommCareFormLoader
+
+        page1 = MagicMock()
+        page1.status_code = 200
+        page1.json.return_value = {
+            # A top-level ``next`` should be IGNORED — TastyPie never puts it
+            # here. Older code read this field and incorrectly returned None.
+            "next": None,
+            "meta": {
+                "total_count": 4,
+                "next": "/a/dimagi/api/v0.5/form/?offset=2&limit=2",
+            },
+            "objects": [{"id": "f1", "form": {}}, {"id": "f2", "form": {}}],
+        }
+        page2 = MagicMock()
+        page2.status_code = 200
+        page2.json.return_value = {
+            "meta": {"total_count": 4, "next": None},
+            "objects": [{"id": "f3", "form": {}}, {"id": "f4", "form": {}}],
+        }
+
+        with _mock_session([page1, page2]) as mock_session_cls:
+            forms = CommCareFormLoader(
+                domain="dimagi", credential={"type": "api_key", "value": "user:key"}
+            ).load()
+
+        assert len(forms) == 4
+        session = mock_session_cls.return_value
+        assert session.get.call_count == 2
+        # Second call must resolve the relative meta.next path against the
+        # API base URL.
+        second_call_url = session.get.call_args_list[1].args[0]
+        assert second_call_url == (
+            "https://www.commcarehq.org/a/dimagi/api/v0.5/form/?offset=2&limit=2"
+        )
 
     def test_raises_on_auth_failure(self):
         from mcp_server.loaders.commcare_base import CommCareAuthError

--- a/tests/test_commcare_metadata_loader.py
+++ b/tests/test_commcare_metadata_loader.py
@@ -36,7 +36,7 @@ def _make_app_response():
                 ],
             }
         ],
-        "next": None,
+        "meta": {"next": None},
     }
 
 
@@ -116,25 +116,37 @@ class TestCommCareMetadataLoader:
             ).load()
 
     def test_paginates_apps(self):
+        """Pagination must follow ``meta.next`` (TastyPie envelope), not a
+        top-level ``next`` field. A top-level ``next`` is intentionally
+        included to ensure it is IGNORED.
+        """
         from mcp_server.loaders.commcare_metadata import CommCareMetadataLoader
 
         page1 = MagicMock()
         page1.status_code = 200
         page1.json.return_value = {
             "objects": [{"id": "app1", "name": "App 1", "modules": []}],
-            "next": "https://www.commcarehq.org/a/dimagi/api/v0.5/application/?offset=1",
+            # Top-level next must be ignored.
+            "next": None,
+            "meta": {"next": "/a/dimagi/api/v0.5/application/?offset=1&limit=100"},
         }
         page2 = MagicMock()
         page2.status_code = 200
         page2.json.return_value = {
             "objects": [{"id": "app2", "name": "App 2", "modules": []}],
-            "next": None,
+            "meta": {"next": None},
         }
 
-        with self._mock_session([page1, page2]):
+        with self._mock_session([page1, page2]) as mock_session_cls:
             loader = CommCareMetadataLoader(
                 domain="dimagi", credential={"type": "api_key", "value": "user:key"}
             )
             result = loader.load()
 
         assert len(result["app_definitions"]) == 2
+        session = mock_session_cls.return_value
+        assert session.get.call_count == 2
+        second_call_url = session.get.call_args_list[1].args[0]
+        assert second_call_url == (
+            "https://www.commcarehq.org/a/dimagi/api/v0.5/application/?offset=1&limit=100"
+        )


### PR DESCRIPTION
## Summary

- The CommCare form loader (`api/v0.5/form/`) and application metadata loader (`api/v0.5/application/`) were reading the pagination link from the wrong place — `data[\"next\"]` instead of `data[\"meta\"][\"next\"]`. CommCare HQ's v0.5 endpoints use TastyPie's envelope, so the top-level key never existed; `next` was always `None`, pagination terminated after the first request, and we silently capped at the page size: **1000 forms** and **100 apps**.
- Symptom in the field: users only saw their 1000 most-recently-received forms in the materialized `raw_forms` table.
- Also handles that TastyPie's `meta.next` is **path-only** (e.g. `/a/<domain>/api/v0.5/form/?offset=1000&limit=1000`) — prepend `_BASE_URL` so `requests.get` accepts it.
- Why it slipped through: the old test fixtures matched the buggy code (`next` at the top level), so they always passed. Updated fixtures to mirror the real API shape and added regression tests that assert a second page is actually fetched and that relative `meta.next` paths are resolved against the base URL.

## Scope check — other loaders

- **CommCare cases** (Case API v2): top-level `next` per the v2 envelope — fine
- **CommCare Connect** (7 loaders): centralized in `connect_base._paginate_export_pages`, DRF-style top-level `next`/`count` — fine
- **OCS** (4 loaders): centralized in `ocs_base._paginate`, DRF cursor-style top-level `next` — fine
- **Connect/OCS metadata**: single-fetch, no pagination

## Test plan

- [x] `uv run pytest` — 900 passed, 8 skipped (no regressions)
- [x] New regression tests fail under the old code and pass under the fix:
  - `test_follows_meta_next_url_across_pages` (forms)
  - `test_paginates_apps` updated to ignore a stray top-level `next` and require the second call to hit the resolved absolute URL from `meta.next`
- [x] `ruff check` / `ruff format --check` clean
- [ ] Re-materialize a CommCare domain known to have >1000 forms and confirm `raw_forms` row count matches `meta.total_count`

🤖 Generated with [Claude Code](https://claude.com/claude-code)