### PR TITLE
fix(auth): use provider display name in OAuth domain-restriction error

### DIFF
--- a/apps/users/adapters.py
+++ b/apps/users/adapters.py
@@ -13,6 +13,7 @@ import logging
 from allauth.core.exceptions import ImmediateHttpResponse
 from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
 from allauth.socialaccount.models import SocialToken
+from allauth.socialaccount.providers import registry as providers_registry
 from cryptography.fernet import Fernet, InvalidToken
 from django.conf import settings
 from django.contrib import messages
@@ -93,10 +94,12 @@ class EncryptingSocialAccountAdapter(DefaultSocialAccountAdapter):
         if domain in allowed_lower:
             return
 
+        provider_class = providers_registry.get_class(provider)
+        provider_name = provider_class.name if provider_class else provider
         messages.error(
             request,
             "Sign-in with this account is not permitted. "
-            f"Login using '{provider.title}' is restricted to {', '.join('@' + d for d in allowed_lower)} addresses.",
+            f"Login using '{provider_name}' is restricted to {', '.join('@' + d for d in allowed_lower)} addresses.",
         )
         raise ImmediateHttpResponse(redirect("account_login"))
 


### PR DESCRIPTION
## Summary

The OAuth domain-restriction rejection message interpolated `provider.title` — a reference to the bound `str.title` method, not a call — so the user-facing error rendered as `<built-in method title of str object at 0x...>` instead of a provider name.

This resolves the proper provider **display name** via the allauth provider registry (e.g. `Google`, `GitHub`, `CommCare`, `Open Chat Studio`), falling back to the raw provider id if the class can't be found. The registry lookup is DB-free, so it adds no query to the rejection path.

The bug originated in commit `650379a` ("tweak error message") from the original OAuth domain-restriction work, which predates this branch.

## Changes

- `apps/users/adapters.py`: resolve provider display name from `providers_registry.get_class(provider).name` instead of the broken `provider.title`.

## Testing

- `uv run pytest tests/test_oauth_domain_restriction.py` — 11 passed
- `uv run ruff check apps/users/adapters.py` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)