### PR TITLE
fix(workspaces): unblock resume task + rebuild view schema post-mat

### DIFF
--- a/apps/workspaces/tasks.py
+++ b/apps/workspaces/tasks.py
@@ -199,9 +199,32 @@ async def materialize_workspace(
                     {"tenant": tenant_id, "success": False, "error": str(e)}
                 )
 
+        all_succeeded = all(r.get("success") for r in tenant_results)
+
+        # Multi-tenant workspaces query through a WorkspaceViewSchema that
+        # UNION ALLs the per-tenant tables. build_view_schema requires every
+        # tenant to have an ACTIVE TenantSchema, so we can only attempt this
+        # after the per-tenant loop completes successfully. This must run
+        # *before* the resume task fires (deferred in the finally block) so
+        # the agent's first list_tables call after materialization returns
+        # the namespaced view instead of "No active view schema for workspace".
+        workspace_tenant_count = await workspace.workspace_tenants.acount()
+        if workspace_tenant_count > 1 and all_succeeded:
+            try:
+                await asyncio.to_thread(SchemaManager().build_view_schema, workspace)
+            except Exception:
+                # Don't re-raise — the resume task should still fire so the
+                # user gets *some* agent response. The view-schema-failed
+                # state is itself queryable by the agent (it will see the
+                # validation error and surface it).
+                logger.exception(
+                    "Post-materialization view schema rebuild failed for workspace %s",
+                    workspace_id,
+                )
+
         return {
             "tenants": tenant_results,
-            "all_succeeded": all(r.get("success") for r in tenant_results),
+            "all_succeeded": all_succeeded,
         }
     finally:
         # ALWAYS defer the resume task so the user is not left with a phantom

--- a/config/deploy-worker.yml
+++ b/config/deploy-worker.yml
@@ -27,12 +27,24 @@ env:
     SENTRY_ENVIRONMENT: "production"
     SENTRY_TRACES_SAMPLE_RATE: "0.1"
     SENTRY_RELEASE: <%= ENV.fetch('IMAGE_TAG', '') %>
+    # Required by resume_thread_after_materialization → get_mcp_tools.
+    # Without this the worker falls back to localhost:8100 and every resume
+    # task fails with httpx.ConnectError.
+    MCP_SERVER_URL: "http://scout-mcp-web:8100/mcp"
+    # Langfuse host for resume-task agent traces (keys come via secrets below).
+    LANGFUSE_BASE_URL: "https://cloud.langfuse.com"
   secret:
     - DATABASE_URL
     - MANAGED_DATABASE_URL
     - DJANGO_SECRET_KEY
     - DB_CREDENTIAL_KEY
     - SENTRY_DSN
+    # Required by ChatAnthropic in build_agent_graph for the resume task.
+    - ANTHROPIC_API_KEY
+    # Without these, the resume task's agent.ainvoke runs untraced — exactly
+    # the blind spot that hid the original ConnectError for two failed runs.
+    - LANGFUSE_SECRET_KEY
+    - LANGFUSE_PUBLIC_KEY
 
 ssh:
   user: scout

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -64,5 +64,10 @@ LOGGING = {
             "level": "INFO",
             "propagate": False,
         },
+        "mcp_server": {
+            "handlers": ["console"],
+            "level": "INFO",
+            "propagate": False,
+        },
     },
 }

