### PR TITLE
Tear down view schema when workspace drops to single-tenant

### DIFF
--- a/apps/workspaces/services/workspace_service.py
+++ b/apps/workspaces/services/workspace_service.py
@@ -6,7 +6,7 @@ from django.core.exceptions import ValidationError
 from django.db import transaction
 
 from apps.workspaces.models import SchemaState, WorkspaceTenant, WorkspaceViewSchema
-from apps.workspaces.tasks import rebuild_workspace_view_schema
+from apps.workspaces.tasks import rebuild_workspace_view_schema, teardown_view_schema_task
 
 
 def add_workspace_tenant(workspace, tenant) -> tuple[WorkspaceTenant, bool]:
@@ -30,12 +30,17 @@ def add_workspace_tenant(workspace, tenant) -> tuple[WorkspaceTenant, bool]:
 
 
 def remove_workspace_tenant(workspace, wt: WorkspaceTenant) -> None:
-    """Remove a tenant from a workspace and mark the view schema for rebuild.
+    """Remove a tenant from a workspace and reconcile the view schema.
 
-    Deletes the WorkspaceTenant record and marks any existing WorkspaceViewSchema
-    as PROVISIONING, then dispatches a rebuild task as part of the transaction
-    (procrastinate's defer is transaction-safe — the row is only visible to
-    workers after commit).
+    Deletes the WorkspaceTenant record. If the workspace remains multi-tenant
+    (>=2 tenants left), marks any existing WorkspaceViewSchema as PROVISIONING
+    and dispatches a rebuild. If the workspace drops to single-tenant (or zero),
+    routing moves to the tenant schema and any active view schema becomes an
+    orphan — mark it TEARDOWN and dispatch teardown so the physical
+    ``ws_<hash>`` schema is dropped.
+
+    Both ``defer`` calls are transaction-safe — the procrastinate row is only
+    visible to workers after commit.
 
     Raises ValidationError if wt is the last tenant in the workspace.
     """
@@ -50,10 +55,19 @@ def remove_workspace_tenant(workspace, wt: WorkspaceTenant) -> None:
         if len(tenant_ids) <= 1:
             raise ValidationError("Cannot remove the last tenant from a workspace.")
         wt.delete()
-        WorkspaceViewSchema.objects.filter(workspace=workspace).update(
-            state=SchemaState.PROVISIONING
-        )
-        rebuild_workspace_view_schema.defer(workspace_id=str(workspace.id))
+        remaining = len(tenant_ids) - 1
+        if remaining <= 1:
+            for vs in WorkspaceViewSchema.objects.filter(
+                workspace=workspace, state=SchemaState.ACTIVE
+            ):
+                vs.state = SchemaState.TEARDOWN
+                vs.save(update_fields=["state"])
+                teardown_view_schema_task.defer(view_schema_id=str(vs.id))
+        else:
+            WorkspaceViewSchema.objects.filter(workspace=workspace).update(
+                state=SchemaState.PROVISIONING
+            )
+            rebuild_workspace_view_schema.defer(workspace_id=str(workspace.id))
 
 
 async def touch_workspace_schemas(workspace) -> None:

--- a/mcp_server/context.py
+++ b/mcp_server/context.py
@@ -86,6 +86,13 @@ async def load_workspace_context(workspace_id: str) -> QueryContext:
     - Single-tenant workspace (1 tenant): delegates to load_tenant_context(tenant.external_id).
     - Multi-tenant workspace (2+ tenants): uses the WorkspaceViewSchema.
 
+    Invariant: for a workspace, exactly one routing target exists at a time —
+    the tenant schema (``t_<id>``) for single-tenant workspaces or the view
+    schema (``ws_<hash>``) for multi-tenant. Any orphan WorkspaceViewSchema
+    rows are marked TEARDOWN and their physical schemas dropped when the
+    tenant count falls to <=1 (see
+    ``apps.workspaces.services.workspace_service.remove_workspace_tenant``).
+
     Raises ValueError if the workspace has no tenants, or if multi-tenant and
     no active WorkspaceViewSchema exists.
     """

--- a/tests/test_workspace_service.py
+++ b/tests/test_workspace_service.py
@@ -1,12 +1,17 @@
+from unittest.mock import patch
+
 import pytest
 
+from apps.users.models import Tenant, TenantMembership
 from apps.workspaces.models import SchemaState, WorkspaceTenant, WorkspaceViewSchema
+from apps.workspaces.services.workspace_service import (
+    add_workspace_tenant,
+    remove_workspace_tenant,
+)
 
 
 @pytest.fixture
 def tenant2(db):
-    from apps.users.models import Tenant
-
     return Tenant.objects.create(
         provider="commcare", external_id="test-domain-2", canonical_name="Test Domain 2"
     )
@@ -14,9 +19,19 @@ def tenant2(db):
 
 @pytest.fixture
 def tenant_membership2(db, user, tenant2):
-    from apps.users.models import TenantMembership
-
     return TenantMembership.objects.create(user=user, tenant=tenant2)
