### PR TITLE
Bound resume ainvoke with timeout, span, and synthetic failure message

### DIFF
--- a/apps/workspaces/tasks.py
+++ b/apps/workspaces/tasks.py
@@ -1,12 +1,15 @@
 """Background tasks for schema lifecycle management."""
 
 import asyncio
+import contextlib
 import logging
+import time
 from datetime import timedelta
 
+import sentry_sdk
 from django.conf import settings
 from django.utils import timezone
-from langchain_core.messages import HumanMessage
+from langchain_core.messages import AIMessage, HumanMessage
 from procrastinate.contrib.django.procrastinate_app import current_app
 
 from apps.agents.graph.base import build_agent_graph
@@ -30,6 +33,20 @@ from mcp_server.pipeline_registry import get_registry
 from mcp_server.services.materializer import (
     MaterializationCancelled,
     run_pipeline,
+)
+
+# User-facing failure copy. The frontend renders these straight from the
+# checkpointer (apps/chat/thread_views.py:_load_thread_messages → AIMessage).
+RESUME_TIMEOUT_MESSAGE = (
+    "The agent took too long to respond after materialization completed. "
+    "Please re-ask your question."
+)
+RESUME_EXCEPTION_MESSAGE = (
+    "Sorry, something went wrong while preparing your answer. Please retry."
+)
+RESUME_STUCK_RUNNING_MESSAGE = (
+    "Your materialization completed but the follow-up response was interrupted "
+    "(likely a server restart). Please re-ask your question."
 )
 
 logger = logging.getLogger(__name__)
@@ -429,7 +446,7 @@ async def teardown_schema(schema_id: str) -> None:
         raise
 
 
-STALE_JOB_THRESHOLD = timedelta(hours=1)
+STALE_JOB_THRESHOLD = timedelta(minutes=10)
 
 
 async def _procrastinate_job_active(job_id: int) -> bool | None:
