### PR TITLE
fix(agents): pre-fetch data availability for multi-tenant workspaces

### DIFF
--- a/apps/agents/graph/base.py
+++ b/apps/agents/graph/base.py
@@ -37,13 +37,19 @@ from apps.agents.tools.artifact_tool import create_artifact_tools
 from apps.agents.tools.learning_tool import create_save_learning_tool
 from apps.agents.tools.recipe_tool import create_recipe_tool
 from apps.knowledge.services.retriever import KnowledgeRetriever
-from apps.workspaces.models import SchemaState, TenantSchema
-from mcp_server.context import load_tenant_context
+from apps.workspaces.models import (
+    MaterializationRun,
+    SchemaState,
+    TenantSchema,
+    WorkspaceViewSchema,
+)
+from mcp_server.context import load_tenant_context, load_workspace_context
 from mcp_server.pipeline_registry import get_registry
 from mcp_server.services.metadata import (
     pipeline_describe_table,
     pipeline_list_tables,
     transformation_aware_list_tables,
+    workspace_list_tables,
 )
 
 if TYPE_CHECKING:
@@ -164,7 +170,7 @@ async def _fetch_schema_context(tenant, user) -> str:
     if ts is None:
         return (
             f"No data has been loaded yet. Call `run_materialization` with "
-            f"`pipeline=\"{pipeline_name}\"` to start loading. This tool returns "
+            f'`pipeline="{pipeline_name}"` to start loading. This tool returns '
             f"IMMEDIATELY with `status: started` — do NOT call other data tools "
             f"in the same turn. Acknowledge to the user in ONE sentence and end "
             f"your turn. The system will resume the conversation automatically "
@@ -238,6 +244,100 @@ async def _fetch_schema_context(tenant, user) -> str:
             "Use the `get_lineage` tool to explore how any table was built."
         )
     return compact
+
+
+_MULTI_TENANT_NAMESPACE_HINT = (
+    "This is a multi-tenant workspace. Tables are namespaced views prefixed with the "
+    "tenant name using double underscore: `{tenant_name}__{table_name}`. "
+    "To query across tenants, use explicit JOINs between namespaced tables."
+)
+
+
+async def _fetch_multi_tenant_schema_context(workspace, user) -> str:
+    """Build the ## Data Availability block for a multi-tenant workspace.
+
+    Mirrors `_fetch_schema_context` but consults `WorkspaceViewSchema` plus the
+    per-tenant `MaterializationRun` records, so the agent knows up front whether
+    data is loaded, still materializing, or missing — without having to call
+    `list_tables` first to discover the state.
+    """
+    vs = await WorkspaceViewSchema.objects.filter(workspace_id=workspace.id).afirst()
+
+    tenant_ids = [t.id async for t in workspace.tenants.all()]
+
+    active_run = None
+    if tenant_ids:
+        active_run = await MaterializationRun.objects.filter(
+            tenant_schema__tenant_id__in=tenant_ids,
+            state__in=list(MaterializationRun.ACTIVE_STATES),
+        ).afirst()
+
+    if active_run is not None or (vs is not None and vs.state == SchemaState.MATERIALIZING):
+        return (
+            "A materialization is already in progress in the background. Do NOT "
+            "trigger another one and do NOT call other data tools (the data is "
+            "not yet ready). Briefly tell the user it's still loading and end "
+            "your turn — the system will resume the conversation automatically "
+            "when the current materialization completes."
+        )
+
+    if vs is None or vs.state != SchemaState.ACTIVE:
+        return (
+            f"{_MULTI_TENANT_NAMESPACE_HINT}\n\n"
+            "No data has been loaded yet. Call `run_materialization` to start "
+            "loading data for all tenants in this workspace. This tool returns "
+            "IMMEDIATELY with `status: started` — do NOT call other data tools "
+            "in the same turn. Acknowledge to the user in ONE sentence and end "
+            "your turn. The system will resume the conversation automatically "
+            "when materialization completes."
+        )
+
+    # View schema is ACTIVE — list the namespaced views from information_schema.
+    tables: list[dict] = []
+    try:
+        ctx = await load_workspace_context(str(workspace.id))
+        tables = await workspace_list_tables(ctx)
+    except Exception:
+        logger.debug("Could not fetch multi-tenant table list for context injection", exc_info=True)
+
+    last_run = None
+    if tenant_ids:
+        last_run = (
+            await MaterializationRun.objects.filter(
+                tenant_schema__tenant_id__in=tenant_ids,
+                state=MaterializationRun.RunState.COMPLETED,
+            )
+            .order_by("-completed_at")
+            .afirst()
+        )
+    last_materialized_at = (
+        last_run.completed_at.isoformat() if last_run and last_run.completed_at else None
+    )
+
+    if not tables:
+        return (
+            f"{_MULTI_TENANT_NAMESPACE_HINT}\n\n"
+            "Data is loaded but no tables are visible yet. The view schema may "
+            "still be initializing — call `list_tables` to re-check shortly."
+        )
+
+    lines: list[str] = []
+    if last_materialized_at:
+        lines.append(f"Data is loaded and ready. Last updated: {last_materialized_at}")
+    else:
+        lines.append("Data is loaded and ready.")
+    lines.append("")
+    lines.append(_MULTI_TENANT_NAMESPACE_HINT)
+    lines.append("")
+    lines.append("### Available Tables")
+    lines.append("")
+    lines.append("| Table |")
+    lines.append("|---|")
+    for t in tables:
+        lines.append(f"| {t['name']} |")
+    lines.append("")
+    lines.append("Use the `describe_table` tool for column details.")
+    return "\n".join(lines)
 
 
 def _llm_tool_schemas(tools: list, hidden_params: list[str]) -> list:
