### PR TITLE
Use SocialApp.name for social login button text

### DIFF
--- a/apps/users/auth_views.py
+++ b/apps/users/auth_views.py
@@ -30,14 +30,6 @@ logger = logging.getLogger(__name__)
 
 UserModel = get_user_model()
 
-PROVIDER_DISPLAY = {
-    "google": "Google",
-    "github": "GitHub",
-    "commcare": "CommCare",
-    "commcare_connect": "CommCare Connect",
-    "ocs": "Open Chat Studio",
-}
-
 
 def _user_response(user, *, onboarding_complete=False):
     """Build standard user JSON response dict."""
@@ -242,7 +234,7 @@ def providers_view(request):
     for app in apps:
         entry = {
             "id": app.provider,
-            "name": PROVIDER_DISPLAY.get(app.provider, app.name),
+            "name": app.name,
             # No prefix — the frontend prepends BASE_PATH to all API-provided URLs
             "login_url": f"/accounts/{app.provider}/login/",
         }


### PR DESCRIPTION
Social login button labels were sourced from a hardcoded `PROVIDER_DISPLAY` dict in `auth_views.py` keyed by provider class id, so editing a `SocialApp`'s name in the Django admin had no effect. Switched to `app.name` so admins can control the label.

No behavior change for existing providers as long as their `SocialApp.name` matches what was in the dict (`Google`, `GitHub`, `CommCare`, `CommCare Connect`, `Open Chat Studio`) — worth a quick check on each environment's admin records before merging.