@@ -461,7 +478,9 @@ async def expire_stale_thread_jobs(timestamp: int = 0) -> dict:
     """
     cutoff = timezone.now() - STALE_JOB_THRESHOLD
     flipped = 0
-    async for tj in ThreadJob.objects.filter(
+    async for tj in ThreadJob.objects.select_related(
+        "thread__workspace", "thread__user",
+    ).filter(
         state__in=list(ThreadJob.ACTIVE_STATES),
         created_at__lt=cutoff,
     ):
@@ -487,6 +506,10 @@ async def expire_stale_thread_jobs(timestamp: int = 0) -> dict:
                     "Janitor: ThreadJob %s stuck in RUNNING (worker crash?); marked FAILED",
                     tj.id,
                 )
+                # Surface the crash to the user via a synthetic AIMessage; the
+                # checkpointer write tolerates failure so a sick worker
+                # doesn't block the FAILED transition.
+                await _persist_synthetic_failure_message(tj, RESUME_STUCK_RUNNING_MESSAGE)
             continue
         # PENDING stuck job — never claimed by any worker. Safe to defer a fresh
         # resume so the user gets an agent follow-up.
@@ -517,6 +540,62 @@ async def _build_agent_for_resume(workspace, user):
         oauth_tokens=oauth_tokens,
     )
     return agent, oauth_tokens
+
+
+def _resume_langfuse_span(*, thread_job_id: str, thread_id: str, status: str):
+    """Open a Langfuse span around the resume ainvoke. No-op when Langfuse is
+    not configured so worker boots without LANGFUSE_* env vars stay quiet."""
+    secret_key = getattr(settings, "LANGFUSE_SECRET_KEY", "")
+    public_key = getattr(settings, "LANGFUSE_PUBLIC_KEY", "")
+    host = getattr(settings, "LANGFUSE_BASE_URL", "")
+    if not all([secret_key, public_key, host]):
+        return contextlib.nullcontext()
+    try:
+        from langfuse import Langfuse
+
+        client = Langfuse(secret_key=secret_key, public_key=public_key, host=host)
+        return client.start_as_current_span(
+            name="resume_thread_after_materialization",
+            input={
+                "thread_job_id": thread_job_id,
+                "thread_id": thread_id,
+                "status": status,
+            },
+        )
+    except Exception:
+        logger.warning("resume: failed to open Langfuse span", exc_info=True)
+        return contextlib.nullcontext()
+
+
+async def _persist_synthetic_failure_message(thread_job, text: str) -> None:
+    """Append a plain-text AIMessage to the LangGraph checkpointer for
+    ``thread_job.thread`` so the chat UI shows a user-visible explanation when
+    the agent never produced one.
+
+    The frontend (apps/chat/thread_views.py:_load_thread_messages) reads
+    assistant responses from the checkpointer, so a failure message that
+    bypasses this path would never appear. We reuse build_agent_graph because
+    aupdate_state requires a compiled graph carrying the AgentState schema and
+    the same checkpointer as a normal turn.
+
+    Failures here are logged but never re-raised — the caller has already
+    decided this is a terminal failure and a synthetic message is a UX nicety,
+    not a correctness invariant.
+    """
+    try:
+        agent, _ = await _build_agent_for_resume(
+            thread_job.thread.workspace, thread_job.thread.user,
+        )
+        config = {"configurable": {"thread_id": str(thread_job.thread.id)}}
+        await agent.aupdate_state(
+            config, {"messages": [AIMessage(content=text)]},
+        )
+    except Exception:
+        logger.warning(
+            "resume: failed to persist synthetic failure message for tj=%s",
+            thread_job.id,
+            exc_info=True,
+        )
 
 
 async def _aggregate_materialization_state(procrastinate_job_id: int) -> tuple[str, list[dict]]:
@@ -625,6 +704,17 @@ async def resume_thread_after_materialization(context, thread_job_id: str) -> di
     workspace = tj.thread.workspace
     user = tj.thread.user
 
+    timeout_s = getattr(settings, "AGENT_RESUME_TIMEOUT_S", 120)
+    sentry_sdk.add_breadcrumb(
+        category="resume",
+        message="ainvoke_start",
+        data={"thread_job_id": str(tj.id), "status": status, "timeout_s": timeout_s},
+    )
+    logger.info(
+        "resume: ainvoke start tj=%s thread=%s workspace=%s status=%s timeout=%ds",
+        thread_job_id, tj.thread.id, workspace.id, status, timeout_s,
+    )
+    start = time.monotonic()
     try:
         agent, oauth_tokens = await _build_agent_for_resume(workspace, user)
         input_state = {
@@ -639,16 +729,56 @@ async def resume_thread_after_materialization(context, thread_job_id: str) -> di
             "recursion_limit": 50,
             "oauth_tokens": oauth_tokens,
         }
-        await agent.ainvoke(input_state, config)
-    except Exception:
+        with _resume_langfuse_span(
+            thread_job_id=thread_job_id,
+            thread_id=str(tj.thread.id),
+            status=status,
+        ):
+            await asyncio.wait_for(
+                agent.ainvoke(input_state, config), timeout=timeout_s,
+            )
+    except TimeoutError:
+        elapsed = time.monotonic() - start
         logger.exception(
-            "resume: agent build or invoke failed for thread_job %s", thread_job_id
+            "resume: ainvoke timed out after %.2fs (limit=%ds, tj=%s)",
+            elapsed, timeout_s, thread_job_id,
         )
+        sentry_sdk.add_breadcrumb(
+            category="resume", message="ainvoke_timeout",
+            data={"thread_job_id": str(tj.id), "elapsed_s": elapsed},
+        )
+        await _persist_synthetic_failure_message(tj, RESUME_TIMEOUT_MESSAGE)
+        await ThreadJob.objects.filter(id=tj.id).aupdate(
+            state=ThreadJob.State.FAILED,
+            completed_at=timezone.now(),
+        )
+        return {"status": "agent_timeout"}
+    except Exception:
+        elapsed = time.monotonic() - start
+        logger.exception(
+            "resume: agent build or invoke failed for thread_job %s after %.2fs",
+            thread_job_id, elapsed,
+        )
+        sentry_sdk.add_breadcrumb(
+            category="resume", message="ainvoke_exception",
+            data={"thread_job_id": str(tj.id), "elapsed_s": elapsed},
+        )
+        await _persist_synthetic_failure_message(tj, RESUME_EXCEPTION_MESSAGE)
         await ThreadJob.objects.filter(id=tj.id).aupdate(
             state=ThreadJob.State.FAILED,
             completed_at=timezone.now(),
         )
         return {"status": "agent_failed"}
+    finally:
+        elapsed = time.monotonic() - start
+        logger.info(
+            "resume: ainvoke complete tj=%s elapsed=%.2fs",
+            thread_job_id, elapsed,
+        )
+    sentry_sdk.add_breadcrumb(
+        category="resume", message="ainvoke_complete",
+        data={"thread_job_id": str(tj.id), "elapsed_s": time.monotonic() - start},
+    )
 
     # Bump Thread.updated_at so the sidebar's "newer than last_viewed" check
     # fires the green-dot indicator after a successful background resume.

--- a/apps/workspaces/tasks.py
+++ b/apps/workspaces/tasks.py
@@ -35,6 +35,11 @@ from mcp_server.services.materializer import (
     run_pipeline,
 )
 
+try:
+    from langfuse import Langfuse
+except ImportError:  # langfuse is an optional observability dependency
+    Langfuse = None
+
 # User-facing failure copy. The frontend renders these straight from the
 # checkpointer (apps/chat/thread_views.py:_load_thread_messages → AIMessage).
 RESUME_TIMEOUT_MESSAGE = (
@@ -545,14 +550,14 @@ async def _build_agent_for_resume(workspace, user):
 def _resume_langfuse_span(*, thread_job_id: str, thread_id: str, status: str):
     """Open a Langfuse span around the resume ainvoke. No-op when Langfuse is
     not configured so worker boots without LANGFUSE_* env vars stay quiet."""
+    if Langfuse is None:
+        return contextlib.nullcontext()
     secret_key = getattr(settings, "LANGFUSE_SECRET_KEY", "")
     public_key = getattr(settings, "LANGFUSE_PUBLIC_KEY", "")
     host = getattr(settings, "LANGFUSE_BASE_URL", "")
     if not all([secret_key, public_key, host]):
         return contextlib.nullcontext()
     try:
-        from langfuse import Langfuse
-
         client = Langfuse(secret_key=secret_key, public_key=public_key, host=host)
         return client.start_as_current_span(
             name="resume_thread_after_materialization",

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -280,6 +280,12 @@ DB_CREDENTIAL_KEY = env("DB_CREDENTIAL_KEY", default="")
 ANTHROPIC_API_KEY = env("ANTHROPIC_API_KEY", default="")
 DEFAULT_LLM_MODEL = "claude-sonnet-4-5-20250929"
 
+# Hard ceiling on the materialization-resume agent.ainvoke. The agent's
+# recursion_limit is 50; 120s is generous for any sane follow-up response.
+# Beyond this, the user sees a synthetic "took too long" message instead of
+# a forever-spinner. Override per-test to exercise the timeout path.
+AGENT_RESUME_TIMEOUT_S = env.int("AGENT_RESUME_TIMEOUT_S", default=120)
+
 # Langfuse observability (optional)
 LANGFUSE_SECRET_KEY = env("LANGFUSE_SECRET_KEY", default="")
 LANGFUSE_PUBLIC_KEY = env("LANGFUSE_PUBLIC_KEY", default="")

--- a/tests/test_resume_thread_task.py
+++ b/tests/test_resume_thread_task.py
@@ -1,8 +1,12 @@
+import asyncio
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from asgiref.sync import sync_to_async
 from django.contrib.auth import get_user_model
+from django.test import override_settings
+from langchain_core.messages import AIMessage
 
 from apps.chat.models import Thread, ThreadJob
 from apps.users.models import Tenant
@@ -12,9 +16,42 @@ from apps.workspaces.models import (
     Workspace,
     WorkspaceTenant,
 )
-from apps.workspaces.tasks import resume_thread_after_materialization
+from apps.workspaces.tasks import (
+    RESUME_EXCEPTION_MESSAGE,
+    RESUME_TIMEOUT_MESSAGE,
+    resume_thread_after_materialization,
+)
 
 User = get_user_model()
+
+
+async def _make_thread_job_ready_to_resume(
+    *, email: str, ws_name: str, ext_id: str, schema_name: str, pj_id: int,
+    tool_call: str, run_state=None,
+):
+    """Create a fully wired ThreadJob + MaterializationRun for resume tests."""
+    if run_state is None:
+        run_state = MaterializationRun.RunState.COMPLETED
+    user = await sync_to_async(User.objects.create_user)(email=email, password="x")
+    ws = await sync_to_async(Workspace.objects.create)(name=ws_name, created_by=user)
+    tenant = await sync_to_async(Tenant.objects.create)(
+        external_id=ext_id, provider="commcare", canonical_name="Tenant",
+    )
+    await sync_to_async(WorkspaceTenant.objects.create)(workspace=ws, tenant=tenant)
+    schema = await sync_to_async(TenantSchema.objects.create)(
+        tenant=tenant, schema_name=schema_name,
+    )
+    thread = await sync_to_async(Thread.objects.create)(workspace=ws, user=user)
+    tj = await sync_to_async(ThreadJob.objects.create)(
+        thread=thread, job_type="materialization",
+        procrastinate_job_id=pj_id, tool_call_id=tool_call,
+        state=ThreadJob.State.PENDING,
+    )
+    await sync_to_async(MaterializationRun.objects.create)(
+        tenant_schema=schema, pipeline="commcare_sync",
+        state=run_state, procrastinate_job_id=pj_id,
+    )
+    return user, ws, thread, tj
 
 
 @pytest.mark.asyncio
@@ -396,3 +433,139 @@ async def test_resume_cas_rejects_already_running_threadjob():
 
     assert result["status"] == "already_claimed"
     mock_agent.ainvoke.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Timeout / exception / observability coverage for the resume task (issue #188)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+@override_settings(AGENT_RESUME_TIMEOUT_S=1)
+async def test_ainvoke_timeout_marks_failed_and_persists_message():
+    """When agent.ainvoke exceeds AGENT_RESUME_TIMEOUT_S, the ThreadJob lands
+    in FAILED and a synthetic AIMessage is persisted via aupdate_state so the
+    user sees a friendly explanation instead of a forever-spinner."""
+    _, _, _, tj = await _make_thread_job_ready_to_resume(
+        email="timeout@b.c", ws_name="W-timeout", ext_id="t-timeout",
+        schema_name="s_timeout", pj_id=10001, tool_call="tc-timeout",
+    )
+
+    async def _sleeping_invoke(*_args, **_kwargs):
+        await asyncio.sleep(5)
+        return {"messages": []}
+
+    mock_agent = MagicMock()
+    mock_agent.ainvoke = AsyncMock(side_effect=_sleeping_invoke)
+    mock_agent.aupdate_state = AsyncMock(return_value=None)
+
+    with patch(
+        "apps.workspaces.tasks._build_agent_for_resume",
+        AsyncMock(return_value=(mock_agent, {})),
+    ):
+        result = await resume_thread_after_materialization(None, thread_job_id=str(tj.id))
+
+    assert result["status"] == "agent_timeout"
+    await sync_to_async(tj.refresh_from_db)()
+    assert tj.state == ThreadJob.State.FAILED
+    assert tj.completed_at is not None
+
+    # aupdate_state was called with a single AIMessage carrying the timeout copy
+    mock_agent.aupdate_state.assert_awaited()
+    update_args = mock_agent.aupdate_state.await_args
+    payload = update_args.args[1]
+    assert "messages" in payload
+    msg = payload["messages"][0]
+    assert isinstance(msg, AIMessage)
+    assert msg.content == RESUME_TIMEOUT_MESSAGE
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_ainvoke_exception_marks_failed_and_persists_message():
+    """When agent.ainvoke raises (non-timeout), the ThreadJob lands in FAILED
+    and a synthetic AIMessage with the generic-exception copy is persisted."""
+    _, _, _, tj = await _make_thread_job_ready_to_resume(
+        email="boom@b.c", ws_name="W-boom", ext_id="t-boom",
+        schema_name="s_boom", pj_id=10002, tool_call="tc-boom",
+    )
+
+    mock_agent = MagicMock()
+    mock_agent.ainvoke = AsyncMock(side_effect=RuntimeError("upstream LLM 500"))
+    mock_agent.aupdate_state = AsyncMock(return_value=None)
+
+    with patch(
+        "apps.workspaces.tasks._build_agent_for_resume",
+        AsyncMock(return_value=(mock_agent, {})),
+    ):
+        result = await resume_thread_after_materialization(None, thread_job_id=str(tj.id))
+
+    assert result["status"] == "agent_failed"
+    await sync_to_async(tj.refresh_from_db)()
+    assert tj.state == ThreadJob.State.FAILED
+
+    mock_agent.aupdate_state.assert_awaited()
+    msg = mock_agent.aupdate_state.await_args.args[1]["messages"][0]
+    assert isinstance(msg, AIMessage)
+    assert msg.content == RESUME_EXCEPTION_MESSAGE
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_successful_ainvoke_logs_bookends(caplog):
+    """On the success path both 'ainvoke start' and 'ainvoke complete' lines
+    bracket the call so 26-minute silent hangs become trivially detectable."""
+    _, _, _, tj = await _make_thread_job_ready_to_resume(
+        email="bookend@b.c", ws_name="W-bookend", ext_id="t-bookend",
+        schema_name="s_bookend", pj_id=10003, tool_call="tc-bookend",
+    )
+
+    mock_agent = MagicMock()
+    mock_agent.ainvoke = AsyncMock(return_value={"messages": []})
+
+    caplog.set_level(logging.INFO, logger="apps.workspaces.tasks")
+    with patch(
+        "apps.workspaces.tasks._build_agent_for_resume",
+        AsyncMock(return_value=(mock_agent, {})),
+    ):
+        result = await resume_thread_after_materialization(None, thread_job_id=str(tj.id))
+
+    assert result["status"] == "resumed"
+    bookends = [r.message for r in caplog.records if "ainvoke" in r.message]
+    assert any("ainvoke start" in m for m in bookends), bookends
+    assert any("ainvoke complete" in m for m in bookends), bookends
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_resume_emits_langfuse_span_on_each_outcome():
+    """The Langfuse span context manager must wrap the ainvoke on success,
+    timeout, and exception paths so traces are emitted on every terminal
+    outcome (the production bug was a silent ainvoke with no trace)."""
+    _, _, _, tj = await _make_thread_job_ready_to_resume(
+        email="lf@b.c", ws_name="W-lf", ext_id="t-lf",
+        schema_name="s_lf", pj_id=10004, tool_call="tc-lf",
+    )
+
+    mock_agent = MagicMock()
+    mock_agent.ainvoke = AsyncMock(return_value={"messages": []})
+
+    span_cm = MagicMock()
+    span_cm.__enter__ = MagicMock(return_value=MagicMock())
+    span_cm.__exit__ = MagicMock(return_value=False)
+
+    with patch(
+        "apps.workspaces.tasks._build_agent_for_resume",
+        AsyncMock(return_value=(mock_agent, {})),
+    ), patch(
+        "apps.workspaces.tasks._resume_langfuse_span", return_value=span_cm,
+    ) as span_helper:
+        await resume_thread_after_materialization(None, thread_job_id=str(tj.id))
+
+    span_helper.assert_called_once()
+    kwargs = span_helper.call_args.kwargs
+    assert kwargs["thread_job_id"] == str(tj.id)
+    assert kwargs["thread_id"] == str(tj.thread_id)
+    span_cm.__enter__.assert_called_once()
+    span_cm.__exit__.assert_called_once()

--- a/tests/test_threadjob_janitor.py
+++ b/tests/test_threadjob_janitor.py
@@ -1,14 +1,19 @@
 from datetime import timedelta
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from asgiref.sync import sync_to_async
 from django.contrib.auth import get_user_model
 from django.utils import timezone
+from langchain_core.messages import AIMessage
 
 from apps.chat.models import Thread, ThreadJob
 from apps.workspaces.models import Workspace
-from apps.workspaces.tasks import expire_stale_thread_jobs
+from apps.workspaces.tasks import (
+    RESUME_STUCK_RUNNING_MESSAGE,
+    STALE_JOB_THRESHOLD,
+    expire_stale_thread_jobs,
+)
 
 User = get_user_model()
 
@@ -132,7 +137,11 @@ async def test_janitor_marks_stuck_running_failed_without_deferring_resume():
 
     with patch("apps.workspaces.tasks._procrastinate_job_active",
                new=AsyncMock(return_value=False)), \
-         patch("apps.workspaces.tasks.resume_thread_after_materialization") as resume:
+         patch("apps.workspaces.tasks.resume_thread_after_materialization") as resume, \
+         patch(
+            "apps.workspaces.tasks._persist_synthetic_failure_message",
+            new=AsyncMock(return_value=None),
+         ):
         resume.defer_async = AsyncMock(return_value=None)
         result = await expire_stale_thread_jobs()
 
@@ -141,3 +150,53 @@ async def test_janitor_marks_stuck_running_failed_without_deferring_resume():
     assert tj.state == ThreadJob.State.FAILED
     assert tj.completed_at is not None
     assert result["flipped"] == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_janitor_persists_synthetic_message_on_stuck_running():
+    """When the janitor flips a stuck RUNNING ThreadJob to FAILED, it must
+    also persist a user-visible AIMessage in the chat so the user sees a
+    clear "your follow-up was interrupted" message instead of a spinner that
+    silently disappears."""
+    user = await sync_to_async(User.objects.create_user)(email="ghost@b.c", password="x")
+    ws = await sync_to_async(Workspace.objects.create)(name="W-ghost", created_by=user)
+    thread = await sync_to_async(Thread.objects.create)(workspace=ws, user=user)
+    tj = await sync_to_async(ThreadJob.objects.create)(
+        thread=thread, job_type="materialization",
+        procrastinate_job_id=54321, tool_call_id="tc-ghost",
+        state=ThreadJob.State.RUNNING,
+    )
+    await ThreadJob.objects.filter(id=tj.id).aupdate(
+        created_at=timezone.now() - STALE_JOB_THRESHOLD - timedelta(minutes=5),
+    )
+
+    mock_agent = MagicMock()
+    mock_agent.aupdate_state = AsyncMock(return_value=None)
+
+    with patch("apps.workspaces.tasks._procrastinate_job_active",
+               new=AsyncMock(return_value=False)), \
+         patch("apps.workspaces.tasks.resume_thread_after_materialization") as resume, \
+         patch(
+             "apps.workspaces.tasks._build_agent_for_resume",
+             new=AsyncMock(return_value=(mock_agent, {})),
+         ):
+        resume.defer_async = AsyncMock(return_value=None)
+        result = await expire_stale_thread_jobs()
+
+    assert result["flipped"] == 1
+    await sync_to_async(tj.refresh_from_db)()
+    assert tj.state == ThreadJob.State.FAILED
+
+    # The synthetic AIMessage made it into the LangGraph state, not just the logs.
+    mock_agent.aupdate_state.assert_awaited()
+    msg = mock_agent.aupdate_state.await_args.args[1]["messages"][0]
+    assert isinstance(msg, AIMessage)
+    assert msg.content == RESUME_STUCK_RUNNING_MESSAGE
+
+
+def test_janitor_cutoff_is_10_minutes():
+    """STALE_JOB_THRESHOLD is the contract with frontend UX: how long before a
+    user sees a synthetic 'we interrupted you' message. Locking the value in a
+    test makes any future tightening intentional rather than accidental."""
+    assert timedelta(minutes=10) == STALE_JOB_THRESHOLD


### PR DESCRIPTION
Fixes #188

## Summary

- Wrap `agent.ainvoke` in the resume task with `asyncio.wait_for(AGENT_RESUME_TIMEOUT_S, default 120s)`, bookend `ainvoke start` / `ainvoke complete` INFO logs, an explicit Langfuse `start_as_current_span`, and Sentry breadcrumbs on each terminal outcome.
- On timeout, exception, or janitor-detected stuck `RUNNING`, persist a synthetic `AIMessage` to the LangGraph checkpointer via `agent.aupdate_state` so the chat UI shows a friendly failure copy instead of letting the spinner disappear silently.
- Lower `STALE_JOB_THRESHOLD` from 1h to 10 min (3x the resume timeout) and have the janitor call the same synthetic-message helper when it flips a stuck `RUNNING` to `FAILED`.

## Persistence path chosen

`agent.aupdate_state(config, {"messages": [AIMessage(...)]})`. The frontend's `GET /api/chat/threads/<id>/messages/` reads `AIMessage` objects straight from the LangGraph checkpointer (`apps/chat/thread_views.py:_load_thread_messages`); there is no separate `Message` table. This mirrors how a normal successful resume persists its assistant reply (via `ainvoke` writing to the same channel) and lets `langchain_messages_to_ui` render the synthetic message without any new converter logic. The helper rebuilds the agent so the janitor (which has no in-scope agent) can call it too.

## Test plan

- [x] `uv run pytest tests/test_resume_thread_task.py tests/test_threadjob_janitor.py` — 19 passing
- [x] `uv run pytest tests/test_chat_thread_ownership.py tests/test_message_converter.py tests/test_dangling_tool_calls.py` — 12 passing regression
- [x] `uv run ruff check` on touched files — clean

New tests:
- `test_ainvoke_timeout_marks_failed_and_persists_message`
- `test_ainvoke_exception_marks_failed_and_persists_message`
- `test_successful_ainvoke_logs_bookends`
- `test_resume_emits_langfuse_span_on_each_outcome`
- `test_janitor_persists_synthetic_message_on_stuck_running`
- `test_janitor_cutoff_is_10_minutes`

## Synthetic-message contract (relevant for #191 / frontend UX)

The synthetic failure message is a plain-text `AIMessage` with no `tool_calls`. After `langchain_messages_to_ui` it lands in the wire format as `{role: "assistant", parts: [{type: "text", text: "..."}]}` — indistinguishable from a normal assistant text reply. The current copy strings (exported as `RESUME_TIMEOUT_MESSAGE`, `RESUME_EXCEPTION_MESSAGE`, `RESUME_STUCK_RUNNING_MESSAGE` from `apps/workspaces/tasks.py`) are user-friendly but unstyled; if the frontend wants to flag them as system-injected rather than agent-authored, the cleanest follow-up would be a marker prefix (or `additional_kwargs`) we can add here and the converter can detect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)