### PR TITLE
feat(tasks): add Task Badger tracking for Procrastinate jobs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,3 +50,8 @@ SENTRY_DSN=
 # SENTRY_RELEASE=
 # SENTRY_TRACES_SAMPLE_RATE=0.0
 # SENTRY_SEND_DEFAULT_PII=False
+
+# Task Badger background-task tracking (optional — leave TASKBADGER_API_KEY blank to disable)
+# Use a project API key (base64-encoded org/project/key).
+TASKBADGER_API_KEY=
+# TASKBADGER_ENVIRONMENT=production

--- a/.kamal/secrets
+++ b/.kamal/secrets
@@ -35,6 +35,12 @@ DB_CREDENTIAL_KEY=$(kamal secrets extract SCOUT_DB_CREDENTIAL_KEY $DJANGO_SECRET
 ANTHROPIC_API_KEY=$(kamal secrets extract SCOUT_ANTHROPIC_API_KEY $DJANGO_SECRETS)
 
 
+## TaskBadger
+TASKBADGER_SECRETS=$(kamal secrets fetch --adapter aws_secrets_manager SCOUT_TASKBADGER_API_KEY)
+
+TASKBADGER_API_KEY=$(kamal secrets extract SCOUT_TASKBADGER_API_KEY $TASKBADGER_SECRETS)
+
+
 ## RDS
 # Use separate script to handle encodeing and more complex secret extraction
 # Requires that the SCOUT_RDS_ENDPOINT is already in the env. See scripts/fetch-deploy-env.sh

--- a/.kamal/secrets
+++ b/.kamal/secrets
@@ -21,10 +21,11 @@ LANGFUSE_SECRET_KEY=$(kamal secrets extract SCOUT_LANGFUSE_SECRET_KEY $LANGFUSE_
 LANGFUSE_PUBLIC_KEY=$(kamal secrets extract SCOUT_LANGFUSE_PUBLIC_KEY $LANGFUSE_SECRETS)
 
 
-## Sentry
-SENTRY_SECRETS=$(kamal secrets fetch --adapter aws_secrets_manager SCOUT_SENTRY_DSN)
+## Observability (Sentry + Task Badger)
+OBSERVABILITY_SECRETS=$(kamal secrets fetch --adapter aws_secrets_manager SCOUT_SENTRY_DSN SCOUT_TASKBADGER_API_KEY)
 
-SENTRY_DSN=$(kamal secrets extract SCOUT_SENTRY_DSN $SENTRY_SECRETS)
+SENTRY_DSN=$(kamal secrets extract SCOUT_SENTRY_DSN $OBSERVABILITY_SECRETS)
+TASKBADGER_API_KEY=$(kamal secrets extract SCOUT_TASKBADGER_API_KEY $OBSERVABILITY_SECRETS)
 
 
 ## Django
@@ -33,12 +34,6 @@ DJANGO_SECRETS=$(kamal secrets fetch --adapter aws_secrets_manager SCOUT_DJANGO_
 DJANGO_SECRET_KEY=$(kamal secrets extract SCOUT_DJANGO_SECRET_KEY $DJANGO_SECRETS)
 DB_CREDENTIAL_KEY=$(kamal secrets extract SCOUT_DB_CREDENTIAL_KEY $DJANGO_SECRETS)
 ANTHROPIC_API_KEY=$(kamal secrets extract SCOUT_ANTHROPIC_API_KEY $DJANGO_SECRETS)
-
-
-## TaskBadger
-TASKBADGER_SECRETS=$(kamal secrets fetch --adapter aws_secrets_manager SCOUT_TASKBADGER_API_KEY)
-
-TASKBADGER_API_KEY=$(kamal secrets extract SCOUT_TASKBADGER_API_KEY $TASKBADGER_SECRETS)
 
 
 ## RDS

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -74,9 +74,45 @@ The deploy pipeline fetches these secrets from AWS Secrets Manager via Kamal's
 | `SCOUT_DB_CREDENTIAL_KEY` | Fernet key for DB credential encryption |
 | `SCOUT_ANTHROPIC_API_KEY` | Claude API key |
 | `SCOUT_SENTRY_DSN` | Sentry DSN for the backend Django project (API, worker, MCP all share it) |
+| `SCOUT_TASKBADGER_API_KEY` | Task Badger project API key for background-job tracking (API + worker share it) |
 
 The RDS master password is auto-managed by AWS (referenced via `SCOUT_RDS_SECRET_ARN`).
 `DATABASE_URL` is resolved at deploy time by `scripts/resolve-database-url.sh`.
+
+### Adding a new secret
+
+The chain runs AWS Secrets Manager → `.kamal/secrets` → `env.secret` in each Kamal
+config. To add one (using `SCOUT_TASKBADGER_API_KEY` as the example):
+
+1. **Store it in AWS Secrets Manager**, following the `SCOUT_*` naming convention:
+   ```bash
+   aws secretsmanager create-secret \
+     --name SCOUT_TASKBADGER_API_KEY \
+     --secret-string '<value>' \
+     --region us-east-1
+   ```
+   (Use `put-secret-value` instead of `create-secret` to rotate an existing one.)
+
+2. **Map it in `.kamal/secrets`** — fetch it from AWS, then extract it into the env
+   var name your app reads. Group related keys into one `fetch` call to cut AWS round-trips:
+   ```bash
+   TASKBADGER_SECRETS=$(kamal secrets fetch --adapter aws_secrets_manager SCOUT_TASKBADGER_API_KEY)
+   TASKBADGER_API_KEY=$(kamal secrets extract SCOUT_TASKBADGER_API_KEY $TASKBADGER_SECRETS)
+   ```
+
+3. **Reference it under `env.secret:`** in every Kamal config whose container needs it
+   (`config/deploy.yml`, `config/deploy-worker.yml`, `config/deploy-mcp.yml`):
+   ```yaml
+   env:
+     secret:
+       - TASKBADGER_API_KEY
+   ```
+
+4. **Verify and deploy.** `kamal secrets print` resolves the file locally so you can
+   confirm the value is non-empty before shipping; then redeploy the affected services.
+
+Only `env.secret` entries are injected from `.kamal/secrets`. Non-sensitive config goes
+in `env.clear` instead, written inline in the Kamal config (no AWS entry needed).
 
 ## Error monitoring (Sentry)
 

--- a/apps/workspaces/apps.py
+++ b/apps/workspaces/apps.py
@@ -1,4 +1,9 @@
+import logging
+
 from django.apps import AppConfig
+from django.conf import settings
+
+from config.taskbadger import init_taskbadger
 
 
 class WorkspacesConfig(AppConfig):
@@ -7,13 +12,11 @@ class WorkspacesConfig(AppConfig):
     verbose_name = "Workspaces"
 
     def ready(self):
-        import logging
-
-        from django.conf import settings
-
         cache_backend = settings.CACHES.get("default", {}).get("BACKEND", "")
         if "LocMemCache" in cache_backend:
             logging.getLogger("scout.config").warning(
                 "Using LocMemCache. "
                 "Rate limiting and caching will not work across multiple workers."
             )
+
+        init_taskbadger()

--- a/config/deploy-worker.yml
+++ b/config/deploy-worker.yml
@@ -45,6 +45,9 @@ env:
     # the blind spot that hid the original ConnectError for two failed runs.
     - LANGFUSE_SECRET_KEY
     - LANGFUSE_PUBLIC_KEY
+    # Worker executes tasks and updates their Task Badger status; it also chains
+    # the resume task, so it defers (creates) Task Badger records too.
+    - TASKBADGER_API_KEY
 
 ssh:
   user: scout

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -51,6 +51,7 @@ env:
     - OCS_OAUTH_CLIENT_ID
     - OCS_OAUTH_CLIENT_SECRET
     - SENTRY_DSN
+    - TASKBADGER_API_KEY
 
 ssh:
   user: scout

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -283,6 +283,13 @@ if SENTRY_DSN:
         send_default_pii=env.bool("SENTRY_SEND_DEFAULT_PII", default=False),
     )
 
+# Task Badger background-task tracking (optional — leave TASKBADGER_API_KEY blank to disable)
+TASKBADGER_API_KEY = env("TASKBADGER_API_KEY", default="")
+TASKBADGER_ENVIRONMENT = env(
+    "TASKBADGER_ENVIRONMENT",
+    default="development" if DEBUG else "production",
+)
+
 # MCP server URL (Scout data access layer)
 MCP_SERVER_URL = env("MCP_SERVER_URL", default="http://localhost:8100/mcp")
 

--- a/config/taskbadger.py
+++ b/config/taskbadger.py
@@ -1,0 +1,46 @@
+"""Task Badger initialization.
+
+Wires the Procrastinate system integration so every ``@app.task`` decorated
+function is automatically tracked. Call ``init_taskbadger`` once during Django
+startup (see ``apps.workspaces.apps.WorkspacesConfig.ready``).
+
+Disabled when ``TASKBADGER_API_KEY`` is blank.
+"""
+
+import logging
+
+import taskbadger
+from django.conf import settings
+from taskbadger.systems.procrastinate import ProcrastinateSystemIntegration
+
+from config.procrastinate import app as procrastinate_app
+
+log = logging.getLogger(__name__)
+
+_initialized = False
+
+
+def init_taskbadger() -> None:
+    """Initialize Task Badger with Procrastinate auto-tracking.
+
+    Idempotent: subsequent calls are no-ops so this can safely be invoked from
+    AppConfig.ready, which may run more than once under some Django reloader
+    configurations.
+    """
+    global _initialized
+    if _initialized or not settings.TASKBADGER_API_KEY:
+        return
+
+    taskbadger.init(
+        token=settings.TASKBADGER_API_KEY,
+        systems=[
+            ProcrastinateSystemIntegration(
+                app=procrastinate_app,
+                auto_track_tasks=True,
+                record_task_args=True,
+            )
+        ],
+        tags={"environment": settings.TASKBADGER_ENVIRONMENT},
+    )
+    _initialized = True
+    log.info("Task Badger initialized with Procrastinate integration")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
     "dbt-postgres>=1.10.0",
     "whitenoise>=6.12.0",
     "sentry-sdk[django]>=2.0",
-    "taskbadger>=2.1.0a1",
+    "taskbadger>=2.1.0a2",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dependencies = [
     "dbt-postgres>=1.10.0",
     "whitenoise>=6.12.0",
     "sentry-sdk[django]>=2.0",
+    "taskbadger>=2.1.0a1",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_oauth_domain_restriction.py
+++ b/tests/test_oauth_domain_restriction.py
@@ -17,8 +17,8 @@ class TestAllowedEmailDomainsSetting:
     def test_setting_exists_and_is_dict(self):
         assert isinstance(settings.SOCIALACCOUNT_ALLOWED_EMAIL_DOMAINS, dict)
 
-    def test_default_restricts_three_providers_to_dimagi_com(self):
-        expected_providers = {"commcare", "commcare_connect", "ocs"}
+    def test_default_restricts_providers_to_dimagi_com(self):
+        expected_providers = {"commcare"}
         actual = settings.SOCIALACCOUNT_ALLOWED_EMAIL_DOMAINS
         assert set(actual.keys()) == expected_providers
         for provider, domains in actual.items():

--- a/uv.lock
+++ b/uv.lock
@@ -2792,6 +2792,7 @@ dependencies = [
     { name = "sentry-sdk", extra = ["django"] },
     { name = "sqlalchemy" },
     { name = "sqlglot" },
+    { name = "taskbadger" },
     { name = "uvicorn", extra = ["standard"] },
     { name = "whitenoise" },
 ]
@@ -2863,6 +2864,7 @@ requires-dist = [
     { name = "sentry-sdk", extras = ["django"], specifier = ">=2.0" },
     { name = "sqlalchemy", specifier = ">=2.0" },
     { name = "sqlglot", specifier = ">=25.0" },
+    { name = "taskbadger", specifier = ">=2.1.0a1" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30" },
     { name = "whitenoise", specifier = ">=6.12.0" },
 ]
@@ -3077,6 +3079,21 @@ wheels = [
 ]
 
 [[package]]
+name = "taskbadger"
+version = "2.1.0a1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "httpx" },
+    { name = "python-dateutil" },
+    { name = "tomlkit" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7a/5c/d9931d3c811922aa68776449f4d69bdca1111a14000710d3e292f5604a91/taskbadger-2.1.0a1.tar.gz", hash = "sha256:cb04ce1cf2b735a69517a75f56f5a581c8eb7f269244fdbaaa1e5bb416493c2d", size = 36709, upload-time = "2026-05-26T10:08:18.754Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/eb/3293edfa11b58621b7a7ad6457955d73b2d8635200fa79111158d2de97f8/taskbadger-2.1.0a1-py3-none-any.whl", hash = "sha256:ff13e7fb0b87242fd38453f0f4408083fa4f21b21bfd84937fc22cd121bcc9ef", size = 67169, upload-time = "2026-05-26T10:08:17.343Z" },
+]
+
+[[package]]
 name = "tenacity"
 version = "9.1.3"
 source = { registry = "https://pypi.org/simple" }
@@ -3146,6 +3163,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/de/69/9aa0c6a505c2f80e519b43764f8b4ba93b5a0bbd2d9a9de6e2b24271b9a5/tomli-2.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:2add28aacc7425117ff6364fe9e06a183bb0251b03f986df0e78e974047571fd", size = 120504, upload-time = "2026-01-11T11:22:35.764Z" },
     { url = "https://files.pythonhosted.org/packages/b3/9f/f1668c281c58cfae01482f7114a4b88d345e4c140386241a1a24dcc9e7bc/tomli-2.4.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2b1e3b80e1d5e52e40e9b924ec43d81570f0e7d09d11081b797bc4692765a3d4", size = 99561, upload-time = "2026-01-11T11:22:36.624Z" },
     { url = "https://files.pythonhosted.org/packages/23/d1/136eb2cb77520a31e1f64cbae9d33ec6df0d78bdf4160398e86eec8a8754/tomli-2.4.0-py3-none-any.whl", hash = "sha256:1f776e7d669ebceb01dee46484485f43a4048746235e683bcdffacdf1fb4785a", size = 14477, upload-time = "2026-01-11T11:22:37.446Z" },
+]
+
+[[package]]
+name = "tomlkit"
+version = "0.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/db/03eaf4331631ef6b27d6e3c9b68c54dc6f0d63d87201fed600cc409307fd/tomlkit-0.15.0.tar.gz", hash = "sha256:7d1a9ecba3086638211b13814ea79c90dd54dd11993564376f3aa92271f5c7a3", size = 161875, upload-time = "2026-05-10T07:38:22.245Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/43/8bd850ee71a191bf072e31302c73a66be413fecdd98fdcd111ecbcce13ca/tomlkit-0.15.0-py3-none-any.whl", hash = "sha256:4dbc8f0fc024412b57ced8757ac7461305126a648ff8c2c807fcb8e133a78738", size = 41328, upload-time = "2026-05-10T07:38:23.517Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -2864,7 +2864,7 @@ requires-dist = [
     { name = "sentry-sdk", extras = ["django"], specifier = ">=2.0" },
     { name = "sqlalchemy", specifier = ">=2.0" },
     { name = "sqlglot", specifier = ">=25.0" },
-    { name = "taskbadger", specifier = ">=2.1.0a1" },
+    { name = "taskbadger", specifier = ">=2.1.0a2" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30" },
     { name = "whitenoise", specifier = ">=6.12.0" },
 ]
@@ -3080,7 +3080,7 @@ wheels = [
 
 [[package]]
 name = "taskbadger"
-version = "2.1.0a1"
+version = "2.1.0a2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -3088,9 +3088,9 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "tomlkit" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7a/5c/d9931d3c811922aa68776449f4d69bdca1111a14000710d3e292f5604a91/taskbadger-2.1.0a1.tar.gz", hash = "sha256:cb04ce1cf2b735a69517a75f56f5a581c8eb7f269244fdbaaa1e5bb416493c2d", size = 36709, upload-time = "2026-05-26T10:08:18.754Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/07/e9/0f847eb40e00dbf82e9a791bef0024ccf25f9464fea7a38b32bdf5e4b826/taskbadger-2.1.0a2.tar.gz", hash = "sha256:a356f9f3478692d1e5caca6a448aaf9b9bc5084b26457665faa8d98f4ab64876", size = 37215, upload-time = "2026-05-26T18:30:13.909Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/eb/3293edfa11b58621b7a7ad6457955d73b2d8635200fa79111158d2de97f8/taskbadger-2.1.0a1-py3-none-any.whl", hash = "sha256:ff13e7fb0b87242fd38453f0f4408083fa4f21b21bfd84937fc22cd121bcc9ef", size = 67169, upload-time = "2026-05-26T10:08:17.343Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/5c/c5ac955bddf683ecae6478e337db49fde98cf85023f4219e7dcb256c192e/taskbadger-2.1.0a2-py3-none-any.whl", hash = "sha256:b28bfe80573b83b9d361113982c0b48c98b2daf2b8db3707566ea1bd5a24747b", size = 67664, upload-time = "2026-05-26T18:30:15.121Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds opt-in [Task Badger](https://taskbadger.net) tracking for background jobs, using the pre-release `taskbadger>=2.1.0a1` which ships native Procrastinate support.

`init_taskbadger()` runs from `WorkspacesConfig.ready()` (the app that owns every `@app.task`) and installs `ProcrastinateSystemIntegration` with `auto_track_tasks=True`, so all tasks are tracked without per-task decorators. It's a no-op when `TASKBADGER_API_KEY` is blank, mirroring the existing Sentry toggle, so nothing changes for environments that don't set it.

Worth a look:
- Init lives in `ready()` rather than at settings-load time because the Procrastinate `app` isn't constructed until Django apps are loaded. The integration patches `app.task`, so it catches tasks registered after init as well as those already present.
- `record_task_args=True` means defer kwargs are sent to Task Badger — fine here since task args are workspace/thread IDs, not secrets.

Enable by setting `TASKBADGER_API_KEY` to a base64 project API key.