### PR TITLE
Fix Sentry/Task Badger environment label on production

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -5,6 +5,7 @@ Settings common to all environments. Environment-specific settings
 override these in development.py, production.py, and test.py.
 """
 
+import os
 from pathlib import Path
 
 import environ
@@ -31,6 +32,17 @@ SECRET_KEY = env("DJANGO_SECRET_KEY")
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = env("DJANGO_DEBUG", default=True)
+
+# Default deployment environment label for Sentry / Task Badger. Derived from the
+# settings module (set before settings load) rather than DEBUG: base.py defaults
+# DEBUG to True and production.py only flips it after this file is imported, so a
+# DEBUG-based default would freeze to "development" even under production settings.
+# An explicit SENTRY_ENVIRONMENT / TASKBADGER_ENVIRONMENT env var still wins.
+DEPLOY_ENVIRONMENT = (
+    "production"
+    if os.environ.get("DJANGO_SETTINGS_MODULE", "").endswith(".production")
+    else "development"
+)
 
 ALLOWED_HOSTS = env("DJANGO_ALLOWED_HOSTS")
 
@@ -278,10 +290,7 @@ SENTRY_DSN = env("SENTRY_DSN", default="")
 if SENTRY_DSN:
     sentry_sdk.init(
         dsn=SENTRY_DSN,
-        environment=env(
-            "SENTRY_ENVIRONMENT",
-            default="development" if DEBUG else "production",
-        ),
+        environment=env("SENTRY_ENVIRONMENT", default=DEPLOY_ENVIRONMENT),
         release=env("SENTRY_RELEASE", default="") or None,
         traces_sample_rate=env.float("SENTRY_TRACES_SAMPLE_RATE", default=0.0),
         send_default_pii=env.bool("SENTRY_SEND_DEFAULT_PII", default=False),
@@ -289,10 +298,7 @@ if SENTRY_DSN:
 
 # Task Badger background-task tracking (optional — leave TASKBADGER_API_KEY blank to disable)
 TASKBADGER_API_KEY = env("TASKBADGER_API_KEY", default="")
-TASKBADGER_ENVIRONMENT = env(
-    "TASKBADGER_ENVIRONMENT",
-    default="development" if DEBUG else "production",
-)
+TASKBADGER_ENVIRONMENT = env("TASKBADGER_ENVIRONMENT", default=DEPLOY_ENVIRONMENT)
 
 # MCP server URL (Scout data access layer)
 MCP_SERVER_URL = env("MCP_SERVER_URL", default="http://localhost:8100/mcp")

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -10,12 +10,6 @@ from .base import *
 
 DEBUG = False
 
-# Re-evaluate DEBUG-derived defaults that base.py froze before DEBUG was set to
-# False here. base.py defaults DEBUG to True, so any setting whose default keys
-# off DEBUG must be recomputed once production has flipped it. The env var still
-# wins when explicitly set.
-TASKBADGER_ENVIRONMENT = env("TASKBADGER_ENVIRONMENT", default="production")
-
 # Security settings
 SECURE_BROWSER_XSS_FILTER = True
 SECURE_CONTENT_TYPE_NOSNIFF = True


### PR DESCRIPTION
## Problem

The Task Badger environment showed as `development` on production even with no env var set; Sentry had the same latent bug.

## Root cause

Evaluation-order issue in the layered settings. `base.py` defaults `DEBUG=True`, and the prod deploy only sets `DJANGO_SETTINGS_MODULE` (never `DJANGO_DEBUG`). The Sentry/Task Badger defaults computed `"development" if DEBUG else "production"` at `base.py` import time — before `production.py` flips `DEBUG = False` — so they froze to `development`. Sentry is worse: `sentry_sdk.init()` runs during `base.py` import, so a `production.py` override can't fix it.

## Fix

Introduce a single `DEPLOY_ENVIRONMENT` constant in `base.py` derived from `DJANGO_SETTINGS_MODULE` (reliably set before settings load), and use it as the default for both `SENTRY_ENVIRONMENT` and `TASKBADGER_ENVIRONMENT`. Explicit env vars still override.

## Verification

- Production settings → `production`; development → `development`.
- Explicit `SENTRY_ENVIRONMENT` override path inits cleanly.
- `ruff check` / `ruff format --check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)