### PR TITLE
feat(users): cross-provider account linking by email

### DIFF
--- a/apps/users/apps.py
+++ b/apps/users/apps.py
@@ -7,10 +7,18 @@ class UsersConfig(AppConfig):
     verbose_name = "Users"
 
     def ready(self):
-        from allauth.socialaccount.signals import social_account_added, social_account_updated
+        from allauth.socialaccount.signals import (
+            pre_social_login,
+            social_account_added,
+            social_account_updated,
+        )
 
         import apps.users.signals  # noqa: F401 — connects auto_create_workspace_on_membership
-        from apps.users.signals import resolve_tenant_on_social_login
+        from apps.users.signals import (
+            reconcile_existing_user_on_login,
+            resolve_tenant_on_social_login,
+        )
 
         social_account_added.connect(resolve_tenant_on_social_login)
         social_account_updated.connect(resolve_tenant_on_social_login)
+        pre_social_login.connect(reconcile_existing_user_on_login)

--- a/apps/users/management/commands/merge_duplicate_users.py
+++ b/apps/users/management/commands/merge_duplicate_users.py
@@ -26,7 +26,8 @@ class Command(BaseCommand):
         parser.add_argument("--dry-run", action="store_true", help="Print plan, write nothing.")
         parser.add_argument("--email", help="Only operate on the group sharing this email.")
         parser.add_argument(
-            "--canonical-id", type=int,
+            "--canonical-id",
+            type=int,
             help="Force this user as canonical. Must be in the targeted group.",
         )
         parser.add_argument("--yes", action="store_true", help="Skip the confirmation prompt.")
@@ -35,9 +36,7 @@ class Command(BaseCommand):
         groups = self._find_groups(target_email=opts.get("email"))
         if not groups:
             target = opts.get("email")
-            self.stdout.write(
-                f"no duplicates found{' for ' + target if target else ''}"
-            )
+            self.stdout.write(f"no duplicates found{' for ' + target if target else ''}")
             return
 
         plans: list[tuple[list[User], MergeReport, User]] = []
@@ -54,9 +53,9 @@ class Command(BaseCommand):
             return
 
         if not opts.get("yes"):
-            response = input(
-                f"About to merge {len(plans)} duplicate(s). Continue? [y/N] "
-            ).strip().lower()
+            response = (
+                input(f"About to merge {len(plans)} duplicate(s). Continue? [y/N] ").strip().lower()
+            )
             if response != "y":
                 self.stdout.write("aborted")
                 return
@@ -67,7 +66,7 @@ class Command(BaseCommand):
             try:
                 merge_users(canonical=canonical, duplicate=dup)
                 self.stdout.write(f"merged User#{dup_pk} -> User#{canonical.pk}")
-            except Exception as exc:  # noqa: BLE001 — best-effort per-group recovery
+            except Exception as exc:
                 self.stderr.write(f"failed User#{dup_pk} -> User#{canonical.pk}: {exc!r}")
 
     def _find_groups(self, *, target_email: str | None) -> list[list[User]]:

--- a/apps/users/management/commands/merge_duplicate_users.py
+++ b/apps/users/management/commands/merge_duplicate_users.py
@@ -63,11 +63,12 @@ class Command(BaseCommand):
 
         for users, _plan, canonical in plans:
             dup = next(u for u in users if u.pk != canonical.pk)
+            dup_pk = dup.pk  # capture before merge_users() deletes the duplicate
             try:
                 merge_users(canonical=canonical, duplicate=dup)
-                self.stdout.write(f"merged User#{dup.pk} -> User#{canonical.pk}")
+                self.stdout.write(f"merged User#{dup_pk} -> User#{canonical.pk}")
             except Exception as exc:  # noqa: BLE001 — best-effort per-group recovery
-                self.stderr.write(f"failed User#{dup.pk} -> User#{canonical.pk}: {exc!r}")
+                self.stderr.write(f"failed User#{dup_pk} -> User#{canonical.pk}: {exc!r}")
 
     def _find_groups(self, *, target_email: str | None) -> list[list[User]]:
         qs = User.objects.exclude(email__isnull=True).exclude(email="")

--- a/apps/users/management/commands/merge_duplicate_users.py
+++ b/apps/users/management/commands/merge_duplicate_users.py
@@ -1,0 +1,104 @@
+"""Operator command to merge duplicate User rows that share an email.
+
+Usage:
+    python manage.py merge_duplicate_users [--dry-run] [--email EMAIL]
+                                           [--canonical-id ID] [--yes]
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any
+
+from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand, CommandError
+from django.db.models.functions import Lower
+
+from apps.users.services.merge import MergeReport, merge_users, select_canonical
+
+User = get_user_model()
+
+
+class Command(BaseCommand):
+    help = "Merge duplicate User rows that share an email address."
+
+    def add_arguments(self, parser) -> None:
+        parser.add_argument("--dry-run", action="store_true", help="Print plan, write nothing.")
+        parser.add_argument("--email", help="Only operate on the group sharing this email.")
+        parser.add_argument(
+            "--canonical-id", type=int,
+            help="Force this user as canonical. Must be in the targeted group.",
+        )
+        parser.add_argument("--yes", action="store_true", help="Skip the confirmation prompt.")
+
+    def handle(self, *args: Any, **opts: Any) -> None:
+        groups = self._find_groups(target_email=opts.get("email"))
+        if not groups:
+            target = opts.get("email")
+            self.stdout.write(
+                f"no duplicates found{' for ' + target if target else ''}"
+            )
+            return
+
+        plans: list[tuple[list[User], MergeReport, User]] = []
+        for users in groups:
+            canonical = self._pick_canonical(users, forced_id=opts.get("canonical_id"))
+            for dup in users:
+                if dup.pk == canonical.pk:
+                    continue
+                report = merge_users(canonical=canonical, duplicate=dup, dry_run=True)
+                plans.append(([canonical, dup], report, canonical))
+                self._print_plan(canonical, dup, report)
+
+        if opts.get("dry_run"):
+            return
+
+        if not opts.get("yes"):
+            response = input(
+                f"About to merge {len(plans)} duplicate(s). Continue? [y/N] "
+            ).strip().lower()
+            if response != "y":
+                self.stdout.write("aborted")
+                return
+
+        for users, _plan, canonical in plans:
+            dup = next(u for u in users if u.pk != canonical.pk)
+            try:
+                merge_users(canonical=canonical, duplicate=dup)
+                self.stdout.write(f"merged User#{dup.pk} -> User#{canonical.pk}")
+            except Exception as exc:  # noqa: BLE001 — best-effort per-group recovery
+                self.stderr.write(f"failed User#{dup.pk} -> User#{canonical.pk}: {exc!r}")
+
+    def _find_groups(self, *, target_email: str | None) -> list[list[User]]:
+        qs = User.objects.exclude(email__isnull=True).exclude(email="")
+        if target_email:
+            qs = qs.filter(email__iexact=target_email)
+        buckets: dict[str, list[User]] = defaultdict(list)
+        for u in qs.annotate(lower_email=Lower("email")).order_by("created_at", "pk"):
+            buckets[u.lower_email].append(u)
+        return [group for group in buckets.values() if len(group) > 1]
+
+    def _pick_canonical(self, users: list[User], *, forced_id: int | None) -> User:
+        if forced_id is not None:
+            forced = next((u for u in users if u.pk == forced_id), None)
+            if forced is None:
+                raise CommandError(
+                    f"--canonical-id={forced_id} is not in the targeted duplicate group",
+                )
+            return forced
+        return select_canonical(users)
+
+    def _print_plan(self, canonical: User, duplicate: User, report: MergeReport) -> None:
+        self.stdout.write(
+            f"[merge] email='{canonical.email}'  canonical: User#{canonical.pk}  "
+            f"duplicate: User#{duplicate.pk}"
+        )
+        self.stdout.write(
+            f"  plan: socialaccounts={report.socialaccount_repointed} "
+            f"emails(repoint/delete)={report.emailaddress_repointed}/"
+            f"{report.emailaddress_deleted} "
+            f"tenant(repoint/conflict)={report.tenant_membership_repointed}/"
+            f"{report.tenant_membership_conflict_deleted} "
+            f"workspace(repoint/conflict)={report.workspace_membership_repointed}/"
+            f"{report.workspace_membership_conflict_merged}"
+        )

--- a/apps/users/services/merge.py
+++ b/apps/users/services/merge.py
@@ -16,6 +16,8 @@ from allauth.account.models import EmailAddress
 from allauth.socialaccount.models import SocialAccount
 from django.db import transaction
 
+from apps.users.models import TenantMembership
+
 if TYPE_CHECKING:
     from apps.users.models import User
 
@@ -91,6 +93,21 @@ def _dedupe_email_addresses(canonical: User, duplicate: User) -> tuple[int, int]
     return repointed, deleted
 
 
+def _merge_tenant_memberships(canonical: User, duplicate: User) -> tuple[int, int]:
+    """Returns (repointed_count, conflict_deleted_count).
+
+    If canonical already has a membership for a given tenant, delete duplicate's
+    row (its OneToOne TenantCredential cascades). Otherwise repoint to canonical.
+    """
+    canonical_tenant_ids = set(
+        TenantMembership.objects.filter(user=canonical).values_list("tenant_id", flat=True)
+    )
+    dup_qs = TenantMembership.objects.filter(user=duplicate)
+    conflict_deleted, _ = dup_qs.filter(tenant_id__in=canonical_tenant_ids).delete()
+    repointed = dup_qs.exclude(tenant_id__in=canonical_tenant_ids).update(user=canonical)
+    return repointed, conflict_deleted
+
+
 def _merge_user_fields(canonical: User, duplicate: User) -> dict[str, str]:
     """Apply field-level merge rules. Mutates canonical in place; returns changes."""
     changes: dict[str, str] = {}
@@ -145,11 +162,24 @@ def merge_users(
         dup_qs = EmailAddress.objects.filter(user=duplicate)
         report.emailaddress_deleted = dup_qs.filter(email__in=canonical_emails).count()
         report.emailaddress_repointed = dup_qs.exclude(email__in=canonical_emails).count()
+        canonical_tenant_ids = set(
+            TenantMembership.objects.filter(user=canonical).values_list("tenant_id", flat=True)
+        )
+        dup_tms = TenantMembership.objects.filter(user=duplicate)
+        report.tenant_membership_conflict_deleted = dup_tms.filter(
+            tenant_id__in=canonical_tenant_ids,
+        ).count()
+        report.tenant_membership_repointed = dup_tms.exclude(
+            tenant_id__in=canonical_tenant_ids,
+        ).count()
         return report
     with transaction.atomic():
         report.field_changes = _merge_user_fields(canonical, duplicate)
         report.socialaccount_repointed = _repoint_social_accounts(canonical, duplicate)
         report.emailaddress_repointed, report.emailaddress_deleted = (
             _dedupe_email_addresses(canonical, duplicate)
+        )
+        report.tenant_membership_repointed, report.tenant_membership_conflict_deleted = (
+            _merge_tenant_memberships(canonical, duplicate)
         )
     return report

--- a/apps/users/services/merge.py
+++ b/apps/users/services/merge.py
@@ -12,6 +12,7 @@ import logging
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
+from allauth.account.models import EmailAddress
 from allauth.socialaccount.models import SocialAccount
 from django.db import transaction
 
@@ -58,6 +59,36 @@ def select_canonical(users: list[User]) -> User:
 
 def _repoint_social_accounts(canonical: User, duplicate: User) -> int:
     return SocialAccount.objects.filter(user=duplicate).update(user=canonical)
+
+
+def _dedupe_email_addresses(canonical: User, duplicate: User) -> tuple[int, int]:
+    """Returns (repointed_count, deleted_count).
+
+    For each EmailAddress on duplicate: if canonical already has a row with the
+    same email, delete duplicate's; otherwise repoint to canonical. Then ensure
+    canonical has exactly one primary+verified row matching User.email.
+    """
+    canonical_emails = set(
+        EmailAddress.objects.filter(user=canonical).values_list("email", flat=True)
+    )
+    dup_qs = EmailAddress.objects.filter(user=duplicate)
+    deleted, _ = dup_qs.filter(email__in=canonical_emails).delete()
+    repointed = dup_qs.exclude(email__in=canonical_emails).update(user=canonical)
+    if canonical.email:
+        # Demote any existing primaries on canonical before creating/promoting
+        # the canonical-email row, to avoid violating unique(user_id, primary=True).
+        EmailAddress.objects.filter(user=canonical, primary=True).exclude(
+            email=canonical.email,
+        ).update(primary=False)
+        primary, _created = EmailAddress.objects.get_or_create(
+            user=canonical, email=canonical.email,
+            defaults={"primary": True, "verified": True},
+        )
+        if not primary.primary or not primary.verified:
+            primary.primary = True
+            primary.verified = True
+            primary.save(update_fields=["primary", "verified"])
+    return repointed, deleted
 
 
 def _merge_user_fields(canonical: User, duplicate: User) -> dict[str, str]:
@@ -108,8 +139,17 @@ def merge_users(
     )
     if dry_run:
         report.socialaccount_repointed = SocialAccount.objects.filter(user=duplicate).count()
+        canonical_emails = set(
+            EmailAddress.objects.filter(user=canonical).values_list("email", flat=True)
+        )
+        dup_qs = EmailAddress.objects.filter(user=duplicate)
+        report.emailaddress_deleted = dup_qs.filter(email__in=canonical_emails).count()
+        report.emailaddress_repointed = dup_qs.exclude(email__in=canonical_emails).count()
         return report
     with transaction.atomic():
         report.field_changes = _merge_user_fields(canonical, duplicate)
         report.socialaccount_repointed = _repoint_social_accounts(canonical, duplicate)
+        report.emailaddress_repointed, report.emailaddress_deleted = (
+            _dedupe_email_addresses(canonical, duplicate)
+        )
     return report

--- a/apps/users/services/merge.py
+++ b/apps/users/services/merge.py
@@ -12,6 +12,9 @@ import logging
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
+from allauth.socialaccount.models import SocialAccount
+from django.db import transaction
+
 if TYPE_CHECKING:
     from apps.users.models import User
 
@@ -51,6 +54,10 @@ def select_canonical(users: list[User]) -> User:
             u.pk,
         ),
     )
+
+
+def _repoint_social_accounts(canonical: User, duplicate: User) -> int:
+    return SocialAccount.objects.filter(user=duplicate).update(user=canonical)
 
 
 def _merge_user_fields(canonical: User, duplicate: User) -> dict[str, str]:
@@ -100,6 +107,9 @@ def merge_users(
         dry_run=dry_run,
     )
     if dry_run:
+        report.socialaccount_repointed = SocialAccount.objects.filter(user=duplicate).count()
         return report
-    report.field_changes = _merge_user_fields(canonical, duplicate)
+    with transaction.atomic():
+        report.field_changes = _merge_user_fields(canonical, duplicate)
+        report.socialaccount_repointed = _repoint_social_accounts(canonical, duplicate)
     return report

--- a/apps/users/services/merge.py
+++ b/apps/users/services/merge.py
@@ -17,11 +17,19 @@ from allauth.socialaccount.models import SocialAccount
 from django.db import transaction
 
 from apps.users.models import TenantMembership
+from apps.workspaces.models import WorkspaceMembership, WorkspaceRole
 
 if TYPE_CHECKING:
     from apps.users.models import User
 
 logger = logging.getLogger(__name__)
+
+
+_ROLE_RANK = {
+    WorkspaceRole.READ: 0,
+    WorkspaceRole.READ_WRITE: 1,
+    WorkspaceRole.MANAGE: 2,
+}
 
 
 @dataclass
@@ -108,6 +116,34 @@ def _merge_tenant_memberships(canonical: User, duplicate: User) -> tuple[int, in
     return repointed, conflict_deleted
 
 
+def _merge_workspace_memberships(canonical: User, duplicate: User) -> tuple[int, int]:
+    """Returns (repointed_count, conflict_merged_count).
+
+    If canonical already has a membership for a workspace, upgrade its role to
+    the higher of the two (per _ROLE_RANK) and delete the duplicate's row.
+    Otherwise repoint duplicate's row to canonical.
+    """
+    canonical_by_ws = {
+        m.workspace_id: m for m in WorkspaceMembership.objects.filter(user=canonical)
+    }
+    dup_memberships = list(WorkspaceMembership.objects.filter(user=duplicate))
+    conflict_merged = 0
+    repointed = 0
+    for dup_m in dup_memberships:
+        canon_m = canonical_by_ws.get(dup_m.workspace_id)
+        if canon_m is None:
+            dup_m.user = canonical
+            dup_m.save(update_fields=["user"])
+            repointed += 1
+            continue
+        if _ROLE_RANK[WorkspaceRole(dup_m.role)] > _ROLE_RANK[WorkspaceRole(canon_m.role)]:
+            canon_m.role = dup_m.role
+            canon_m.save(update_fields=["role"])
+        dup_m.delete()
+        conflict_merged += 1
+    return repointed, conflict_merged
+
+
 def _merge_user_fields(canonical: User, duplicate: User) -> dict[str, str]:
     """Apply field-level merge rules. Mutates canonical in place; returns changes."""
     changes: dict[str, str] = {}
@@ -172,6 +208,18 @@ def merge_users(
         report.tenant_membership_repointed = dup_tms.exclude(
             tenant_id__in=canonical_tenant_ids,
         ).count()
+        canonical_ws_ids = set(
+            WorkspaceMembership.objects.filter(user=canonical).values_list(
+                "workspace_id", flat=True,
+            )
+        )
+        dup_wms = WorkspaceMembership.objects.filter(user=duplicate)
+        report.workspace_membership_conflict_merged = dup_wms.filter(
+            workspace_id__in=canonical_ws_ids,
+        ).count()
+        report.workspace_membership_repointed = dup_wms.exclude(
+            workspace_id__in=canonical_ws_ids,
+        ).count()
         return report
     with transaction.atomic():
         report.field_changes = _merge_user_fields(canonical, duplicate)
@@ -181,5 +229,8 @@ def merge_users(
         )
         report.tenant_membership_repointed, report.tenant_membership_conflict_deleted = (
             _merge_tenant_memberships(canonical, duplicate)
+        )
+        report.workspace_membership_repointed, report.workspace_membership_conflict_merged = (
+            _merge_workspace_memberships(canonical, duplicate)
         )
     return report

--- a/apps/users/services/merge.py
+++ b/apps/users/services/merge.py
@@ -43,13 +43,14 @@ _SPECIAL_CASE_RELATIONS: frozenset[tuple[str, str]] = frozenset(
         ("account.EmailAddress", "user"),
         ("users.TenantMembership", "user"),
         ("workspaces.WorkspaceMembership", "user"),
-        # Django auth join tables — unique on (user, group) / (user, permission).
-        # If both users happen to share a group/permission, a bulk repoint would
-        # IntegrityError. Scout doesn't actively use django.contrib.auth.Group, so
-        # the simplest safe handling is to skip; if Group ever becomes load-bearing
-        # we revisit with explicit conflict resolution.
-        ("auth.User_groups", "user"),
-        ("auth.User_user_permissions", "user"),
+        # Django auth join tables — auto-generated through-tables for the custom
+        # User model. Unique on (user, group) / (user, permission); a bulk repoint
+        # would IntegrityError if both users share a group/permission. Scout
+        # doesn't actively use django.contrib.auth.Group, so the simplest safe
+        # handling is to skip; if Group ever becomes load-bearing we revisit
+        # with explicit conflict resolution.
+        ("users.User_groups", "user"),
+        ("users.User_user_permissions", "user"),
     }
 )
 

--- a/apps/users/services/merge.py
+++ b/apps/users/services/merge.py
@@ -225,7 +225,17 @@ def merge_users(
 ) -> MergeReport:
     """Merge ``duplicate`` into ``canonical`` and return a MergeReport.
 
-    Implementation arrives across the remaining tasks in this phase.
+    Field-level rules are applied to ``canonical`` (password copy, staff/super
+    OR, oldest-last-login, empty-name backfill, timezone backfill). All
+    User-pointing rows are then repointed or merged: SocialAccount,
+    EmailAddress (with dedupe + primary normalization), TenantMembership and
+    WorkspaceMembership (with conflict resolution), and every other
+    reverse-FK relation discovered via Django's `_meta` (the "long tail"). The
+    duplicate row is deleted last. All write steps run inside a single
+    ``transaction.atomic()`` block so any failure rolls the whole merge back.
+
+    When ``dry_run=True`` no writes occur and the returned MergeReport carries
+    counts only — useful for previewing the impact from the operator command.
     """
     if canonical.pk == duplicate.pk:
         raise ValueError("canonical and duplicate must be different users")
@@ -235,13 +245,14 @@ def merge_users(
         dry_run=dry_run,
     )
     if dry_run:
+        # Count-only plan (no writes).
         report.socialaccount_repointed = SocialAccount.objects.filter(user=duplicate).count()
         canonical_emails = set(
             EmailAddress.objects.filter(user=canonical).values_list("email", flat=True)
         )
-        dup_qs = EmailAddress.objects.filter(user=duplicate)
-        report.emailaddress_deleted = dup_qs.filter(email__in=canonical_emails).count()
-        report.emailaddress_repointed = dup_qs.exclude(email__in=canonical_emails).count()
+        dup_emails = EmailAddress.objects.filter(user=duplicate)
+        report.emailaddress_deleted = dup_emails.filter(email__in=canonical_emails).count()
+        report.emailaddress_repointed = dup_emails.exclude(email__in=canonical_emails).count()
         canonical_tenant_ids = set(
             TenantMembership.objects.filter(user=canonical).values_list("tenant_id", flat=True)
         )
@@ -265,6 +276,7 @@ def merge_users(
             workspace_id__in=canonical_ws_ids,
         ).count()
         return report
+
     with transaction.atomic():
         report.field_changes = _merge_user_fields(canonical, duplicate)
         report.socialaccount_repointed = _repoint_social_accounts(canonical, duplicate)
@@ -278,4 +290,10 @@ def merge_users(
             _merge_workspace_memberships(canonical, duplicate)
         )
         report.long_tail_fk_counts = _repoint_long_tail_fks(canonical, duplicate)
+        duplicate.delete()
+        report.duplicate_user_deleted = True
+    logger.info(
+        "Merged user=%s into canonical=%s: %s",
+        report.duplicate_id, report.canonical_id, report,
+    )
     return report

--- a/apps/users/services/merge.py
+++ b/apps/users/services/merge.py
@@ -53,6 +53,34 @@ def select_canonical(users: list[User]) -> User:
     )
 
 
+def _merge_user_fields(canonical, duplicate) -> dict[str, str]:
+    """Apply field-level merge rules. Mutates canonical in place; returns changes."""
+    changes: dict[str, str] = {}
+    if not canonical.has_usable_password() and duplicate.has_usable_password():
+        canonical.password = duplicate.password
+        changes["password"] = "copied from duplicate"  # noqa: S105
+    if duplicate.is_staff and not canonical.is_staff:
+        canonical.is_staff = True
+        changes["is_staff"] = "True (OR with duplicate)"
+    if duplicate.is_superuser and not canonical.is_superuser:
+        canonical.is_superuser = True
+        changes["is_superuser"] = "True (OR with duplicate)"
+    if duplicate.last_login and (
+        canonical.last_login is None or duplicate.last_login > canonical.last_login
+    ):
+        canonical.last_login = duplicate.last_login
+        changes["last_login"] = duplicate.last_login.isoformat()
+    for field_name in ("first_name", "last_name", "avatar_url"):
+        if not getattr(canonical, field_name) and getattr(duplicate, field_name):
+            setattr(canonical, field_name, getattr(duplicate, field_name))
+            changes[field_name] = f"copied: {getattr(duplicate, field_name)!r}"
+    if canonical.timezone == "UTC" and duplicate.timezone and duplicate.timezone != "UTC":
+        canonical.timezone = duplicate.timezone
+        changes["timezone"] = f"copied: {duplicate.timezone!r}"
+    canonical.save()
+    return changes
+
+
 def merge_users(
     *,
     canonical: User,
@@ -65,8 +93,12 @@ def merge_users(
     """
     if canonical.pk == duplicate.pk:
         raise ValueError("canonical and duplicate must be different users")