@@ -583,13 +683,8 @@ When results are truncated, suggest adding filters or using aggregations to redu
 
 When results are truncated, suggest adding filters or using aggregations to reduce the result size.
 """)
-        sections.append(
-            "\n## Data Availability\n\n"
-            "This is a multi-tenant workspace. Tables are prefixed with the tenant name "
-            "using double underscore: `{tenant_name}__{table_name}`.\n"
-            "To query across tenants, use explicit JOINs between namespaced tables.\n"
-            "Call `list_tables` to see all available tables.\n"
-        )
+        schema_context = await _fetch_multi_tenant_schema_context(workspace, user)
+        sections.append(f"\n## Data Availability\n\n{schema_context}\n")
 
     result = "\n".join(sections)
 

--- a/tests/agents/test_schema_context.py
+++ b/tests/agents/test_schema_context.py
@@ -4,7 +4,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from apps.agents.graph.base import _fetch_schema_context
+from apps.agents.graph.base import (
+    _fetch_multi_tenant_schema_context,
+    _fetch_schema_context,
+)
 
 
 @pytest.fixture
@@ -232,3 +235,180 @@ async def test_build_system_prompt_no_schema_status_call():
     assert "call `get_schema_status`" not in prompt
     assert "start of every conversation" not in prompt
     assert "## Data Availability" in prompt
+
+
+# --- Multi-tenant ---
+
+
+class _AsyncIter:
+    """Re-iterable async iterator over a fixed list, for mocking Django async QuerySets."""
+
+    def __init__(self, items):
+        self._items = list(items)
+
+    def __aiter__(self):
+        # Return a fresh iterator so `async for` can be used multiple times.
+        return _AsyncIter(self._items).__aiter_inner__()
+
+    async def __aiter_inner__(self):
+        for item in self._items:
+            yield item
+
+
+@pytest.fixture
+def mock_multi_workspace():
+    """Workspace with 2 tenants. Subclass tunes `tenants` queryset behavior per test."""
+    ws = MagicMock()
+    ws.id = "11111111-1111-1111-1111-111111111111"
+    t1 = MagicMock()
+    t1.id = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    t2 = MagicMock()
+    t2.id = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+    ws.tenants.all.return_value = _AsyncIter([t1, t2])
+    return ws
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+async def test_fetch_multi_tenant_no_view_schema_no_runs(mock_multi_workspace, mock_user):
+    """No view schema and no active runs -> agent told to call run_materialization."""
+    with (
+        patch("apps.agents.graph.base.WorkspaceViewSchema") as MockVS,
+        patch("apps.agents.graph.base.MaterializationRun") as MockMR,
+    ):
+        MockVS.objects.filter.return_value.afirst = AsyncMock(return_value=None)
+        MockMR.objects.filter.return_value.afirst = AsyncMock(return_value=None)
+        MockMR.ACTIVE_STATES = frozenset({"started", "discovering", "loading", "transforming"})
+
+        result = await _fetch_multi_tenant_schema_context(mock_multi_workspace, mock_user)
+
+    assert "No data has been loaded yet" in result
+    assert "run_materialization" in result
+    assert "multi-tenant" in result.lower()
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+async def test_fetch_multi_tenant_view_schema_materializing(mock_multi_workspace, mock_user):
+    """View schema in MATERIALIZING -> 'still loading' message."""
+    from apps.workspaces.models import SchemaState
+
+    vs = MagicMock()
+    vs.state = SchemaState.MATERIALIZING
+
+    with (
+        patch("apps.agents.graph.base.WorkspaceViewSchema") as MockVS,
+        patch("apps.agents.graph.base.MaterializationRun") as MockMR,
+    ):
+        MockVS.objects.filter.return_value.afirst = AsyncMock(return_value=vs)
+        MockMR.objects.filter.return_value.afirst = AsyncMock(return_value=None)
+        MockMR.ACTIVE_STATES = frozenset({"started", "discovering", "loading", "transforming"})
+
+        result = await _fetch_multi_tenant_schema_context(mock_multi_workspace, mock_user)
+
+    assert "in progress" in result.lower()
+    assert "run_materialization" not in result
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+async def test_fetch_multi_tenant_active_materialization_run(mock_multi_workspace, mock_user):
+    """An active MaterializationRun for a tenant -> 'still loading' message, even if
+    the view schema is not present yet."""
+    active_run = MagicMock()
+
+    with (
+        patch("apps.agents.graph.base.WorkspaceViewSchema") as MockVS,
+        patch("apps.agents.graph.base.MaterializationRun") as MockMR,
+    ):
+        MockVS.objects.filter.return_value.afirst = AsyncMock(return_value=None)
+        MockMR.objects.filter.return_value.afirst = AsyncMock(return_value=active_run)
+        MockMR.ACTIVE_STATES = frozenset({"started", "discovering", "loading", "transforming"})
+
+        result = await _fetch_multi_tenant_schema_context(mock_multi_workspace, mock_user)
+
+    assert "in progress" in result.lower()
+    assert "run_materialization" not in result
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+async def test_fetch_multi_tenant_active_with_tables(mock_multi_workspace, mock_user):
+    """View schema ACTIVE -> emits table list from workspace_list_tables + namespacing hint."""
+    from apps.workspaces.models import SchemaState
+
+    vs = MagicMock()
+    vs.state = SchemaState.ACTIVE
+
+    completed_run = MagicMock()
+    completed_run.completed_at.isoformat.return_value = "2026-05-22T10:00:00"
+
+    tables = [
+        {"name": "tenant_a__raw_cases", "type": "view", "row_count": None},
+        {"name": "tenant_a__raw_forms", "type": "view", "row_count": None},
+        {"name": "tenant_b__raw_cases", "type": "view", "row_count": None},
+        {"name": "tenant_b__raw_forms", "type": "view", "row_count": None},
+    ]
+
+    with (
+        patch("apps.agents.graph.base.WorkspaceViewSchema") as MockVS,
+        patch("apps.agents.graph.base.MaterializationRun") as MockMR,
+        patch(
+            "apps.agents.graph.base.load_workspace_context",
+            new=AsyncMock(return_value=MagicMock()),
+        ),
+        patch(
+            "apps.agents.graph.base.workspace_list_tables",
+            new=AsyncMock(return_value=tables),
+        ),
+    ):
+        MockVS.objects.filter.return_value.afirst = AsyncMock(return_value=vs)
+        MockMR.ACTIVE_STATES = frozenset({"started", "discovering", "loading", "transforming"})
+        # filter(...).afirst() resolves the active-run check (None);
+        # filter(...).order_by(...).afirst() resolves the last-completed-run lookup.
+        MockMR.objects.filter.return_value.afirst = AsyncMock(return_value=None)
+        MockMR.objects.filter.return_value.order_by.return_value.afirst = AsyncMock(
+            return_value=completed_run
+        )
+
+        result = await _fetch_multi_tenant_schema_context(mock_multi_workspace, mock_user)
+
+    assert "Data is loaded and ready" in result
+    assert "2026-05-22T10:00:00" in result
+    assert "tenant_a__raw_cases" in result
+    assert "tenant_b__raw_forms" in result
+    assert "{tenant_name}__{table_name}" in result
+    assert "describe_table" in result
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+async def test_build_system_prompt_multi_tenant_no_data_pre_fetched():
+    """Multi-tenant workspace with no data: system prompt tells the agent upfront,
+    NOT 'call list_tables to discover'."""
+    from apps.agents.graph.base import _build_system_prompt
+
+    ws = MagicMock()
+    ws.id = "22222222-2222-2222-2222-222222222222"
+    ws.system_prompt = None
+    ws.tenants.acount = AsyncMock(return_value=2)
+    ws.tenants.all.return_value = _AsyncIter([MagicMock(id="aa"), MagicMock(id="bb")])
+
+    with (
+        patch("apps.agents.graph.base.KnowledgeRetriever") as MockKR,
+        patch("apps.agents.graph.base.WorkspaceViewSchema") as MockVS,
+        patch("apps.agents.graph.base.MaterializationRun") as MockMR,
+    ):
+        MockKR.return_value.retrieve = AsyncMock(return_value="")
+        MockVS.objects.filter.return_value.afirst = AsyncMock(return_value=None)
+        MockMR.objects.filter.return_value.afirst = AsyncMock(return_value=None)
+        MockMR.ACTIVE_STATES = frozenset({"started", "discovering", "loading", "transforming"})
+
+        prompt = await _build_system_prompt(ws, MagicMock())
+
+    assert "## Data Availability" in prompt
+    assert "No data has been loaded yet" in prompt
+    assert "run_materialization" in prompt
+    # The old "just call list_tables to discover" hint must not be the only signal
+    # — that was the bug. The agent should know up front there is no data.
+    assert "Call `list_tables` to see all available tables." not in prompt


### PR DESCRIPTION
## Summary
- Multi-tenant workspaces previously got only a static "call \`list_tables\` to discover tables" hint in the system prompt, so the agent always had to do an exploratory tool call before it could tell the user there was no data — single-tenant workspaces skip that round-trip because `_fetch_schema_context` injects `TenantSchema` state up front.
- Add `_fetch_multi_tenant_schema_context` that consults `WorkspaceViewSchema` + per-tenant `MaterializationRun` rows and emits the matching three states (no-data → call `run_materialization`; in-progress → wait; active → table list with namespacing hint).
- Wire it into the `tenant_count > 1` branch of `_build_system_prompt`.

## Test plan
- [x] `uv run pytest tests/agents/test_schema_context.py` — 11 tests pass (5 new: no view schema, view schema materializing, active MaterializationRun, active with tables, full system-prompt integration)
- [x] `uv run pytest tests/test_agent_graph.py tests/test_agent_graph_caching.py` — 6 existing tests still pass
- [x] `uv run ruff check` + `ruff format --check` clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)