### PR TITLE
feat(workspace): show opportunity IDs + search in tenant picker

### DIFF
--- a/docs/superpowers/specs/2026-05-22-tenant-picker-ids-and-search-design.md
+++ b/docs/superpowers/specs/2026-05-22-tenant-picker-ids-and-search-design.md
@@ -1,0 +1,59 @@
+# Tenant picker: show opportunity IDs + search
+
+## Problem
+
+When adding data sources to a workspace via the **Tenants** tab on `WorkspaceDetailPage`, the available-tenants list shows only the human-readable name plus the provider (e.g. `Mother Baby Wellness [Cohort 1 - Solina]   commcare_connect`). Many CommCare projects share near-identical names ("Mother Baby Wellness [Cohort 1 - Ruwoyd]", "Mother Baby Wellness [Cohort 2 - Ruwoyd]", "Mother Baby Wellness - [Ruwoyd - Learn Experiment 2]", ...), so reproducing a workspace from a list of opportunity IDs (e.g. `524, 675, 874, 938, 1236, 1487, 1488, 1739, 1790`) requires guessing which name maps to which ID.
+
+The opportunity ID is already returned by the API (`UserTenant.tenant_id`, see `frontend/src/api/auth.ts:6`), but never rendered.
+
+## Scope
+
+Smallest viable change. **Out of scope:** a bulk paste-IDs flow, fuzzy matching, debouncing, backend changes.
+
+## Changes
+
+**File:** `frontend/src/pages/WorkspaceDetailPage/WorkspaceDetailPage.tsx`, `TenantsTab` component (lines 293-448).
+
+### 1. Render `tenant_id` in the available list
+
+Available rows currently render `tenant_name` and `provider` inline on one line (lines 374-378). Restructure to match the two-line layout already used by the connected-tenants list below it:
+
+- Line 1 (`font-medium`): `{tenant_name}`
+- Line 2 (`text-xs text-muted-foreground`): `#{tenant_id} · {provider}`
+
+### 2. Render `tenant_id` in the connected-tenants list
+
+Lines 403-411 currently show `{tenant_name}` over `{provider}`. Change the subtitle to `#{tenant_id} · {provider}` so the user can audit which opportunities ended up in the workspace.
+
+### 3. Search input above the available list
+
+When the add panel is open (`showAdd && available.length > 0`), render a search input above the rows.
+
+- Single text field; placeholder `Search by name or opportunity ID…`
+- Client-side filter: case-insensitive match of the query against `tenant_name` OR `tenant_id` (substring match in both fields)
+- `data-testid="tenant-search-input"`
+- Empty-result state: `No data sources match "<query>".`
+- Search query is reset to `""` whenever the add panel closes (`showAdd` toggles to false)
+- Search query is **preserved** when the list refreshes after a successful add — the user is usually adding several in a row that share a substring, and resetting the filter forces them to re-type
+
+## Edge cases
+
+- Query containing only whitespace shows the full list (treat as empty query).
+- A user pastes `"#874"` — the leading `#` should not break the match. Strip a leading `#` from the query before comparing.
+
+## Testing
+
+Manual verification via `playwright-cli` against the dev server:
+
+1. `uv run honcho -f Procfile.dev start`
+2. Open a workspace's Tenants tab
+3. Click **+ Add data source**
+4. Confirm each available row shows `#<id> · <provider>`
+5. Type `874` → only the matching opportunity remains
+6. Type `mother baby` → all MBW opportunities remain
+7. Type `#874` → matches
+8. Type `zzzz` → empty-state message visible
+9. Add one tenant → list refreshes, search query persists
+10. Close the add panel → reopen → search input is empty
+
+No new automated tests. The change is presentational filtering over an already-tested data path; logic complexity does not warrant a unit test.