+
+
+@pytest.fixture
+def tenant3(db):
+    return Tenant.objects.create(
+        provider="commcare", external_id="test-domain-3", canonical_name="Test Domain 3"
+    )
+
+
+@pytest.fixture
+def tenant_membership3(db, user, tenant3):
+    return TenantMembership.objects.create(user=user, tenant=tenant3)
 
 
 @pytest.mark.django_db
@@ -26,7 +41,6 @@ def test_add_workspace_tenant_creates_record_and_marks_provisioning(
     vs = WorkspaceViewSchema.objects.create(
         workspace=workspace, schema_name="ws_test", state=SchemaState.ACTIVE
     )
-    from apps.workspaces.services.workspace_service import add_workspace_tenant
 
     add_workspace_tenant(workspace, tenant2)
 
@@ -36,17 +50,53 @@ def test_add_workspace_tenant_creates_record_and_marks_provisioning(
 
 
 @pytest.mark.django_db
-def test_remove_workspace_tenant_deletes_record_and_marks_provisioning(
+def test_remove_tenant_dispatches_view_schema_teardown_when_count_drops_to_one(
     workspace, tenant2, tenant_membership2
 ):
     wt = WorkspaceTenant.objects.create(workspace=workspace, tenant=tenant2)
     vs = WorkspaceViewSchema.objects.create(
         workspace=workspace, schema_name="ws_test", state=SchemaState.ACTIVE
     )
-    from apps.workspaces.services.workspace_service import remove_workspace_tenant
 
-    remove_workspace_tenant(workspace, wt)
+    with (
+        patch(
+            "apps.workspaces.services.workspace_service.teardown_view_schema_task.defer"
+        ) as mock_teardown,
+        patch(
+            "apps.workspaces.services.workspace_service.rebuild_workspace_view_schema.defer"
+        ) as mock_rebuild,
+    ):
+        remove_workspace_tenant(workspace, wt)
 
     assert not WorkspaceTenant.objects.filter(id=wt.id).exists()
     vs.refresh_from_db()
+    assert vs.state == SchemaState.TEARDOWN
+    mock_teardown.assert_called_once_with(view_schema_id=str(vs.id))
+    mock_rebuild.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_remove_tenant_no_op_on_tenant_count_above_one(
+    workspace, tenant2, tenant_membership2, tenant3, tenant_membership3
+):
+    WorkspaceTenant.objects.create(workspace=workspace, tenant=tenant2)
+    wt3 = WorkspaceTenant.objects.create(workspace=workspace, tenant=tenant3)
+    vs = WorkspaceViewSchema.objects.create(
+        workspace=workspace, schema_name="ws_test", state=SchemaState.ACTIVE
+    )
+
+    with (
+        patch(
+            "apps.workspaces.services.workspace_service.teardown_view_schema_task.defer"
+        ) as mock_teardown,
+        patch(
+            "apps.workspaces.services.workspace_service.rebuild_workspace_view_schema.defer"
+        ) as mock_rebuild,
+    ):
+        remove_workspace_tenant(workspace, wt3)
+
+    assert not WorkspaceTenant.objects.filter(id=wt3.id).exists()
+    vs.refresh_from_db()
     assert vs.state == SchemaState.PROVISIONING
+    mock_rebuild.assert_called_once_with(workspace_id=str(workspace.id))
+    mock_teardown.assert_not_called()


### PR DESCRIPTION
## Summary

When the last "extra" tenant is removed from a workspace, the workspace transitions from multi-tenant to single-tenant. `load_workspace_context` then routes via the tenant schema (`t_<id>`), but the existing `WorkspaceViewSchema` (`ws_<hash>`) was left active in the database. Agents probing `pg_namespace` could discover the orphan schema, get confused, and fail to query it (not in the allow-list).

This change reconciles the view schema on tenant removal:

- If the workspace remains multi-tenant (>=2 tenants), keep the existing behaviour — mark the view schema PROVISIONING and dispatch a rebuild.
- If the workspace drops to <=1 tenant, mark the view schema TEARDOWN and dispatch `teardown_view_schema_task` so the physical `ws_<hash>` schema is dropped.

Also updates the `load_workspace_context` docstring to document the invariant: exactly one routing target exists per workspace, and orphan view schemas are torn down on tenant removal.

Fixes #193

## Follow-ups (out of scope)

- A one-time backfill management command to clean up existing orphan `ws_*` schemas in production. Intentionally not implemented here — that's a careful operator-driven cleanup; this PR prevents new orphans.

## Test plan

- [x] `tests/test_workspace_service.py::test_remove_tenant_dispatches_view_schema_teardown_when_count_drops_to_one` — removing a tenant from a 2-tenant workspace marks the view schema TEARDOWN and dispatches `teardown_view_schema_task`; no rebuild is dispatched.
- [x] `tests/test_workspace_service.py::test_remove_tenant_no_op_on_tenant_count_above_one` — removing one tenant from a 3-tenant workspace still marks the view schema PROVISIONING and dispatches a rebuild; teardown is NOT dispatched.
- [x] `tests/test_workspace_service.py::test_add_workspace_tenant_creates_record_and_marks_provisioning` — unchanged.
- [x] Broader regression sweep: `pytest -k "workspace or view_schema or tenant or schema_ttl"` — 304 passed.
- [x] `ruff check .` and `ruff format .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)