### PR TITLE
Add bounded retry + sentry-trace capture for Connect 5xx

### DIFF
--- a/apps/workspaces/tasks.py
+++ b/apps/workspaces/tasks.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 from datetime import timedelta
 
+import sentry_sdk
 from django.conf import settings
 from django.utils import timezone
 from langchain_core.messages import HumanMessage
@@ -26,6 +27,7 @@ from apps.workspaces.models import (
 )
 from apps.workspaces.services.schema_manager import SchemaManager
 from config.procrastinate import app
+from mcp_server.loaders.connect_base import ConnectExportError
 from mcp_server.pipeline_registry import get_registry
 from mcp_server.services.materializer import (
     MaterializationCancelled,
@@ -193,6 +195,24 @@ async def materialize_workspace(
                 tenant_results.append({"tenant": tenant_id, "success": False, "cancelled": True})
                 # Stop processing remaining tenants — the user has cancelled.
                 break
+            except ConnectExportError as e:
+                # Upstream Connect failure after retry exhaustion. Capture
+                # the response's sentry-trace header so support can correlate
+                # with Connect's Sentry in a single hop. sentry_sdk.set_tag
+                # is a no-op when the SDK was never initialised (no DSN).
+                logger.exception(
+                    "Materialization failed for tenant %s on pipeline %s: "
+                    "connect status=%s after %d attempts (last_id=%s, sentry-trace=%s)",
+                    tenant_id,
+                    pipeline_name,
+                    e.status,
+                    e.attempts,
+                    e.last_id,
+                    e.sentry_trace,
+                )
+                sentry_sdk.set_tag("connect.upstream_sentry_trace", e.sentry_trace or "")
+                sentry_sdk.set_tag("connect.pipeline", pipeline_name or "")
+                tenant_results.append({"tenant": tenant_id, "success": False, "error": str(e)})
             except Exception as e:
                 logger.exception("Materialization failed for tenant %s", tenant_id)
                 tenant_results.append(

--- a/mcp_server/loaders/connect_base.py
+++ b/mcp_server/loaders/connect_base.py
@@ -9,8 +9,11 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Iterator
+from urllib.parse import parse_qs, urlparse
 
 import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 logger = logging.getLogger(__name__)
 
@@ -25,13 +28,75 @@ HTTP_TIMEOUT: tuple[int, int] = (10, 300)
 # unaffected.
 EXPORT_ACCEPT_HEADER = "application/json; version=2.0"
 
+# Bounded retry policy for transient upstream failures. backoff_factor=2.0
+# yields waits of 0s, 2s, 4s, 8s between the 4 total attempts (~14s worst case).
+# raise_on_status=False lets us inspect the final response (headers, status)
+# so we can surface upstream Sentry trace IDs rather than just propagating
+# the raw requests.HTTPError.
+RETRY_TOTAL = 3
+RETRY_STATUS_FORCELIST = (500, 502, 503, 504, 408, 429)
+
+
+def _extract_last_id(url: str, params: dict | None) -> int | None:
+    """Best-effort recovery of the cursor value at the time of failure.
+
+    On the first page, the cursor (if any) is in ``params``; on subsequent
+    pages the server-built ``next`` URL embeds it as a query string.
+    """
+    if params and "last_id" in params:
+        try:
+            return int(params["last_id"])
+        except (TypeError, ValueError):
+            return None
+    qs = parse_qs(urlparse(url).query)
+    values = qs.get("last_id")
+    if not values:
+        return None
+    try:
+        return int(values[0])
+    except (TypeError, ValueError):
+        return None
+
+
+def _build_retry() -> Retry:
+    return Retry(
+        total=RETRY_TOTAL,
+        backoff_factor=2.0,
+        status_forcelist=list(RETRY_STATUS_FORCELIST),
+        allowed_methods=["GET"],
+        respect_retry_after_header=True,
+        raise_on_status=False,
+    )
+
 
 class ConnectAuthError(Exception):
     """Raised when Connect returns a 401 or 403 response."""
 
 
 class ConnectExportError(Exception):
-    """Raised when a v2 export response is malformed (missing 'results', invalid JSON)."""
+    """Raised on unrecoverable Connect export failures.
+
+    Covers both malformed responses (missing ``results`` key, invalid JSON)
+    and non-2xx responses that survived the retry policy. When raised after
+    retry exhaustion, ``status``, ``attempts``, ``sentry_trace``, and
+    ``last_id`` are populated so the materializer can log structured context
+    and operators can correlate with upstream traces.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status: int | None = None,
+        sentry_trace: str | None = None,
+        attempts: int = 1,
+        last_id: int | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.status = status
+        self.sentry_trace = sentry_trace
+        self.attempts = attempts
+        self.last_id = last_id
 
 
 class ConnectBaseLoader:
@@ -60,6 +125,9 @@ class ConnectBaseLoader:
         self.base_url = base_url.rstrip("/")
         self._session = requests.Session()
         self._session.headers.update({"Authorization": f"Bearer {credential['value']}"})
+        adapter = HTTPAdapter(max_retries=_build_retry())
+        self._session.mount("https://", adapter)
+        self._session.mount("http://", adapter)
 
     def _get(self, url: str, params: dict | None = None) -> requests.Response:
         """GET a URL, raising ConnectAuthError on 401/403."""
@@ -95,9 +163,11 @@ class ConnectBaseLoader:
 
         Raises:
             ConnectAuthError: on 401/403.
-            ConnectExportError: when the response is not valid JSON or is
-                missing the ``results`` key.
-            requests.HTTPError: on any other non-2xx response.
+            ConnectExportError: when the response is not valid JSON, is
+                missing the ``results`` key, or returns a non-2xx status
+                that survives the configured retry policy. On retry
+                exhaustion, ``status``, ``attempts``, ``sentry_trace``, and
+                ``last_id`` are populated for structured logging.
         """
         url: str | None = self._opp_url(suffix)
         request_params: dict | None = params
@@ -121,7 +191,19 @@ class ConnectBaseLoader:
                     f"Connect auth failed for opportunity {self.opportunity_id}: "
                     f"HTTP {resp.status_code}"
                 )
-            resp.raise_for_status()
+            if not resp.ok:
+                # A status in the forcelist means the urllib3 Retry policy
+                # ran to exhaustion (RETRY_TOTAL retries on top of the initial
+                # attempt). Anything else short-circuited on the first try.
+                attempts = RETRY_TOTAL + 1 if resp.status_code in RETRY_STATUS_FORCELIST else 1
+                raise ConnectExportError(
+                    f"Connect export request failed for opportunity "
+                    f"{self.opportunity_id}: HTTP {resp.status_code} for {url}",
+                    status=resp.status_code,
+                    sentry_trace=resp.headers.get("sentry-trace"),
+                    attempts=attempts,
+                    last_id=_extract_last_id(url, request_params),
+                )
 
             try:
                 payload = resp.json()

--- a/tests/test_connect_base_loader.py
+++ b/tests/test_connect_base_loader.py
@@ -1,8 +1,14 @@
+import io
+from unittest.mock import MagicMock, patch
+
 import pytest
 import requests_mock as rm
+from urllib3.connectionpool import HTTPSConnectionPool
+from urllib3.response import HTTPResponse
 
 from mcp_server.loaders.connect_base import (
     EXPORT_ACCEPT_HEADER,
+    RETRY_TOTAL,
     ConnectAuthError,
     ConnectBaseLoader,
     ConnectExportError,
@@ -190,3 +196,124 @@ class TestPaginateExportPages:
             # requests preserves Authorization on same-host http→https upgrades.
             redirected_request = next(req for req in m.request_history if req.url == next_https)
             assert redirected_request.headers["Authorization"] == "Bearer test-token-123"
+
+
+def _make_urllib3_response(status, body=b"", headers=None):
+    return HTTPResponse(
+        body=io.BytesIO(body),
+        headers=headers or {},
+        status=status,
+        version=11,
+        version_string="HTTP/1.1",
+        reason="",
+        preload_content=False,
+        decode_content=False,
+    )
+
+
+def _drive_with_statuses(loader, scripted):
+    """Patch urllib3's connection pool so the loader's real Retry adapter
+    sees a scripted sequence of responses.
+
+    ``requests-mock`` replaces the session's adapter and so completely
+    bypasses urllib3's Retry logic. Patching ``HTTPSConnectionPool._make_request``
+    instead lets the real configured Retry on the adapter drive the retry
+    loop, which is what we actually want to test.
+
+    ``scripted`` is a list of ``(status, body_bytes, headers_dict)`` tuples
+    consumed in order; the last entry is reused if the loader makes more
+    requests than scripted.
+    """
+    queue = list(scripted)
+    calls: list[dict] = []
+
+    def fake_make_request(self, conn, method, url, **kwargs):
+        spec = queue.pop(0) if len(queue) > 1 else queue[0]
+        status, body, headers = spec
+        calls.append({"method": method, "url": url, "status": status})
+        return _make_urllib3_response(status, body, headers)
+
+    return patch.multiple(
+        HTTPSConnectionPool,
+        _make_request=fake_make_request,
+        _get_conn=lambda self, timeout=None: MagicMock(),
+        _put_conn=lambda self, conn: None,
+    ), calls
+
+
+@pytest.fixture
+def fast_retry_loader(loader):
+    """Loader with backoff_factor=0 so retry tests are not timing-bound.
+
+    Connect 5xx retry semantics are what we test here; the actual sleep
+    between retries is urllib3's responsibility and not our code under test.
+    """
+    adapter = loader._session.get_adapter("https://connect.example.com/")
+    adapter.max_retries.backoff_factor = 0
+    return loader
+
+
+class TestConnectRetryBehaviour:
+    def test_retries_on_5xx_then_succeeds(self, fast_retry_loader):
+        ctx, calls = _drive_with_statuses(
+            fast_retry_loader,
+            scripted=[
+                (500, b"", {}),
+                (500, b"", {}),
+                (
+                    200,
+                    b'{"next": null, "results": [{"id": 1}, {"id": 2}], "count": 2}',
+                    {"Content-Type": "application/json"},
+                ),
+            ],
+        )
+        with ctx:
+            pages = list(fast_retry_loader._paginate_export_pages("user_visits/"))
+
+        assert pages == [([{"id": 1}, {"id": 2}], 2)]
+        assert len(calls) == 3
+
+    def test_raises_after_max_retries(self, fast_retry_loader):
+        ctx, calls = _drive_with_statuses(
+            fast_retry_loader,
+            scripted=[(500, b"", {})],
+        )
+        with ctx, pytest.raises(ConnectExportError) as exc:
+            list(fast_retry_loader._paginate_export_pages("user_visits/"))
+
+        assert exc.value.status == 500
+        assert exc.value.attempts == RETRY_TOTAL + 1 == 4
+        assert len(calls) == 4
+
+    def test_captures_sentry_trace_header_on_failure(self, fast_retry_loader):
+        sentry_trace_value = "1234567890abcdef1234567890abcdef-abcd-1"
+        ctx, _ = _drive_with_statuses(
+            fast_retry_loader,
+            scripted=[(503, b"", {"sentry-trace": sentry_trace_value})],
+        )
+        with ctx, pytest.raises(ConnectExportError) as exc:
+            list(fast_retry_loader._paginate_export_pages("user_visits/"))
+
+        assert exc.value.sentry_trace == sentry_trace_value
+        assert exc.value.status == 503
+        assert exc.value.attempts == RETRY_TOTAL + 1
+
+    def test_does_not_retry_on_401(self, fast_retry_loader):
+        ctx, calls = _drive_with_statuses(
+            fast_retry_loader,
+            scripted=[(401, b"", {})],
+        )
+        with ctx, pytest.raises(ConnectAuthError):
+            list(fast_retry_loader._paginate_export_pages("user_visits/"))
+
+        assert len(calls) == 1
+
+    def test_does_not_retry_on_403(self, fast_retry_loader):
+        ctx, calls = _drive_with_statuses(
+            fast_retry_loader,
+            scripted=[(403, b"", {})],
+        )
+        with ctx, pytest.raises(ConnectAuthError):
+            list(fast_retry_loader._paginate_export_pages("user_visits/"))
+
+        assert len(calls) == 1


### PR DESCRIPTION
## Summary

A single transient 5xx from `connect.dimagi.com` was aborting the entire materialization pipeline with no retry and no upstream trace ID captured for support correlation.

- Mounts a `urllib3.Retry` adapter on the `ConnectBaseLoader` session: 3 retries, `backoff_factor=2.0` (waits 0s/2s/4s/8s, ~14s worst case), GET-only, only retries on 500/502/503/504/408/429.
- Replaces the bare `resp.raise_for_status()` in `_paginate_export_pages` with a `ConnectExportError(status, attempts, sentry_trace, last_id)` raise so the retry-exhausted response's `sentry-trace` header is captured for one-hop correlation with Connect's Sentry.
- Catches `ConnectExportError` separately in `materialize_workspace` and surfaces the structured context via `logger.exception` + `sentry_sdk.set_tag`. `sentry_sdk.set_tag` is a no-op when no DSN is configured, so no behaviour change in dev/test.
- 401/403 still raise `ConnectAuthError` immediately (no retry).

Fixes #186

## Test plan

- [ ] `uv run pytest tests/test_connect_base_loader.py` — 5 new tests cover the acceptance criteria (retry-then-succeed, retry exhaustion sets `attempts == 4`, sentry-trace capture, no-retry on 401, no-retry on 403); all existing tests pass.
- [ ] `uv run pytest tests/test_connect_data_loaders.py tests/test_connect_mcp_integration.py` — downstream loader/integration regression suite passes.
- [ ] `uv run ruff check .` is clean on touched files.
- [ ] Manual: confirm Sentry sees `connect.upstream_sentry_trace` and `connect.pipeline` tags on a forced failure once deployed (requires `SENTRY_DSN`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)