### PR TITLE
Align system prompt with actual SQL allow-list

### DIFF
--- a/apps/agents/prompts/base_system.py
+++ b/apps/agents/prompts/base_system.py
@@ -121,7 +121,7 @@ Your access is strictly limited for safety:
 
 2. **Schema-Scoped**: You can ONLY access tables within the current project's schema. Attempts to access other schemas will fail.
 
-3. **No System Tables**: You cannot query pg_catalog, information_schema directly, or any system tables.
+3. **No `information_schema`**: You cannot query `information_schema` directly. Use the `describe_table` and `list_tables` tools to inspect schema. Unqualified `pg_catalog` views (`pg_namespace`, `pg_class`, `pg_views`, `pg_tables`) are reachable if you really need raw system-state introspection, but prefer the dedicated tools.
 
 4. **Query Limits**: Large queries have row limits and timeouts to prevent runaway operations.
 

--- a/tests/test_sql_validator.py
+++ b/tests/test_sql_validator.py
@@ -13,6 +13,7 @@ Tests cover security-critical functionality:
 
 import pytest
 
+from apps.agents.prompts.base_system import BASE_SYSTEM_PROMPT
 from mcp_server.services.sql_validator import SQLValidationError, SQLValidator
 
 
@@ -500,3 +501,40 @@ class TestEdgeCases:
         tables = validator.get_tables_accessed(statement)
         assert isinstance(tables, list)
         assert "users" in tables
+
+
+class TestPromptValidatorAlignment:
+    """Meta-tests ensuring the system prompt matches the validator's real behavior."""
+
+    def test_information_schema_qualified_is_rejected(self):
+        validator = SQLValidator(schema="ws_demo")
+        with pytest.raises(SQLValidationError, match="information_schema"):
+            validator.validate("SELECT * FROM information_schema.columns")
+
+    def test_unqualified_pg_catalog_views_are_allowed(self):
+        validator = SQLValidator(schema="ws_demo")
+        for sql in (
+            "SELECT schemaname, tablename FROM pg_tables",
+            "SELECT schemaname, viewname FROM pg_views",
+            "SELECT nspname FROM pg_namespace",
+            "SELECT relname FROM pg_class",
+        ):
+            validator.validate(sql)
+
+    def test_prompt_mentions_information_schema_restriction(self):
+        prompt = BASE_SYSTEM_PROMPT.lower()
+        assert "information_schema" in prompt
+        assert "describe_table" in prompt
+        assert "list_tables" in prompt
+
+    def test_prompt_does_not_claim_pg_catalog_is_blocked(self):
+        prompt = BASE_SYSTEM_PROMPT
+        forbidden_phrases = [
+            "cannot query pg_catalog",
+            "cannot access pg_catalog",
+        ]
+        for phrase in forbidden_phrases:
+            assert phrase.lower() not in prompt.lower(), (
+                f"Prompt still claims pg_catalog is blocked ({phrase!r}), but the "
+                "validator allows unqualified pg_* views."
+            )


### PR DESCRIPTION
## Summary

- The base system prompt claimed the agent could not query `pg_catalog` or `information_schema`. In reality, only `information_schema` (and any other unauthorised schema explicitly qualified) is rejected by `SQLValidator`. Unqualified `pg_catalog` views (`pg_tables`, `pg_views`, `pg_namespace`, `pg_class`) pass validation because the validator only checks `table.db` when a schema is set on the table reference.
- Reworded the "Security Constraints" item to match what the validator actually does and steer the agent toward `describe_table` / `list_tables` by default.
- Added a small meta-test class (`TestPromptValidatorAlignment`) in `tests/test_sql_validator.py` so the prompt and validator can't drift apart silently.

Fixes #192

## Reality check (validator behavior)

| Query                                                | Validator outcome |
| ---------------------------------------------------- | ----------------- |
| `SELECT ... FROM pg_tables`                          | Allowed           |
| `SELECT ... FROM pg_views`                           | Allowed           |
| `SELECT ... FROM pg_namespace`                       | Allowed           |
| `SELECT ... FROM pg_class JOIN pg_namespace ...`     | Allowed           |
| `SELECT * FROM pg_catalog.pg_tables`                 | Blocked (schema)  |
| `SELECT * FROM information_schema.columns`           | Blocked (schema)  |

The schema-qualified `pg_catalog.*` form is rejected, but the unqualified form (which PostgreSQL resolves via `search_path`) is reachable. Reflected this nuance in the prompt rather than overclaiming.

## Out of scope

- The allow-list itself (we went with approach (a), not (b)).
- The schema-broken escalation rule (#190) and metadata provenance rule (#189).

## Test plan

- [x] `uv run pytest tests/test_sql_validator.py tests/test_query_role_isolation.py tests/test_agent_graph.py` (54 passed)
- [x] `uv run ruff check apps/agents/prompts/base_system.py tests/test_sql_validator.py`
- [x] `uv run ruff format --check apps/agents/prompts/base_system.py tests/test_sql_validator.py`