### PR TITLE
fix(artifacts): expose full Recharts surface to React sandbox

### DIFF
--- a/apps/agents/prompts/artifact_prompt.py
+++ b/apps/agents/prompts/artifact_prompt.py
@@ -65,7 +65,15 @@ Choose the appropriate artifact type based on the use case:
 For React artifacts, follow these patterns:
 
 **Available Libraries (pre-loaded, no imports needed from CDN):**
-- `recharts` - For charts (LineChart, BarChart, PieChart, AreaChart, etc.)
+- `recharts` - For charts. The sandbox exposes the full Recharts v2 surface:
+  - Charts: `LineChart`, `BarChart`, `AreaChart`, `ComposedChart`, `PieChart`,
+    `RadarChart`, `RadialBarChart`, `ScatterChart`, `FunnelChart`, `Treemap`, `Sankey`
+  - Series: `Line`, `Bar`, `Area`, `Pie`, `Radar`, `RadialBar`, `Scatter`, `Funnel`
+  - Axes & grids: `XAxis`, `YAxis`, `ZAxis`, `CartesianGrid`, `PolarGrid`,
+    `PolarAngleAxis`, `PolarRadiusAxis`
+  - Reference shapes: `ReferenceLine`, `ReferenceArea`, `ReferenceDot`
+  - Decorations: `Tooltip`, `Legend`, `Label`, `LabelList`, `Cell`, `Brush`,
+    `ErrorBar`, `Customized`, `ResponsiveContainer`
 - `react` - Core React (useState, useEffect, useMemo, etc.)
 - `lucide-react` - Icons
 

--- a/apps/artifacts/views.py
+++ b/apps/artifacts/views.py
@@ -354,12 +354,24 @@ SANDBOX_HTML_TEMPLATE = """<!DOCTYPE html>
                         `
                         const { useState, useEffect, useRef, useMemo, useCallback, memo, Fragment } = React;
                         const {
-                            LineChart, Line, AreaChart, Area, BarChart, Bar,
-                            PieChart, Pie, Cell, ScatterChart, Scatter,
-                            XAxis, YAxis, CartesianGrid, Tooltip, Legend,
-                            ResponsiveContainer, ComposedChart, RadarChart, Radar,
+                            // Charts
+                            AreaChart, BarChart, ComposedChart, LineChart, PieChart,
+                            RadarChart, RadialBarChart, ScatterChart, FunnelChart,
+                            Treemap, Sankey,
+                            // Series
+                            Area, Bar, Line, Pie, Radar, RadialBar, Scatter, Funnel,
+                            // Axes & grids
+                            XAxis, YAxis, ZAxis, CartesianGrid, CartesianAxis,
                             PolarGrid, PolarAngleAxis, PolarRadiusAxis,
-                            Treemap, Sankey, FunnelChart, Funnel
+                            // Reference shapes
+                            ReferenceLine, ReferenceArea, ReferenceDot,
+                            // Decorations
+                            Tooltip, Legend, Label, LabelList, Cell, Customized,
+                            Brush, ErrorBar,
+                            // Containers & primitives
+                            ResponsiveContainer, Cross, Curve, Dot, Polygon,
+                            Rectangle, Sector, Symbols, Trapezoid,
+                            Layer, Surface, Text
                         } = Recharts;
 
                         // Lucide icon helper: creates a React component from a lucide icon name


### PR DESCRIPTION
> ⚠️ **Partial fix.** This resolves the specific `ReferenceError: ReferenceLine is not defined` failure that Nazier reported, but the broader "Scout artifacts sometimes don't render" problem has additional layers that this PR does NOT touch. See "What this PR does not fix" below.

## Summary
- The sandbox destructured only ~25 Recharts components into scope; artifacts that reached for `ReferenceLine`, `Label`, `LabelList`, `Brush`, `ReferenceArea`, `RadialBarChart`, etc. crashed at render with `ReferenceError: X is not defined`.
- Expanded the destructure in `apps/artifacts/views.py` to cover the full Recharts v2 export surface (charts, series, axes, reference shapes, decorations, containers, primitives).
- Updated `apps/agents/prompts/artifact_prompt.py` to list the supported components so the agent knows what it can use.

## Context
Reported by Nazier on Slack: histograms with a median/mean reference line failed to render with `ReferenceError: ReferenceLine is not defined at Metric1Histogram`. The model legitimately reached for `ReferenceLine` from Recharts; the sandbox just wasn't binding it.

## What this PR does NOT fix
1. **Standalone HTML export (`apps/artifacts/services/export.py`).** It doesn't strip module syntax or destructure Recharts at all, so any React artifact with `import { ... } from "recharts"` is likely broken in exported HTML. Separate PR.
2. **No error feedback to the agent when the sandbox crashes.** Today the chat happily reports "Perfect! I've created..." even when the artifact blows up at render — the agent can't self-correct or warn the user. Worth a follow-up; we may want a postMessage error channel from the sandbox iframe back to the chat surface.
3. **Lucide icon allowlist has the same shape of bug.** `views.py` hardcodes ~10 icon names (TrendingUp, ShoppingCart, etc.); any other lucide icon the model asks for will be `undefined`. Not changed here.

## Test plan
- [ ] Local: create a React artifact that uses `ReferenceLine` (and `Label`, `Brush`) and confirm it renders in the sandbox
- [ ] Reproduce the original Slack scenario (histogram with median line) on a real chat and confirm it renders
- [ ] Spot-check existing artifacts still render (regression check on `LineChart`, `BarChart`, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