--- a/tests/test_materialize_workspace_task.py
+++ b/tests/test_materialize_workspace_task.py
@@ -111,6 +111,147 @@ async def test_materialize_workspace_records_failure(
     assert "upstream API down" in result["tenants"][0]["error"]
 
 
+@pytest.fixture
+def multi_tenant_workspace(db, workspace, user):
+    """Augment the single-tenant `workspace` fixture with a second tenant +
+    membership, so workspace_tenants.acount() > 1."""
+    from apps.users.models import Tenant, TenantMembership
+    from apps.workspaces.models import WorkspaceTenant
+
+    second_tenant = Tenant.objects.create(
+        provider="commcare", external_id="test-domain-2", canonical_name="Test Domain 2"
+    )
+    WorkspaceTenant.objects.create(workspace=workspace, tenant=second_tenant)
+    TenantMembership.objects.create(user=user, tenant=second_tenant)
+    return workspace
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_materialize_workspace_rebuilds_view_schema_when_multi_tenant_succeeds(
+    multi_tenant_workspace, tenant_membership_obj, context_with_job_id
+):
+    """After all tenants materialize, the workspace view schema is rebuilt
+    so the agent's next list_tables call sees the namespaced views."""
+    mock_manager = MagicMock()
+
+    with (
+        patch("apps.workspaces.tasks.aresolve_credential", new_callable=AsyncMock) as mock_cred,
+        patch("apps.workspaces.tasks.get_registry", return_value=_mock_registry("commcare")),
+        patch(
+            "apps.workspaces.tasks._run_pipeline_with_progress",
+            return_value={"status": "completed"},
+        ),
+        patch("apps.workspaces.tasks.SchemaManager", return_value=mock_manager),
+        patch("apps.workspaces.tasks._defer_resume_for_job", new_callable=AsyncMock),
+    ):
+        mock_cred.return_value = {"type": "api_key", "value": "k"}
+        result = await materialize_workspace(
+            context_with_job_id,
+            workspace_id=str(multi_tenant_workspace.id),
+            user_id="",
+        )
+
+    assert result["all_succeeded"] is True
+    mock_manager.build_view_schema.assert_called_once_with(multi_tenant_workspace)
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_materialize_workspace_skips_view_rebuild_for_single_tenant(
+    workspace, tenant_membership_obj, context_with_job_id
+):
+    """Single-tenant workspaces don't use a view schema, so we must not
+    attempt to build one (build_view_schema would raise for tenant_count==1)."""
+    mock_manager = MagicMock()
+
+    with (
+        patch("apps.workspaces.tasks.aresolve_credential", new_callable=AsyncMock) as mock_cred,
+        patch("apps.workspaces.tasks.get_registry", return_value=_mock_registry("commcare")),
+        patch(
+            "apps.workspaces.tasks._run_pipeline_with_progress",
+            return_value={"status": "completed"},
+        ),
+        patch("apps.workspaces.tasks.SchemaManager", return_value=mock_manager),
+        patch("apps.workspaces.tasks._defer_resume_for_job", new_callable=AsyncMock),
+    ):
+        mock_cred.return_value = {"type": "api_key", "value": "k"}
+        await materialize_workspace(
+            context_with_job_id,
+            workspace_id=str(workspace.id),
+            user_id="",
+        )
+
+    mock_manager.build_view_schema.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_materialize_workspace_skips_view_rebuild_when_any_tenant_failed(
+    multi_tenant_workspace, tenant_membership_obj, context_with_job_id
+):
+    """When even one tenant pipeline fails, the view rebuild would itself
+    fail (it requires every tenant to have an ACTIVE schema), so we skip
+    it rather than burning a noisy traceback."""
+    mock_manager = MagicMock()
+
+    with (
+        patch("apps.workspaces.tasks.aresolve_credential", new_callable=AsyncMock) as mock_cred,
+        patch("apps.workspaces.tasks.get_registry", return_value=_mock_registry("commcare")),
+        patch(
+            "apps.workspaces.tasks._run_pipeline_with_progress",
+            side_effect=RuntimeError("upstream API down"),
+        ),
+        patch("apps.workspaces.tasks.SchemaManager", return_value=mock_manager),
+        patch("apps.workspaces.tasks._defer_resume_for_job", new_callable=AsyncMock),
+    ):
+        mock_cred.return_value = {"type": "api_key", "value": "k"}
+        result = await materialize_workspace(
+            context_with_job_id,
+            workspace_id=str(multi_tenant_workspace.id),
+            user_id="",
+        )
+
+    assert result["all_succeeded"] is False
+    mock_manager.build_view_schema.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_materialize_workspace_view_rebuild_failure_does_not_block_resume(
+    multi_tenant_workspace, tenant_membership_obj, context_with_job_id
+):
+    """If build_view_schema raises (e.g. DB write failure), the materialize
+    task must still defer the resume task so the user is not left with a
+    silent phantom spinner."""
+    mock_manager = MagicMock()
+    mock_manager.build_view_schema.side_effect = RuntimeError("DDL failed")
+    defer_mock = AsyncMock()
+
+    with (
+        patch("apps.workspaces.tasks.aresolve_credential", new_callable=AsyncMock) as mock_cred,
+        patch("apps.workspaces.tasks.get_registry", return_value=_mock_registry("commcare")),
+        patch(
+            "apps.workspaces.tasks._run_pipeline_with_progress",
+            return_value={"status": "completed"},
+        ),
+        patch("apps.workspaces.tasks.SchemaManager", return_value=mock_manager),
+        patch("apps.workspaces.tasks._defer_resume_for_job", defer_mock),
+    ):
+        mock_cred.return_value = {"type": "api_key", "value": "k"}
+        result = await materialize_workspace(
+            context_with_job_id,
+            workspace_id=str(multi_tenant_workspace.id),
+            user_id="",
+        )
+
+    # The task returns successfully (tenants succeeded), the view rebuild
+    # exception is swallowed, and the resume task is still deferred.
+    assert result["all_succeeded"] is True
+    mock_manager.build_view_schema.assert_called_once()
+    defer_mock.assert_awaited_once()
+
+
 @pytest.mark.asyncio
 @pytest.mark.django_db(transaction=True)
 async def test_materialize_workspace_breaks_on_cancel(

--- a/tests/test_materialize_workspace_task.py
+++ b/tests/test_materialize_workspace_task.py
@@ -9,7 +9,7 @@ from django.test import AsyncClient
 from django.utils import timezone
 
 from apps.chat.models import Thread, ThreadJob
-from apps.users.models import TenantMembership
+from apps.users.models import Tenant, TenantMembership
 from apps.workspaces import tasks as workspaces_tasks
 from apps.workspaces.models import (
     MaterializationRun,
@@ -18,6 +18,7 @@ from apps.workspaces.models import (
     Workspace,
     WorkspaceMembership,
     WorkspaceRole,
+    WorkspaceTenant,
 )
 from apps.workspaces.tasks import _run_pipeline_with_progress, materialize_workspace
 from mcp_server.services.materializer import MaterializationCancelled
@@ -115,9 +116,6 @@ async def test_materialize_workspace_records_failure(
 def multi_tenant_workspace(db, workspace, user):
     """Augment the single-tenant `workspace` fixture with a second tenant +
     membership, so workspace_tenants.acount() > 1."""
-    from apps.users.models import Tenant, TenantMembership
-    from apps.workspaces.models import WorkspaceTenant
-
     second_tenant = Tenant.objects.create(
         provider="commcare", external_id="test-domain-2", canonical_name="Test Domain 2"
     )


### PR DESCRIPTION
## Summary
- Worker container was missing `MCP_SERVER_URL` and `ANTHROPIC_API_KEY`, so every `resume_thread_after_materialization` since the feature shipped in #172 has failed silently with `httpx.ConnectError`. Confirmed against `/scout/worker` CloudWatch: 2/2 resume runs across two users hit the same error before reaching `agent.ainvoke`. Added the two missing vars plus `LANGFUSE_*` so future worker agent runs are traceable like the API's are.
- `materialize_workspace` never rebuilt `WorkspaceViewSchema` after per-tenant pipelines completed, so multi-tenant chat queries kept returning `"No active view schema for workspace..."` even after a successful materialization. Now chained after the loop, gated on `all_succeeded` (since `build_view_schema` requires every tenant to have an ACTIVE schema), with exceptions swallowed so the `finally`-block resume defer still fires.
- Production logging was suppressing all `mcp_server.*` INFO output — exactly the `"Loaded N rows..."` and `"Pipeline complete..."` lines that would have shown whether the LOAD phase ran. Added `mcp_server` logger at INFO.

## Test plan
- [x] `uv run pytest tests/test_materialize_workspace_task.py` — 18/18 pass (incl. 4 new covering rebuild conditions)
- [x] `uv run pytest tests/test_resume_thread_task.py` — 9/9 pass
- [x] `uv run ruff check` — clean
- [ ] Post-deploy: kick off a chat on a fresh multi-tenant workspace; expect spinner → green dot → automatic agent follow-up message in the chat, AND a corresponding Langfuse LangGraph trace with `[__system_resume__]` as the input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)