-    return MergeReport(
+    report = MergeReport(
         canonical_id=canonical.pk,
         duplicate_id=duplicate.pk,
         dry_run=dry_run,
     )
+    if dry_run:
+        return report
+    report.field_changes = _merge_user_fields(canonical, duplicate)
+    return report

--- a/apps/users/services/merge.py
+++ b/apps/users/services/merge.py
@@ -1,0 +1,72 @@
+"""Merge two duplicate User rows into one canonical row.
+
+Used by:
+- ``apps.users.signals.reconcile_existing_user_on_login`` to absorb a freshly
+  email-bearing OAuth user into an existing email-owning user during login.
+- ``manage.py merge_duplicate_users`` for operator-driven cleanup.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from apps.users.models import User
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class MergeReport:
+    """Per-merge summary used for logging and command output."""
+
+    canonical_id: int
+    duplicate_id: int
+    dry_run: bool = False
+    field_changes: dict[str, str] = field(default_factory=dict)
+    socialaccount_repointed: int = 0
+    emailaddress_repointed: int = 0
+    emailaddress_deleted: int = 0
+    tenant_membership_repointed: int = 0
+    tenant_membership_conflict_deleted: int = 0
+    workspace_membership_repointed: int = 0
+    workspace_membership_conflict_merged: int = 0
+    long_tail_fk_counts: dict[str, int] = field(default_factory=dict)
+    duplicate_user_deleted: bool = False
+
+
+def select_canonical(users: list[User]) -> User:
+    """Return the canonical user from a list of duplicates.
+
+    Priority (highest wins): has a usable password, oldest ``created_at``,
+    lowest ``pk``.
+    """
+    return min(
+        users,
+        key=lambda u: (
+            not u.has_usable_password(),
+            u.created_at,
+            u.pk,
+        ),
+    )
+
+
+def merge_users(
+    *,
+    canonical: User,
+    duplicate: User,
+    dry_run: bool = False,
+) -> MergeReport:
+    """Merge ``duplicate`` into ``canonical`` and return a MergeReport.
+
+    Implementation arrives across the remaining tasks in this phase.
+    """
+    if canonical.pk == duplicate.pk:
+        raise ValueError("canonical and duplicate must be different users")
+    return MergeReport(
+        canonical_id=canonical.pk,
+        duplicate_id=duplicate.pk,
+        dry_run=dry_run,
+    )

--- a/apps/users/services/merge.py
+++ b/apps/users/services/merge.py
@@ -32,33 +32,42 @@ _ROLE_RANK = {
 }
 
 
-_SPECIAL_CASE_MODELS = frozenset({
-    "socialaccount.SocialAccount",
-    "account.EmailAddress",
-    "users.TenantMembership",
-    "workspaces.WorkspaceMembership",
+# Reverse FK relations handled by explicit helpers above. Anything else with a
+# User FK gets the generic bulk-repoint in _repoint_long_tail_fks.
+# Identified by (model label, field name) so we can skip the canonical
+# `user` field on a model while still picking up other User-pointing fields
+# on the same model (e.g. WorkspaceMembership.invited_by).
+_SPECIAL_CASE_RELATIONS: frozenset[tuple[str, str]] = frozenset({
+    ("socialaccount.SocialAccount", "user"),
+    ("account.EmailAddress", "user"),
+    ("users.TenantMembership", "user"),
+    ("workspaces.WorkspaceMembership", "user"),
+    # Django auth join tables — unique on (user, group) / (user, permission).
+    # If both users happen to share a group/permission, a bulk repoint would
+    # IntegrityError. Scout doesn't actively use django.contrib.auth.Group, so
+    # the simplest safe handling is to skip; if Group ever becomes load-bearing
+    # we revisit with explicit conflict resolution.
+    ("auth.User_groups", "user"),
+    ("auth.User_user_permissions", "user"),
 })
 
 
 def _repoint_long_tail_fks(canonical: User, duplicate: User) -> dict[str, int]:
-    """Bulk-update every User FK except those handled by special-case logic.
+    """Bulk-update every User reverse FK except those handled by explicit helpers.
 
-    Picks up new User FKs added by future apps without code changes. Uses
-    ``get_fields(include_hidden=True)`` so relations declared with
-    ``related_name="+"`` (e.g. ``Workspace.created_by``) are also repointed.
-    If a new FK has a unique constraint involving the user field, this raises
-    IntegrityError on the bulk update — surface that and add explicit
-    handling to merge_users.
+    Skips the (model, field) pairs in _SPECIAL_CASE_RELATIONS. Picks up new
+    User FKs added by future apps without code changes. If a new FK has a
+    unique constraint involving the user field, the bulk update will raise
+    IntegrityError — surface that and add explicit handling.
     """
     counts: dict[str, int] = {}
     for rel in canonical._meta.get_fields(include_hidden=True):
-        # Only one-to-many reverse relations (FKs pointing at User).
-        if not rel.is_relation or not rel.one_to_many:
+        if not (rel.is_relation and rel.one_to_many):
             continue
         label = rel.related_model._meta.label
-        if label in _SPECIAL_CASE_MODELS:
-            continue
         field_name = rel.field.name
+        if (label, field_name) in _SPECIAL_CASE_RELATIONS:
+            continue
         n = rel.related_model._default_manager.filter(
             **{field_name: duplicate},
         ).update(**{field_name: canonical})

--- a/apps/users/services/merge.py
+++ b/apps/users/services/merge.py
@@ -53,7 +53,7 @@ def select_canonical(users: list[User]) -> User:
     )
 
 
-def _merge_user_fields(canonical, duplicate) -> dict[str, str]:
+def _merge_user_fields(canonical: User, duplicate: User) -> dict[str, str]:
     """Apply field-level merge rules. Mutates canonical in place; returns changes."""
     changes: dict[str, str] = {}
     if not canonical.has_usable_password() and duplicate.has_usable_password():
@@ -77,7 +77,8 @@ def _merge_user_fields(canonical, duplicate) -> dict[str, str]:
     if canonical.timezone == "UTC" and duplicate.timezone and duplicate.timezone != "UTC":
         canonical.timezone = duplicate.timezone
         changes["timezone"] = f"copied: {duplicate.timezone!r}"
-    canonical.save()
+    if changes:
+        canonical.save(update_fields=list(changes.keys()))
     return changes
 
 

--- a/apps/users/services/merge.py
+++ b/apps/users/services/merge.py
@@ -37,19 +37,21 @@ _ROLE_RANK = {
 # Identified by (model label, field name) so we can skip the canonical
 # `user` field on a model while still picking up other User-pointing fields
 # on the same model (e.g. WorkspaceMembership.invited_by).
-_SPECIAL_CASE_RELATIONS: frozenset[tuple[str, str]] = frozenset({
-    ("socialaccount.SocialAccount", "user"),
-    ("account.EmailAddress", "user"),
-    ("users.TenantMembership", "user"),
-    ("workspaces.WorkspaceMembership", "user"),
-    # Django auth join tables — unique on (user, group) / (user, permission).
-    # If both users happen to share a group/permission, a bulk repoint would
-    # IntegrityError. Scout doesn't actively use django.contrib.auth.Group, so
-    # the simplest safe handling is to skip; if Group ever becomes load-bearing
-    # we revisit with explicit conflict resolution.
-    ("auth.User_groups", "user"),
-    ("auth.User_user_permissions", "user"),
-})
+_SPECIAL_CASE_RELATIONS: frozenset[tuple[str, str]] = frozenset(
+    {
+        ("socialaccount.SocialAccount", "user"),
+        ("account.EmailAddress", "user"),
+        ("users.TenantMembership", "user"),
+        ("workspaces.WorkspaceMembership", "user"),
+        # Django auth join tables — unique on (user, group) / (user, permission).
+        # If both users happen to share a group/permission, a bulk repoint would
+        # IntegrityError. Scout doesn't actively use django.contrib.auth.Group, so
+        # the simplest safe handling is to skip; if Group ever becomes load-bearing
+        # we revisit with explicit conflict resolution.
+        ("auth.User_groups", "user"),
+        ("auth.User_user_permissions", "user"),
+    }
+)
 
 
 def _repoint_long_tail_fks(canonical: User, duplicate: User) -> dict[str, int]:
@@ -135,7 +137,8 @@ def _dedupe_email_addresses(canonical: User, duplicate: User) -> tuple[int, int]
             email=canonical.email,
         ).update(primary=False)
         primary, _created = EmailAddress.objects.get_or_create(
-            user=canonical, email=canonical.email,
+            user=canonical,
+            email=canonical.email,
             defaults={"primary": True, "verified": True},
         )
         if not primary.primary or not primary.verified:
@@ -265,7 +268,8 @@ def merge_users(
         ).count()
         canonical_ws_ids = set(
             WorkspaceMembership.objects.filter(user=canonical).values_list(
-                "workspace_id", flat=True,
+                "workspace_id",
+                flat=True,
             )
         )
         dup_wms = WorkspaceMembership.objects.filter(user=duplicate)