--- a/frontend/src/pages/WorkspaceDetailPage/WorkspaceDetailPage.tsx
+++ b/frontend/src/pages/WorkspaceDetailPage/WorkspaceDetailPage.tsx
@@ -298,8 +298,14 @@ function TenantsTab({ workspaceId, isManager }: { workspaceId: string; isManager
   const [addingId, setAddingId] = useState<string | null>(null)
   const [removingId, setRemovingId] = useState<string | null>(null)
   const [showAdd, setShowAdd] = useState(false)
+  const [query, setQuery] = useState("")
   const [confirmRemoveId, setConfirmRemoveId] = useState<string | null>(null)
   const [mutationError, setMutationError] = useState<string | null>(null)
+
+  // Reset search when the add panel is closed manually.
+  useEffect(() => {
+    if (!showAdd) setQuery("")
+  }, [showAdd])
 
   const load = useCallback(async () => {
     setLoading(true)
@@ -324,12 +330,23 @@ function TenantsTab({ workspaceId, isManager }: { workspaceId: string; isManager
   const inWorkspaceIds = new Set(tenants.map((t) => t.tenant_id))
   const available = userTenants.filter((t) => !inWorkspaceIds.has(t.tenant_uuid))
 
+  // Internal-UUID → external opportunity ID, for the connected list display.
+  const externalIdByUuid = new Map(userTenants.map((t) => [t.tenant_uuid, t.tenant_id]))
+
+  const normalizedQuery = query.trim().replace(/^#/, "").toLowerCase()
+  const filteredAvailable = normalizedQuery
+    ? available.filter(
+        (t) =>
+          t.tenant_name.toLowerCase().includes(normalizedQuery) ||
+          t.tenant_id.toLowerCase().includes(normalizedQuery),
+      )
+    : available
+
   async function handleAdd(tenantUuid: string) {
     setAddingId(tenantUuid)
     try {
       await workspaceApi.addTenant(workspaceId, tenantUuid)
       await load()
-      setShowAdd(false)
     } catch (err) {
       setMutationError(err instanceof ApiError ? err.message : "Failed to add data source")
     } finally {
@@ -369,24 +386,40 @@ function TenantsTab({ workspaceId, isManager }: { workspaceId: string; isManager
       {showAdd && available.length > 0 && (
         <div className="mb-4 rounded-lg border bg-muted/30 p-4">
           <p className="mb-2 text-sm font-medium">Available data sources</p>
-          <div className="space-y-2">
-            {available.map((t) => (
-              <div key={t.tenant_uuid} className="flex items-center justify-between">
-                <div>
-                  <span className="text-sm">{t.tenant_name}</span>
-                  <span className="ml-2 text-xs text-muted-foreground">{t.provider}</span>
+          <Input
+            type="search"
+            placeholder="Search by name or opportunity ID…"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            className="mb-3"
+            data-testid="tenant-search-input"
+          />
+          {filteredAvailable.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              No data sources match &ldquo;{normalizedQuery}&rdquo;.
+            </p>
+          ) : (
+            <div className="space-y-2">
+              {filteredAvailable.map((t) => (
+                <div key={t.tenant_uuid} className="flex items-center justify-between">
+                  <div>
+                    <div className="text-sm font-medium">{t.tenant_name}</div>
+                    <div className="text-xs text-muted-foreground">
+                      #{t.tenant_id} · {t.provider}
+                    </div>
+                  </div>
+                  <Button
+                    size="sm"
+                    onClick={() => handleAdd(t.tenant_uuid)}
+                    disabled={addingId === t.tenant_uuid}
+                    data-testid={`add-tenant-${t.tenant_uuid}`}
+                  >
+                    {addingId === t.tenant_uuid ? "Adding…" : "Add"}
+                  </Button>
                 </div>
-                <Button
-                  size="sm"
-                  onClick={() => handleAdd(t.tenant_uuid)}
-                  disabled={addingId === t.tenant_uuid}
-                  data-testid={`add-tenant-${t.tenant_uuid}`}
-                >
-                  {addingId === t.tenant_uuid ? "Adding…" : "Add"}
-                </Button>
-              </div>
-            ))}
-          </div>
+              ))}
+            </div>
+          )}
         </div>
       )}
 
@@ -408,7 +441,11 @@ function TenantsTab({ workspaceId, isManager }: { workspaceId: string; isManager
             >
               <div>
                 <div className="font-medium">{t.tenant_name}</div>
-                <div className="text-xs text-muted-foreground">{t.provider}</div>
+                <div className="text-xs text-muted-foreground">
+                  {externalIdByUuid.has(t.tenant_id)
+                    ? `#${externalIdByUuid.get(t.tenant_id)} · ${t.provider}`
+                    : t.provider}
+                </div>
               </div>
               {isManager && tenants.length > 1 && (
                 confirmRemoveId === t.id ? (


### PR DESCRIPTION
## Summary

- Reproducing a workspace from a list of opportunity IDs was effectively impossible from the UI — many CommCare projects share near-identical names (multiple "Mother Baby Wellness [Cohort N - ...]" entries) and the opportunity ID was never rendered, even though the API already returns it (`UserTenant.tenant_id`).
- Render `#<external-id> · <provider>` on both the available and connected tenant lists in `WorkspaceDetailPage` → Tenants tab.
- Add a search input above the available list, filtering by name or opportunity ID (case-insensitive substring; a leading `#` is tolerated).
- Stop auto-closing the add panel after a successful add, so users adding several opportunities in a row keep their filter active.

Spec: `docs/superpowers/specs/2026-05-22-tenant-picker-ids-and-search-design.md`

## Test plan

- [ ] Open a workspace → Tenants tab → click **+ Add data source**
- [ ] Each available row shows `#<id> · <provider>` under the name
- [ ] Type an opportunity ID (e.g. `874`) → only the matching opportunity remains
- [ ] Type `#874` → still matches
- [ ] Type `mother baby` → all MBW opportunities remain
- [ ] Type `zzzz` → empty-state message visible
- [ ] Add one tenant → list refreshes, search query persists, panel stays open
- [ ] Close the add panel → reopen → search input is empty
- [ ] Connected list also shows `#<id> · <provider>` subtitle

🤖 Generated with [Claude Code](https://claude.com/claude-code)