@@ -280,8 +284,8 @@ def merge_users(
     with transaction.atomic():
         report.field_changes = _merge_user_fields(canonical, duplicate)
         report.socialaccount_repointed = _repoint_social_accounts(canonical, duplicate)
-        report.emailaddress_repointed, report.emailaddress_deleted = (
-            _dedupe_email_addresses(canonical, duplicate)
+        report.emailaddress_repointed, report.emailaddress_deleted = _dedupe_email_addresses(
+            canonical, duplicate
         )
         report.tenant_membership_repointed, report.tenant_membership_conflict_deleted = (
             _merge_tenant_memberships(canonical, duplicate)
@@ -294,6 +298,8 @@ def merge_users(
         report.duplicate_user_deleted = True
     logger.info(
         "Merged user=%s into canonical=%s: %s",
-        report.duplicate_id, report.canonical_id, report,
+        report.duplicate_id,
+        report.canonical_id,
+        report,
     )
     return report

--- a/apps/users/services/merge.py
+++ b/apps/users/services/merge.py
@@ -32,6 +32,41 @@ _ROLE_RANK = {
 }
 
 
+_SPECIAL_CASE_MODELS = frozenset({
+    "socialaccount.SocialAccount",
+    "account.EmailAddress",
+    "users.TenantMembership",
+    "workspaces.WorkspaceMembership",
+})
+
+
+def _repoint_long_tail_fks(canonical: User, duplicate: User) -> dict[str, int]:
+    """Bulk-update every User FK except those handled by special-case logic.
+
+    Picks up new User FKs added by future apps without code changes. Uses
+    ``get_fields(include_hidden=True)`` so relations declared with
+    ``related_name="+"`` (e.g. ``Workspace.created_by``) are also repointed.
+    If a new FK has a unique constraint involving the user field, this raises
+    IntegrityError on the bulk update — surface that and add explicit
+    handling to merge_users.
+    """
+    counts: dict[str, int] = {}
+    for rel in canonical._meta.get_fields(include_hidden=True):
+        # Only one-to-many reverse relations (FKs pointing at User).
+        if not rel.is_relation or not rel.one_to_many:
+            continue
+        label = rel.related_model._meta.label
+        if label in _SPECIAL_CASE_MODELS:
+            continue
+        field_name = rel.field.name
+        n = rel.related_model._default_manager.filter(
+            **{field_name: duplicate},
+        ).update(**{field_name: canonical})
+        if n:
+            counts[f"{label}.{field_name}"] = n
+    return counts
+
+
 @dataclass
 class MergeReport:
     """Per-merge summary used for logging and command output."""
@@ -233,4 +268,5 @@ def merge_users(
         report.workspace_membership_repointed, report.workspace_membership_conflict_merged = (
             _merge_workspace_memberships(canonical, duplicate)
         )
+        report.long_tail_fk_counts = _repoint_long_tail_fks(canonical, duplicate)
     return report

--- a/apps/users/signals.py
+++ b/apps/users/signals.py
@@ -73,3 +73,21 @@ def resolve_tenant_on_social_login(request, sociallogin, **kwargs):
             async_to_sync(resolve_commcare_domains)(sociallogin.user, token.token)
         except Exception:
             logger.warning("Failed to resolve CommCare domains after OAuth", exc_info=True)
+
+
+def reconcile_existing_user_on_login(sender, request, sociallogin, **kwargs):
+    """Bridge the gap where allauth's _lookup_by_socialaccount short-circuits.
+
+    When an existing OAuth user logs in and the provider now returns an email
+    that the User row doesn't yet have, either backfill it (Task 12) or merge
+    into the user that already owns that email (Task 13).
+    """
+    new_email = sociallogin.account.extra_data.get("email")
+    if not new_email:
+        return
+    user = sociallogin.user
+    if user.pk is None:
+        return  # brand-new user; allauth's _lookup_by_email handles it
+    if user.email:
+        return  # already has an email — nothing to reconcile
+    # Branches for backfill/collision arrive in Tasks 12-14.

--- a/apps/users/signals.py
+++ b/apps/users/signals.py
@@ -3,6 +3,7 @@
 import logging
 
 from asgiref.sync import async_to_sync
+from django.contrib.auth import get_user_model
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
@@ -79,8 +80,8 @@ def reconcile_existing_user_on_login(sender, request, sociallogin, **kwargs):
     """Bridge the gap where allauth's _lookup_by_socialaccount short-circuits.
 
     When an existing OAuth user logs in and the provider now returns an email
-    that the User row doesn't yet have, either backfill it (Task 12) or merge
-    into the user that already owns that email (Task 13).
+    that the User row doesn't yet have, either backfill it or merge into the
+    user that already owns that email.
     """
     new_email = sociallogin.account.extra_data.get("email")
     if not new_email:
@@ -90,4 +91,13 @@ def reconcile_existing_user_on_login(sender, request, sociallogin, **kwargs):
         return  # brand-new user; allauth's _lookup_by_email handles it
     if user.email:
         return  # already has an email — nothing to reconcile
-    # Branches for backfill/collision arrive in Tasks 12-14.
+
+    UserModel = get_user_model()
+    canonical = (
+        UserModel.objects.filter(email__iexact=new_email).exclude(pk=user.pk).first()
+    )
+    if canonical is None:
+        user.email = new_email
+        user.save(update_fields=["email"])
+        return
+    # Collision branch lives in Task 13.

--- a/apps/users/signals.py
+++ b/apps/users/signals.py
@@ -94,9 +94,7 @@ def reconcile_existing_user_on_login(sender, request, sociallogin, **kwargs):
         return  # already has an email — nothing to reconcile
 
     UserModel = get_user_model()
-    canonical = (
-        UserModel.objects.filter(email__iexact=new_email).exclude(pk=user.pk).first()
-    )
+    canonical = UserModel.objects.filter(email__iexact=new_email).exclude(pk=user.pk).first()
     if canonical is None:
         user.email = new_email
         user.save(update_fields=["email"])
@@ -107,12 +105,17 @@ def reconcile_existing_user_on_login(sender, request, sociallogin, **kwargs):
         merge_users(canonical=canonical, duplicate=user)
     except Exception:
         logger.exception(
-            "Auto-merge failed for user=%s into canonical=%s", original_pk, canonical.pk,
+            "Auto-merge failed for user=%s into canonical=%s",
+            original_pk,
+            canonical.pk,
         )
         return
     sociallogin.user = canonical
     sociallogin.account.user = canonical
     logger.info(
         "auto-merge: user=%s into canonical=%s email=%s provider=%s",
-        original_pk, canonical.pk, new_email, sociallogin.account.provider,
+        original_pk,
+        canonical.pk,
+        new_email,
+        sociallogin.account.provider,
     )

--- a/apps/users/signals.py
+++ b/apps/users/signals.py
@@ -7,6 +7,7 @@ from django.contrib.auth import get_user_model
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
+from apps.users.services.merge import merge_users
 from apps.users.services.tenant_resolution import (
     resolve_commcare_domains,
     resolve_connect_opportunities,
@@ -100,4 +101,12 @@ def reconcile_existing_user_on_login(sender, request, sociallogin, **kwargs):
         user.email = new_email
         user.save(update_fields=["email"])
         return
-    # Collision branch lives in Task 13.
+
+    original_pk = user.pk
+    merge_users(canonical=canonical, duplicate=user)
+    sociallogin.user = canonical
+    sociallogin.account.user = canonical
+    logger.info(
+        "auto-merge: user=%s into canonical=%s email=%s provider=%s",
+        original_pk, canonical.pk, new_email, sociallogin.account.provider,
+    )

--- a/apps/users/signals.py
+++ b/apps/users/signals.py
@@ -103,7 +103,13 @@ def reconcile_existing_user_on_login(sender, request, sociallogin, **kwargs):
         return
 
     original_pk = user.pk
-    merge_users(canonical=canonical, duplicate=user)
+    try:
+        merge_users(canonical=canonical, duplicate=user)
+    except Exception:
+        logger.exception(
+            "Auto-merge failed for user=%s into canonical=%s", original_pk, canonical.pk,
+        )
+        return
     sociallogin.user = canonical
     sociallogin.account.user = canonical
     logger.info(

--- a/apps/users/signals.py
+++ b/apps/users/signals.py
@@ -2,6 +2,7 @@
 
 import logging
 
+from allauth.account.models import EmailAddress
 from asgiref.sync import async_to_sync
 from django.contrib.auth import get_user_model
 from django.db.models.signals import post_save
@@ -98,6 +99,19 @@ def reconcile_existing_user_on_login(sender, request, sociallogin, **kwargs):
     if canonical is None:
         user.email = new_email
         user.save(update_fields=["email"])
+        return
+
+    canonical_owns_email = EmailAddress.objects.filter(
+        user=canonical,
+        email__iexact=new_email,
+        verified=True,
+    ).exists()
+    if not canonical_owns_email:
+        logger.warning(
+            "Refusing auto-merge: canonical user=%s lacks verified EmailAddress for %s",
+            canonical.pk,
+            new_email,
+        )
         return
 
     original_pk = user.pk

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -195,6 +195,9 @@ SOCIALACCOUNT_AUTO_SIGNUP = True
 SOCIALACCOUNT_EMAIL_REQUIRED = False
 # Auto-connect social account to existing user with matching email
 SOCIALACCOUNT_EMAIL_AUTHENTICATION_AUTO_CONNECT = True
+# Trust Dimagi-operated providers to have verified the email address on their
+# end. Required so allauth's _lookup_by_email gate fires for these providers.
+SOCIALACCOUNT_EMAIL_AUTHENTICATION = True
 # Allow OAuth users to skip email verification since provider already verified
 SOCIALACCOUNT_EMAIL_VERIFICATION = "none"
 # Store OAuth tokens so we can use them for data materialization
@@ -210,12 +213,15 @@ LOGOUT_REDIRECT_URL = "/"
 SOCIALACCOUNT_PROVIDERS = {
     "commcare_connect": {
         "OAUTH_PKCE_ENABLED": True,
+        "VERIFIED_EMAIL": True,
     },
     "commcare": {
         "OAUTH_PKCE_ENABLED": True,
+        "VERIFIED_EMAIL": True,
     },
     "ocs": {
         "OAUTH_PKCE_ENABLED": True,
+        "VERIFIED_EMAIL": True,
     },
 }
 

--- a/docs/superpowers/plans/2026-05-26-cross-provider-account-linking.md
+++ b/docs/superpowers/plans/2026-05-26-cross-provider-account-linking.md
@@ -1,0 +1,2189 @@
+# Cross-provider account linking — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a single human user log in via CommCare HQ, CommCare Connect, or OCS and always land on the same `User` row, with a management command to merge existing duplicates.
+
+**Architecture:** Four pieces. (A) allauth settings enable email-based auto-link for new OAuth signups. (B) A `pre_social_login` signal handler covers the repeat-login case where allauth short-circuits before its email lookup — either backfilling `User.email` or merging mid-login. (C) A shared `merge_users` service does the actual record merging in one atomic transaction. (D) A `manage.py merge_duplicate_users` command provides operator-driven merges.
+
+**Tech Stack:** Django 5 (async-first), django-allauth 65.x, pytest + pytest-django, ruff (line-length=100, py311).
+
+**Spec:** `docs/superpowers/specs/2026-05-22-cross-provider-account-linking-design.md`
+
+---
+
+## File map
+
+**Modified:**
+- `config/settings/base.py` — three lines: `SOCIALACCOUNT_EMAIL_AUTHENTICATION`, plus `VERIFIED_EMAIL: True` on three providers
+- `apps/users/signals.py` — add `reconcile_existing_user_on_login` receiver
+- `apps/users/apps.py` — wire the new signal alongside the existing two
+
+**Created:**
+- `apps/users/services/merge.py` — `MergeReport` dataclass, `select_canonical`, `merge_users`, and internal helpers
+- `apps/users/management/commands/merge_duplicate_users.py` — operator-facing CLI
+- `tests/test_merge_users_service.py` — direct unit tests on the service
+- `tests/test_social_login_reconciliation.py` — handler tests using constructed `SocialLogin` mocks
+
+---
+
+## Phase 1 — Settings
+
+### Task 1: Enable email-based auto-link in allauth
+
+**Files:**
+- Modify: `config/settings/base.py:183-229`
+- Test: `tests/test_auth_settings.py` (new)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_auth_settings.py`:
+
+```python
+"""Pin the auth settings that enable cross-provider account linking by email."""
+
+from django.conf import settings
+
+
+def test_email_authentication_is_enabled():
+    assert settings.SOCIALACCOUNT_EMAIL_AUTHENTICATION is True
+
+
+def test_email_authentication_auto_connect_is_enabled():
+    assert settings.SOCIALACCOUNT_EMAIL_AUTHENTICATION_AUTO_CONNECT is True
+
+
+def test_dimagi_providers_have_verified_email():
+    providers = settings.SOCIALACCOUNT_PROVIDERS
+    for pid in ("commcare", "commcare_connect", "ocs"):
+        assert providers[pid].get("VERIFIED_EMAIL") is True, (
+            f"{pid} must declare VERIFIED_EMAIL=True so allauth treats its emails as verified"
+        )
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```
+uv run pytest tests/test_auth_settings.py -v
+```
+
+Expected: `test_email_authentication_is_enabled` FAILS (`AttributeError` or `False`), `test_dimagi_providers_have_verified_email` FAILS.
+
+- [ ] **Step 3: Update settings**
+
+Edit `config/settings/base.py`. After the existing `SOCIALACCOUNT_EMAIL_AUTHENTICATION_AUTO_CONNECT = True` line (around line 197), add:
+
+```python
+# Trust Dimagi-operated providers to have verified the email address on their
+# end. Required so allauth's _lookup_by_email gate fires for these providers.
+SOCIALACCOUNT_EMAIL_AUTHENTICATION = True
+```
+
+Then update `SOCIALACCOUNT_PROVIDERS` (currently 3 entries: `commcare_connect`, `commcare`, `ocs`) to add `"VERIFIED_EMAIL": True` to each:
+
+```python
+SOCIALACCOUNT_PROVIDERS = {
+    "commcare_connect": {
+        "OAUTH_PKCE_ENABLED": True,
+        "VERIFIED_EMAIL": True,
+    },
+    "commcare": {
+        "OAUTH_PKCE_ENABLED": True,
+        "VERIFIED_EMAIL": True,
+    },
+    "ocs": {
+        "OAUTH_PKCE_ENABLED": True,
+        "VERIFIED_EMAIL": True,
+    },
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```
+uv run pytest tests/test_auth_settings.py -v
+```
+
+Expected: all 3 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add config/settings/base.py tests/test_auth_settings.py
+git commit -m "feat(auth): enable email-based auto-link across Dimagi OAuth providers"
+```
+
+---
+
+## Phase 2 — Merge service
+
+The merge service is built up test-by-test. Each task creates one focused capability and a test that pins it down. By the end, `merge_users(canonical, duplicate)` is fully functional.
+
+### Task 2: Service skeleton + canonical selection
+
+**Files:**
+- Create: `apps/users/services/merge.py`
+- Test: `tests/test_merge_users_service.py` (new)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_merge_users_service.py`:
+
+```python
+"""Unit tests for apps.users.services.merge.merge_users and helpers."""
+
+import pytest
+from django.contrib.auth import get_user_model
+
+from apps.users.services.merge import select_canonical
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+def test_select_canonical_prefers_usable_password():
+    no_pw = User.objects.create(email="x@y.com", username="a")
+    no_pw.set_unusable_password()
+    no_pw.save()
+    with_pw = User.objects.create(email="x@y.com", username="b")
+    with_pw.set_password("real-password")
+    with_pw.save()
+
+    assert select_canonical([no_pw, with_pw]) == with_pw
+
+
+@pytest.mark.django_db
+def test_select_canonical_prefers_oldest_when_passwords_equal():
+    older = User.objects.create(email="x@y.com", username="older")
+    older.set_password("pw")
+    older.save()
+    newer = User.objects.create(email="x@y.com", username="newer")
+    newer.set_password("pw")
+    newer.save()
+
+    assert select_canonical([newer, older]) == older
+```
+
+Note: `email` is nullable+unique in this codebase, but we set the same string here because `User.save()` only stores the email when the `__init__` value is provided; we'll only ever pass groups of duplicates that already share a real email through `select_canonical`.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```
+uv run pytest tests/test_merge_users_service.py -v
+```
+
+Expected: ImportError — `apps.users.services.merge` doesn't exist yet.
+
+Wait — `User.email` has `unique=True`. Creating two users with the same email will violate the constraint. The above test won't work as-written.
+
+Re-write the tests using distinct emails (the helper only orders within a group; the actual email-grouping is done by the command, not the helper):
+
+```python
+@pytest.mark.django_db
+def test_select_canonical_prefers_usable_password():
+    no_pw = User.objects.create(email="a@y.com", username="a")
+    no_pw.set_unusable_password()
+    no_pw.save()
+    with_pw = User.objects.create(email="b@y.com", username="b")
+    with_pw.set_password("real-password")
+    with_pw.save()
+
+    assert select_canonical([no_pw, with_pw]) == with_pw
+
+
+@pytest.mark.django_db
+def test_select_canonical_prefers_oldest_when_passwords_equal():
+    older = User.objects.create(email="older@y.com", username="older")
+    older.set_password("pw")
+    older.save()
+    newer = User.objects.create(email="newer@y.com", username="newer")
+    newer.set_password("pw")
+    newer.save()
+
+    assert select_canonical([newer, older]) == older
+```
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `apps/users/services/merge.py`:
+
+```python
+"""Merge two duplicate User rows into one canonical row.
+
+Used by:
+- ``apps.users.signals.reconcile_existing_user_on_login`` to absorb a freshly
+  email-bearing OAuth user into an existing email-owning user during login.
+- ``manage.py merge_duplicate_users`` for operator-driven cleanup.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from django.contrib.auth import get_user_model
+
+if TYPE_CHECKING:
+    from apps.users.models import User
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class MergeReport:
+    """Per-merge summary used for logging and command output."""
+
+    canonical_id: int
+    duplicate_id: int
+    dry_run: bool = False
+    field_changes: dict[str, str] = field(default_factory=dict)
+    socialaccount_repointed: int = 0
+    emailaddress_repointed: int = 0
+    emailaddress_deleted: int = 0
+    tenant_membership_repointed: int = 0
+    tenant_membership_conflict_deleted: int = 0
+    workspace_membership_repointed: int = 0
+    workspace_membership_conflict_merged: int = 0
+    long_tail_fk_counts: dict[str, int] = field(default_factory=dict)
+    duplicate_user_deleted: bool = False
+
+
+def select_canonical(users: list["User"]) -> "User":
+    """Return the canonical user from a list of duplicates.
+
+    Priority (highest wins): has a usable password, oldest ``created_at``,
+    lowest ``pk``.
+    """
+    return min(
+        users,
+        key=lambda u: (
+            not u.has_usable_password(),
+            u.created_at,
+            u.pk,
+        ),
+    )
+
+
+def merge_users(
+    *,
+    canonical: "User",
+    duplicate: "User",
+    dry_run: bool = False,
+) -> MergeReport:
+    """Merge ``duplicate`` into ``canonical`` and return a MergeReport.
+
+    Implementation arrives across the remaining tasks in this phase.
+    """
+    if canonical.pk == duplicate.pk:
+        raise ValueError("canonical and duplicate must be different users")
+    return MergeReport(
+        canonical_id=canonical.pk,
+        duplicate_id=duplicate.pk,
+        dry_run=dry_run,
+    )
+```
+
+Also create `apps/users/services/__init__.py` (likely already exists from earlier imports).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```
+uv run pytest tests/test_merge_users_service.py -v
+```
+
+Expected: both tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/users/services/merge.py tests/test_merge_users_service.py
+git commit -m "feat(users): scaffold merge_users service with canonical selection"
+```
+
+---
+
+### Task 3: User field-level merge
+
+**Files:**
+- Modify: `apps/users/services/merge.py`
+- Modify: `tests/test_merge_users_service.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/test_merge_users_service.py`:
+
+```python
+from apps.users.services.merge import merge_users
+
+
+@pytest.mark.django_db
+def test_field_level_merge_copies_password_from_duplicate():
+    canonical = User.objects.create(email="canon@y.com", username="canon")
+    canonical.set_unusable_password()
+    canonical.save()
+    duplicate = User.objects.create(email="dup@y.com", username="dup")
+    duplicate.set_password("real-password")
+    duplicate.save()
+    dup_hash = duplicate.password
+
+    merge_users(canonical=canonical, duplicate=duplicate)
+
+    canonical.refresh_from_db()
+    assert canonical.password == dup_hash
+    assert canonical.has_usable_password()
+
+
+@pytest.mark.django_db
+def test_field_level_merge_ors_staff_and_superuser_flags():
+    canonical = User.objects.create(email="canon@y.com", username="canon")
+    duplicate = User.objects.create(
+        email="dup@y.com", username="dup", is_staff=True, is_superuser=True,
+    )
+
+    merge_users(canonical=canonical, duplicate=duplicate)
+
+    canonical.refresh_from_db()
+    assert canonical.is_staff is True
+    assert canonical.is_superuser is True
+
+
+@pytest.mark.django_db
+def test_field_level_merge_fills_empty_name_fields_from_duplicate():
+    canonical = User.objects.create(email="canon@y.com", username="canon")
+    duplicate = User.objects.create(
+        email="dup@y.com", username="dup",
+        first_name="Brian", last_name="DeRenzi", avatar_url="https://x/y.png",
+    )
+
+    merge_users(canonical=canonical, duplicate=duplicate)
+
+    canonical.refresh_from_db()
+    assert canonical.first_name == "Brian"
+    assert canonical.last_name == "DeRenzi"
+    assert canonical.avatar_url == "https://x/y.png"
+
+
+@pytest.mark.django_db
+def test_field_level_merge_keeps_canonical_name_when_already_set():
+    canonical = User.objects.create(
+        email="canon@y.com", username="canon", first_name="Already", last_name="Set",
+    )
+    duplicate = User.objects.create(
+        email="dup@y.com", username="dup", first_name="Newer", last_name="Name",
+    )
+
+    merge_users(canonical=canonical, duplicate=duplicate)
+
+    canonical.refresh_from_db()
+    assert canonical.first_name == "Already"
+    assert canonical.last_name == "Set"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```
+uv run pytest tests/test_merge_users_service.py -v
+```
+
+Expected: the four new tests FAIL (no field-level merge runs yet).
+
+- [ ] **Step 3: Implement field-level merge**
+
+In `apps/users/services/merge.py`, add at module level (above `merge_users`):
+
+```python
+def _merge_user_fields(canonical: "User", duplicate: "User") -> dict[str, str]:
+    """Apply field-level merge rules. Mutates canonical in place; returns changes."""
+    changes: dict[str, str] = {}
+    if not canonical.has_usable_password() and duplicate.has_usable_password():
+        canonical.password = duplicate.password
+        changes["password"] = "copied from duplicate"
+    if duplicate.is_staff and not canonical.is_staff:
+        canonical.is_staff = True
+        changes["is_staff"] = "True (OR with duplicate)"
+    if duplicate.is_superuser and not canonical.is_superuser:
+        canonical.is_superuser = True
+        changes["is_superuser"] = "True (OR with duplicate)"
+    if duplicate.last_login and (
+        canonical.last_login is None or duplicate.last_login > canonical.last_login
+    ):
+        canonical.last_login = duplicate.last_login
+        changes["last_login"] = f"{duplicate.last_login.isoformat()}"
+    for field_name in ("first_name", "last_name", "avatar_url"):
+        if not getattr(canonical, field_name) and getattr(duplicate, field_name):
+            setattr(canonical, field_name, getattr(duplicate, field_name))
+            changes[field_name] = f"copied: {getattr(duplicate, field_name)!r}"
+    if canonical.timezone == "UTC" and duplicate.timezone and duplicate.timezone != "UTC":
+        canonical.timezone = duplicate.timezone
+        changes["timezone"] = f"copied: {duplicate.timezone!r}"
+    canonical.save()
+    return changes
+```
+
+Then modify `merge_users` to call it:
+
+```python
+def merge_users(*, canonical, duplicate, dry_run=False):
+    if canonical.pk == duplicate.pk:
+        raise ValueError("canonical and duplicate must be different users")
+    report = MergeReport(
+        canonical_id=canonical.pk,
+        duplicate_id=duplicate.pk,
+        dry_run=dry_run,
+    )
+    if dry_run:
+        return report
+    report.field_changes = _merge_user_fields(canonical, duplicate)
+    return report
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```
+uv run pytest tests/test_merge_users_service.py -v
+```
+
+Expected: all 6 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/users/services/merge.py tests/test_merge_users_service.py
+git commit -m "feat(users): merge user-row fields (password, flags, last_login, names)"
+```
+
+---
+
+### Task 4: Repoint SocialAccount rows
+
+**Files:**
+- Modify: `apps/users/services/merge.py`
+- Modify: `tests/test_merge_users_service.py`
+
+- [ ] **Step 1: Write failing test**
+
+Append to `tests/test_merge_users_service.py`:
+
+```python
+from allauth.socialaccount.models import SocialAccount
+
+
+@pytest.mark.django_db
+def test_socialaccounts_are_repointed_to_canonical():
+    canonical = User.objects.create(email="canon@y.com", username="canon")
+    duplicate = User.objects.create(email="dup@y.com", username="dup")
+    SocialAccount.objects.create(user=duplicate, provider="commcare", uid="42")
+    SocialAccount.objects.create(user=duplicate, provider="ocs", uid="ocs-7")
+    SocialAccount.objects.create(user=canonical, provider="commcare_connect", uid="9")
+
+    report = merge_users(canonical=canonical, duplicate=duplicate)
+
+    assert report.socialaccount_repointed == 2
+    assert SocialAccount.objects.filter(user=canonical).count() == 3
+    assert SocialAccount.objects.filter(user=duplicate).count() == 0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```
+uv run pytest tests/test_merge_users_service.py::test_socialaccounts_are_repointed_to_canonical -v
+```
+
+Expected: FAIL — `socialaccount_repointed == 0`, no rows moved.
+
+- [ ] **Step 3: Implement repointing**
+
+Add to `apps/users/services/merge.py` (module level imports first):
+
+```python
+from django.db import transaction
+from allauth.socialaccount.models import SocialAccount
+```
+
+Add helper:
+
+```python
+def _repoint_social_accounts(canonical: "User", duplicate: "User") -> int:
+    return SocialAccount.objects.filter(user=duplicate).update(user=canonical)
+```
+
+Wrap `merge_users` body in a transaction and call the helper:
+
+```python
+def merge_users(*, canonical, duplicate, dry_run=False):
+    if canonical.pk == duplicate.pk:
+        raise ValueError("canonical and duplicate must be different users")
+    report = MergeReport(
+        canonical_id=canonical.pk, duplicate_id=duplicate.pk, dry_run=dry_run,
+    )
+    if dry_run:
+        report.socialaccount_repointed = SocialAccount.objects.filter(user=duplicate).count()
+        return report
+    with transaction.atomic():
+        report.field_changes = _merge_user_fields(canonical, duplicate)
+        report.socialaccount_repointed = _repoint_social_accounts(canonical, duplicate)
+    return report
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```
+uv run pytest tests/test_merge_users_service.py -v
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/users/services/merge.py tests/test_merge_users_service.py
+git commit -m "feat(users): repoint SocialAccount rows during merge"
+```
+
+---
+
+### Task 5: Dedupe EmailAddress rows
+
+**Files:**
+- Modify: `apps/users/services/merge.py`
+- Modify: `tests/test_merge_users_service.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/test_merge_users_service.py`:
+
+```python
+from allauth.account.models import EmailAddress
+
+
+@pytest.mark.django_db
+def test_emailaddress_dedupes_when_both_have_same_email():
+    canonical = User.objects.create(email="brian@y.com", username="canon")
+    duplicate = User.objects.create(email="brian-old@y.com", username="dup")
+    EmailAddress.objects.create(user=canonical, email="brian@y.com", primary=True, verified=True)
+    EmailAddress.objects.create(user=duplicate, email="brian@y.com", primary=True, verified=False)
+
+    report = merge_users(canonical=canonical, duplicate=duplicate)
+
+    assert report.emailaddress_deleted == 1
+    assert EmailAddress.objects.filter(email="brian@y.com").count() == 1
+    survivor = EmailAddress.objects.get(email="brian@y.com")
+    assert survivor.user == canonical
+    assert survivor.primary is True
+    assert survivor.verified is True
+
+
+@pytest.mark.django_db
+def test_emailaddress_repoints_distinct_addresses():
+    canonical = User.objects.create(email="brian@y.com", username="canon")
+    duplicate = User.objects.create(email="brian-old@y.com", username="dup")
+    EmailAddress.objects.create(user=duplicate, email="brian-old@y.com", primary=True, verified=True)
+
+    report = merge_users(canonical=canonical, duplicate=duplicate)
+
+    assert report.emailaddress_repointed == 1
+    assert EmailAddress.objects.filter(user=canonical, email="brian-old@y.com").exists()
+
+
+@pytest.mark.django_db
+def test_emailaddress_creates_primary_row_for_canonical_email():
+    canonical = User.objects.create(email="brian@y.com", username="canon")
+    duplicate = User.objects.create(email="brian-old@y.com", username="dup")
+    # No EmailAddress rows for canonical; merge should create one.
+
+    merge_users(canonical=canonical, duplicate=duplicate)
+
+    primary = EmailAddress.objects.get(user=canonical, email="brian@y.com")
+    assert primary.primary is True
+    assert primary.verified is True
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```
+uv run pytest tests/test_merge_users_service.py -v
+```
+
+Expected: three new tests FAIL.
+
+- [ ] **Step 3: Implement EmailAddress dedupe**
+
+Add to `apps/users/services/merge.py` imports:
+
+```python
+from allauth.account.models import EmailAddress
+```
+
+Add helper:
+
+```python
+def _dedupe_email_addresses(canonical: "User", duplicate: "User") -> tuple[int, int]:
+    """Returns (repointed_count, deleted_count)."""
+    canonical_emails = set(
+        EmailAddress.objects.filter(user=canonical).values_list("email", flat=True)
+    )
+    dup_qs = EmailAddress.objects.filter(user=duplicate)
+    deleted, _ = dup_qs.filter(email__in=canonical_emails).delete()
+    repointed = dup_qs.exclude(email__in=canonical_emails).update(user=canonical)
+    if canonical.email:
+        primary, _created = EmailAddress.objects.get_or_create(
+            user=canonical, email=canonical.email,
+            defaults={"primary": True, "verified": True},
+        )
+        if not primary.primary or not primary.verified:
+            primary.primary = True
+            primary.verified = True
+            primary.save(update_fields=["primary", "verified"])
+        EmailAddress.objects.filter(user=canonical).exclude(pk=primary.pk).filter(
+            primary=True,
+        ).update(primary=False)
+    return repointed, deleted
+```
+
+Call it in `merge_users` after `_repoint_social_accounts`:
+
+```python
+        report.emailaddress_repointed, report.emailaddress_deleted = (
+            _dedupe_email_addresses(canonical, duplicate)
+        )
+```
+
+And in the `dry_run` branch:
+
+```python
+        canonical_emails = set(
+            EmailAddress.objects.filter(user=canonical).values_list("email", flat=True)
+        )
+        dup_qs = EmailAddress.objects.filter(user=duplicate)
+        report.emailaddress_deleted = dup_qs.filter(email__in=canonical_emails).count()
+        report.emailaddress_repointed = dup_qs.exclude(email__in=canonical_emails).count()
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```
+uv run pytest tests/test_merge_users_service.py -v
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/users/services/merge.py tests/test_merge_users_service.py
+git commit -m "feat(users): dedupe EmailAddress rows during merge"
+```
+
+---
+
+### Task 6: Merge TenantMembership with conflict resolution
+
+**Files:**
+- Modify: `apps/users/services/merge.py`
+- Modify: `tests/test_merge_users_service.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/test_merge_users_service.py`:
+
+```python
+from apps.users.models import Tenant, TenantCredential, TenantMembership
+
+
+@pytest.mark.django_db
+def test_tenantmembership_repoints_when_canonical_has_no_overlap():
+    canonical = User.objects.create(email="canon@y.com", username="canon")
+    duplicate = User.objects.create(email="dup@y.com", username="dup")
+    t1 = Tenant.objects.create(provider="commcare", external_id="d1", canonical_name="D1")
+    t2 = Tenant.objects.create(provider="commcare", external_id="d2", canonical_name="D2")
+    TenantMembership.objects.create(user=duplicate, tenant=t1)
+    TenantMembership.objects.create(user=duplicate, tenant=t2)
+
+    report = merge_users(canonical=canonical, duplicate=duplicate)
+
+    assert report.tenant_membership_repointed == 2
+    assert report.tenant_membership_conflict_deleted == 0
+    assert TenantMembership.objects.filter(user=canonical).count() == 2
+
+
+@pytest.mark.django_db
+def test_tenantmembership_conflict_keeps_canonical_and_deletes_duplicates():
+    canonical = User.objects.create(email="canon@y.com", username="canon")
+    duplicate = User.objects.create(email="dup@y.com", username="dup")
+    shared = Tenant.objects.create(provider="commcare", external_id="d1", canonical_name="D1")
+    only_dup = Tenant.objects.create(provider="ocs", external_id="exp9", canonical_name="Exp9")
+    canon_tm = TenantMembership.objects.create(user=canonical, tenant=shared)
+    TenantCredential.objects.create(
+        tenant_membership=canon_tm, credential_type=TenantCredential.OAUTH,
+    )
+    TenantMembership.objects.create(user=duplicate, tenant=shared)  # conflict
+    TenantMembership.objects.create(user=duplicate, tenant=only_dup)
+
+    report = merge_users(canonical=canonical, duplicate=duplicate)
+
+    assert report.tenant_membership_repointed == 1
+    assert report.tenant_membership_conflict_deleted == 1
+    # canonical still has its row for the shared tenant
+    assert TenantMembership.objects.filter(user=canonical, tenant=shared).count() == 1
+    # canonical now also has only_dup's tenant
+    assert TenantMembership.objects.filter(user=canonical, tenant=only_dup).exists()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```
+uv run pytest tests/test_merge_users_service.py -v
+```
+
+Expected: two new tests FAIL.
+
+- [ ] **Step 3: Implement TenantMembership merge**
+
+Add to `apps/users/services/merge.py` imports:
+
+```python
+from apps.users.models import TenantMembership
+```
+
+Add helper:
+
+```python
+def _merge_tenant_memberships(canonical: "User", duplicate: "User") -> tuple[int, int]:
+    """Returns (repointed_count, conflict_deleted_count)."""
+    canonical_tenant_ids = set(
+        TenantMembership.objects.filter(user=canonical).values_list("tenant_id", flat=True)
+    )
+    dup_qs = TenantMembership.objects.filter(user=duplicate)
+    conflicts = dup_qs.filter(tenant_id__in=canonical_tenant_ids)
+    conflict_deleted, _ = conflicts.delete()  # TenantCredential cascades
+    repointed = dup_qs.exclude(tenant_id__in=canonical_tenant_ids).update(user=canonical)
+    return repointed, conflict_deleted
+```
+
+Call it in `merge_users`:
+
+```python
+        report.tenant_membership_repointed, report.tenant_membership_conflict_deleted = (
+            _merge_tenant_memberships(canonical, duplicate)
+        )
+```
+
+And update the `dry_run` branch similarly with `.count()` calls.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```
+uv run pytest tests/test_merge_users_service.py -v
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/users/services/merge.py tests/test_merge_users_service.py
+git commit -m "feat(users): merge TenantMembership with conflict resolution"
+```
+
+---
+
+### Task 7: Merge WorkspaceMembership with role upgrade
+
+**Files:**
+- Modify: `apps/users/services/merge.py`
+- Modify: `tests/test_merge_users_service.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/test_merge_users_service.py`:
+
+```python
+from apps.workspaces.models import Workspace, WorkspaceMembership, WorkspaceRole
+
+
+@pytest.mark.django_db
+def test_workspacemembership_repoints_when_no_overlap():
+    canonical = User.objects.create(email="canon@y.com", username="canon")
+    duplicate = User.objects.create(email="dup@y.com", username="dup")
+    ws = Workspace.objects.create(name="W")
+    WorkspaceMembership.objects.create(workspace=ws, user=duplicate, role=WorkspaceRole.READ)
+
+    report = merge_users(canonical=canonical, duplicate=duplicate)
+
+    assert report.workspace_membership_repointed == 1
+    assert report.workspace_membership_conflict_merged == 0
+    assert WorkspaceMembership.objects.get(workspace=ws).user == canonical
+
+
+@pytest.mark.django_db
+def test_workspacemembership_conflict_upgrades_to_higher_role():
+    canonical = User.objects.create(email="canon@y.com", username="canon")
+    duplicate = User.objects.create(email="dup@y.com", username="dup")
+    ws = Workspace.objects.create(name="W")
+    WorkspaceMembership.objects.create(workspace=ws, user=canonical, role=WorkspaceRole.READ)
+    WorkspaceMembership.objects.create(workspace=ws, user=duplicate, role=WorkspaceRole.MANAGE)
+
+    report = merge_users(canonical=canonical, duplicate=duplicate)
+
+    assert report.workspace_membership_conflict_merged == 1
+    membership = WorkspaceMembership.objects.get(workspace=ws)
+    assert membership.user == canonical
+    assert membership.role == WorkspaceRole.MANAGE
+
+
+@pytest.mark.django_db
+def test_workspacemembership_conflict_keeps_canonical_when_higher():
+    canonical = User.objects.create(email="canon@y.com", username="canon")
+    duplicate = User.objects.create(email="dup@y.com", username="dup")
+    ws = Workspace.objects.create(name="W")
+    WorkspaceMembership.objects.create(workspace=ws, user=canonical, role=WorkspaceRole.MANAGE)
+    WorkspaceMembership.objects.create(workspace=ws, user=duplicate, role=WorkspaceRole.READ)
+
+    merge_users(canonical=canonical, duplicate=duplicate)
+
+    assert WorkspaceMembership.objects.get(workspace=ws).role == WorkspaceRole.MANAGE
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```
+uv run pytest tests/test_merge_users_service.py -v
+```
+
+Expected: three new tests FAIL.
+
+- [ ] **Step 3: Implement WorkspaceMembership merge**
+
+Add to `apps/users/services/merge.py` imports:
+
+```python
+from apps.workspaces.models import WorkspaceMembership, WorkspaceRole
+```
+
+Add helper:
+
+```python
+_ROLE_RANK = {
+    WorkspaceRole.READ: 0,
+    WorkspaceRole.READ_WRITE: 1,
+    WorkspaceRole.MANAGE: 2,
+}
+
+
+def _merge_workspace_memberships(canonical: "User", duplicate: "User") -> tuple[int, int]:
+    """Returns (repointed_count, conflict_merged_count)."""
+    canonical_by_ws = {
+        m.workspace_id: m for m in WorkspaceMembership.objects.filter(user=canonical)
+    }
+    dup_memberships = list(WorkspaceMembership.objects.filter(user=duplicate))
+    conflict_merged = 0
+    repointed = 0
+    for dup_m in dup_memberships:
+        canon_m = canonical_by_ws.get(dup_m.workspace_id)
+        if canon_m is None:
+            dup_m.user = canonical
+            dup_m.save(update_fields=["user"])
+            repointed += 1
+            continue
+        if _ROLE_RANK[WorkspaceRole(dup_m.role)] > _ROLE_RANK[WorkspaceRole(canon_m.role)]:
+            canon_m.role = dup_m.role
+            canon_m.save(update_fields=["role"])
+        dup_m.delete()
+        conflict_merged += 1
+    return repointed, conflict_merged
+```
+
+Call in `merge_users`:
+
+```python
+        report.workspace_membership_repointed, report.workspace_membership_conflict_merged = (
+            _merge_workspace_memberships(canonical, duplicate)
+        )
+```
+
+And add equivalent count-only logic in the `dry_run` branch.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```
+uv run pytest tests/test_merge_users_service.py -v
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/users/services/merge.py tests/test_merge_users_service.py
+git commit -m "feat(users): merge WorkspaceMembership with role-upgrade conflict resolution"
+```
+
+---
+
+### Task 8: Long-tail FK repointing via introspection
+
+**Files:**
+- Modify: `apps/users/services/merge.py`
+- Modify: `tests/test_merge_users_service.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/test_merge_users_service.py`:
+
+```python
+from apps.chat.models import Thread
+
+
+@pytest.mark.django_db
+def test_chat_threads_are_repointed_via_introspection():
+    canonical = User.objects.create(email="canon@y.com", username="canon")
+    duplicate = User.objects.create(email="dup@y.com", username="dup")
+    Thread.objects.create(user=duplicate, title="T1")
+    Thread.objects.create(user=duplicate, title="T2")
+
+    report = merge_users(canonical=canonical, duplicate=duplicate)
+
+    assert Thread.objects.filter(user=canonical).count() == 2
+    assert Thread.objects.filter(user=duplicate).count() == 0
+    label = "chat.Thread.user"
+    assert report.long_tail_fk_counts.get(label) == 2
+
+
+@pytest.mark.django_db
+def test_setnull_fk_is_repointed_via_introspection():
+    canonical = User.objects.create(email="canon@y.com", username="canon")
+    duplicate = User.objects.create(email="dup@y.com", username="dup")
+    ws = Workspace.objects.create(name="W", created_by=duplicate)
+
+    merge_users(canonical=canonical, duplicate=duplicate)
+
+    ws.refresh_from_db()
+    assert ws.created_by == canonical
+```
+
+Note: `Thread` may require a workspace FK or other related fields. Adjust the test setup based on `apps/chat/models.py` — read the file before writing the test if `Thread.objects.create(user=...)` raises `IntegrityError` for missing required fields. Use `pytest -x` to short-circuit on the first failure and inspect.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```
+uv run pytest tests/test_merge_users_service.py -v
+```
+
+Expected: both new tests FAIL (no long-tail loop yet).
+
+- [ ] **Step 3: Implement introspection loop**
+
+In `apps/users/services/merge.py`, add at module level:
+
+```python
+_SPECIAL_CASE_MODELS = frozenset({
+    "socialaccount.SocialAccount",
+    "account.EmailAddress",
+    "users.TenantMembership",
+    "workspaces.WorkspaceMembership",
+})
+
+
+def _repoint_long_tail_fks(canonical: "User", duplicate: "User") -> dict[str, int]:
+    """Bulk-update every User FK except those handled by special-case logic.
+
+    Picks up new User FKs added by future apps without code changes. If a
+    new FK has a unique constraint involving the user field, this raises
+    IntegrityError on the bulk update — surface that and add explicit
+    handling to merge_users.
+    """
+    counts: dict[str, int] = {}
+    for rel in canonical._meta.related_objects:
+        label = rel.related_model._meta.label
+        if label in _SPECIAL_CASE_MODELS:
+            continue
+        field_name = rel.field.name
+        n = rel.related_model._default_manager.filter(
+            **{field_name: duplicate},
+        ).update(**{field_name: canonical})
+        if n:
+            counts[f"{label}.{field_name}"] = n
+    return counts
+```
+
+Call in `merge_users` after the workspace membership step:
+
+```python
+        report.long_tail_fk_counts = _repoint_long_tail_fks(canonical, duplicate)
+```
+
+Skip in the `dry_run` branch (counting per-field via introspection is verbose; the per-field detail isn't load-bearing for the plan preview).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```
+uv run pytest tests/test_merge_users_service.py -v
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/users/services/merge.py tests/test_merge_users_service.py
+git commit -m "feat(users): repoint long-tail User FKs via _meta.related_objects"
+```
+
+---
+
+### Task 9: Delete the duplicate user + atomic rollback
+
+**Files:**
+- Modify: `apps/users/services/merge.py`
+- Modify: `tests/test_merge_users_service.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/test_merge_users_service.py`:
+
+```python
+from unittest.mock import patch
+
+
+@pytest.mark.django_db
+def test_duplicate_user_row_is_deleted():
+    canonical = User.objects.create(email="canon@y.com", username="canon")
+    duplicate = User.objects.create(email="dup@y.com", username="dup")
+
+    report = merge_users(canonical=canonical, duplicate=duplicate)
+
+    assert report.duplicate_user_deleted is True
+    assert not User.objects.filter(pk=duplicate.pk).exists()
+    assert User.objects.filter(pk=canonical.pk).exists()
+
+
+@pytest.mark.django_db
+def test_merge_rolls_back_on_exception():
+    canonical = User.objects.create(email="canon@y.com", username="canon")
+    duplicate = User.objects.create(email="dup@y.com", username="dup")
+    SocialAccount.objects.create(user=duplicate, provider="commcare", uid="42")
+
+    with patch(
+        "apps.users.services.merge._repoint_long_tail_fks",
+        side_effect=RuntimeError("simulated failure"),
+    ), pytest.raises(RuntimeError):
+        merge_users(canonical=canonical, duplicate=duplicate)
+
+    # Everything must be untouched
+    assert User.objects.filter(pk=duplicate.pk).exists()
+    assert SocialAccount.objects.get(provider="commcare", uid="42").user == duplicate
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```
+uv run pytest tests/test_merge_users_service.py -v
+```
+
+Expected: both new tests FAIL.
+
+- [ ] **Step 3: Implement deletion + finalize atomic wrapping**
+
+Update `merge_users` body. Full state of the function should now be:
+
+```python
+def merge_users(*, canonical, duplicate, dry_run=False):
+    if canonical.pk == duplicate.pk:
+        raise ValueError("canonical and duplicate must be different users")
+    report = MergeReport(
+        canonical_id=canonical.pk, duplicate_id=duplicate.pk, dry_run=dry_run,
+    )
+    if dry_run:
+        # Count-only plan (no writes).
+        report.socialaccount_repointed = SocialAccount.objects.filter(user=duplicate).count()
+        canonical_emails = set(
+            EmailAddress.objects.filter(user=canonical).values_list("email", flat=True)
+        )
+        dup_emails = EmailAddress.objects.filter(user=duplicate)
+        report.emailaddress_deleted = dup_emails.filter(email__in=canonical_emails).count()
+        report.emailaddress_repointed = dup_emails.exclude(email__in=canonical_emails).count()
+        canonical_tenant_ids = set(
+            TenantMembership.objects.filter(user=canonical).values_list("tenant_id", flat=True)
+        )
+        dup_tms = TenantMembership.objects.filter(user=duplicate)
+        report.tenant_membership_conflict_deleted = dup_tms.filter(
+            tenant_id__in=canonical_tenant_ids,
+        ).count()
+        report.tenant_membership_repointed = dup_tms.exclude(
+            tenant_id__in=canonical_tenant_ids,
+        ).count()
+        canonical_ws_ids = set(
+            WorkspaceMembership.objects.filter(user=canonical).values_list(
+                "workspace_id", flat=True,
+            )
+        )
+        dup_wms = WorkspaceMembership.objects.filter(user=duplicate)
+        report.workspace_membership_conflict_merged = dup_wms.filter(
+            workspace_id__in=canonical_ws_ids,
+        ).count()
+        report.workspace_membership_repointed = dup_wms.exclude(
+            workspace_id__in=canonical_ws_ids,
+        ).count()
+        return report
+
+    with transaction.atomic():
+        report.field_changes = _merge_user_fields(canonical, duplicate)
+        report.socialaccount_repointed = _repoint_social_accounts(canonical, duplicate)
+        report.emailaddress_repointed, report.emailaddress_deleted = (
+            _dedupe_email_addresses(canonical, duplicate)
+        )
+        report.tenant_membership_repointed, report.tenant_membership_conflict_deleted = (
+            _merge_tenant_memberships(canonical, duplicate)
+        )
+        report.workspace_membership_repointed, report.workspace_membership_conflict_merged = (
+            _merge_workspace_memberships(canonical, duplicate)
+        )
+        report.long_tail_fk_counts = _repoint_long_tail_fks(canonical, duplicate)
+        duplicate.delete()
+        report.duplicate_user_deleted = True
+    logger.info(
+        "Merged user=%s into canonical=%s: %s",
+        report.duplicate_id, report.canonical_id, report,
+    )
+    return report
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```
+uv run pytest tests/test_merge_users_service.py -v
+```
+
+Expected: all tests (~16) PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/users/services/merge.py tests/test_merge_users_service.py
+git commit -m "feat(users): finalize merge — delete duplicate, atomic rollback on failure"
+```
+
+---
+
+### Task 10: Dry-run preserves DB state
+
+**Files:**
+- Modify: `tests/test_merge_users_service.py`
+
+This task is verification-only — the dry-run code path was added in Task 4 and refined through Task 9. We pin it down with a dedicated test.
+
+- [ ] **Step 1: Write the test**
+
+Append to `tests/test_merge_users_service.py`:
+
+```python
+@pytest.mark.django_db
+def test_dry_run_writes_nothing_and_returns_a_plan():
+    canonical = User.objects.create(email="canon@y.com", username="canon")
+    duplicate = User.objects.create(email="dup@y.com", username="dup")
+    SocialAccount.objects.create(user=duplicate, provider="commcare", uid="42")
+    EmailAddress.objects.create(user=duplicate, email="canon@y.com", primary=True)
+
+    report = merge_users(canonical=canonical, duplicate=duplicate, dry_run=True)
+
+    assert report.dry_run is True
+    assert report.socialaccount_repointed == 1
+    assert report.emailaddress_deleted == 1
+    # Nothing actually changed
+    assert SocialAccount.objects.get(provider="commcare", uid="42").user == duplicate
+    assert User.objects.filter(pk=duplicate.pk).exists()
+    assert not report.duplicate_user_deleted
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+```
+uv run pytest tests/test_merge_users_service.py::test_dry_run_writes_nothing_and_returns_a_plan -v
+```
+
+Expected: PASS (dry-run already implemented; this is the regression pin).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_merge_users_service.py
+git commit -m "test(users): pin merge_users dry-run leaves DB untouched"
+```
+
+---
+
+## Phase 3 — Signal handler
+
+### Task 11: Handler skeleton + no-op branches
+
+**Files:**
+- Modify: `apps/users/signals.py`
+- Create: `tests/test_social_login_reconciliation.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/test_social_login_reconciliation.py`:
+
+```python
+"""Tests for the pre_social_login handler that backfills/merges emails."""
+
+from types import SimpleNamespace
+
+import pytest
+from django.contrib.auth import get_user_model
+
+from apps.users.signals import reconcile_existing_user_on_login
+
+User = get_user_model()
+
+
+def _sociallogin(user, extra_data):
+    """Build a SocialLogin-shaped stub. Handler only touches .user and .account."""
+    return SimpleNamespace(
+        user=user,
+        account=SimpleNamespace(extra_data=extra_data, user=user),
+    )
+
+
+@pytest.mark.django_db
+def test_brand_new_user_is_noop():
+    new_user = User(email=None)  # unsaved → pk is None
+    sl = _sociallogin(new_user, {"email": "x@y.com"})
+
+    reconcile_existing_user_on_login(sender=None, request=None, sociallogin=sl)
+
+    # No DB writes; new_user remains unsaved
+    assert new_user.pk is None
+
+
+@pytest.mark.django_db
+def test_existing_user_with_email_is_noop():
+    existing = User.objects.create(email="brian@y.com", username="b")
+    sl = _sociallogin(existing, {"email": "other@y.com"})
+
+    reconcile_existing_user_on_login(sender=None, request=None, sociallogin=sl)
+
+    existing.refresh_from_db()
+    assert existing.email == "brian@y.com"  # untouched
+
+
+@pytest.mark.django_db
+def test_no_email_in_extra_data_is_noop():
+    existing = User.objects.create(email=None, username="b")
+    sl = _sociallogin(existing, {})  # no email key
+
+    reconcile_existing_user_on_login(sender=None, request=None, sociallogin=sl)
+
+    existing.refresh_from_db()
+    assert existing.email is None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```
+uv run pytest tests/test_social_login_reconciliation.py -v
+```
+
+Expected: ImportError — `reconcile_existing_user_on_login` doesn't exist yet.
+
+- [ ] **Step 3: Implement handler skeleton**
+
+Edit `apps/users/signals.py`. Add to existing imports (module level):
+
+```python
+from allauth.socialaccount.signals import pre_social_login
+from django.contrib.auth import get_user_model
+
+from apps.users.services.merge import merge_users
+```
+
+Append at module level (below existing `resolve_tenant_on_social_login`):
+
+```python
+def reconcile_existing_user_on_login(sender, request, sociallogin, **kwargs):
+    """Bridge the gap where allauth's _lookup_by_socialaccount short-circuits.
+
+    When an existing OAuth user logs in and the provider now returns an email
+    that the User row doesn't yet have, either backfill it or merge into the
+    user that already owns that email.
+
+    Implementation arrives across this phase's tasks.
+    """
+    new_email = sociallogin.account.extra_data.get("email")
+    if not new_email:
+        return
+    user = sociallogin.user
+    if user.pk is None:
+        return  # brand-new user; allauth's _lookup_by_email already handled it
+    if user.email:
+        return  # already has an email; nothing to reconcile
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```
+uv run pytest tests/test_social_login_reconciliation.py -v
+```
+
+Expected: all 3 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/users/signals.py tests/test_social_login_reconciliation.py
+git commit -m "feat(users): scaffold pre_social_login handler with no-op branches"
+```
+
+---
+
+### Task 12: Backfill email when no collision
+
+**Files:**
+- Modify: `apps/users/signals.py`
+- Modify: `tests/test_social_login_reconciliation.py`
+
+- [ ] **Step 1: Write failing test**
+
+Append to `tests/test_social_login_reconciliation.py`:
+
+```python
+@pytest.mark.django_db
+def test_no_collision_backfills_user_email():
+    existing = User.objects.create(email=None, username="connect-user")
+    sl = _sociallogin(existing, {"email": "brian@y.com"})
+
+    reconcile_existing_user_on_login(sender=None, request=None, sociallogin=sl)
+
+    existing.refresh_from_db()
+    assert existing.email == "brian@y.com"
+```
+
+(Case-insensitive collision behavior is tested in Task 13 once the merge branch lands.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```
+uv run pytest tests/test_social_login_reconciliation.py -v
+```
+
+Expected: `test_no_collision_backfills_user_email` FAILS (email stays None).
+
+- [ ] **Step 3: Implement backfill branch**
+
+In `apps/users/signals.py`, extend `reconcile_existing_user_on_login`:
+
+```python
+def reconcile_existing_user_on_login(sender, request, sociallogin, **kwargs):
+    new_email = sociallogin.account.extra_data.get("email")
+    if not new_email:
+        return
+    user = sociallogin.user
+    if user.pk is None:
+        return
+    if user.email:
+        return
+
+    UserModel = get_user_model()
+    canonical = (
+        UserModel.objects.filter(email__iexact=new_email).exclude(pk=user.pk).first()
+    )
+    if canonical is None:
+        user.email = new_email
+        user.save(update_fields=["email"])
+        return
+    # Collision branch lives in task 13.
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```
+uv run pytest tests/test_social_login_reconciliation.py -v
+```
+
+Expected: all 5 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/users/signals.py tests/test_social_login_reconciliation.py
+git commit -m "feat(users): backfill User.email on OAuth login when no collision"
+```
+
+---
+
+### Task 13: Trigger merge on collision and redirect session
+
+**Files:**
+- Modify: `apps/users/signals.py`
+- Modify: `tests/test_social_login_reconciliation.py`
+
+- [ ] **Step 1: Write failing test**
+
+Append to `tests/test_social_login_reconciliation.py`:
+
+```python
+from allauth.socialaccount.models import SocialAccount
+
+
+@pytest.mark.django_db
+def test_collision_merges_user_and_redirects_session():
+    canonical = User.objects.create(email="brian@y.com", username="canon")
+    duplicate = User.objects.create(email=None, username="connect-user")
+    dup_account = SocialAccount.objects.create(
+        user=duplicate, provider="commcare_connect", uid="999",
+        extra_data={"email": "brian@y.com"},
+    )
+    sl = SimpleNamespace(user=duplicate, account=dup_account)
+
+    reconcile_existing_user_on_login(sender=None, request=None, sociallogin=sl)
+
+    # duplicate was merged away
+    assert not User.objects.filter(pk=duplicate.pk).exists()
+    # Connect SocialAccount now points at canonical
+    dup_account.refresh_from_db()
+    assert dup_account.user == canonical
+    # Session redirected
+    assert sl.user == canonical
+    assert sl.account.user == canonical
+
+
+@pytest.mark.django_db
+def test_collision_match_is_case_insensitive():
+    canonical = User.objects.create(email="Brian@Y.com", username="canon")
+    duplicate = User.objects.create(email=None, username="dup")
+    dup_account = SocialAccount.objects.create(
+        user=duplicate, provider="commcare_connect", uid="x",
+        extra_data={"email": "brian@y.com"},
+    )
+    sl = SimpleNamespace(user=duplicate, account=dup_account)
+
+    reconcile_existing_user_on_login(sender=None, request=None, sociallogin=sl)
+
+    assert not User.objects.filter(pk=duplicate.pk).exists()
+    assert sl.user == canonical
+```
+
+`SocialAccount` has a real `extra_data` JSONField, so we set the email via the model's `extra_data=` kwarg rather than stubbing a `SimpleNamespace`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```
+uv run pytest tests/test_social_login_reconciliation.py::test_collision_merges_user_and_redirects_session -v
+```
+
+Expected: FAIL — duplicate not deleted, account not repointed.
+
+- [ ] **Step 3: Implement collision branch**
+
+Replace the final lines of `reconcile_existing_user_on_login` in `apps/users/signals.py`:
+
+```python
+    if canonical is None:
+        user.email = new_email
+        user.save(update_fields=["email"])
+        return
+
+    merge_users(canonical=canonical, duplicate=user)
+    sociallogin.user = canonical
+    sociallogin.account.user = canonical
+    logger.info(
+        "auto-merge: user=%s into canonical=%s email=%s provider=%s",
+        user.pk, canonical.pk, new_email, sociallogin.account.provider,
+    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```
+uv run pytest tests/test_social_login_reconciliation.py -v
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/users/signals.py tests/test_social_login_reconciliation.py
+git commit -m "feat(users): auto-merge on collision and redirect login session"
+```
+
+---
+
+### Task 14: Merge failure must not block login
+
+**Files:**
+- Modify: `apps/users/signals.py`
+- Modify: `tests/test_social_login_reconciliation.py`
+
+- [ ] **Step 1: Write failing test**
+
+Append to `tests/test_social_login_reconciliation.py`:
+
+```python
+from unittest.mock import patch
+
+
+@pytest.mark.django_db
+def test_merge_failure_does_not_break_login(caplog):
+    canonical = User.objects.create(email="brian@y.com", username="canon")
+    duplicate = User.objects.create(email=None, username="connect-user")
+    dup_account = SocialAccount.objects.create(
+        user=duplicate, provider="commcare_connect", uid="999",
+        extra_data={"email": "brian@y.com"},
+    )
+    sl = SimpleNamespace(user=duplicate, account=dup_account)
+
+    with patch(
+        "apps.users.signals.merge_users",
+        side_effect=RuntimeError("boom"),
+    ):
+        # Must not raise.
+        reconcile_existing_user_on_login(sender=None, request=None, sociallogin=sl)
+
+    # Duplicate still present, login continues on duplicate
+    assert User.objects.filter(pk=duplicate.pk).exists()
+    assert sl.user == duplicate
+    # Failure was logged at ERROR
+    assert any(
+        r.levelname == "ERROR" and "Auto-merge failed" in r.message
+        for r in caplog.records
+    )
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```
+uv run pytest tests/test_social_login_reconciliation.py::test_merge_failure_does_not_break_login -v
+```
+
+Expected: FAIL — `RuntimeError` propagates out of the handler.
+
+- [ ] **Step 3: Wrap merge in try/except**
+
+In `apps/users/signals.py`, replace the collision branch:
+
+```python
+    try:
+        merge_users(canonical=canonical, duplicate=user)
+    except Exception:
+        logger.exception(
+            "Auto-merge failed for user=%s into canonical=%s", user.pk, canonical.pk,
+        )
+        return
+    sociallogin.user = canonical
+    sociallogin.account.user = canonical
+    logger.info(
+        "auto-merge: user=%s into canonical=%s email=%s provider=%s",
+        user.pk, canonical.pk, new_email, sociallogin.account.provider,
+    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```
+uv run pytest tests/test_social_login_reconciliation.py -v
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/users/signals.py tests/test_social_login_reconciliation.py
+git commit -m "feat(users): swallow merge failure during login so users can still sign in"
+```
+
+---
+
+### Task 15: Wire the signal in apps.py
+
+**Files:**
+- Modify: `apps/users/apps.py`
+- Modify: `tests/test_social_login_reconciliation.py` (add wiring assertion)
+
+- [ ] **Step 1: Write failing test**
+
+Append to `tests/test_social_login_reconciliation.py`:
+
+```python
+def test_signal_is_wired_in_app_ready():
+    from allauth.socialaccount.signals import pre_social_login
+
+    receivers = [
+        ref() for _, ref in pre_social_login.receivers if ref() is not None
+    ]
+    receiver_names = [getattr(r, "__name__", "") for r in receivers]
+    assert "reconcile_existing_user_on_login" in receiver_names
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```
+uv run pytest tests/test_social_login_reconciliation.py::test_signal_is_wired_in_app_ready -v
+```
+
+Expected: FAIL — handler isn't connected yet.
+
+- [ ] **Step 3: Wire the signal in apps.py**
+
+Edit `apps/users/apps.py`:
+
+```python
+from django.apps import AppConfig
+
+
+class UsersConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "apps.users"
+    verbose_name = "Users"
+
+    def ready(self):
+        from allauth.socialaccount.signals import (
+            pre_social_login,
+            social_account_added,
+            social_account_updated,
+        )
+
+        import apps.users.signals  # noqa: F401 — connects auto_create_workspace_on_membership
+        from apps.users.signals import (
+            reconcile_existing_user_on_login,
+            resolve_tenant_on_social_login,
+        )
+
+        social_account_added.connect(resolve_tenant_on_social_login)
+        social_account_updated.connect(resolve_tenant_on_social_login)
+        pre_social_login.connect(reconcile_existing_user_on_login)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```
+uv run pytest tests/test_social_login_reconciliation.py -v
+```
+
+Expected: all tests PASS.
+
+Also run the full test suite to make sure nothing else broke:
+
+```
+uv run pytest -q
+```
+
+Expected: green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/users/apps.py tests/test_social_login_reconciliation.py
+git commit -m "feat(users): wire pre_social_login handler in UsersConfig.ready"
+```
+
+---
+
+## Phase 4 — Management command
+
+### Task 16: Command skeleton — find duplicate groups + canonical selection
+
+**Files:**
+- Create: `apps/users/management/commands/merge_duplicate_users.py`
+- Create: `tests/test_merge_duplicate_users_command.py`
+
+- [ ] **Step 1: Write failing test**
+
+`User.email` has `unique=True`, enforced at the DB level. We can't directly insert two rows with the same email — but the model's unique constraint is case-sensitive in PostgreSQL, so `brian@y.com` and `Brian@Y.com` legally coexist. The command groups case-insensitively (per spec), so these count as one duplicate group. Tests use case variations to construct the duplicate state.
+
+Create `tests/test_merge_duplicate_users_command.py`:
+
+```python
+"""Tests for the merge_duplicate_users management command."""
+
+from io import StringIO
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.core.management import call_command
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+def test_dry_run_finds_no_duplicates_when_emails_are_unique():
+    User.objects.create(email="a@y.com", username="a")
+    User.objects.create(email="b@y.com", username="b")
+    out = StringIO()
+
+    call_command("merge_duplicate_users", "--dry-run", stdout=out)
+
+    assert "no duplicates found" in out.getvalue().lower()
+
+
+@pytest.mark.django_db
+def test_dry_run_lists_duplicate_groups():
+    older = User.objects.create(email="brian@y.com", username="older")
+    older.set_password("pw")
+    older.save()
+    newer = User.objects.create(email="Brian@Y.com", username="newer")
+    out = StringIO()
+
+    call_command("merge_duplicate_users", "--dry-run", stdout=out)
+
+    output = out.getvalue()
+    assert "brian@y.com" in output.lower()
+    assert f"canonical: User#{older.pk}" in output
+    # dry-run leaves DB intact
+    assert User.objects.filter(pk=newer.pk).exists()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```
+uv run pytest tests/test_merge_duplicate_users_command.py -v
+```
+
+Expected: FAIL — command doesn't exist.
+
+- [ ] **Step 3: Implement command skeleton**
+
+Create `apps/users/management/commands/merge_duplicate_users.py`:
+
+```python
+"""Operator command to merge duplicate User rows that share an email.
+
+Usage:
+    python manage.py merge_duplicate_users [--dry-run] [--email EMAIL]
+                                           [--canonical-id ID] [--yes]
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any
+
+from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand, CommandError
+from django.db.models.functions import Lower
+
+from apps.users.services.merge import MergeReport, merge_users, select_canonical
+
+User = get_user_model()
+
+
+class Command(BaseCommand):
+    help = "Merge duplicate User rows that share an email address."
+
+    def add_arguments(self, parser) -> None:
+        parser.add_argument("--dry-run", action="store_true", help="Print plan, write nothing.")
+        parser.add_argument("--email", help="Only operate on the group sharing this email.")
+        parser.add_argument(
+            "--canonical-id", type=int,
+            help="Force this user as canonical. Must be in the targeted group.",
+        )
+        parser.add_argument("--yes", action="store_true", help="Skip the confirmation prompt.")
+
+    def handle(self, *args: Any, **opts: Any) -> None:
+        groups = self._find_groups(target_email=opts.get("email"))
+        if not groups:
+            target = opts.get("email")
+            self.stdout.write(
+                f"no duplicates found{' for ' + target if target else ''}"
+            )
+            return
+
+        plans: list[tuple[list[User], MergeReport, User]] = []
+        for users in groups:
+            canonical = self._pick_canonical(users, forced_id=opts.get("canonical_id"))
+            for dup in users:
+                if dup.pk == canonical.pk:
+                    continue
+                report = merge_users(canonical=canonical, duplicate=dup, dry_run=True)
+                plans.append(([canonical, dup], report, canonical))
+                self._print_plan(canonical, dup, report)
+
+        if opts.get("dry_run"):
+            return
+
+        if not opts.get("yes"):
+            response = input(
+                f"About to merge {len(plans)} duplicate(s). Continue? [y/N] "
+            ).strip().lower()
+            if response != "y":
+                self.stdout.write("aborted")
+                return
+
+        for users, _plan, canonical in plans:
+            dup = next(u for u in users if u.pk != canonical.pk)
+            try:
+                merge_users(canonical=canonical, duplicate=dup)
+                self.stdout.write(f"merged User#{dup.pk} → User#{canonical.pk}")
+            except Exception as exc:  # noqa: BLE001 — best-effort per-group recovery
+                self.stderr.write(f"failed User#{dup.pk} → User#{canonical.pk}: {exc!r}")
+
+    def _find_groups(self, *, target_email: str | None) -> list[list[User]]:
+        qs = User.objects.exclude(email__isnull=True).exclude(email="")
+        if target_email:
+            qs = qs.filter(email__iexact=target_email)
+        buckets: dict[str, list[User]] = defaultdict(list)
+        for u in qs.annotate(lower_email=Lower("email")).order_by("created_at", "pk"):
+            buckets[u.lower_email].append(u)
+        return [group for group in buckets.values() if len(group) > 1]
+
+    def _pick_canonical(self, users: list[User], *, forced_id: int | None) -> User:
+        if forced_id is not None:
+            forced = next((u for u in users if u.pk == forced_id), None)
+            if forced is None:
+                raise CommandError(
+                    f"--canonical-id={forced_id} is not in the targeted duplicate group",
+                )
+            return forced
+        return select_canonical(users)
+
+    def _print_plan(self, canonical: User, duplicate: User, report: MergeReport) -> None:
+        self.stdout.write(
+            f"[merge] email='{canonical.email}'  canonical: User#{canonical.pk}  "
+            f"duplicate: User#{duplicate.pk}"
+        )
+        self.stdout.write(
+            f"  plan: socialaccounts={report.socialaccount_repointed} "
+            f"emails(repoint/delete)={report.emailaddress_repointed}/"
+            f"{report.emailaddress_deleted} "
+            f"tenant(repoint/conflict)={report.tenant_membership_repointed}/"
+            f"{report.tenant_membership_conflict_deleted} "
+            f"workspace(repoint/conflict)={report.workspace_membership_repointed}/"
+            f"{report.workspace_membership_conflict_merged}"
+        )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```
+uv run pytest tests/test_merge_duplicate_users_command.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/users/management/commands/merge_duplicate_users.py tests/test_merge_duplicate_users_command.py
+git commit -m "feat(users): add merge_duplicate_users management command (dry-run)"
+```
+
+---
+
+### Task 17: --email and --canonical-id targeting
+
+**Files:**
+- Modify: `tests/test_merge_duplicate_users_command.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Append:
+
+```python
+@pytest.mark.django_db
+def test_email_flag_targets_only_one_group():
+    User.objects.create(email="x@y.com", username="x1")
+    User.objects.create(email="X@y.com", username="x2")
+    User.objects.create(email="a@y.com", username="a1")
+    User.objects.create(email="A@y.com", username="a2")
+    out = StringIO()
+
+    call_command("merge_duplicate_users", "--dry-run", "--email", "x@y.com", stdout=out)
+
+    output = out.getvalue()
+    assert "x@y.com" in output.lower()
+    assert "a@y.com" not in output.lower()
+
+
+@pytest.mark.django_db
+def test_email_flag_with_no_duplicates_exits_gracefully():
+    User.objects.create(email="only@y.com", username="only")
+    out = StringIO()
+
+    call_command("merge_duplicate_users", "--dry-run", "--email", "only@y.com", stdout=out)
+
+    assert "no duplicates found" in out.getvalue().lower()
+
+
+@pytest.mark.django_db
+def test_canonical_id_forces_canonical_choice():
+    from django.core.management import CommandError as _CE
+
+    older = User.objects.create(email="x@y.com", username="x1")
+    older.set_password("pw")
+    older.save()
+    newer = User.objects.create(email="X@y.com", username="x2")
+    out = StringIO()
+
+    call_command(
+        "merge_duplicate_users", "--dry-run", "--email", "x@y.com",
+        "--canonical-id", str(newer.pk), stdout=out,
+    )
+
+    output = out.getvalue()
+    assert f"canonical: User#{newer.pk}" in output
+
+    # Invalid canonical-id raises
+    with pytest.raises(_CE):
+        call_command(
+            "merge_duplicate_users", "--dry-run", "--email", "x@y.com",
+            "--canonical-id", "999999", stdout=out,
+        )
+```
+
+- [ ] **Step 2: Run tests to verify they fail or pass**
+
+```
+uv run pytest tests/test_merge_duplicate_users_command.py -v
+```
+
+Expected: all PASS (the command already supports both flags from Task 16).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_merge_duplicate_users_command.py
+git commit -m "test(users): pin --email and --canonical-id behavior"
+```
+
+---
+
+### Task 18: Confirmation prompt + --yes + real execution
+
+**Files:**
+- Modify: `tests/test_merge_duplicate_users_command.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Append:
+
+```python
+from unittest.mock import patch
+
+
+@pytest.mark.django_db
+def test_yes_flag_skips_prompt_and_executes_merge():
+    older = User.objects.create(email="x@y.com", username="x1")
+    older.set_password("pw")
+    older.save()
+    newer = User.objects.create(email="X@y.com", username="x2")
+    out = StringIO()
+
+    call_command("merge_duplicate_users", "--yes", stdout=out)
+
+    assert not User.objects.filter(pk=newer.pk).exists()
+    assert User.objects.filter(pk=older.pk).exists()
+    assert f"merged User#{newer.pk}" in out.getvalue()
+
+
+@pytest.mark.django_db
+def test_prompt_rejection_aborts_without_changes():
+    older = User.objects.create(email="x@y.com", username="x1")
+    older.set_password("pw")
+    older.save()
+    newer = User.objects.create(email="X@y.com", username="x2")
+    out = StringIO()
+
+    with patch("builtins.input", return_value="n"):
+        call_command("merge_duplicate_users", stdout=out)
+
+    assert User.objects.filter(pk=newer.pk).exists()
+    assert "aborted" in out.getvalue().lower()
+
+
+@pytest.mark.django_db
+def test_failure_in_one_group_does_not_block_others():
+    # Group A — will fail
+    a1 = User.objects.create(email="a@y.com", username="a1")
+    a2 = User.objects.create(email="A@y.com", username="a2")
+    # Group B — will succeed
+    b1 = User.objects.create(email="b@y.com", username="b1")
+    b1.set_password("pw")
+    b1.save()
+    b2 = User.objects.create(email="B@y.com", username="b2")
+    out = StringIO()
+    err = StringIO()
+
+    call_count = {"n": 0}
+
+    def fake_merge(*, canonical, duplicate, dry_run=False):
+        if dry_run:
+            return MergeReport(canonical_id=canonical.pk, duplicate_id=duplicate.pk, dry_run=True)
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            raise RuntimeError("simulated failure on first group")
+        # Real merge for second group
+        from apps.users.services.merge import merge_users as real_merge
+        return real_merge(canonical=canonical, duplicate=duplicate)
+
+    with patch("apps.users.management.commands.merge_duplicate_users.merge_users", side_effect=fake_merge):
+        call_command("merge_duplicate_users", "--yes", stdout=out, stderr=err)
+
+    assert "failed" in err.getvalue().lower()
+    # Second group still merged
+    assert not User.objects.filter(pk=b2.pk).exists()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```
+uv run pytest tests/test_merge_duplicate_users_command.py -v
+```
+
+Expected: PASS if the command was implemented per Task 16 (it already includes prompt + try/except). If the failure-isolation test fails, ensure the command catches per-group exceptions and continues.
+
+- [ ] **Step 3: If needed, refine the command**
+
+Confirm the body of the execution loop in `merge_duplicate_users.py` matches:
+
+```python
+        for users, _plan, canonical in plans:
+            dup = next(u for u in users if u.pk != canonical.pk)
+            try:
+                merge_users(canonical=canonical, duplicate=dup)
+                self.stdout.write(f"merged User#{dup.pk} → User#{canonical.pk}")
+            except Exception as exc:  # noqa: BLE001
+                self.stderr.write(f"failed User#{dup.pk} → User#{canonical.pk}: {exc!r}")
+```
+
+- [ ] **Step 4: Run tests**
+
+```
+uv run pytest tests/test_merge_duplicate_users_command.py -v
+```
+
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/users/management/commands/merge_duplicate_users.py tests/test_merge_duplicate_users_command.py
+git commit -m "test(users): pin prompt/--yes behavior and per-group failure isolation"
+```
+
+---
+
+## Phase 5 — Final verification
+
+### Task 19: Full-suite green + lint
+
+- [ ] **Step 1: Run all tests**
+
+```
+uv run pytest -q
+```
+
+Expected: green. If any pre-existing tests now fail, investigate — most likely a test relied on the absence of `SOCIALACCOUNT_EMAIL_AUTHENTICATION`, or on a provider's `VERIFIED_EMAIL` being False (e.g., asserts that an OAuth login created a new user when an email match was possible). Update those tests to match the new contract.
+
+- [ ] **Step 2: Run ruff**
+
+```
+uv run ruff check apps/users tests/test_merge_users_service.py tests/test_social_login_reconciliation.py tests/test_merge_duplicate_users_command.py tests/test_auth_settings.py
+uv run ruff format apps/users tests/test_merge_users_service.py tests/test_social_login_reconciliation.py tests/test_merge_duplicate_users_command.py tests/test_auth_settings.py
+```
+
+Expected: no lint errors. Fix anything reported (commonly: import ordering, line length).
+
+- [ ] **Step 3: Commit any formatting fixes**
+
+```bash
+git add -p
+git commit -m "chore: ruff formatting on new modules"
+```
+
+(Skip the commit if ruff made no changes.)
+
+---
+
+### Task 20: PR-ready end-to-end check
+
+- [ ] **Step 1: Manually verify the dry-run command works on a clean DB**
+
+```
+docker compose up platform-db -d
+uv run python manage.py migrate
+uv run python manage.py merge_duplicate_users --dry-run
+```
+
+Expected output:
+
+```
+no duplicates found
+```
+
+- [ ] **Step 2: Create a synthetic duplicate and re-run**
+
+In a Django shell (`uv run python manage.py shell`):
+
+```python
+from django.contrib.auth import get_user_model
+U = get_user_model()
+a = U.objects.create(email="dup@example.com", username="a"); a.set_password("x"); a.save()
+b = U.objects.create(email="Dup@Example.com", username="b")
+```
+
+Then:
+
+```
+uv run python manage.py merge_duplicate_users --dry-run --email dup@example.com
+```
+
+Expected: prints the plan with canonical = User#`a.pk`. No DB changes.
+
+```
+uv run python manage.py merge_duplicate_users --yes --email dup@example.com
+```
+
+Expected: deletes User#`b.pk`, prints `merged ...`. Re-running shows `no duplicates found`.
+
+- [ ] **Step 3: Confirm with git status that no stray files were created**
+
+```
+git status
+```
+
+Expected: clean.
+
+- [ ] **Step 4: Final commit message review**
+
+```
+git log --oneline origin/main..HEAD
+```
+
+Expected: ~18-22 small commits, each describing one capability. PR can be opened as-is.
+
+---
+
+## Notes for the executing engineer
+
+- **Adapter `pre_social_login` already exists.** `apps/users/adapters.py:73` (`EncryptingSocialAccountAdapter.pre_social_login`) implements OAuth domain restriction via `SOCIALACCOUNT_ALLOWED_EMAIL_DOMAINS`. allauth fires the adapter method **first** (`allauth/socialaccount/internal/flows/login.py:35`), then sends the `pre_social_login` signal. Domain-blocked logins raise `ImmediateHttpResponse` and our signal handler never runs — no conflict. Don't move our logic into the adapter; the adapter is already doing two things (token encryption + domain restriction), and the signal path keeps separation of concerns.
+- **Imports at module level.** This codebase enforces no-inline-imports (per `CLAUDE.md`). The signal handler imports `merge_users` at module top — if you find yourself reaching for an inline import to dodge a circular dependency, stop and restructure instead.
+- **Async vs sync.** All code in this plan is sync. The merge service uses `transaction.atomic()` which is sync-only; the signal handler also runs synchronously (allauth's signals are sync). Don't async-ify any of it.
+- **ruff.** Line length is 100. Watch the long log/format strings — use parenthesized concatenation if needed.
+- **Tests use `pytest-django` patterns.** `@pytest.mark.django_db` for any test that hits the DB; `transaction=True` only when the test exercises async ORM, which none of these do.
+- **The merge service is the heart.** Spend extra care on Tasks 4–9 — every other piece depends on `merge_users` being correct.
+
+## Spec coverage check
+
+| Spec section | Tasks |
+|---|---|
+| A. Settings change | Task 1 |
+| B. `pre_social_login` handler | Tasks 11–15 |
+| C. Merge service (field merge) | Task 3 |
+| C. Merge service (SocialAccount) | Task 4 |
+| C. Merge service (EmailAddress) | Task 5 |
+| C. Merge service (TenantMembership) | Task 6 |
+| C. Merge service (WorkspaceMembership) | Task 7 |
+| C. Merge service (long-tail introspection) | Task 8 |
+| C. Merge service (delete + atomic) | Task 9 |
+| C. Merge service (dry-run) | Task 10 |
+| D. Merge command | Tasks 16–18 |
+| Trust model | (Settings comment in Task 1) |
+| Edge cases — case-insensitive | Task 12 |
+| Edge cases — merge failure | Tasks 9, 14, 18 |
+| Testing — service file | Tasks 2–10 |
+| Testing — handler file | Tasks 11–15 |
+| Rollout — dry-run + targeted | Task 20 |
+| Observability — INFO log on auto-merge | Task 13 |
+| Observability — ERROR log on failure | Task 14 |

--- a/docs/superpowers/specs/2026-05-22-cross-provider-account-linking-design.md
+++ b/docs/superpowers/specs/2026-05-22-cross-provider-account-linking-design.md
@@ -1,0 +1,273 @@
+# Cross-provider account linking by email
+
+## Problem
+
+A single user logging in through different OAuth providers (CommCare HQ, CommCare Connect, Open Chat Studio) ends up with a separate `User` row per provider, even when each provider returns the same email address. Two issues:
+
+1. **No cross-provider linking.** `SOCIALACCOUNT_EMAIL_AUTHENTICATION` is unset (defaults to `False`) and no provider in `SOCIALACCOUNT_PROVIDERS` declares `VERIFIED_EMAIL: True`. allauth's `_lookup_by_email` gate (`allauth/socialaccount/models.py:386`) therefore never fires, so each new provider login creates a brand-new `User` row.
+2. **Connect-only users have NULL emails.** Connect's `/api/users/me/` doesn't currently return an email field, so `extract_common_fields` in `apps/users/providers/commcare_connect/provider.py:48` writes `email=None`. These users render as `user-47` in the UI.
+
+Connect is going to start returning email in their API (separate work, outside this spec). Once they do, we need pre-existing email-less Connect User rows to absorb that email — and to merge into any other Scout user already owning that email.
+
+## Scope
+
+In scope:
+- Enable allauth's email-based auto-link for the three Dimagi providers.
+- Backfill `User.email` on subsequent OAuth logins when a provider belatedly supplies one.
+- Auto-merge mid-login when the supplied email collides with another existing user.
+- A one-off management command for explicit/admin-driven merges of existing duplicates in prod.
+
+Out of scope:
+- Connect API changes (handled by the Connect team).
+- Querying Connect for emails of users who never log in again.
+- Cross-email merges (user changed email between providers — manual `--canonical-id` only).
+- UI improvements for accounts still rendering as `user-47`.
+
+## Approach
+
+Three small pieces working together:
+
+| Piece | Where | What it does |
+|---|---|---|
+| **A — settings** | `config/settings/base.py` | Mark the 3 Dimagi providers' emails as verified and turn on allauth's email-authentication gate. New OAuth logins with email auto-link to an existing email-owning user. |
+| **B — `pre_social_login` handler** | `apps/users/signals.py` | For repeat OAuth logins on existing User rows (where allauth short-circuits before email lookup), either backfill `User.email` or trigger an inline merge. |
+| **C — merge service** | `apps/users/services/merge.py` | One shared merge implementation called by both the signal handler and the management command. |
+| **D — merge command** | `apps/users/management/commands/merge_duplicate_users.py` | Operator-facing entry point for explicit/admin-driven merges of existing duplicates. |
+
+A handles new account links. B handles existing email-less rows that become email-bearing later (the Connect rollout case). C is the building block for B. D cleans up duplicates that already exist in prod.
+
+## Detailed design
+
+### A. Settings change
+
+`config/settings/base.py`:
+
+```python
+# Treat the verified email returned by trusted Dimagi OAuth providers as
+# authoritative for matching against an existing local user account. Enables
+# allauth's _lookup_by_email flow.
+SOCIALACCOUNT_EMAIL_AUTHENTICATION = True
+
+SOCIALACCOUNT_PROVIDERS = {
+    # ... unchanged google, github entries ...
+    "commcare_connect": {"OAUTH_PKCE_ENABLED": True, "VERIFIED_EMAIL": True},
+    "commcare": {"OAUTH_PKCE_ENABLED": True, "VERIFIED_EMAIL": True},
+    "ocs": {"OAUTH_PKCE_ENABLED": True, "VERIFIED_EMAIL": True},
+}
+```
+
+`SOCIALACCOUNT_EMAIL_AUTHENTICATION_AUTO_CONNECT = True` is already set (`base.py:197`), so once an email match succeeds allauth attaches the new `SocialAccount` to the matched user automatically. No further wiring needed for the first-time-link path.
+
+### B. `pre_social_login` handler
+
+New receiver in `apps/users/signals.py`, wired in `apps/users/apps.py` alongside the existing `resolve_tenant_on_social_login` connect:
+
+```python
+@receiver(pre_social_login)
+def reconcile_existing_user_on_login(sender, request, sociallogin, **kwargs):
+    """
+    When an existing OAuth user (matched via SocialAccount uid) has the
+    provider return an email for the first time, either backfill the User row
+    or merge into the email-owning user.
+
+    allauth's `_lookup_by_email` doesn't fire for repeat logins (the prior
+    `_lookup_by_socialaccount` short-circuits in models.py:340), so this
+    handler closes that gap.
+    """
+    new_email = sociallogin.account.extra_data.get("email")
+    if not new_email:
+        return
+    user = sociallogin.user
+    if user.pk is None:
+        return  # brand-new user; allauth's lookup_by_email handles it
+    if user.email:
+        return  # already has an email — nothing to reconcile
+
+    canonical = User.objects.filter(email__iexact=new_email).exclude(pk=user.pk).first()
+    if canonical is None:
+        user.email = new_email
+        user.save(update_fields=["email"])
+        return
+
+    try:
+        merge_users(canonical=canonical, duplicate=user)
+    except Exception:
+        logger.exception(
+            "Auto-merge failed for user=%s into canonical=%s", user.pk, canonical.pk,
+        )
+        return  # let login proceed on the duplicate row; admin can run command later
+    sociallogin.user = canonical
+    sociallogin.account.user = canonical
+```
+
+Branches:
+- No email in extra_data → no-op.
+- User already has an email → no-op.
+- No collision → backfill `User.email`.
+- Collision → call `merge_users(...)`, redirect `sociallogin.user` and `sociallogin.account.user` so the login session lands on the canonical row.
+
+Merge failure never blocks login. The exception is logged at ERROR and the user lands on the duplicate row; admin can run the management command to clean up.
+
+### C. Merge service
+
+`apps/users/services/merge.py` exports:
+
+```python
+def merge_users(*, canonical: User, duplicate: User, dry_run: bool = False) -> MergeReport: ...
+```
+
+A single `transaction.atomic()` wraps the entire merge — partial failure rolls everything back. `MergeReport` is a dataclass holding counts and per-table notes for logging and for the management command's output.
+
+**Field-level merge** applied to canonical:
+- `password`: if canonical's is unusable (`has_usable_password() is False`) and duplicate's is usable, copy duplicate's hash.
+- `is_staff`, `is_superuser`: logical OR.
+- `last_login`: max of the two (handle `None`).
+- `first_name`, `last_name`, `avatar_url`: fill from duplicate only when canonical's value is empty.
+- `timezone`: fill from duplicate only when canonical is at default (`"UTC"`).
+- `email`, `username`: untouched on canonical.
+
+**FK repointing** — four tables with unique constraints involving the user FK get explicit conflict resolution; everything else is straight-update via `User._meta.related_objects` introspection.
+
+| Table | Unique key | Resolution |
+|---|---|---|
+| `socialaccount.SocialAccount` | `(provider, uid)` | Straight repoint — different external users have different uids per provider, no collisions. |
+| `account.EmailAddress` | `(email,)` | If both have a row for the same email, delete duplicate's. After repointing, ensure canonical has exactly one row matching `User.email`, marked `primary=True, verified=True`. |
+| `users.TenantMembership` | `(user, tenant)` | If canonical already has a membership for that tenant, delete duplicate's (its `TenantCredential` cascades). Otherwise repoint. |
+| `workspaces.WorkspaceMembership` | `(workspace, user)` | If canonical already has a membership for that workspace, keep canonical's row but upgrade `role` to the higher of the two per the explicit hierarchy below. Delete duplicate's row. Otherwise repoint. |
+
+`WorkspaceRole` is a `TextChoices` enum (`apps/workspaces/models.py:101`) with values `READ`, `READ_WRITE`, `MANAGE`. The merge service defines an explicit ordering map `{READ: 0, READ_WRITE: 1, MANAGE: 2}` and picks the higher-ranked role on conflict.
+
+**Introspection loop** — iterates `User._meta.related_objects`, skips the four special-case relations above, and runs `Model.objects.filter(field=duplicate).update(field=canonical)` for each. Covers:
+- `Workspace.created_by`, `WorkspaceMembership.invited_by`
+- `chat.Thread.user`
+- `artifacts.Artifact.created_by`, `artifacts.Artifact.deleted_by`
+- `transformations.*.created_by`
+- `recipes.*.created_by`, `recipes.*.deleted_by`, `recipes.*.run_by`
+- `knowledge.*.updated_by`, `knowledge.*.created_by`, `knowledge.*.discovered_by_user`
+- Django's `auth_user_groups`, `auth_user_user_permissions`, `django_admin_log`
+
+When a new app adds a `User` FK in the future, the loop picks it up automatically. Only when the new FK has a unique constraint involving `user` does the merge service need to be updated (the introspection loop will raise an `IntegrityError`, surfacing the need clearly).
+
+Final step: delete the duplicate `User` row.
+
+`dry_run=True` builds the same plan and returns a populated `MergeReport`, but performs no writes (and does not enter `atomic()` at all — easier to reason about than execute-and-raise).
+
+### D. Merge command
+
+`apps/users/management/commands/merge_duplicate_users.py`:
+
+```
+python manage.py merge_duplicate_users [--dry-run] [--email EMAIL]
+                                       [--canonical-id ID] [--yes]
+```
+
+| Flag | Effect |
+|---|---|
+| (none) | Find every email group with >1 user, merge each |
+| `--dry-run` | Print plan, write nothing |
+| `--email` | Only operate on the group sharing that email (case-insensitive) |
+| `--canonical-id` | Force this user as the survivor (must be in the targeted group) |
+| `--yes` | Skip the interactive `[y/N]` confirmation |
+
+**Canonical selection** (default tiebreak, when not forced):
+1. Has a usable password (preserves email/password login capability).
+2. Oldest `created_at`.
+3. Lowest `pk`.
+
+Users with `email IS NULL` are never grouped — no meaningful match key.
+
+**Flow:**
+1. Build list of duplicate groups (or single group if `--email`).
+2. If `--email` was supplied and the targeted email has <2 users, exit 0 with `no duplicates found for <email>` — not an error.
+3. For each group, pick canonical, build a plan via `merge_users(dry_run=True)`.
+4. Print all plans.
+5. If not `--dry-run` and not `--yes`, prompt `Continue? [y/N]`. Empty input or anything other than `y`/`Y` aborts.
+6. For each group, call `merge_users(...)` for real. Exceptions in one group are logged and skipped; remaining groups proceed.
+
+**Per-group output:**
+
+```
+[merge] email='brian@acompahealth.com'  3 users found
+  canonical: User#12  created=2026-03-14  providers=[ocs, commcare_connect]  has_password=True
+  duplicates: User#47, User#52
+  plan:
+    SocialAccount         repoint 2 (commcare, github)
+    EmailAddress          delete 2 (canonical already has primary+verified row)
+    TenantMembership      repoint 4, conflict-delete 1
+    WorkspaceMembership   repoint 3, conflict-merge 1 (role: READ → MANAGE)
+    Workspace.created_by  repoint 2
+    chat.Thread           repoint 11
+    [...]
+    User                  copy password from #47, OR is_staff(False|True)=True
+  → would delete User#47, User#52
+```
+
+Real-mode last line: `→ deleted User#47, User#52`.
+
+## Trust model
+
+`VERIFIED_EMAIL: True` on `commcare`, `commcare_connect`, and `ocs` declares that Dimagi vouches for the email's verification status. This is the security trade-off allauth warns about: an untrustworthy provider could fabricate email data to gain access to another user's account.
+
+For Scout this is acceptable because all three providers are operated by Dimagi. For Connect specifically, the flag is dormant today (Connect returns no email field at all); it becomes load-bearing only once Connect ships email. If Connect's email rollout does not include server-side verification, this assumption will need to be revisited.
+
+## Edge cases
+
+- **Brand-new social login (`sociallogin.user.pk is None`)** — handler returns early; allauth's `_lookup_by_email` is the authoritative path.
+- **User already has email** — handler returns early; we don't overwrite an existing email even if the provider's differs (could indicate the user changed email upstream, which we don't auto-handle).
+- **Case mismatch** — `email__iexact` lookup so `Brian@Foo.com` matches `brian@foo.com`.
+- **Three-way duplicates** — pick one canonical, merge the others into it sequentially in the same command run.
+- **Multi-tab session** — when auto-merge fires mid-login, an open session on the duplicate row in another browser/tab becomes invalid on its next request (Django can't load the deleted user). Acceptable.
+- **Connect-only users who never re-log-in** — stay split. Not addressable without external user data.
+- **Merge failure** — signal handler catches and logs; login proceeds on the duplicate row. Management command's `atomic()` rolls back the affected group, others still proceed.
+
+## Testing
+
+Two new files; no changes to existing `tests/test_auth.py` beyond regression spot-checks.
+
+### `tests/test_social_login_reconciliation.py`
+
+Covers the `pre_social_login` handler with constructed `SocialLogin` fixtures (no live OAuth).
+
+- `test_brand_new_user_is_noop`
+- `test_existing_user_with_email_is_noop`
+- `test_no_email_in_extra_data_is_noop`
+- `test_no_collision_backfills_email`
+- `test_collision_triggers_merge_and_redirects_session`
+- `test_merge_failure_does_not_break_login` (patch `merge_users` to raise)
+- `test_case_insensitive_email_collision_match`
+
+### `tests/test_merge_users_service.py`
+
+Direct unit tests on `merge_users` without OAuth machinery.
+
+- `test_canonical_selection_prefers_usable_password`
+- `test_canonical_selection_prefers_oldest_when_passwords_equal`
+- `test_socialaccounts_repointed`
+- `test_emailaddress_dedupes_when_both_have_same_email`
+- `test_tenantmembership_repoint_with_no_overlap`
+- `test_tenantmembership_conflict_keeps_canonical_membership`
+- `test_workspacemembership_conflict_keeps_higher_role`
+- `test_chat_threads_repointed_via_introspection`
+- `test_setnull_fks_repointed_via_introspection`
+- `test_field_level_merge_copies_password`
+- `test_field_level_merge_or_staff_flags`
+- `test_duplicate_user_row_deleted`
+- `test_atomic_rollback_on_failure`
+- `test_dry_run_writes_nothing`
+
+The management command's interactive `[y/N]` prompt is not unit-tested; the underlying service has full coverage and the command is a thin wrapper.
+
+## Rollout
+
+1. Ship the settings + signal handler + merge service + command in one PR.
+2. After deploy, run `python manage.py merge_duplicate_users --dry-run` in prod to preview the full sweep.
+3. Execute the sweep — either targeted (`--email brian@acompahealth.com` to start with one known case) or global (no flags). Both invoke the same underlying service; targeted is recommended for the first run.
+4. From this point on, new logins auto-link via email (path A). Existing email-less Connect rows auto-heal on next login once Connect ships email (path B).
+
+### Observability
+
+- Auto-merges (path B collision branch) log at INFO: `"auto-merged user=X into canonical=Y email=...@... provider=..."`.
+- Auto-merge failures log at ERROR with traceback.
+- The management command prints a per-group summary to stdout.
+
+Grep `auto-merge` in production logs to audit handler behavior over time.

--- a/tests/test_auth_settings.py
+++ b/tests/test_auth_settings.py
@@ -1,0 +1,19 @@
+"""Pin the auth settings that enable cross-provider account linking by email."""
+
+from django.conf import settings
+
+
+def test_email_authentication_is_enabled():
+    assert settings.SOCIALACCOUNT_EMAIL_AUTHENTICATION is True
+
+
+def test_email_authentication_auto_connect_is_enabled():
+    assert settings.SOCIALACCOUNT_EMAIL_AUTHENTICATION_AUTO_CONNECT is True
+
+
+def test_dimagi_providers_have_verified_email():
+    providers = settings.SOCIALACCOUNT_PROVIDERS
+    for pid in ("commcare", "commcare_connect", "ocs"):
+        assert providers[pid].get("VERIFIED_EMAIL") is True, (
+            f"{pid} must declare VERIFIED_EMAIL=True so allauth treats its emails as verified"
+        )

--- a/tests/test_merge_duplicate_users_command.py
+++ b/tests/test_merge_duplicate_users_command.py
@@ -1,10 +1,13 @@
 """Tests for the merge_duplicate_users management command."""
 
 from io import StringIO
+from unittest.mock import patch
 
 import pytest
 from django.contrib.auth import get_user_model
 from django.core.management import CommandError, call_command
+
+from apps.users.services.merge import MergeReport
 
 User = get_user_model()
 
@@ -84,3 +87,71 @@ def test_canonical_id_forces_canonical_choice():
             "merge_duplicate_users", "--dry-run", "--email", "x@y.com",
             "--canonical-id", "999999", stdout=out,
         )
+
+
+@pytest.mark.django_db
+def test_yes_flag_skips_prompt_and_executes_merge():
+    older = User.objects.create(email="x@y.com", username="x1")
+    older.set_password("pw")
+    older.save()
+    newer = User.objects.create(email="X@y.com", username="x2")
+    out = StringIO()
+
+    call_command("merge_duplicate_users", "--yes", stdout=out)
+
+    assert not User.objects.filter(pk=newer.pk).exists()
+    assert User.objects.filter(pk=older.pk).exists()
+    assert f"merged User#{newer.pk}" in out.getvalue()
+
+
+@pytest.mark.django_db
+def test_prompt_rejection_aborts_without_changes():
+    older = User.objects.create(email="x@y.com", username="x1")
+    older.set_password("pw")
+    older.save()
+    newer = User.objects.create(email="X@y.com", username="x2")
+    out = StringIO()
+
+    with patch("builtins.input", return_value="n"):
+        call_command("merge_duplicate_users", stdout=out)
+
+    assert User.objects.filter(pk=newer.pk).exists()
+    assert "aborted" in out.getvalue().lower()
+
+
+@pytest.mark.django_db
+def test_failure_in_one_group_does_not_block_others():
+    # Group A — will fail
+    User.objects.create(email="a@y.com", username="a1")
+    User.objects.create(email="A@y.com", username="a2")
+    # Group B — will succeed
+    b1 = User.objects.create(email="b@y.com", username="b1")
+    b1.set_password("pw")
+    b1.save()
+    b2 = User.objects.create(email="B@y.com", username="b2")
+    out = StringIO()
+    err = StringIO()
+
+    call_count = {"n": 0}
+
+    def fake_merge(*, canonical, duplicate, dry_run=False):
+        from apps.users.services.merge import merge_users as real_merge
+        if dry_run:
+            return MergeReport(
+                canonical_id=canonical.pk, duplicate_id=duplicate.pk, dry_run=True,
+            )
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            raise RuntimeError("simulated failure on first group")
+        # Real merge for second group
+        return real_merge(canonical=canonical, duplicate=duplicate)
+
+    with patch(
+        "apps.users.management.commands.merge_duplicate_users.merge_users",
+        side_effect=fake_merge,
+    ):
+        call_command("merge_duplicate_users", "--yes", stdout=out, stderr=err)
+
+    assert "failed" in err.getvalue().lower()
+    # Second group still merged
+    assert not User.objects.filter(pk=b2.pk).exists()

--- a/tests/test_merge_duplicate_users_command.py
+++ b/tests/test_merge_duplicate_users_command.py
@@ -74,8 +74,13 @@ def test_canonical_id_forces_canonical_choice():
     out = StringIO()
 
     call_command(
-        "merge_duplicate_users", "--dry-run", "--email", "x@y.com",
-        "--canonical-id", str(newer.pk), stdout=out,
+        "merge_duplicate_users",
+        "--dry-run",
+        "--email",
+        "x@y.com",
+        "--canonical-id",
+        str(newer.pk),
+        stdout=out,
     )
 
     output = out.getvalue()
@@ -84,8 +89,13 @@ def test_canonical_id_forces_canonical_choice():
     # Invalid canonical-id raises
     with pytest.raises(CommandError):
         call_command(
-            "merge_duplicate_users", "--dry-run", "--email", "x@y.com",
-            "--canonical-id", "999999", stdout=out,
+            "merge_duplicate_users",
+            "--dry-run",
+            "--email",
+            "x@y.com",
+            "--canonical-id",
+            "999999",
+            stdout=out,
         )
 
 
@@ -136,9 +146,12 @@ def test_failure_in_one_group_does_not_block_others():
 
     def fake_merge(*, canonical, duplicate, dry_run=False):
         from apps.users.services.merge import merge_users as real_merge
+
         if dry_run:
             return MergeReport(
-                canonical_id=canonical.pk, duplicate_id=duplicate.pk, dry_run=True,
+                canonical_id=canonical.pk,
+                duplicate_id=duplicate.pk,
+                dry_run=True,
             )
         call_count["n"] += 1
         if call_count["n"] == 1:

--- a/tests/test_merge_duplicate_users_command.py
+++ b/tests/test_merge_duplicate_users_command.py
@@ -4,7 +4,7 @@ from io import StringIO
 
 import pytest
 from django.contrib.auth import get_user_model
-from django.core.management import call_command
+from django.core.management import CommandError, call_command
 
 User = get_user_model()
 
@@ -35,3 +35,52 @@ def test_dry_run_lists_duplicate_groups():
     assert f"canonical: User#{older.pk}" in output
     # dry-run leaves DB intact
     assert User.objects.filter(pk=newer.pk).exists()
+
+
+@pytest.mark.django_db
+def test_email_flag_targets_only_one_group():
+    User.objects.create(email="x@y.com", username="x1")
+    User.objects.create(email="X@y.com", username="x2")
+    User.objects.create(email="a@y.com", username="a1")
+    User.objects.create(email="A@y.com", username="a2")
+    out = StringIO()
+
+    call_command("merge_duplicate_users", "--dry-run", "--email", "x@y.com", stdout=out)
+
+    output = out.getvalue()
+    assert "x@y.com" in output.lower()
+    assert "a@y.com" not in output.lower()
+
+
+@pytest.mark.django_db
+def test_email_flag_with_no_duplicates_exits_gracefully():
+    User.objects.create(email="only@y.com", username="only")
+    out = StringIO()
+
+    call_command("merge_duplicate_users", "--dry-run", "--email", "only@y.com", stdout=out)
+
+    assert "no duplicates found" in out.getvalue().lower()
+
+
+@pytest.mark.django_db
+def test_canonical_id_forces_canonical_choice():
+    older = User.objects.create(email="x@y.com", username="x1")
+    older.set_password("pw")
+    older.save()
+    newer = User.objects.create(email="X@y.com", username="x2")
+    out = StringIO()
+
+    call_command(
+        "merge_duplicate_users", "--dry-run", "--email", "x@y.com",
+        "--canonical-id", str(newer.pk), stdout=out,
+    )
+
+    output = out.getvalue()
+    assert f"canonical: User#{newer.pk}" in output
+
+    # Invalid canonical-id raises
+    with pytest.raises(CommandError):
+        call_command(
+            "merge_duplicate_users", "--dry-run", "--email", "x@y.com",
+            "--canonical-id", "999999", stdout=out,
+        )

--- a/tests/test_merge_duplicate_users_command.py
+++ b/tests/test_merge_duplicate_users_command.py
@@ -8,6 +8,7 @@ from django.contrib.auth import get_user_model
 from django.core.management import CommandError, call_command
 
 from apps.users.services.merge import MergeReport
+from apps.users.services.merge import merge_users as _merge_users_real
 
 User = get_user_model()
 
@@ -145,8 +146,6 @@ def test_failure_in_one_group_does_not_block_others():
     call_count = {"n": 0}
 
     def fake_merge(*, canonical, duplicate, dry_run=False):
-        from apps.users.services.merge import merge_users as real_merge
-
         if dry_run:
             return MergeReport(
                 canonical_id=canonical.pk,
@@ -157,7 +156,7 @@ def test_failure_in_one_group_does_not_block_others():
         if call_count["n"] == 1:
             raise RuntimeError("simulated failure on first group")
         # Real merge for second group
-        return real_merge(canonical=canonical, duplicate=duplicate)
+        return _merge_users_real(canonical=canonical, duplicate=duplicate)
 
     with patch(
         "apps.users.management.commands.merge_duplicate_users.merge_users",

--- a/tests/test_merge_duplicate_users_command.py
+++ b/tests/test_merge_duplicate_users_command.py
@@ -1,0 +1,37 @@
+"""Tests for the merge_duplicate_users management command."""
+
+from io import StringIO
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.core.management import call_command
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+def test_dry_run_finds_no_duplicates_when_emails_are_unique():
+    User.objects.create(email="a@y.com", username="a")
+    User.objects.create(email="b@y.com", username="b")
+    out = StringIO()
+
+    call_command("merge_duplicate_users", "--dry-run", stdout=out)
+
+    assert "no duplicates found" in out.getvalue().lower()
+
+
+@pytest.mark.django_db
+def test_dry_run_lists_duplicate_groups():
+    older = User.objects.create(email="brian@y.com", username="older")
+    older.set_password("pw")
+    older.save()
+    newer = User.objects.create(email="Brian@Y.com", username="newer")
+    out = StringIO()
+
+    call_command("merge_duplicate_users", "--dry-run", stdout=out)
+
+    output = out.getvalue()
+    assert "brian@y.com" in output.lower()
+    assert f"canonical: User#{older.pk}" in output
+    # dry-run leaves DB intact
+    assert User.objects.filter(pk=newer.pk).exists()

--- a/tests/test_merge_users_service.py
+++ b/tests/test_merge_users_service.py
@@ -265,3 +265,23 @@ def test_setnull_fk_is_repointed_via_introspection():
 
     ws.refresh_from_db()
     assert ws.created_by == canonical
+
+
+@pytest.mark.django_db
+def test_workspacemembership_invited_by_is_repointed_via_introspection():
+    """invited_by is a SET_NULL FK to User; it should be repointed by the
+    long-tail loop even though WorkspaceMembership.user has special-case
+    handling for the role-merge path."""
+    canonical = User.objects.create(email="canon@y.com", username="canon")
+    duplicate = User.objects.create(email="dup@y.com", username="dup")
+    other = User.objects.create(email="other@y.com", username="other")
+    ws = Workspace.objects.create(name="W")
+    # `other` has a membership; `duplicate` invited them.
+    WorkspaceMembership.objects.create(
+        workspace=ws, user=other, role=WorkspaceRole.READ, invited_by=duplicate,
+    )
+
+    merge_users(canonical=canonical, duplicate=duplicate)
+
+    membership = WorkspaceMembership.objects.get(workspace=ws, user=other)
+    assert membership.invited_by == canonical

--- a/tests/test_merge_users_service.py
+++ b/tests/test_merge_users_service.py
@@ -1,0 +1,32 @@
+"""Unit tests for apps.users.services.merge.merge_users and helpers."""
+
+import pytest
+from django.contrib.auth import get_user_model
+
+from apps.users.services.merge import select_canonical
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+def test_select_canonical_prefers_usable_password():
+    no_pw = User.objects.create(email="a@y.com", username="a")
+    no_pw.set_unusable_password()
+    no_pw.save()
+    with_pw = User.objects.create(email="b@y.com", username="b")
+    with_pw.set_password("real-password")
+    with_pw.save()
+
+    assert select_canonical([no_pw, with_pw]) == with_pw
+
+
+@pytest.mark.django_db
+def test_select_canonical_prefers_oldest_when_passwords_equal():
+    older = User.objects.create(email="older@y.com", username="older")
+    older.set_password("pw")
+    older.save()
+    newer = User.objects.create(email="newer@y.com", username="newer")
+    newer.set_password("pw")
+    newer.save()
+
+    assert select_canonical([newer, older]) == older

--- a/tests/test_merge_users_service.py
+++ b/tests/test_merge_users_service.py
@@ -318,3 +318,22 @@ def test_merge_rolls_back_on_exception():
     # Everything must be untouched
     assert User.objects.filter(pk=duplicate.pk).exists()
     assert SocialAccount.objects.get(provider="commcare", uid="42").user == duplicate
+
+
+@pytest.mark.django_db
+def test_dry_run_writes_nothing_and_returns_a_plan():
+    canonical = User.objects.create(email="canon@y.com", username="canon")
+    duplicate = User.objects.create(email="dup@y.com", username="dup")
+    SocialAccount.objects.create(user=duplicate, provider="commcare", uid="42")
+    EmailAddress.objects.create(user=canonical, email="canon@y.com", primary=True)
+    EmailAddress.objects.create(user=duplicate, email="canon@y.com", primary=True)
+
+    report = merge_users(canonical=canonical, duplicate=duplicate, dry_run=True)
+
+    assert report.dry_run is True
+    assert report.socialaccount_repointed == 1
+    assert report.emailaddress_deleted == 1
+    # Nothing actually changed
+    assert SocialAccount.objects.get(provider="commcare", uid="42").user == duplicate
+    assert User.objects.filter(pk=duplicate.pk).exists()
+    assert not report.duplicate_user_deleted

--- a/tests/test_merge_users_service.py
+++ b/tests/test_merge_users_service.py
@@ -1,5 +1,7 @@
 """Unit tests for apps.users.services.merge.merge_users and helpers."""
 
+from unittest.mock import patch
+
 import pytest
 from allauth.account.models import EmailAddress
 from allauth.socialaccount.models import SocialAccount
@@ -104,6 +106,7 @@ def test_field_level_merge_keeps_canonical_name_when_already_set():
 def test_socialaccounts_are_repointed_to_canonical():
     canonical = User.objects.create(email="canon@y.com", username="canon")
     duplicate = User.objects.create(email="dup@y.com", username="dup")
+    duplicate_pk = duplicate.pk
     SocialAccount.objects.create(user=duplicate, provider="commcare", uid="42")
     SocialAccount.objects.create(user=duplicate, provider="ocs", uid="ocs-7")
     SocialAccount.objects.create(user=canonical, provider="commcare_connect", uid="9")
@@ -112,7 +115,7 @@ def test_socialaccounts_are_repointed_to_canonical():
 
     assert report.socialaccount_repointed == 2
     assert SocialAccount.objects.filter(user=canonical).count() == 3
-    assert SocialAccount.objects.filter(user=duplicate).count() == 0
+    assert SocialAccount.objects.filter(user_id=duplicate_pk).count() == 0
 
 
 @pytest.mark.django_db
@@ -243,6 +246,7 @@ def test_workspacemembership_conflict_keeps_canonical_when_higher():
 def test_chat_threads_are_repointed_via_introspection():
     canonical = User.objects.create(email="canon@y.com", username="canon")
     duplicate = User.objects.create(email="dup@y.com", username="dup")
+    duplicate_pk = duplicate.pk
     ws = Workspace.objects.create(name="W")
     Thread.objects.create(user=duplicate, workspace=ws, title="T1")
     Thread.objects.create(user=duplicate, workspace=ws, title="T2")
@@ -250,7 +254,7 @@ def test_chat_threads_are_repointed_via_introspection():
     report = merge_users(canonical=canonical, duplicate=duplicate)
 
     assert Thread.objects.filter(user=canonical).count() == 2
-    assert Thread.objects.filter(user=duplicate).count() == 0
+    assert Thread.objects.filter(user_id=duplicate_pk).count() == 0
     label = "chat.Thread.user"
     assert report.long_tail_fk_counts.get(label) == 2
 
@@ -285,3 +289,32 @@ def test_workspacemembership_invited_by_is_repointed_via_introspection():
 
     membership = WorkspaceMembership.objects.get(workspace=ws, user=other)
     assert membership.invited_by == canonical
+
+
+@pytest.mark.django_db
+def test_duplicate_user_row_is_deleted():
+    canonical = User.objects.create(email="canon@y.com", username="canon")
+    duplicate = User.objects.create(email="dup@y.com", username="dup")
+
+    report = merge_users(canonical=canonical, duplicate=duplicate)
+
+    assert report.duplicate_user_deleted is True
+    assert not User.objects.filter(pk=duplicate.pk).exists()
+    assert User.objects.filter(pk=canonical.pk).exists()
+
+
+@pytest.mark.django_db
+def test_merge_rolls_back_on_exception():
+    canonical = User.objects.create(email="canon@y.com", username="canon")
+    duplicate = User.objects.create(email="dup@y.com", username="dup")
+    SocialAccount.objects.create(user=duplicate, provider="commcare", uid="42")
+
+    with patch(
+        "apps.users.services.merge._repoint_long_tail_fks",
+        side_effect=RuntimeError("simulated failure"),
+    ), pytest.raises(RuntimeError):
+        merge_users(canonical=canonical, duplicate=duplicate)
+
+    # Everything must be untouched
+    assert User.objects.filter(pk=duplicate.pk).exists()
+    assert SocialAccount.objects.get(provider="commcare", uid="42").user == duplicate

--- a/tests/test_merge_users_service.py
+++ b/tests/test_merge_users_service.py
@@ -1,6 +1,7 @@
 """Unit tests for apps.users.services.merge.merge_users and helpers."""
 
 import pytest
+from allauth.account.models import EmailAddress
 from allauth.socialaccount.models import SocialAccount
 from django.contrib.auth import get_user_model
 
@@ -109,3 +110,45 @@ def test_socialaccounts_are_repointed_to_canonical():
     assert report.socialaccount_repointed == 2
     assert SocialAccount.objects.filter(user=canonical).count() == 3
     assert SocialAccount.objects.filter(user=duplicate).count() == 0
+
+
+@pytest.mark.django_db
+def test_emailaddress_dedupes_when_both_have_same_email():
+    canonical = User.objects.create(email="brian@y.com", username="canon")
+    duplicate = User.objects.create(email="brian-old@y.com", username="dup")
+    EmailAddress.objects.create(user=canonical, email="brian@y.com", primary=True, verified=True)
+    EmailAddress.objects.create(user=duplicate, email="brian@y.com", primary=True, verified=False)
+
+    report = merge_users(canonical=canonical, duplicate=duplicate)
+
+    assert report.emailaddress_deleted == 1
+    assert EmailAddress.objects.filter(email="brian@y.com").count() == 1
+    survivor = EmailAddress.objects.get(email="brian@y.com")
+    assert survivor.user == canonical
+    assert survivor.primary is True
+    assert survivor.verified is True
+
+
+@pytest.mark.django_db
+def test_emailaddress_repoints_distinct_addresses():
+    canonical = User.objects.create(email="brian@y.com", username="canon")
+    duplicate = User.objects.create(email="brian-old@y.com", username="dup")
+    EmailAddress.objects.create(user=duplicate, email="brian-old@y.com", primary=True, verified=True)
+
+    report = merge_users(canonical=canonical, duplicate=duplicate)
+
+    assert report.emailaddress_repointed == 1
+    assert EmailAddress.objects.filter(user=canonical, email="brian-old@y.com").exists()
+
+
+@pytest.mark.django_db
+def test_emailaddress_creates_primary_row_for_canonical_email():
+    canonical = User.objects.create(email="brian@y.com", username="canon")
+    duplicate = User.objects.create(email="brian-old@y.com", username="dup")
+    # No EmailAddress rows for canonical; merge should create one.
+
+    merge_users(canonical=canonical, duplicate=duplicate)
+
+    primary = EmailAddress.objects.get(user=canonical, email="brian@y.com")
+    assert primary.primary is True
+    assert primary.verified is True

--- a/tests/test_merge_users_service.py
+++ b/tests/test_merge_users_service.py
@@ -3,7 +3,7 @@
 import pytest
 from django.contrib.auth import get_user_model
 
-from apps.users.services.merge import select_canonical
+from apps.users.services.merge import merge_users, select_canonical
 
 User = get_user_model()
 
@@ -30,3 +30,66 @@ def test_select_canonical_prefers_oldest_when_passwords_equal():
     newer.save()
 
     assert select_canonical([newer, older]) == older
+
+
+@pytest.mark.django_db
+def test_field_level_merge_copies_password_from_duplicate():
+    canonical = User.objects.create(email="canon@y.com", username="canon")
+    canonical.set_unusable_password()
+    canonical.save()
+    duplicate = User.objects.create(email="dup@y.com", username="dup")
+    duplicate.set_password("real-password")
+    duplicate.save()
+    dup_hash = duplicate.password
+
+    merge_users(canonical=canonical, duplicate=duplicate)
+
+    canonical.refresh_from_db()
+    assert canonical.password == dup_hash
+    assert canonical.has_usable_password()
+
+
+@pytest.mark.django_db
+def test_field_level_merge_ors_staff_and_superuser_flags():
+    canonical = User.objects.create(email="canon@y.com", username="canon")
+    duplicate = User.objects.create(
+        email="dup@y.com", username="dup", is_staff=True, is_superuser=True,
+    )
+
+    merge_users(canonical=canonical, duplicate=duplicate)
+
+    canonical.refresh_from_db()
+    assert canonical.is_staff is True
+    assert canonical.is_superuser is True
+
+
+@pytest.mark.django_db
+def test_field_level_merge_fills_empty_name_fields_from_duplicate():
+    canonical = User.objects.create(email="canon@y.com", username="canon")
+    duplicate = User.objects.create(
+        email="dup@y.com", username="dup",
+        first_name="Brian", last_name="DeRenzi", avatar_url="https://x/y.png",
+    )
+
+    merge_users(canonical=canonical, duplicate=duplicate)
+
+    canonical.refresh_from_db()
+    assert canonical.first_name == "Brian"
+    assert canonical.last_name == "DeRenzi"
+    assert canonical.avatar_url == "https://x/y.png"
+
+
+@pytest.mark.django_db
+def test_field_level_merge_keeps_canonical_name_when_already_set():
+    canonical = User.objects.create(
+        email="canon@y.com", username="canon", first_name="Already", last_name="Set",
+    )
+    duplicate = User.objects.create(
+        email="dup@y.com", username="dup", first_name="Newer", last_name="Name",
+    )
+
+    merge_users(canonical=canonical, duplicate=duplicate)
+
+    canonical.refresh_from_db()
+    assert canonical.first_name == "Already"
+    assert canonical.last_name == "Set"

--- a/tests/test_merge_users_service.py
+++ b/tests/test_merge_users_service.py
@@ -5,6 +5,7 @@ from allauth.account.models import EmailAddress
 from allauth.socialaccount.models import SocialAccount
 from django.contrib.auth import get_user_model
 
+from apps.users.models import Tenant, TenantCredential, TenantMembership
 from apps.users.services.merge import merge_users, select_canonical
 
 User = get_user_model()
@@ -152,3 +153,42 @@ def test_emailaddress_creates_primary_row_for_canonical_email():
     primary = EmailAddress.objects.get(user=canonical, email="brian@y.com")
     assert primary.primary is True
     assert primary.verified is True
+
+
+@pytest.mark.django_db
+def test_tenantmembership_repoints_when_canonical_has_no_overlap():
+    canonical = User.objects.create(email="canon@y.com", username="canon")
+    duplicate = User.objects.create(email="dup@y.com", username="dup")
+    t1 = Tenant.objects.create(provider="commcare", external_id="d1", canonical_name="D1")
+    t2 = Tenant.objects.create(provider="commcare", external_id="d2", canonical_name="D2")
+    TenantMembership.objects.create(user=duplicate, tenant=t1)
+    TenantMembership.objects.create(user=duplicate, tenant=t2)
+
+    report = merge_users(canonical=canonical, duplicate=duplicate)
+
+    assert report.tenant_membership_repointed == 2
+    assert report.tenant_membership_conflict_deleted == 0
+    assert TenantMembership.objects.filter(user=canonical).count() == 2
+
+
+@pytest.mark.django_db
+def test_tenantmembership_conflict_keeps_canonical_and_deletes_duplicates():
+    canonical = User.objects.create(email="canon@y.com", username="canon")
+    duplicate = User.objects.create(email="dup@y.com", username="dup")
+    shared = Tenant.objects.create(provider="commcare", external_id="d1", canonical_name="D1")
+    only_dup = Tenant.objects.create(provider="ocs", external_id="exp9", canonical_name="Exp9")
+    canon_tm = TenantMembership.objects.create(user=canonical, tenant=shared)
+    TenantCredential.objects.create(
+        tenant_membership=canon_tm, credential_type=TenantCredential.OAUTH,
+    )
+    TenantMembership.objects.create(user=duplicate, tenant=shared)  # conflict
+    TenantMembership.objects.create(user=duplicate, tenant=only_dup)
+
+    report = merge_users(canonical=canonical, duplicate=duplicate)
+
+    assert report.tenant_membership_repointed == 1
+    assert report.tenant_membership_conflict_deleted == 1
+    # canonical still has its row for the shared tenant
+    assert TenantMembership.objects.filter(user=canonical, tenant=shared).count() == 1
+    # canonical now also has only_dup's tenant
+    assert TenantMembership.objects.filter(user=canonical, tenant=only_dup).exists()

--- a/tests/test_merge_users_service.py
+++ b/tests/test_merge_users_service.py
@@ -60,7 +60,10 @@ def test_field_level_merge_copies_password_from_duplicate():
 def test_field_level_merge_ors_staff_and_superuser_flags():
     canonical = User.objects.create(email="canon@y.com", username="canon")
     duplicate = User.objects.create(
-        email="dup@y.com", username="dup", is_staff=True, is_superuser=True,
+        email="dup@y.com",
+        username="dup",
+        is_staff=True,
+        is_superuser=True,
     )
 
     merge_users(canonical=canonical, duplicate=duplicate)
@@ -74,8 +77,11 @@ def test_field_level_merge_ors_staff_and_superuser_flags():
 def test_field_level_merge_fills_empty_name_fields_from_duplicate():
     canonical = User.objects.create(email="canon@y.com", username="canon")
     duplicate = User.objects.create(
-        email="dup@y.com", username="dup",
-        first_name="Brian", last_name="DeRenzi", avatar_url="https://x/y.png",
+        email="dup@y.com",
+        username="dup",
+        first_name="Brian",
+        last_name="DeRenzi",
+        avatar_url="https://x/y.png",
     )
 
     merge_users(canonical=canonical, duplicate=duplicate)
@@ -89,10 +95,16 @@ def test_field_level_merge_fills_empty_name_fields_from_duplicate():
 @pytest.mark.django_db
 def test_field_level_merge_keeps_canonical_name_when_already_set():
     canonical = User.objects.create(
-        email="canon@y.com", username="canon", first_name="Already", last_name="Set",
+        email="canon@y.com",
+        username="canon",
+        first_name="Already",
+        last_name="Set",
     )
     duplicate = User.objects.create(
-        email="dup@y.com", username="dup", first_name="Newer", last_name="Name",
+        email="dup@y.com",
+        username="dup",
+        first_name="Newer",
+        last_name="Name",
     )
 
     merge_users(canonical=canonical, duplicate=duplicate)
@@ -139,7 +151,9 @@ def test_emailaddress_dedupes_when_both_have_same_email():
 def test_emailaddress_repoints_distinct_addresses():
     canonical = User.objects.create(email="brian@y.com", username="canon")
     duplicate = User.objects.create(email="brian-old@y.com", username="dup")
-    EmailAddress.objects.create(user=duplicate, email="brian-old@y.com", primary=True, verified=True)
+    EmailAddress.objects.create(
+        user=duplicate, email="brian-old@y.com", primary=True, verified=True
+    )
 
     report = merge_users(canonical=canonical, duplicate=duplicate)
 
@@ -184,7 +198,8 @@ def test_tenantmembership_conflict_keeps_canonical_and_deletes_duplicates():
     only_dup = Tenant.objects.create(provider="ocs", external_id="exp9", canonical_name="Exp9")
     canon_tm = TenantMembership.objects.create(user=canonical, tenant=shared)
     TenantCredential.objects.create(
-        tenant_membership=canon_tm, credential_type=TenantCredential.OAUTH,
+        tenant_membership=canon_tm,
+        credential_type=TenantCredential.OAUTH,
     )
     TenantMembership.objects.create(user=duplicate, tenant=shared)  # conflict
     TenantMembership.objects.create(user=duplicate, tenant=only_dup)
@@ -282,7 +297,10 @@ def test_workspacemembership_invited_by_is_repointed_via_introspection():
     ws = Workspace.objects.create(name="W")
     # `other` has a membership; `duplicate` invited them.
     WorkspaceMembership.objects.create(
-        workspace=ws, user=other, role=WorkspaceRole.READ, invited_by=duplicate,
+        workspace=ws,
+        user=other,
+        role=WorkspaceRole.READ,
+        invited_by=duplicate,
     )
 
     merge_users(canonical=canonical, duplicate=duplicate)
@@ -309,10 +327,13 @@ def test_merge_rolls_back_on_exception():
     duplicate = User.objects.create(email="dup@y.com", username="dup")
     SocialAccount.objects.create(user=duplicate, provider="commcare", uid="42")
 
-    with patch(
-        "apps.users.services.merge._repoint_long_tail_fks",
-        side_effect=RuntimeError("simulated failure"),
-    ), pytest.raises(RuntimeError):
+    with (
+        patch(
+            "apps.users.services.merge._repoint_long_tail_fks",
+            side_effect=RuntimeError("simulated failure"),
+        ),
+        pytest.raises(RuntimeError),
+    ):
         merge_users(canonical=canonical, duplicate=duplicate)
 
     # Everything must be untouched

--- a/tests/test_merge_users_service.py
+++ b/tests/test_merge_users_service.py
@@ -7,6 +7,7 @@ from django.contrib.auth import get_user_model
 
 from apps.users.models import Tenant, TenantCredential, TenantMembership
 from apps.users.services.merge import merge_users, select_canonical
+from apps.workspaces.models import Workspace, WorkspaceMembership, WorkspaceRole
 
 User = get_user_model()
 
@@ -192,3 +193,46 @@ def test_tenantmembership_conflict_keeps_canonical_and_deletes_duplicates():
     assert TenantMembership.objects.filter(user=canonical, tenant=shared).count() == 1
     # canonical now also has only_dup's tenant
     assert TenantMembership.objects.filter(user=canonical, tenant=only_dup).exists()
+
+
+@pytest.mark.django_db
+def test_workspacemembership_repoints_when_no_overlap():
+    canonical = User.objects.create(email="canon@y.com", username="canon")
+    duplicate = User.objects.create(email="dup@y.com", username="dup")
+    ws = Workspace.objects.create(name="W")
+    WorkspaceMembership.objects.create(workspace=ws, user=duplicate, role=WorkspaceRole.READ)
+
+    report = merge_users(canonical=canonical, duplicate=duplicate)
+
+    assert report.workspace_membership_repointed == 1
+    assert report.workspace_membership_conflict_merged == 0
+    assert WorkspaceMembership.objects.get(workspace=ws).user == canonical
+
+
+@pytest.mark.django_db
+def test_workspacemembership_conflict_upgrades_to_higher_role():
+    canonical = User.objects.create(email="canon@y.com", username="canon")
+    duplicate = User.objects.create(email="dup@y.com", username="dup")
+    ws = Workspace.objects.create(name="W")
+    WorkspaceMembership.objects.create(workspace=ws, user=canonical, role=WorkspaceRole.READ)
+    WorkspaceMembership.objects.create(workspace=ws, user=duplicate, role=WorkspaceRole.MANAGE)
+
+    report = merge_users(canonical=canonical, duplicate=duplicate)
+
+    assert report.workspace_membership_conflict_merged == 1
+    membership = WorkspaceMembership.objects.get(workspace=ws)
+    assert membership.user == canonical
+    assert membership.role == WorkspaceRole.MANAGE
+
+
+@pytest.mark.django_db
+def test_workspacemembership_conflict_keeps_canonical_when_higher():
+    canonical = User.objects.create(email="canon@y.com", username="canon")
+    duplicate = User.objects.create(email="dup@y.com", username="dup")
+    ws = Workspace.objects.create(name="W")
+    WorkspaceMembership.objects.create(workspace=ws, user=canonical, role=WorkspaceRole.MANAGE)
+    WorkspaceMembership.objects.create(workspace=ws, user=duplicate, role=WorkspaceRole.READ)
+
+    merge_users(canonical=canonical, duplicate=duplicate)
+
+    assert WorkspaceMembership.objects.get(workspace=ws).role == WorkspaceRole.MANAGE

--- a/tests/test_merge_users_service.py
+++ b/tests/test_merge_users_service.py
@@ -358,3 +358,24 @@ def test_dry_run_writes_nothing_and_returns_a_plan():
     assert SocialAccount.objects.get(provider="commcare", uid="42").user == duplicate
     assert User.objects.filter(pk=duplicate.pk).exists()
     assert not report.duplicate_user_deleted
+
+
+@pytest.mark.django_db
+def test_merge_skips_auth_group_through_tables_when_shared():
+    """Both users share a django.contrib.auth Group. The introspection loop
+    must skip the User_groups through-table, otherwise the bulk update would
+    IntegrityError on the (user, group) unique constraint."""
+    from django.contrib.auth.models import Group
+
+    canonical = User.objects.create(email="canon@y.com", username="canon")
+    duplicate = User.objects.create(email="dup@y.com", username="dup")
+    g = Group.objects.create(name="shared-group")
+    canonical.groups.add(g)
+    duplicate.groups.add(g)
+
+    # Should not raise IntegrityError
+    merge_users(canonical=canonical, duplicate=duplicate)
+
+    # Canonical still has the group; through-table state is consistent.
+    canonical.refresh_from_db()
+    assert g in canonical.groups.all()

--- a/tests/test_merge_users_service.py
+++ b/tests/test_merge_users_service.py
@@ -6,6 +6,7 @@ import pytest
 from allauth.account.models import EmailAddress
 from allauth.socialaccount.models import SocialAccount
 from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
 
 from apps.chat.models import Thread
 from apps.users.models import Tenant, TenantCredential, TenantMembership
@@ -365,8 +366,6 @@ def test_merge_skips_auth_group_through_tables_when_shared():
     """Both users share a django.contrib.auth Group. The introspection loop
     must skip the User_groups through-table, otherwise the bulk update would
     IntegrityError on the (user, group) unique constraint."""
-    from django.contrib.auth.models import Group
-
     canonical = User.objects.create(email="canon@y.com", username="canon")
     duplicate = User.objects.create(email="dup@y.com", username="dup")
     g = Group.objects.create(name="shared-group")

--- a/tests/test_merge_users_service.py
+++ b/tests/test_merge_users_service.py
@@ -5,6 +5,7 @@ from allauth.account.models import EmailAddress
 from allauth.socialaccount.models import SocialAccount
 from django.contrib.auth import get_user_model
 
+from apps.chat.models import Thread
 from apps.users.models import Tenant, TenantCredential, TenantMembership
 from apps.users.services.merge import merge_users, select_canonical
 from apps.workspaces.models import Workspace, WorkspaceMembership, WorkspaceRole
@@ -236,3 +237,31 @@ def test_workspacemembership_conflict_keeps_canonical_when_higher():
     merge_users(canonical=canonical, duplicate=duplicate)
 
     assert WorkspaceMembership.objects.get(workspace=ws).role == WorkspaceRole.MANAGE
+
+
+@pytest.mark.django_db
+def test_chat_threads_are_repointed_via_introspection():
+    canonical = User.objects.create(email="canon@y.com", username="canon")
+    duplicate = User.objects.create(email="dup@y.com", username="dup")
+    ws = Workspace.objects.create(name="W")
+    Thread.objects.create(user=duplicate, workspace=ws, title="T1")
+    Thread.objects.create(user=duplicate, workspace=ws, title="T2")
+
+    report = merge_users(canonical=canonical, duplicate=duplicate)
+
+    assert Thread.objects.filter(user=canonical).count() == 2
+    assert Thread.objects.filter(user=duplicate).count() == 0
+    label = "chat.Thread.user"
+    assert report.long_tail_fk_counts.get(label) == 2
+
+
+@pytest.mark.django_db
+def test_setnull_fk_is_repointed_via_introspection():
+    canonical = User.objects.create(email="canon@y.com", username="canon")
+    duplicate = User.objects.create(email="dup@y.com", username="dup")
+    ws = Workspace.objects.create(name="W", created_by=duplicate)
+
+    merge_users(canonical=canonical, duplicate=duplicate)
+
+    ws.refresh_from_db()
+    assert ws.created_by == canonical

--- a/tests/test_merge_users_service.py
+++ b/tests/test_merge_users_service.py
@@ -1,6 +1,7 @@
 """Unit tests for apps.users.services.merge.merge_users and helpers."""
 
 import pytest
+from allauth.socialaccount.models import SocialAccount
 from django.contrib.auth import get_user_model
 
 from apps.users.services.merge import merge_users, select_canonical
@@ -93,3 +94,18 @@ def test_field_level_merge_keeps_canonical_name_when_already_set():
     canonical.refresh_from_db()
     assert canonical.first_name == "Already"
     assert canonical.last_name == "Set"
+
+
+@pytest.mark.django_db
+def test_socialaccounts_are_repointed_to_canonical():
+    canonical = User.objects.create(email="canon@y.com", username="canon")
+    duplicate = User.objects.create(email="dup@y.com", username="dup")
+    SocialAccount.objects.create(user=duplicate, provider="commcare", uid="42")
+    SocialAccount.objects.create(user=duplicate, provider="ocs", uid="ocs-7")
+    SocialAccount.objects.create(user=canonical, provider="commcare_connect", uid="9")
+
+    report = merge_users(canonical=canonical, duplicate=duplicate)
+
+    assert report.socialaccount_repointed == 2
+    assert SocialAccount.objects.filter(user=canonical).count() == 3
+    assert SocialAccount.objects.filter(user=duplicate).count() == 0

--- a/tests/test_social_login_reconciliation.py
+++ b/tests/test_social_login_reconciliation.py
@@ -1,6 +1,7 @@
 """Tests for the pre_social_login handler that backfills/merges emails."""
 
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 from allauth.socialaccount.models import SocialAccount
@@ -99,3 +100,30 @@ def test_collision_match_is_case_insensitive():
 
     assert not User.objects.filter(pk=duplicate.pk).exists()
     assert sl.user == canonical
+
+
+@pytest.mark.django_db
+def test_merge_failure_does_not_break_login(caplog):
+    canonical = User.objects.create(email="brian@y.com", username="canon")
+    duplicate = User.objects.create(email=None, username="connect-user")
+    dup_account = SocialAccount.objects.create(
+        user=duplicate, provider="commcare_connect", uid="999",
+        extra_data={"email": "brian@y.com"},
+    )
+    sl = SimpleNamespace(user=duplicate, account=dup_account)
+
+    with patch(
+        "apps.users.signals.merge_users",
+        side_effect=RuntimeError("boom"),
+    ):
+        # Must not raise.
+        reconcile_existing_user_on_login(sender=None, request=None, sociallogin=sl)
+
+    # Duplicate still present, login continues on duplicate
+    assert User.objects.filter(pk=duplicate.pk).exists()
+    assert sl.user == duplicate
+    # Failure was logged at ERROR
+    assert any(
+        r.levelname == "ERROR" and "Auto-merge failed" in r.message
+        for r in caplog.records
+    )

--- a/tests/test_social_login_reconciliation.py
+++ b/tests/test_social_login_reconciliation.py
@@ -70,7 +70,9 @@ def test_collision_merges_user_and_redirects_session():
     canonical = User.objects.create(email="brian@y.com", username="canon")
     duplicate = User.objects.create(email=None, username="connect-user")
     dup_account = SocialAccount.objects.create(
-        user=duplicate, provider="commcare_connect", uid="999",
+        user=duplicate,
+        provider="commcare_connect",
+        uid="999",
         extra_data={"email": "brian@y.com"},
     )
     sl = SimpleNamespace(user=duplicate, account=dup_account)
@@ -92,7 +94,9 @@ def test_collision_match_is_case_insensitive():
     canonical = User.objects.create(email="Brian@Y.com", username="canon")
     duplicate = User.objects.create(email=None, username="dup")
     dup_account = SocialAccount.objects.create(
-        user=duplicate, provider="commcare_connect", uid="x",
+        user=duplicate,
+        provider="commcare_connect",
+        uid="x",
         extra_data={"email": "brian@y.com"},
     )
     sl = SimpleNamespace(user=duplicate, account=dup_account)
@@ -105,10 +109,12 @@ def test_collision_match_is_case_insensitive():
 
 @pytest.mark.django_db
 def test_merge_failure_does_not_break_login(caplog):
-    canonical = User.objects.create(email="brian@y.com", username="canon")
+    User.objects.create(email="brian@y.com", username="canon")
     duplicate = User.objects.create(email=None, username="connect-user")
     dup_account = SocialAccount.objects.create(
-        user=duplicate, provider="commcare_connect", uid="999",
+        user=duplicate,
+        provider="commcare_connect",
+        uid="999",
         extra_data={"email": "brian@y.com"},
     )
     sl = SimpleNamespace(user=duplicate, account=dup_account)
@@ -124,15 +130,10 @@ def test_merge_failure_does_not_break_login(caplog):
     assert User.objects.filter(pk=duplicate.pk).exists()
     assert sl.user == duplicate
     # Failure was logged at ERROR
-    assert any(
-        r.levelname == "ERROR" and "Auto-merge failed" in r.message
-        for r in caplog.records
-    )
+    assert any(r.levelname == "ERROR" and "Auto-merge failed" in r.message for r in caplog.records)
 
 
 def test_signal_is_wired_in_app_ready():
-    receivers = [
-        entry[1]() for entry in pre_social_login.receivers if entry[1]() is not None
-    ]
+    receivers = [entry[1]() for entry in pre_social_login.receivers if entry[1]() is not None]
     receiver_names = [getattr(r, "__name__", "") for r in receivers]
     assert "reconcile_existing_user_on_login" in receiver_names

--- a/tests/test_social_login_reconciliation.py
+++ b/tests/test_social_login_reconciliation.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 import pytest
 from allauth.socialaccount.models import SocialAccount
+from allauth.socialaccount.signals import pre_social_login
 from django.contrib.auth import get_user_model
 
 from apps.users.signals import reconcile_existing_user_on_login
@@ -127,3 +128,11 @@ def test_merge_failure_does_not_break_login(caplog):
         r.levelname == "ERROR" and "Auto-merge failed" in r.message
         for r in caplog.records
     )
+
+
+def test_signal_is_wired_in_app_ready():
+    receivers = [
+        entry[1]() for entry in pre_social_login.receivers if entry[1]() is not None
+    ]
+    receiver_names = [getattr(r, "__name__", "") for r in receivers]
+    assert "reconcile_existing_user_on_login" in receiver_names

--- a/tests/test_social_login_reconciliation.py
+++ b/tests/test_social_login_reconciliation.py
@@ -1,0 +1,51 @@
+"""Tests for the pre_social_login handler that backfills/merges emails."""
+
+from types import SimpleNamespace
+
+import pytest
+from django.contrib.auth import get_user_model
+
+from apps.users.signals import reconcile_existing_user_on_login
+
+User = get_user_model()
+
+
+def _sociallogin(user, extra_data):
+    """Build a SocialLogin-shaped stub. Handler only touches .user and .account."""
+    return SimpleNamespace(
+        user=user,
+        account=SimpleNamespace(extra_data=extra_data, user=user),
+    )
+
+
+@pytest.mark.django_db
+def test_brand_new_user_is_noop():
+    new_user = User(email=None)  # unsaved -> pk is None
+    sl = _sociallogin(new_user, {"email": "x@y.com"})
+
+    reconcile_existing_user_on_login(sender=None, request=None, sociallogin=sl)
+
+    # No DB writes; new_user remains unsaved
+    assert new_user.pk is None
+
+
+@pytest.mark.django_db
+def test_existing_user_with_email_is_noop():
+    existing = User.objects.create(email="brian@y.com", username="b")
+    sl = _sociallogin(existing, {"email": "other@y.com"})
+
+    reconcile_existing_user_on_login(sender=None, request=None, sociallogin=sl)
+
+    existing.refresh_from_db()
+    assert existing.email == "brian@y.com"  # untouched
+
+
+@pytest.mark.django_db
+def test_no_email_in_extra_data_is_noop():
+    existing = User.objects.create(email=None, username="b")
+    sl = _sociallogin(existing, {})  # no email key
+
+    reconcile_existing_user_on_login(sender=None, request=None, sociallogin=sl)
+
+    existing.refresh_from_db()
+    assert existing.email is None

--- a/tests/test_social_login_reconciliation.py
+++ b/tests/test_social_login_reconciliation.py
@@ -3,6 +3,7 @@
 from types import SimpleNamespace
 
 import pytest
+from allauth.socialaccount.models import SocialAccount
 from django.contrib.auth import get_user_model
 
 from apps.users.signals import reconcile_existing_user_on_login
@@ -60,3 +61,41 @@ def test_no_collision_backfills_user_email():
 
     existing.refresh_from_db()
     assert existing.email == "brian@y.com"
+
+
+@pytest.mark.django_db
+def test_collision_merges_user_and_redirects_session():
+    canonical = User.objects.create(email="brian@y.com", username="canon")
+    duplicate = User.objects.create(email=None, username="connect-user")
+    dup_account = SocialAccount.objects.create(
+        user=duplicate, provider="commcare_connect", uid="999",
+        extra_data={"email": "brian@y.com"},
+    )
+    sl = SimpleNamespace(user=duplicate, account=dup_account)
+
+    reconcile_existing_user_on_login(sender=None, request=None, sociallogin=sl)
+
+    # duplicate was merged away
+    assert not User.objects.filter(pk=duplicate.pk).exists()
+    # Connect SocialAccount now points at canonical
+    dup_account.refresh_from_db()
+    assert dup_account.user == canonical
+    # Session redirected
+    assert sl.user == canonical
+    assert sl.account.user == canonical
+
+
+@pytest.mark.django_db
+def test_collision_match_is_case_insensitive():
+    canonical = User.objects.create(email="Brian@Y.com", username="canon")
+    duplicate = User.objects.create(email=None, username="dup")
+    dup_account = SocialAccount.objects.create(
+        user=duplicate, provider="commcare_connect", uid="x",
+        extra_data={"email": "brian@y.com"},
+    )
+    sl = SimpleNamespace(user=duplicate, account=dup_account)
+
+    reconcile_existing_user_on_login(sender=None, request=None, sociallogin=sl)
+
+    assert not User.objects.filter(pk=duplicate.pk).exists()
+    assert sl.user == canonical

--- a/tests/test_social_login_reconciliation.py
+++ b/tests/test_social_login_reconciliation.py
@@ -49,3 +49,14 @@ def test_no_email_in_extra_data_is_noop():
 
     existing.refresh_from_db()
     assert existing.email is None
+
+
+@pytest.mark.django_db
+def test_no_collision_backfills_user_email():
+    existing = User.objects.create(email=None, username="connect-user")
+    sl = _sociallogin(existing, {"email": "brian@y.com"})
+
+    reconcile_existing_user_on_login(sender=None, request=None, sociallogin=sl)
+
+    existing.refresh_from_db()
+    assert existing.email == "brian@y.com"

--- a/tests/test_social_login_reconciliation.py
+++ b/tests/test_social_login_reconciliation.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
+from allauth.account.models import EmailAddress
 from allauth.socialaccount.models import SocialAccount
 from allauth.socialaccount.signals import pre_social_login
 from django.contrib.auth import get_user_model
@@ -68,6 +69,9 @@ def test_no_collision_backfills_user_email():
 @pytest.mark.django_db
 def test_collision_merges_user_and_redirects_session():
     canonical = User.objects.create(email="brian@y.com", username="canon")
+    EmailAddress.objects.create(
+        user=canonical, email="brian@y.com", verified=True, primary=True,
+    )
     duplicate = User.objects.create(email=None, username="connect-user")
     dup_account = SocialAccount.objects.create(
         user=duplicate,
@@ -92,6 +96,9 @@ def test_collision_merges_user_and_redirects_session():
 @pytest.mark.django_db
 def test_collision_match_is_case_insensitive():
     canonical = User.objects.create(email="Brian@Y.com", username="canon")
+    EmailAddress.objects.create(
+        user=canonical, email="Brian@Y.com", verified=True, primary=True,
+    )
     duplicate = User.objects.create(email=None, username="dup")
     dup_account = SocialAccount.objects.create(
         user=duplicate,
@@ -109,7 +116,10 @@ def test_collision_match_is_case_insensitive():
 
 @pytest.mark.django_db
 def test_merge_failure_does_not_break_login(caplog):
-    User.objects.create(email="brian@y.com", username="canon")
+    canonical = User.objects.create(email="brian@y.com", username="canon")
+    EmailAddress.objects.create(
+        user=canonical, email="brian@y.com", verified=True, primary=True,
+    )
     duplicate = User.objects.create(email=None, username="connect-user")
     dup_account = SocialAccount.objects.create(
         user=duplicate,
@@ -131,6 +141,55 @@ def test_merge_failure_does_not_break_login(caplog):
     assert sl.user == duplicate
     # Failure was logged at ERROR
     assert any(r.levelname == "ERROR" and "Auto-merge failed" in r.message for r in caplog.records)
+
+
+@pytest.mark.django_db
+def test_collision_refuses_merge_when_canonical_email_not_verified(caplog):
+    """If the canonical row's email is not verified (e.g. created via /signup
+    without verification), refuse the merge — otherwise an attacker who
+    /signup'd with a victim's email could absorb the victim's OAuth account."""
+    # Canonical exists but has NO verified EmailAddress for new_email
+    canonical = User.objects.create(email="brian@y.com", username="canon")
+    duplicate = User.objects.create(email=None, username="connect-user")
+    dup_account = SocialAccount.objects.create(
+        user=duplicate, provider="commcare_connect", uid="999",
+        extra_data={"email": "brian@y.com"},
+    )
+    sl = SimpleNamespace(user=duplicate, account=dup_account)
+
+    reconcile_existing_user_on_login(sender=None, request=None, sociallogin=sl)
+
+    # Refused — both users remain, no session redirect
+    assert User.objects.filter(pk=duplicate.pk).exists()
+    assert User.objects.filter(pk=canonical.pk).exists()
+    assert sl.user == duplicate
+    # Logged at WARNING
+    assert any(
+        r.levelname == "WARNING" and "Refusing auto-merge" in r.message
+        for r in caplog.records
+    )
+
+
+@pytest.mark.django_db
+def test_collision_allows_merge_when_canonical_email_verified(caplog):
+    """Canonical row has a verified EmailAddress for the email — the merge
+    proceeds as normal."""
+    canonical = User.objects.create(email="brian@y.com", username="canon")
+    EmailAddress.objects.create(
+        user=canonical, email="brian@y.com", verified=True, primary=True,
+    )
+    duplicate = User.objects.create(email=None, username="connect-user")
+    dup_account = SocialAccount.objects.create(
+        user=duplicate, provider="commcare_connect", uid="999",
+        extra_data={"email": "brian@y.com"},
+    )
+    sl = SimpleNamespace(user=duplicate, account=dup_account)
+
+    reconcile_existing_user_on_login(sender=None, request=None, sociallogin=sl)
+
+    # Merge proceeded
+    assert not User.objects.filter(pk=duplicate.pk).exists()
+    assert sl.user == canonical
 
 
 def test_signal_is_wired_in_app_ready():


### PR DESCRIPTION
## Summary

Lets a single human user log in through any of the 3 Dimagi OAuth providers (CommCare HQ, CommCare Connect, OCS) and land on the same `User` row, with a management command to clean up existing duplicates.

Three pieces:
- **Settings** (`config/settings/base.py`): enable allauth's `SOCIALACCOUNT_EMAIL_AUTHENTICATION` + `VERIFIED_EMAIL: True` on the 3 Dimagi providers — turns on email-based auto-link for *new* OAuth signups.
- **`pre_social_login` signal handler** (`apps/users/signals.py`): for *existing* OAuth users where allauth's lookup short-circuits, either backfill `User.email` from `extra_data` or auto-merge into the user that already owns that email (then redirect the login session).
- **Merge service + command** (`apps/users/services/merge.py`, `apps/users/management/commands/merge_duplicate_users.py`): `merge_users` does the actual record merging — field-level merge, FK repointing with conflict resolution for `SocialAccount` / `EmailAddress` / `TenantMembership` / `WorkspaceMembership`, long-tail introspection for everything else, all inside one `transaction.atomic()`. The command exposes this for operator-driven cleanup of pre-existing duplicates.

Background investigation, full design, and per-task implementation plan live in:
- `docs/superpowers/specs/2026-05-22-cross-provider-account-linking-design.md`
- `docs/superpowers/plans/2026-05-26-cross-provider-account-linking.md`

## Test plan

- [x] 41 new tests across 4 files (`test_auth_settings.py`, `test_merge_users_service.py`, `test_social_login_reconciliation.py`, `test_merge_duplicate_users_command.py`) — all green
- [x] Full pytest suite: `1006 passed, 8 skipped` (no pre-existing tests regressed)
- [x] Ruff clean on touched files
- [x] Manual end-to-end via `manage.py shell`: synthetic duplicate created → `merge_duplicate_users --dry-run --email …` plans correctly → `--yes --email …` executes → re-run confirms `no duplicates found`
- [ ] Reviewer: confirm `VERIFIED_EMAIL: True` trust posture for CommCare Connect (assumes Connect will server-side-verify email when their API ships it; spec section "Trust model")

## Rollout

After merge, in prod:
1. `python manage.py merge_duplicate_users --dry-run` — preview the full sweep.
2. `python manage.py merge_duplicate_users --email brian@acompahealth.com` — fix Brian's known split first (or run without `--email` for a global sweep).
3. From then on, new OAuth signups auto-link via email. Existing email-less Connect rows will heal on next Connect login once Connect ships email.

🤖 Generated with [Claude Code](https://claude.com/claude-code)