### PR TITLE
Resumable materialization via per-page cursor watermark

### DIFF
--- a/apps/workspaces/tasks.py
+++ b/apps/workspaces/tasks.py
@@ -581,6 +581,13 @@ async def _aggregate_materialization_state(procrastinate_job_id: int) -> tuple[s
                 detail = {"state": src_state, "rows": info.get("rows", 0)}
                 if "error" in info:
                     detail["error"] = info["error"]
+                # Expose ``cursor_state.last_id`` so the resume prompt can
+                # tell the agent "completed_works partially loaded up to
+                # id=X — the next materialization will continue from there"
+                # (issue #187).
+                cursor_state = info.get("cursor_state")
+                if isinstance(cursor_state, dict) and isinstance(cursor_state.get("last_id"), int):
+                    detail["resume_last_id"] = cursor_state["last_id"]
                 sources_detail[source] = detail
         summary.append(
             {
@@ -681,7 +688,10 @@ async def resume_thread_after_materialization(context, thread_job_id: str) -> di
             f"(some sources loaded, others failed or were skipped). Answer what "
             f"you can from the available data and tell the user which sources are "
             f"unavailable. Do NOT claim that data is loaded for sources marked "
-            f"failed or skipped. Per-tenant: {summary}"
+            f"failed or skipped. A source with state=in_progress or state=failed "
+            f"and a non-null resume_last_id has partially-loaded rows that the "
+            f"next materialization will continue from — do NOT query its table "
+            f"as if it were complete. Per-tenant: {summary}"
         )
     else:
         body = (

--- a/mcp_server/loaders/connect_assessments.py
+++ b/mcp_server/loaders/connect_assessments.py
@@ -18,9 +18,13 @@ logger = logging.getLogger(__name__)
 class ConnectAssessmentLoader(ConnectBaseLoader):
     """Fetch assessment data from Connect."""
 
-    def load_pages(self) -> Iterator[tuple[list[dict], int | None]]:
+    def load_pages(
+        self, start_last_id: int | None = None
+    ) -> Iterator[tuple[list[dict], int | None]]:
         total = 0
-        for page, page_total in self._paginate_export_pages("assessment/"):
+        for page, page_total in self._paginate_export_pages(
+            "assessment/", start_last_id=start_last_id
+        ):
             if not page:
                 continue
             total += len(page)

--- a/mcp_server/loaders/connect_base.py
+++ b/mcp_server/loaders/connect_base.py
@@ -80,12 +80,18 @@ class ConnectBaseLoader:
         self,
         suffix: str,
         params: dict | None = None,
+        start_last_id: int | None = None,
     ) -> Iterator[tuple[list[dict], int | None]]:
         """Yield ``(page, total_count)`` from a v2 paginated JSON export endpoint.
 
         Calls ``_opp_url(suffix)`` first, then follows the server-provided
         ``next`` URL until it is null. ``params`` are sent only on the first
         request — the ``next`` URL already includes preserved query params.
+
+        When ``start_last_id`` is provided, the initial request includes
+        ``last_id=<start_last_id>`` so Connect's keyset pagination resumes
+        with records strictly greater than that id (forward order). This
+        supports the resumable-materialization path in issue #187.
 
         Each yielded ``page`` is the ``results`` list from one response
         (bounded server-side, default ~1000 records). ``total_count`` is the
@@ -100,7 +106,10 @@ class ConnectBaseLoader:
             requests.HTTPError: on any other non-2xx response.
         """
         url: str | None = self._opp_url(suffix)
-        request_params: dict | None = params
+        request_params: dict | None = dict(params) if params else None
+        if start_last_id is not None:
+            request_params = request_params or {}
+            request_params["last_id"] = start_last_id
         headers = {"Accept": EXPORT_ACCEPT_HEADER}
         first_page = True
 

--- a/mcp_server/loaders/connect_completed_modules.py
+++ b/mcp_server/loaders/connect_completed_modules.py
@@ -18,9 +18,13 @@ logger = logging.getLogger(__name__)
 class ConnectCompletedModuleLoader(ConnectBaseLoader):
     """Fetch completed module data from Connect."""
 
-    def load_pages(self) -> Iterator[tuple[list[dict], int | None]]:
+    def load_pages(
+        self, start_last_id: int | None = None
+    ) -> Iterator[tuple[list[dict], int | None]]:
         total = 0
-        for page, page_total in self._paginate_export_pages("completed_module/"):
+        for page, page_total in self._paginate_export_pages(
+            "completed_module/", start_last_id=start_last_id
+        ):
             if not page:
                 continue
             total += len(page)

--- a/mcp_server/loaders/connect_completed_works.py
+++ b/mcp_server/loaders/connect_completed_works.py
@@ -18,9 +18,13 @@ logger = logging.getLogger(__name__)
 class ConnectCompletedWorkLoader(ConnectBaseLoader):
     """Fetch completed work data from Connect."""
 
-    def load_pages(self) -> Iterator[tuple[list[dict], int | None]]:
+    def load_pages(
+        self, start_last_id: int | None = None
+    ) -> Iterator[tuple[list[dict], int | None]]:
         total = 0
-        for page, page_total in self._paginate_export_pages("completed_works/"):
+        for page, page_total in self._paginate_export_pages(
+            "completed_works/", start_last_id=start_last_id
+        ):
             if not page:
                 continue
             total += len(page)

--- a/mcp_server/loaders/connect_invoices.py
+++ b/mcp_server/loaders/connect_invoices.py
@@ -18,9 +18,13 @@ logger = logging.getLogger(__name__)
 class ConnectInvoiceLoader(ConnectBaseLoader):
     """Fetch invoice data from Connect."""
 
-    def load_pages(self) -> Iterator[tuple[list[dict], int | None]]:
+    def load_pages(
+        self, start_last_id: int | None = None
+    ) -> Iterator[tuple[list[dict], int | None]]:
         total = 0
-        for page, page_total in self._paginate_export_pages("invoice/"):
+        for page, page_total in self._paginate_export_pages(
+            "invoice/", start_last_id=start_last_id
+        ):
             if not page:
                 continue
             total += len(page)

--- a/mcp_server/loaders/connect_payments.py
+++ b/mcp_server/loaders/connect_payments.py
@@ -18,9 +18,13 @@ logger = logging.getLogger(__name__)
 class ConnectPaymentLoader(ConnectBaseLoader):
     """Fetch payment data from Connect."""
 
-    def load_pages(self) -> Iterator[tuple[list[dict], int | None]]:
+    def load_pages(
+        self, start_last_id: int | None = None
+    ) -> Iterator[tuple[list[dict], int | None]]:
         total = 0
-        for page, page_total in self._paginate_export_pages("payment/"):
+        for page, page_total in self._paginate_export_pages(
+            "payment/", start_last_id=start_last_id
+        ):
             if not page:
                 continue
             total += len(page)

--- a/mcp_server/loaders/connect_visits.py
+++ b/mcp_server/loaders/connect_visits.py
@@ -69,9 +69,13 @@ def _normalize_visit(raw: dict, opportunity_id: int) -> dict:
 class ConnectVisitLoader(ConnectBaseLoader):
     """Fetch and normalize user visit data from Connect (v2 paginated JSON)."""
 
-    def load_pages(self) -> Iterator[tuple[list[dict], int | None]]:
+    def load_pages(
+        self, start_last_id: int | None = None
+    ) -> Iterator[tuple[list[dict], int | None]]:
         total = 0
-        for page, page_total in self._paginate_export_pages("user_visits/"):
+        for page, page_total in self._paginate_export_pages(
+            "user_visits/", start_last_id=start_last_id
+        ):
             if not page:
                 continue
             normalized = [_normalize_visit(r, self.opportunity_id) for r in page]

--- a/mcp_server/pipeline_registry.py
+++ b/mcp_server/pipeline_registry.py
@@ -18,6 +18,11 @@ class SourceConfig:
     name: str
     description: str = ""
     table_name: str = ""  # Explicit override; empty = use default
+    # Whether this source supports page-level resume on retry (issue #187).
+    # Append-mostly Connect resources (visits, completed_works, etc.) keep the
+    # default True. Mutable rows like Connect ``users`` set this to False so
+    # the writer always does a full DROP/CREATE/INSERT.
+    resumable: bool = True
 
     @property
     def physical_table_name(self) -> str:
@@ -112,6 +117,7 @@ def _parse_pipeline(data: dict) -> PipelineConfig:
             name=s["name"],
             description=s.get("description", ""),
             table_name=s.get("table_name", ""),
+            resumable=s.get("resumable", True),
         )
         for s in data.get("sources", [])
     ]

--- a/mcp_server/services/materializer.py
+++ b/mcp_server/services/materializer.py
@@ -487,22 +487,28 @@ def _load_prior_resume_cursors(tenant_schema: Any, exclude_run_id: Any) -> dict[
     ``in_progress`` or ``failed`` AND ``cursor_state.last_id`` is set,
     matching the resume-eligibility rules in issue #187.
 
+    Crucially, we look at the **most recent** prior run regardless of its
+    run-level state, and only use cursors when *that* run is PARTIAL or FAILED.
+    This prevents a stale PARTIAL run from being surfaced after an intervening
+    COMPLETED run, which would re-insert rows already present in the table and
+    cause duplicate-key errors (for tables with a PK) or silent row duplication
+    (for tables without one).
+
     Returns an empty dict if no eligible prior run exists or none of its
     sources have a usable cursor.
     """
     prior = (
-        MaterializationRun.objects.filter(
-            tenant_schema=tenant_schema,
-            state__in=[
-                MaterializationRun.RunState.PARTIAL,
-                MaterializationRun.RunState.FAILED,
-            ],
-        )
+        MaterializationRun.objects.filter(tenant_schema=tenant_schema)
         .exclude(id=exclude_run_id)
         .order_by("-started_at")
         .first()
     )
-    if prior is None or not isinstance(prior.result, dict):
+    if prior is None or prior.state not in (
+        MaterializationRun.RunState.PARTIAL,
+        MaterializationRun.RunState.FAILED,
+    ):
+        return {}
+    if not isinstance(prior.result, dict):
         return {}
     cursors: dict[str, int] = {}
     for name, info in (prior.result.get("sources") or {}).items():

--- a/mcp_server/services/materializer.py
+++ b/mcp_server/services/materializer.py
@@ -1196,47 +1196,52 @@ _CONNECT_USERS_INSERT = psql.SQL(
 _CONNECT_COMPLETED_WORKS_INSERT = psql.SQL(
     """
     INSERT INTO {schema}.raw_completed_works
-        (username, opportunity_id, payment_unit_id, status, last_modified,
+        (id, username, opportunity_id, payment_unit_id, status, last_modified,
          entity_id, entity_name, reason, status_modified_date, payment_date,
          date_created, saved_completed_count, saved_approved_count,
          saved_payment_accrued, saved_payment_accrued_usd,
          saved_org_payment_accrued, saved_org_payment_accrued_usd)
-    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+    ON CONFLICT (id) DO NOTHING
     """
 )
 
 _CONNECT_PAYMENTS_INSERT = psql.SQL(
     """
     INSERT INTO {schema}.raw_payments
-        (username, opportunity_id, created_at, amount, amount_usd, date_paid,
+        (id, username, opportunity_id, created_at, amount, amount_usd, date_paid,
          payment_unit, confirmed, confirmation_date, organization, invoice_id,
          payment_method, payment_operator)
-    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+    ON CONFLICT (id) DO NOTHING
     """
 )
 
 _CONNECT_INVOICES_INSERT = psql.SQL(
     """
     INSERT INTO {schema}.raw_invoices
-        (opportunity_id, amount, amount_usd, date, invoice_number,
+        (id, opportunity_id, amount, amount_usd, date, invoice_number,
          service_delivery, exchange_rate)
-    VALUES (%s, %s, %s, %s, %s, %s, %s)
+    VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+    ON CONFLICT (id) DO NOTHING
     """
 )
 
 _CONNECT_ASSESSMENTS_INSERT = psql.SQL(
     """
     INSERT INTO {schema}.raw_assessments
-        (username, app, opportunity_id, date, score, passing_score, passed)
-    VALUES (%s, %s, %s, %s, %s, %s, %s)
+        (id, username, app, opportunity_id, date, score, passing_score, passed)
+    VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+    ON CONFLICT (id) DO NOTHING
     """
 )
 
 _CONNECT_COMPLETED_MODULES_INSERT = psql.SQL(
     """
     INSERT INTO {schema}.raw_completed_modules
-        (username, module, opportunity_id, date, duration)
-    VALUES (%s, %s, %s, %s, %s)
+        (id, username, module, opportunity_id, date, duration)
+    VALUES (%s, %s, %s, %s, %s, %s)
+    ON CONFLICT (id) DO NOTHING
     """
 )
 
@@ -1500,6 +1505,7 @@ def _write_connect_completed_works(
         psql.SQL(
             """
         CREATE TABLE IF NOT EXISTS {schema}.raw_completed_works (
+            id BIGINT PRIMARY KEY,
             username TEXT,
             opportunity_id BIGINT,
             payment_unit_id BIGINT,
@@ -1533,6 +1539,7 @@ def _write_connect_completed_works(
             rows_total = page_total
         rows = [
             (
+                r.get("id"),
                 r.get("username", ""),
                 r.get("opportunity_id"),
                 r.get("payment_unit_id"),
@@ -1592,6 +1599,7 @@ def _write_connect_payments(
         psql.SQL(
             """
         CREATE TABLE IF NOT EXISTS {schema}.raw_payments (
+            id BIGINT PRIMARY KEY,
             username TEXT,
             opportunity_id BIGINT,
             created_at TIMESTAMPTZ,
@@ -1621,6 +1629,7 @@ def _write_connect_payments(
             rows_total = page_total
         rows = [
             (
+                r.get("id"),
                 r.get("username", ""),
                 r.get("opportunity_id"),
                 r.get("created_at"),
@@ -1677,6 +1686,7 @@ def _write_connect_invoices(
         psql.SQL(
             """
         CREATE TABLE IF NOT EXISTS {schema}.raw_invoices (
+            id BIGINT PRIMARY KEY,
             opportunity_id BIGINT,
             amount NUMERIC(14, 2),
             amount_usd NUMERIC(14, 2),
@@ -1700,6 +1710,7 @@ def _write_connect_invoices(
             rows_total = page_total
         rows = [
             (
+                r.get("id"),
                 r.get("opportunity_id"),
                 r.get("amount"),
                 r.get("amount_usd"),
@@ -1748,6 +1759,7 @@ def _write_connect_assessments(
         psql.SQL(
             """
         CREATE TABLE IF NOT EXISTS {schema}.raw_assessments (
+            id BIGINT PRIMARY KEY,
             username TEXT,
             app BIGINT,
             opportunity_id BIGINT,
@@ -1771,6 +1783,7 @@ def _write_connect_assessments(
             rows_total = page_total
         rows = [
             (
+                r.get("id"),
                 r.get("username", ""),
                 r.get("app"),
                 r.get("opportunity_id"),
@@ -1819,6 +1832,7 @@ def _write_connect_completed_modules(
         psql.SQL(
             """
         CREATE TABLE IF NOT EXISTS {schema}.raw_completed_modules (
+            id BIGINT PRIMARY KEY,
             username TEXT,
             module BIGINT,
             opportunity_id BIGINT,
@@ -1840,6 +1854,7 @@ def _write_connect_completed_modules(
             rows_total = page_total
         rows = [
             (
+                r.get("id"),
                 r.get("username", ""),
                 r.get("module"),
                 r.get("opportunity_id"),

--- a/mcp_server/services/materializer.py
+++ b/mcp_server/services/materializer.py
@@ -1,10 +1,11 @@
 """Three-phase materialization orchestrator: Discover → Load → Transform.
 
 Design notes:
-- Each source is loaded inside its own psycopg connection and committed
-  independently. A failure on source N+1 does NOT roll back rows source N
-  already committed. The writer (``_write_*``) DDL+INSERT sequence stays
-  internally atomic — it runs inside a single transaction per source.
+- Each source is loaded inside its own psycopg connection. Non-resumable
+  sources commit once at the end inside ``_load_and_commit_source``;
+  resumable sources (issue #187) commit per page from inside the writer.
+  A failure on source N+1 does NOT roll back rows source N already
+  committed.
 - A mid-pipeline failure marks the run PARTIAL (if at least one source
   committed) or FAILED (if none did) and short-circuits the remaining
   sources, recording them as ``skipped`` in ``result["sources"]``.
@@ -22,10 +23,18 @@ Design notes:
   (an unconditional ``run.save`` would silently clobber it). The
   TRANSFORMING→COMPLETED CAS also preserves PARTIAL.
 - ``result["sources"][name]`` records one of ``completed``, ``failed``,
-  ``skipped``, ``cancelled``. Never ``loaded`` — that string indicated rows
-  written but un-committed, which was a lie when the transaction rolled back.
-- The per-source dict reserves a ``cursor_state`` field (currently always
-  ``None``) for future page-level resumable materialization (issue #187).
+  ``skipped``, ``cancelled``, or ``in_progress``. Never ``loaded`` — that
+  string indicated rows written but un-committed, which was a lie when the
+  transaction rolled back.
+  ``in_progress`` is the per-page state for a resumable source whose load
+  is mid-flight: its physical table may be partially populated, and the
+  catalog (``pipeline_list_tables``) must hide that table until the source
+  flips to ``completed``.
+- For resumable sources, ``cursor_state = {"last_id": int,
+  "last_committed_at": iso}`` records the watermark advanced after each
+  committed page. A crash leaves a recoverable watermark; the next run
+  reads the prior MaterializationRun and continues from ``last_id`` with
+  no DROP TABLE. For non-resumable sources, ``cursor_state`` is ``None``.
 - A step count check at the end guards against total_steps / report() drift.
 """
 
@@ -67,6 +76,13 @@ logger = logging.getLogger(__name__)
 
 ProgressUpdater = Callable[[dict], None]
 OnPage = Callable[[int, int | None], None]
+# Called by resumable writers after each per-page commit with
+# ``(last_id, rows_committed_so_far)``. The materializer persists last_id
+# to ``MaterializationRun.result["sources"][name].cursor_state`` so a
+# crash leaves a recoverable watermark for the next run, and rolls
+# ``rows_committed_so_far`` into the in-progress source entry so the
+# resume-prompt and catalog observers see partial progress.
+CursorCallback = Callable[[int, int], None]
 
 
 class MaterializationCancelled(Exception):
@@ -205,11 +221,47 @@ def run_pipeline(
             raise MaterializationCancelled()
         run.state = MaterializationRun.RunState.LOADING
 
+        # Read the most recent non-terminal-success prior run on this tenant
+        # schema so we can resume each resumable source from its last
+        # committed cursor (issue #187). PARTIAL or FAILED runs are the only
+        # ones that can carry usable ``cursor_state``; COMPLETED runs are
+        # whole-history checkpoints (out of scope for this issue).
+        prior_cursors = _load_prior_resume_cursors(tenant_schema, exclude_run_id=run.id)
+
+        # The resumable code path (start_cursor + per-page cursor_callback) is
+        # currently implemented only for Connect writers. Other providers
+        # ignore ``source.resumable`` until their writers are migrated.
+        is_resumable_provider = pipeline.provider == "commcare_connect"
+
         sources_list = list(pipeline.sources)
         for idx, source in enumerate(sources_list):
             current_source = source.name
             load_message = f"Loading {source.name} from {pipeline.provider} API..."
             report(load_message)
+            source_is_resumable = is_resumable_provider and source.resumable
+            start_cursor = prior_cursors.get(source.name) if source_is_resumable else None
+            if source_is_resumable:
+                # Surface ``in_progress`` immediately so a fresh crash mid-resume
+                # leaves an observable state. The catalog (pipeline_list_tables)
+                # treats this as "do not surface this table yet".
+                source_results[source.name] = {
+                    "state": "in_progress",
+                    "rows": 0,
+                    "cursor_state": (
+                        {
+                            "last_id": start_cursor,
+                            "last_committed_at": None,
+                        }
+                        if start_cursor is not None
+                        else None
+                    ),
+                }
+                _persist_source_results(run, pipeline, source_results)
+            cursor_callback = (
+                _make_cursor_callback(run, pipeline, source_results, source.name)
+                if source_is_resumable
+                else None
+            )
             try:
                 rows = _load_and_commit_source(
                     source.name,
@@ -218,15 +270,19 @@ def run_pipeline(
                     schema_name,
                     provider=pipeline.provider,
                     on_page=make_on_page(source.name, load_message),
+                    resumable=source_is_resumable,
+                    start_cursor=start_cursor,
+                    cursor_callback=cursor_callback,
                 )
             except MaterializationCancelled:
                 # Earlier sources stay committed; this in-flight source rolled
                 # back inside _load_and_commit_source. Record per-source state
                 # before bubbling the cancellation up.
+                prior_cursor = (source_results.get(source.name) or {}).get("cursor_state")
                 source_results[source.name] = {
                     "state": "cancelled",
                     "rows": 0,
-                    "cursor_state": None,
+                    "cursor_state": prior_cursor,
                 }
                 for remaining in sources_list[idx + 1 :]:
                     source_results[remaining.name] = {
@@ -241,13 +297,16 @@ def run_pipeline(
                     source.name,
                     schema_name,
                 )
+                # Preserve any cursor_state advanced by per-page commits so the
+                # next run can resume from the last durable watermark (#187).
+                prior_cursor = (source_results.get(source.name) or {}).get("cursor_state")
                 source_results[source.name] = {
                     "state": "failed",
-                    "rows": 0,
+                    "rows": (source_results.get(source.name) or {}).get("rows", 0),
                     "error": _summarize_error(e),
                     "attempts": getattr(e, "attempts", 1),
                     "failed_at": datetime.now(UTC).isoformat(),
-                    "cursor_state": None,
+                    "cursor_state": prior_cursor,
                 }
                 for remaining in sources_list[idx + 1 :]:
                     source_results[remaining.name] = {
@@ -255,7 +314,14 @@ def run_pipeline(
                         "rows": 0,
                         "cursor_state": None,
                     }
-                any_committed = any(s.get("state") == "completed" for s in source_results.values())
+                # A resumable source whose per-page commits advanced the cursor
+                # has committed rows even though the source as a whole failed;
+                # treat that as PARTIAL too so the next run resumes from the
+                # watermark.
+                any_committed = any(
+                    s.get("state") == "completed" or _has_committed_cursor(s)
+                    for s in source_results.values()
+                )
                 final_state = (
                     MaterializationRun.RunState.PARTIAL
                     if any_committed
@@ -269,12 +335,18 @@ def run_pipeline(
                 }
                 run.save(update_fields=["state", "completed_at", "result"])
                 raise
+            # Preserve the final cursor watermark (resumable sources only) so a
+            # future incremental-update feature can read it; non-resumable keep
+            # ``None``.
+            final_cursor = (source_results.get(source.name) or {}).get("cursor_state")
             source_results[source.name] = {
                 "state": "completed",
                 "rows": rows,
                 "committed_at": datetime.now(UTC).isoformat(),
-                "cursor_state": None,
+                "cursor_state": final_cursor if source_is_resumable else None,
             }
+            if source_is_resumable:
+                _persist_source_results(run, pipeline, source_results)
             logger.info("Loaded %d rows into %s.%s", rows, schema_name, source.name)
         current_source = None
 
@@ -406,6 +478,99 @@ def _run_discover_phase(
     logger.info("Stored metadata for tenant %s", tenant_membership.tenant.external_id)
 
 
+def _load_prior_resume_cursors(tenant_schema: Any, exclude_run_id: Any) -> dict[str, int]:
+    """Return ``{source_name: last_id}`` for the most recent prior run, if any.
+
+    Only PARTIAL or FAILED runs carry a usable per-source ``cursor_state``
+    (a COMPLETED run is a whole-history checkpoint, not a resume target).
+    A source's cursor is returned only when its prior ``state`` was
+    ``in_progress`` or ``failed`` AND ``cursor_state.last_id`` is set,
+    matching the resume-eligibility rules in issue #187.
+
+    Returns an empty dict if no eligible prior run exists or none of its
+    sources have a usable cursor.
+    """
+    prior = (
+        MaterializationRun.objects.filter(
+            tenant_schema=tenant_schema,
+            state__in=[
+                MaterializationRun.RunState.PARTIAL,
+                MaterializationRun.RunState.FAILED,
+            ],
+        )
+        .exclude(id=exclude_run_id)
+        .order_by("-started_at")
+        .first()
+    )
+    if prior is None or not isinstance(prior.result, dict):
+        return {}
+    cursors: dict[str, int] = {}
+    for name, info in (prior.result.get("sources") or {}).items():
+        if not isinstance(info, dict):
+            continue
+        if info.get("state") not in ("in_progress", "failed"):
+            continue
+        last_id = (info.get("cursor_state") or {}).get("last_id")
+        if isinstance(last_id, int):
+            cursors[name] = last_id
+    return cursors
+
+
+def _persist_source_results(run: Any, pipeline: PipelineConfig, source_results: dict) -> None:
+    """Write the current ``source_results`` snapshot to ``run.result``.
+
+    The CAS-scoped update preserves a concurrent CANCELLED (set externally
+    by the cancel endpoint) from being clobbered by per-page checkpoints.
+    Failures here are logged but never raise — a checkpoint write that
+    fails must not break the in-flight load.
+    """
+    try:
+        MaterializationRun.objects.filter(
+            id=run.id,
+            state__in=MaterializationRun.ACTIVE_STATES,
+        ).update(
+            result={
+                "pipeline": pipeline.name,
+                "sources": source_results,
+            }
+        )
+    except Exception:
+        logger.warning(
+            "Failed to persist source_results checkpoint for run %s", run.id, exc_info=True
+        )
+
+
+def _make_cursor_callback(
+    run: Any, pipeline: PipelineConfig, source_results: dict, source_name: str
+) -> CursorCallback:
+    """Return a callback the writer invokes after each per-page commit.
+
+    The callback advances ``source_results[source_name].cursor_state.last_id``
+    and persists the snapshot to ``MaterializationRun.result``. A crash
+    after this point leaves a recoverable watermark on disk.
+    """
+
+    def _on_page_committed(last_id: int, rows_committed: int) -> None:
+        entry = source_results.setdefault(
+            source_name, {"state": "in_progress", "rows": 0, "cursor_state": None}
+        )
+        entry["state"] = "in_progress"
+        entry["rows"] = rows_committed
+        entry["cursor_state"] = {
+            "last_id": last_id,
+            "last_committed_at": datetime.now(UTC).isoformat(),
+        }
+        _persist_source_results(run, pipeline, source_results)
+
+    return _on_page_committed
+
+
+def _has_committed_cursor(entry: dict) -> bool:
+    """True when this source has any durably-committed pages (cursor_state set)."""
+    cs = entry.get("cursor_state") if isinstance(entry, dict) else None
+    return isinstance(cs, dict) and isinstance(cs.get("last_id"), int)
+
+
 def _summarize_error(exc: BaseException) -> str:
     """Return a short, single-line error description for ``result["sources"][n].error``.
 
@@ -426,13 +591,21 @@ def _load_and_commit_source(
     schema_name: str,
     provider: str,
     on_page: OnPage | None = None,
+    resumable: bool = False,
+    start_cursor: int | None = None,
+    cursor_callback: CursorCallback | None = None,
 ) -> int:
     """Open a fresh psycopg connection, run the writer, commit, and close.
 
-    Each source loads inside its own transaction so a later source's failure
-    cannot roll back rows this source already committed. The writer functions
-    (``_write_*``) still depend on ``autocommit=False`` and a caller-controlled
-    commit — that contract is preserved here.
+    Non-resumable path (``resumable=False``): the writer runs inside one
+    transaction; this function calls ``conn.commit()`` once at the end.
+
+    Resumable path (``resumable=True``): the writer commits per page
+    internally (using the shared ``conn``) and calls ``cursor_callback``
+    after each commit. This function does NOT call an outer commit — the
+    writer's per-page commits are the source of durability. On a mid-page
+    crash, pages already committed are durable; the next run resumes from
+    ``cursor_state.last_id`` recorded by the callback.
     """
     conn = get_managed_db_connection()
     conn.autocommit = False
@@ -445,8 +618,11 @@ def _load_and_commit_source(
             conn,
             provider=provider,
             on_page=on_page,
+            start_cursor=start_cursor,
+            cursor_callback=cursor_callback,
         )
-        conn.commit()
+        if not resumable:
+            conn.commit()
         return rows
     except Exception:
         try:
@@ -472,10 +648,19 @@ def _load_source(
     conn: Any,
     provider: str = "commcare",
     on_page: OnPage | None = None,
+    start_cursor: int | None = None,
+    cursor_callback: CursorCallback | None = None,
 ) -> int:
     if provider == "commcare_connect":
         return _load_connect_source(
-            source_name, tenant_membership, credential, schema_name, conn, on_page
+            source_name,
+            tenant_membership,
+            credential,
+            schema_name,
+            conn,
+            on_page,
+            start_cursor=start_cursor,
+            cursor_callback=cursor_callback,
         )
     if provider == "ocs":
         return _load_ocs_source(
@@ -492,6 +677,14 @@ def _load_source(
     raise ValueError(f"Unknown source '{source_name}'. Known sources: cases, forms")
 
 
+# Connect sources that the materializer should drive in resumable mode.
+# ``users`` is intentionally excluded — its rows are mutable, so a partial
+# resume could miss in-place updates behind the cursor (issue #187).
+_RESUMABLE_CONNECT_SOURCES = frozenset(
+    {"visits", "completed_works", "payments", "invoices", "assessments", "completed_modules"}
+)
+
+
 def _load_connect_source(
     source_name: str,
     tenant_membership: Any,
@@ -499,6 +692,8 @@ def _load_connect_source(
     schema_name: str,
     conn: Any,
     on_page: OnPage | None = None,
+    start_cursor: int | None = None,
+    cursor_callback: CursorCallback | None = None,
 ) -> int:
     opp_id = int(tenant_membership.tenant.external_id)
     loader_map = {
@@ -516,6 +711,17 @@ def _load_connect_source(
 
     loader_cls, writer_fn = loader_map[source_name]
     loader = loader_cls(opportunity_id=opp_id, credential=credential)
+    if source_name in _RESUMABLE_CONNECT_SOURCES:
+        pages = loader.load_pages(start_last_id=start_cursor)
+        return writer_fn(
+            pages,
+            schema_name,
+            conn,
+            on_page=on_page,
+            start_cursor=start_cursor,
+            cursor_callback=cursor_callback,
+        )
+    # users: full DROP/CREATE/INSERT, single commit at end (caller-driven).
     return writer_fn(loader.load_pages(), schema_name, conn, on_page=on_page)
 
 
@@ -928,6 +1134,19 @@ def _write_forms(
 # ── Connect table writers ──────────────────────────────────────────────────────
 
 
+def _max_id(page: list[dict], field: str) -> int | None:
+    """Return the maximum integer value of ``field`` over ``page`` rows.
+
+    Used by resumable Connect writers to advance the per-page cursor
+    watermark. Rows with missing or non-integer ids are skipped; if no
+    row has a usable id the function returns ``None`` and the caller
+    will not record a checkpoint for this page.
+    """
+    ids = [r.get(field) for r in page]
+    valid = [i for i in ids if isinstance(i, int)]
+    return max(valid) if valid else None
+
+
 def _json_or_none(value: Any) -> str | None:
     """Serialize a value to a JSON string, or return None for SQL NULL.
 
@@ -1068,8 +1287,20 @@ def _write_connect_visits(
     schema_name: str,
     conn: Any,
     on_page: OnPage | None = None,
+    start_cursor: int | None = None,
+    cursor_callback: CursorCallback | None = None,
 ) -> int:
     """Create the visits table and bulk-insert all pages. Returns total row count.
+
+    When ``start_cursor`` is None this is a clean run (DROP + CREATE +
+    INSERT). When ``start_cursor`` is set this is a resume: skip the DROP,
+    run an idempotent ``CREATE TABLE IF NOT EXISTS``, and continue
+    inserting at the prior watermark. The page-iterator is expected to
+    already be positioned past ``start_cursor`` (the caller passes
+    ``start_last_id`` to the loader).
+
+    Resumable writers commit per page (rather than once per source) so a
+    mid-source crash leaves a partial table the next run can continue.
 
     Column types mirror the Django model + DRF serializer output:
     - ``flag_reason`` is a JSONField, serialized as a dict → JSONB
@@ -1082,11 +1313,12 @@ def _write_connect_visits(
     sid = psql.Identifier(schema_name)
     cur = conn.cursor()
 
-    cur.execute(psql.SQL("DROP TABLE IF EXISTS {}.raw_visits CASCADE").format(sid))
+    if start_cursor is None:
+        cur.execute(psql.SQL("DROP TABLE IF EXISTS {}.raw_visits CASCADE").format(sid))
     cur.execute(
         psql.SQL(
             """
-        CREATE TABLE {schema}.raw_visits (
+        CREATE TABLE IF NOT EXISTS {schema}.raw_visits (
             visit_id BIGINT PRIMARY KEY,
             opportunity_id BIGINT,
             username TEXT,
@@ -1113,6 +1345,7 @@ def _write_connect_visits(
         """
         ).format(schema=sid)
     )
+    conn.commit()
 
     ins_sql = _CONNECT_VISITS_INSERT.format(schema=sid)
     total = 0
@@ -1151,6 +1384,10 @@ def _write_connect_visits(
         ]
         cur.executemany(ins_sql, rows)
         total += len(page)
+        max_id = _max_id(page, "visit_id")
+        conn.commit()
+        if cursor_callback is not None and max_id is not None:
+            cursor_callback(max_id, total)
         if on_page is not None:
             on_page(total, rows_total)
 
@@ -1236,8 +1473,14 @@ def _write_connect_completed_works(
     schema_name: str,
     conn: Any,
     on_page: OnPage | None = None,
+    start_cursor: int | None = None,
+    cursor_callback: CursorCallback | None = None,
 ) -> int:
     """Create the completed_works table and bulk-insert all pages. Returns total row count.
+
+    Resumable: when ``start_cursor`` is set, skip DROP and use
+    ``CREATE TABLE IF NOT EXISTS``. Commits per page; calls
+    ``cursor_callback`` with the page's max ``id``.
 
     Counts become INTEGER, accrued amounts become NUMERIC money, all
     date/datetime fields become TIMESTAMPTZ, opportunity_id becomes BIGINT.
@@ -1245,11 +1488,12 @@ def _write_connect_completed_works(
     sid = psql.Identifier(schema_name)
     cur = conn.cursor()
 
-    cur.execute(psql.SQL("DROP TABLE IF EXISTS {}.raw_completed_works CASCADE").format(sid))
+    if start_cursor is None:
+        cur.execute(psql.SQL("DROP TABLE IF EXISTS {}.raw_completed_works CASCADE").format(sid))
     cur.execute(
         psql.SQL(
             """
-        CREATE TABLE {schema}.raw_completed_works (
+        CREATE TABLE IF NOT EXISTS {schema}.raw_completed_works (
             username TEXT,
             opportunity_id BIGINT,
             payment_unit_id BIGINT,
@@ -1271,6 +1515,7 @@ def _write_connect_completed_works(
         """
         ).format(schema=sid)
     )
+    conn.commit()
 
     ins_sql = _CONNECT_COMPLETED_WORKS_INSERT.format(schema=sid)
     total = 0
@@ -1304,6 +1549,10 @@ def _write_connect_completed_works(
         ]
         cur.executemany(ins_sql, rows)
         total += len(page)
+        max_id = _max_id(page, "id")
+        conn.commit()
+        if cursor_callback is not None and max_id is not None:
+            cursor_callback(max_id, total)
         if on_page is not None:
             on_page(total, rows_total)
 
@@ -1315,8 +1564,14 @@ def _write_connect_payments(
     schema_name: str,
     conn: Any,
     on_page: OnPage | None = None,
+    start_cursor: int | None = None,
+    cursor_callback: CursorCallback | None = None,
 ) -> int:
     """Create the payments table and bulk-insert all pages. Returns total row count.
+
+    Resumable: when ``start_cursor`` is set, skip DROP and use
+    ``CREATE TABLE IF NOT EXISTS``. Commits per page; calls
+    ``cursor_callback`` with the page's max ``id``.
 
     ``amount``/``amount_usd`` become NUMERIC(14,2), ``confirmed`` becomes
     BOOLEAN, all date/datetime fields become TIMESTAMPTZ, ``opportunity_id``
@@ -1325,11 +1580,12 @@ def _write_connect_payments(
     sid = psql.Identifier(schema_name)
     cur = conn.cursor()
 
-    cur.execute(psql.SQL("DROP TABLE IF EXISTS {}.raw_payments CASCADE").format(sid))
+    if start_cursor is None:
+        cur.execute(psql.SQL("DROP TABLE IF EXISTS {}.raw_payments CASCADE").format(sid))
     cur.execute(
         psql.SQL(
             """
-        CREATE TABLE {schema}.raw_payments (
+        CREATE TABLE IF NOT EXISTS {schema}.raw_payments (
             username TEXT,
             opportunity_id BIGINT,
             created_at TIMESTAMPTZ,
@@ -1347,6 +1603,7 @@ def _write_connect_payments(
         """
         ).format(schema=sid)
     )
+    conn.commit()
 
     ins_sql = _CONNECT_PAYMENTS_INSERT.format(schema=sid)
     total = 0
@@ -1376,6 +1633,10 @@ def _write_connect_payments(
         ]
         cur.executemany(ins_sql, rows)
         total += len(page)
+        max_id = _max_id(page, "id")
+        conn.commit()
+        if cursor_callback is not None and max_id is not None:
+            cursor_callback(max_id, total)
         if on_page is not None:
             on_page(total, rows_total)
 
@@ -1387,8 +1648,14 @@ def _write_connect_invoices(
     schema_name: str,
     conn: Any,
     on_page: OnPage | None = None,
+    start_cursor: int | None = None,
+    cursor_callback: CursorCallback | None = None,
 ) -> int:
     """Create the invoices table and bulk-insert all pages. Returns total row count.
+
+    Resumable: when ``start_cursor`` is set, skip DROP and use
+    ``CREATE TABLE IF NOT EXISTS``. Commits per page; calls
+    ``cursor_callback`` with the page's max ``id``.
 
     Money fields are NUMERIC(14,2), ``date`` is DATE, ``opportunity_id`` is
     BIGINT. ``service_delivery`` is a BooleanField (not a text label as the
@@ -1398,11 +1665,12 @@ def _write_connect_invoices(
     sid = psql.Identifier(schema_name)
     cur = conn.cursor()
 
-    cur.execute(psql.SQL("DROP TABLE IF EXISTS {}.raw_invoices CASCADE").format(sid))
+    if start_cursor is None:
+        cur.execute(psql.SQL("DROP TABLE IF EXISTS {}.raw_invoices CASCADE").format(sid))
     cur.execute(
         psql.SQL(
             """
-        CREATE TABLE {schema}.raw_invoices (
+        CREATE TABLE IF NOT EXISTS {schema}.raw_invoices (
             opportunity_id BIGINT,
             amount NUMERIC(14, 2),
             amount_usd NUMERIC(14, 2),
@@ -1414,6 +1682,7 @@ def _write_connect_invoices(
         """
         ).format(schema=sid)
     )
+    conn.commit()
 
     ins_sql = _CONNECT_INVOICES_INSERT.format(schema=sid)
     total = 0
@@ -1437,6 +1706,10 @@ def _write_connect_invoices(
         ]
         cur.executemany(ins_sql, rows)
         total += len(page)
+        max_id = _max_id(page, "id")
+        conn.commit()
+        if cursor_callback is not None and max_id is not None:
+            cursor_callback(max_id, total)
         if on_page is not None:
             on_page(total, rows_total)
 
@@ -1448,8 +1721,14 @@ def _write_connect_assessments(
     schema_name: str,
     conn: Any,
     on_page: OnPage | None = None,
+    start_cursor: int | None = None,
+    cursor_callback: CursorCallback | None = None,
 ) -> int:
     """Create the assessments table and bulk-insert all pages. Returns total row count.
+
+    Resumable: when ``start_cursor`` is set, skip DROP and use
+    ``CREATE TABLE IF NOT EXISTS``. Commits per page; calls
+    ``cursor_callback`` with the page's max ``id``.
 
     Scores become INTEGER, ``passed`` becomes BOOLEAN, ``date`` becomes
     TIMESTAMPTZ, ``opportunity_id`` becomes BIGINT.
@@ -1457,11 +1736,12 @@ def _write_connect_assessments(
     sid = psql.Identifier(schema_name)
     cur = conn.cursor()
 
-    cur.execute(psql.SQL("DROP TABLE IF EXISTS {}.raw_assessments CASCADE").format(sid))
+    if start_cursor is None:
+        cur.execute(psql.SQL("DROP TABLE IF EXISTS {}.raw_assessments CASCADE").format(sid))
     cur.execute(
         psql.SQL(
             """
-        CREATE TABLE {schema}.raw_assessments (
+        CREATE TABLE IF NOT EXISTS {schema}.raw_assessments (
             username TEXT,
             app BIGINT,
             opportunity_id BIGINT,
@@ -1473,6 +1753,7 @@ def _write_connect_assessments(
         """
         ).format(schema=sid)
     )
+    conn.commit()
 
     ins_sql = _CONNECT_ASSESSMENTS_INSERT.format(schema=sid)
     total = 0
@@ -1496,6 +1777,10 @@ def _write_connect_assessments(
         ]
         cur.executemany(ins_sql, rows)
         total += len(page)
+        max_id = _max_id(page, "id")
+        conn.commit()
+        if cursor_callback is not None and max_id is not None:
+            cursor_callback(max_id, total)
         if on_page is not None:
             on_page(total, rows_total)
 
@@ -1507,8 +1792,14 @@ def _write_connect_completed_modules(
     schema_name: str,
     conn: Any,
     on_page: OnPage | None = None,
+    start_cursor: int | None = None,
+    cursor_callback: CursorCallback | None = None,
 ) -> int:
     """Create the completed_modules table and bulk-insert all pages. Returns total row count.
+
+    Resumable: when ``start_cursor`` is set, skip DROP and use
+    ``CREATE TABLE IF NOT EXISTS``. Commits per page; calls
+    ``cursor_callback`` with the page's max ``id``.
 
     ``duration`` becomes INTEGER (seconds), ``date`` becomes TIMESTAMPTZ,
     ``opportunity_id`` becomes BIGINT.
@@ -1516,11 +1807,12 @@ def _write_connect_completed_modules(
     sid = psql.Identifier(schema_name)
     cur = conn.cursor()
 
-    cur.execute(psql.SQL("DROP TABLE IF EXISTS {}.raw_completed_modules CASCADE").format(sid))
+    if start_cursor is None:
+        cur.execute(psql.SQL("DROP TABLE IF EXISTS {}.raw_completed_modules CASCADE").format(sid))
     cur.execute(
         psql.SQL(
             """
-        CREATE TABLE {schema}.raw_completed_modules (
+        CREATE TABLE IF NOT EXISTS {schema}.raw_completed_modules (
             username TEXT,
             module BIGINT,
             opportunity_id BIGINT,
@@ -1530,6 +1822,7 @@ def _write_connect_completed_modules(
         """
         ).format(schema=sid)
     )
+    conn.commit()
 
     ins_sql = _CONNECT_COMPLETED_MODULES_INSERT.format(schema=sid)
     total = 0
@@ -1551,6 +1844,10 @@ def _write_connect_completed_modules(
         ]
         cur.executemany(ins_sql, rows)
         total += len(page)
+        max_id = _max_id(page, "id")
+        conn.commit()
+        if cursor_callback is not None and max_id is not None:
+            cursor_callback(max_id, total)
         if on_page is not None:
             on_page(total, rows_total)
 

--- a/mcp_server/services/metadata.py
+++ b/mcp_server/services/metadata.py
@@ -39,6 +39,9 @@ async def pipeline_list_tables(
     with ``information_schema.tables`` for the tenant schema:
 
     - sources with ``state != "completed"`` in the run record are excluded
+      (this includes ``in_progress`` from issue #187 — a source mid-resume
+      may have a partially-populated physical table that must not be surfaced
+      until the source flips to ``completed``)
     - sources whose physical table is no longer present in the DB are excluded
 
     Returns an empty list if no eligible run exists or none of the recorded

--- a/pipelines/connect_sync.yml
+++ b/pipelines/connect_sync.yml
@@ -8,6 +8,9 @@ sources:
     description: "User visit records with form data"
   - name: users
     description: "FLW/worker roster"
+    # Mutable rows (usernames, suspension status) — full DROP/CREATE/INSERT
+    # every run; do not resume from a partial-page watermark (issue #187).
+    resumable: false
   - name: completed_works
     description: "Completed work records"
   - name: payments

--- a/tests/test_connect_base_loader.py
+++ b/tests/test_connect_base_loader.py
@@ -153,6 +153,52 @@ class TestPaginateExportPages:
             with pytest.raises(ConnectExportError):
                 list(loader._paginate_export_pages("user_visits/"))
 
+    def test_paginate_export_pages_starts_from_provided_cursor(self, loader):
+        """Issue #187: when ``start_last_id`` is set, the first GET URL
+        includes ``last_id=<id>`` so Connect's keyset pagination resumes
+        with records strictly greater than that id.
+        """
+        with rm.Mocker() as m:
+            m.get(
+                "https://connect.example.com/export/opportunity/814/completed_works/",
+                json={"next": None, "previous": None, "results": [{"id": 101}], "count": 1},
+            )
+            list(loader._paginate_export_pages("completed_works/", start_last_id=100))
+            assert m.last_request.qs.get("last_id") == ["100"]
+
+    def test_paginate_export_pages_no_start_cursor_uses_default_url(self, loader):
+        """Regression: omitting ``start_last_id`` makes the first request
+        carry no ``last_id`` query param — identical to pre-#187 behavior.
+        """
+        with rm.Mocker() as m:
+            m.get(
+                "https://connect.example.com/export/opportunity/814/user_visits/",
+                json={"next": None, "previous": None, "results": [], "count": 0},
+            )
+            list(loader._paginate_export_pages("user_visits/"))
+            assert "last_id" not in m.last_request.qs
+
+    def test_paginate_export_pages_start_cursor_combines_with_params(self, loader):
+        """``start_last_id`` is merged into caller-supplied ``params`` —
+        both are sent on the first request, and the original ``params``
+        dict is not mutated.
+        """
+        with rm.Mocker() as m:
+            m.get(
+                "https://connect.example.com/export/opportunity/814/user_visits/",
+                json={"next": None, "previous": None, "results": []},
+            )
+            original_params = {"images": "true"}
+            list(
+                loader._paginate_export_pages(
+                    "user_visits/", params=original_params, start_last_id=500
+                )
+            )
+            assert m.last_request.qs.get("last_id") == ["500"]
+            assert m.last_request.qs.get("images") == ["true"]
+            # Caller's dict must NOT be mutated.
+            assert "last_id" not in original_params
+
     def test_follows_http_to_https_redirect_on_next_url(self, loader):
         """Regression test for dimagi/commcare-connect#1109.
 

--- a/tests/test_materializer.py
+++ b/tests/test_materializer.py
@@ -787,6 +787,7 @@ class TestResumableMaterialization:
         from mcp_server.pipeline_registry import SourceConfig
 
         prior = MagicMock()
+        prior.state = "partial"  # must match RunState.PARTIAL set in _setup_run_mock
         prior.result = {
             "sources": {
                 "completed_works": {
@@ -819,6 +820,7 @@ class TestResumableMaterialization:
         from mcp_server.pipeline_registry import SourceConfig
 
         prior = MagicMock()
+        prior.state = "partial"  # must match RunState.PARTIAL set in _setup_run_mock
         prior.result = {
             "sources": {
                 "users": {
@@ -906,6 +908,51 @@ class TestResumableMaterialization:
         call = invocations["completed_works"].return_value.load_pages.call_args
         # start_last_id is None on a clean run.
         assert call.kwargs.get("start_last_id") is None
+
+    def test_completed_run_after_partial_invalidates_stale_cursor(self):
+        """Regression test for stale-cursor bug: when a COMPLETED run follows an
+        older PARTIAL run, the next run (Run C) must NOT resume from the PARTIAL
+        run's cursor — it must do a clean full reload.
+
+        Scenario:
+          Run A → PARTIAL, cursor_state.last_id = 1500
+          Run B → COMPLETED (full reload, table now complete)
+          Run C → must start clean (start_last_id=None), not from 1500
+
+        Without the fix, _load_prior_resume_cursors would skip Run B (COMPLETED)
+        and return Run A's stale cursor, causing duplicate-key errors or silent
+        row duplication depending on whether the table has a PK.
+        """
+        from mcp_server.pipeline_registry import SourceConfig
+
+        # The most-recent prior run (Run B) is COMPLETED — its state must
+        # invalidate the older PARTIAL cursor from Run A.
+        prior_completed = MagicMock()
+        prior_completed.state = "completed"  # matches RunState.COMPLETED mock value
+        prior_completed.result = {
+            "sources": {
+                "completed_works": {
+                    "state": "completed",
+                    "rows": 5000,
+                    "cursor_state": None,
+                }
+            }
+        }
+
+        cw_loader_cls = MagicMock()
+        cw_loader_cls.return_value.load_pages.return_value = iter([])
+
+        _, invocations = self._run_connect_pipeline(
+            sources=[SourceConfig(name="completed_works", resumable=True)],
+            loader_mocks={"completed_works": cw_loader_cls},
+            prior_run=prior_completed,
+        )
+
+        call = invocations["completed_works"].return_value.load_pages.call_args
+        assert call.kwargs.get("start_last_id") is None, (
+            "A COMPLETED prior run must cause a clean full reload, "
+            f"not a resume from a stale cursor; got start_last_id={call.kwargs.get('start_last_id')}"
+        )
 
     def test_failed_resumable_source_records_cursor_state_for_next_run(self):
         """A resumable source that fails mid-load must preserve its cursor

--- a/tests/test_materializer.py
+++ b/tests/test_materializer.py
@@ -1104,3 +1104,252 @@ class TestWriteForms:
             with conn.cursor() as cur:
                 cur.execute(f"DROP SCHEMA IF EXISTS {test_schema} CASCADE")
             conn.close()
+
+
+@pytest.mark.django_db
+class TestConnectPageReplayIdempotency:
+    """Regression tests for bot comment #3315357471.
+
+    Verifies that re-inserting the same page (simulating a crash between
+    conn.commit() and cursor_callback()) does NOT duplicate rows in the
+    five Connect tables that previously lacked a primary key.
+    """
+
+    def _get_db_url(self):
+        import os
+
+        return os.environ.get("MANAGED_DATABASE_URL") or os.environ.get("DATABASE_URL")
+
+    def _make_schema(self, conn, schema_name):
+        # autocommit=True is set before calling this method (via psycopg.connect autocommit=True)
+        with conn.cursor() as cur:
+            cur.execute(f"DROP SCHEMA IF EXISTS {schema_name} CASCADE")
+            cur.execute(f"CREATE SCHEMA {schema_name}")
+        conn.autocommit = False
+
+    def test_payments_page_replay_no_duplication(self, django_db_setup, db):
+        """Re-inserting a page of payments (simulating crash before watermark
+        persist) must not duplicate rows — ON CONFLICT (id) DO NOTHING applies.
+        """
+        import psycopg
+
+        from mcp_server.services.materializer import _write_connect_payments
+
+        db_url = self._get_db_url()
+        if not db_url:
+            pytest.skip("No MANAGED_DATABASE_URL/DATABASE_URL for writer test")
+
+        test_schema = "test_cpr_payments"
+        conn = psycopg.connect(db_url, autocommit=True)
+        try:
+            self._make_schema(conn, test_schema)
+
+            page = [
+                {
+                    "id": 101,
+                    "username": "user1",
+                    "opportunity_id": 1,
+                    "created_at": "2026-01-01T00:00:00Z",
+                    "amount": "10.00",
+                    "amount_usd": "10.00",
+                    "date_paid": None,
+                    "payment_unit": 1,
+                    "confirmed": False,
+                    "confirmation_date": None,
+                    "organization": "org1",
+                    "invoice_id": None,
+                    "payment_method": "mobile_money",
+                    "payment_operator": "op1",
+                },
+                {
+                    "id": 102,
+                    "username": "user2",
+                    "opportunity_id": 1,
+                    "created_at": "2026-01-02T00:00:00Z",
+                    "amount": "20.00",
+                    "amount_usd": "20.00",
+                    "date_paid": None,
+                    "payment_unit": 2,
+                    "confirmed": True,
+                    "confirmation_date": "2026-01-03T00:00:00Z",
+                    "organization": "org1",
+                    "invoice_id": 5,
+                    "payment_method": "mobile_money",
+                    "payment_operator": "op2",
+                },
+            ]
+
+            # First write — clean run, no cursor yet.
+            _write_connect_payments(
+                pages=iter([(page, 2)]),
+                schema_name=test_schema,
+                conn=conn,
+            )
+
+            # Simulate crash: conn already committed the page, but cursor_callback
+            # was never called. Re-run from the prior watermark by writing the
+            # same page again (start_cursor is set to skip DROP/CREATE).
+            _write_connect_payments(
+                pages=iter([(page, 2)]),
+                schema_name=test_schema,
+                conn=conn,
+                start_cursor=100,  # any non-None value triggers the resume path
+            )
+
+            with conn.cursor() as cur:
+                cur.execute(f"SELECT COUNT(*) FROM {test_schema}.raw_payments")
+                (count,) = cur.fetchone()
+
+            assert count == 2, (
+                f"Expected 2 rows after page replay, got {count} — "
+                "ON CONFLICT (id) DO NOTHING must be present"
+            )
+        finally:
+            conn.rollback()
+            conn.autocommit = True
+            with conn.cursor() as cur:
+                cur.execute(f"DROP SCHEMA IF EXISTS {test_schema} CASCADE")
+            conn.close()
+
+    def test_completed_works_page_replay_no_duplication(self, django_db_setup, db):
+        """Re-inserting a page of completed_works must not duplicate rows."""
+        import psycopg
+
+        from mcp_server.services.materializer import _write_connect_completed_works
+
+        db_url = self._get_db_url()
+        if not db_url:
+            pytest.skip("No MANAGED_DATABASE_URL/DATABASE_URL for writer test")
+
+        test_schema = "test_cpr_completed_works"
+        conn = psycopg.connect(db_url, autocommit=True)
+        try:
+            self._make_schema(conn, test_schema)
+
+            page = [
+                {
+                    "id": 201,
+                    "username": "user1",
+                    "opportunity_id": 1,
+                    "payment_unit_id": 10,
+                    "status": "approved",
+                    "last_modified": "2026-01-01T00:00:00Z",
+                    "entity_id": "e1",
+                    "entity_name": "Entity 1",
+                    "reason": "",
+                    "status_modified_date": "2026-01-01T00:00:00Z",
+                    "payment_date": None,
+                    "date_created": "2026-01-01T00:00:00Z",
+                    "saved_completed_count": 5,
+                    "saved_approved_count": 5,
+                    "saved_payment_accrued": "50.00",
+                    "saved_payment_accrued_usd": "50.00",
+                    "saved_org_payment_accrued": "50.00",
+                    "saved_org_payment_accrued_usd": "50.00",
+                },
+            ]
+
+            # First write — clean run.
+            _write_connect_completed_works(
+                pages=iter([(page, 1)]),
+                schema_name=test_schema,
+                conn=conn,
+            )
+
+            # Replay the same page (crash scenario — watermark not advanced).
+            _write_connect_completed_works(
+                pages=iter([(page, 1)]),
+                schema_name=test_schema,
+                conn=conn,
+                start_cursor=200,
+            )
+
+            with conn.cursor() as cur:
+                cur.execute(f"SELECT COUNT(*) FROM {test_schema}.raw_completed_works")
+                (count,) = cur.fetchone()
+
+            assert count == 1, (
+                f"Expected 1 row after page replay, got {count} — "
+                "ON CONFLICT (id) DO NOTHING must be present"
+            )
+        finally:
+            conn.rollback()
+            conn.autocommit = True
+            with conn.cursor() as cur:
+                cur.execute(f"DROP SCHEMA IF EXISTS {test_schema} CASCADE")
+            conn.close()
+
+    def test_visits_page_replay_no_duplication(self, django_db_setup, db):
+        """Verify raw_visits remains safe: visit_id PK + ON CONFLICT DO UPDATE
+        means a page replay updates existing rows rather than duplicating them.
+        """
+        import psycopg
+
+        from mcp_server.services.materializer import _write_connect_visits
+
+        db_url = self._get_db_url()
+        if not db_url:
+            pytest.skip("No MANAGED_DATABASE_URL/DATABASE_URL for writer test")
+
+        test_schema = "test_cpr_visits"
+        conn = psycopg.connect(db_url, autocommit=True)
+        try:
+            self._make_schema(conn, test_schema)
+
+            page = [
+                {
+                    "visit_id": 301,
+                    "opportunity_id": 1,
+                    "username": "user1",
+                    "deliver_unit": None,
+                    "entity_id": "e1",
+                    "entity_name": "Entity 1",
+                    "visit_date": "2026-01-01T00:00:00Z",
+                    "status": "pending",
+                    "reason": "",
+                    "location": "",
+                    "flagged": False,
+                    "flag_reason": None,
+                    "form_json": {},
+                    "completed_work": None,
+                    "status_modified_date": None,
+                    "review_status": "",
+                    "review_created_on": None,
+                    "justification": "",
+                    "date_created": "2026-01-01T00:00:00Z",
+                    "completed_work_id": None,
+                    "deliver_unit_id": None,
+                    "images": [],
+                },
+            ]
+
+            # First write — clean run.
+            _write_connect_visits(
+                pages=iter([(page, 1)]),
+                schema_name=test_schema,
+                conn=conn,
+            )
+
+            # Replay with an updated status (DO UPDATE should apply the change).
+            updated_page = [{**page[0], "status": "approved"}]
+            _write_connect_visits(
+                pages=iter([(updated_page, 1)]),
+                schema_name=test_schema,
+                conn=conn,
+                start_cursor=300,
+            )
+
+            with conn.cursor() as cur:
+                cur.execute(f"SELECT COUNT(*), MAX(status) FROM {test_schema}.raw_visits")
+                count, status = cur.fetchone()
+
+            assert count == 1, f"Expected 1 row after visit page replay, got {count}"
+            assert status == "approved", (
+                f"Expected status='approved' after DO UPDATE, got '{status}'"
+            )
+        finally:
+            conn.rollback()
+            conn.autocommit = True
+            with conn.cursor() as cur:
+                cur.execute(f"DROP SCHEMA IF EXISTS {test_schema} CASCADE")
+            conn.close()

--- a/tests/test_materializer.py
+++ b/tests/test_materializer.py
@@ -679,6 +679,292 @@ class TestRunPipeline:
         assert commit_called, "Per-source commit() must be invoked"
 
 
+class TestResumableMaterialization:
+    """Issue #187: per-page cursor watermark for resumable Connect sources."""
+
+    def _make_schema(self, name="dimagi"):
+        s = MagicMock()
+        s.schema_name = name
+        return s
+
+    def _make_tm(self, tenant_id="42"):
+        tm = MagicMock()
+        tm.tenant.external_id = tenant_id
+        return tm
+
+    def _setup_run_mock(self, mock_run_cls, prior_run=None):
+        run = MagicMock()
+        run.id = "run-1"
+        mock_run_cls.objects.create.return_value = run
+        for attr in (
+            "DISCOVERING",
+            "LOADING",
+            "TRANSFORMING",
+            "COMPLETED",
+            "PARTIAL",
+            "FAILED",
+            "CANCELLED",
+            "STALE",
+        ):
+            setattr(mock_run_cls.RunState, attr, attr.lower())
+        mock_run_cls.ACTIVE_STATES = frozenset(
+            {"started", "discovering", "loading", "transforming"}
+        )
+        # _load_prior_resume_cursors uses .filter().exclude().order_by().first()
+        # — wire it up to return ``prior_run`` (or None when absent).
+        chain = mock_run_cls.objects.filter.return_value
+        chain.exclude.return_value.order_by.return_value.first.return_value = prior_run
+        return run
+
+    def _run_connect_pipeline(
+        self,
+        sources,
+        loader_mocks,
+        prior_run=None,
+        completed_works_side_effect=None,
+    ):
+        """Run a Connect pipeline with mocked loaders. Returns the run mock."""
+        from mcp_server.pipeline_registry import PipelineConfig
+        from mcp_server.services.materializer import run_pipeline
+
+        pipeline = PipelineConfig(
+            name="connect_sync",
+            description="",
+            version="1.0",
+            provider="commcare_connect",
+            sources=sources,
+        )
+
+        with (
+            patch("mcp_server.services.materializer.SchemaManager") as mock_mgr,
+            patch("mcp_server.services.materializer.MaterializationRun") as mock_run_cls,
+            patch("mcp_server.services.materializer.TenantMetadata"),
+            patch("mcp_server.services.materializer.ConnectMetadataLoader") as mock_meta,
+            patch(
+                "mcp_server.services.materializer.ConnectVisitLoader",
+                loader_mocks.get("visits", MagicMock()),
+            ) as mock_visits,
+            patch(
+                "mcp_server.services.materializer.ConnectUserLoader",
+                loader_mocks.get("users", MagicMock()),
+            ) as mock_users,
+            patch(
+                "mcp_server.services.materializer.ConnectCompletedWorkLoader",
+                loader_mocks.get("completed_works", MagicMock()),
+            ) as mock_cw,
+            patch(
+                "mcp_server.services.materializer.ConnectPaymentLoader",
+                loader_mocks.get("payments", MagicMock()),
+            ),
+            patch("mcp_server.services.materializer.get_managed_db_connection") as mock_conn,
+        ):
+            schema = self._make_schema()
+            mock_mgr.return_value.provision.return_value = schema
+            run = self._setup_run_mock(mock_run_cls, prior_run=prior_run)
+            mock_meta.return_value.load.return_value = {}
+            conn = MagicMock()
+            mock_conn.return_value = conn
+            conn.cursor.return_value = MagicMock()
+
+            invocations = {
+                "visits": mock_visits,
+                "users": mock_users,
+                "completed_works": mock_cw,
+            }
+            if completed_works_side_effect is not None:
+                mock_cw.return_value.load_pages.side_effect = completed_works_side_effect
+            try:
+                run_pipeline(self._make_tm(), {"type": "api_key", "value": "x"}, pipeline)
+            except Exception:
+                pass
+            return run, invocations
+
+    def test_resumes_from_cursor_when_prior_run_partial(self):
+        """When a prior PARTIAL run recorded cursor_state.last_id for a
+        resumable source whose state was in_progress/failed, the next run
+        passes that id as ``start_last_id`` to the loader.
+        """
+        from mcp_server.pipeline_registry import SourceConfig
+
+        prior = MagicMock()
+        prior.result = {
+            "sources": {
+                "completed_works": {
+                    "state": "in_progress",
+                    "rows": 100,
+                    "cursor_state": {"last_id": 1500, "last_committed_at": "2026-05-27T00:00:00Z"},
+                }
+            }
+        }
+
+        cw_loader_cls = MagicMock()
+        cw_loader_cls.return_value.load_pages.return_value = iter([])
+
+        _, invocations = self._run_connect_pipeline(
+            sources=[SourceConfig(name="completed_works", resumable=True)],
+            loader_mocks={"completed_works": cw_loader_cls},
+            prior_run=prior,
+        )
+
+        # load_pages must have been called with start_last_id=1500.
+        call = invocations["completed_works"].return_value.load_pages.call_args
+        assert call.kwargs.get("start_last_id") == 1500, (
+            f"Expected start_last_id=1500, got {call.kwargs}"
+        )
+
+    def test_clean_run_ignores_cursor_state_for_non_resumable_source(self):
+        """Non-resumable sources (e.g. users) MUST do a clean full reload
+        regardless of any cursor_state present on a prior run.
+        """
+        from mcp_server.pipeline_registry import SourceConfig
+
+        prior = MagicMock()
+        prior.result = {
+            "sources": {
+                "users": {
+                    "state": "in_progress",
+                    "rows": 50,
+                    "cursor_state": {"last_id": 999, "last_committed_at": "2026-05-27T00:00:00Z"},
+                }
+            }
+        }
+        users_loader_cls = MagicMock()
+        users_loader_cls.return_value.load_pages.return_value = iter([])
+
+        _, invocations = self._run_connect_pipeline(
+            sources=[SourceConfig(name="users", resumable=False)],
+            loader_mocks={"users": users_loader_cls},
+            prior_run=prior,
+        )
+
+        call = invocations["users"].return_value.load_pages.call_args
+        # The users loader must be called with NO start_last_id (it doesn't
+        # even accept the kwarg). It is called positionally with nothing.
+        assert "start_last_id" not in (call.kwargs or {}), (
+            "Non-resumable source must not receive a resume cursor"
+        )
+
+    def test_cursor_advances_after_each_page_commit(self):
+        """Each per-page commit must update cursor_state.last_id to the
+        max id of the page just committed (and rows count too).
+        """
+        from mcp_server.services.materializer import _make_cursor_callback
+
+        run = MagicMock()
+        run.id = "run-1"
+        # Wire ACTIVE_STATES into the patched MaterializationRun so the CAS
+        # update inside _persist_source_results doesn't blow up.
+        with patch("mcp_server.services.materializer.MaterializationRun") as mock_rc:
+            mock_rc.ACTIVE_STATES = frozenset({"started", "loading"})
+            pipeline = MagicMock(name="connect_sync")
+            pipeline.name = "connect_sync"
+            source_results = {}
+            cb = _make_cursor_callback(run, pipeline, source_results, "completed_works")
+            cb(100, 50)
+            assert source_results["completed_works"]["state"] == "in_progress"
+            assert source_results["completed_works"]["rows"] == 50
+            assert source_results["completed_works"]["cursor_state"]["last_id"] == 100
+            cb(250, 100)
+            assert source_results["completed_works"]["cursor_state"]["last_id"] == 250
+            assert source_results["completed_works"]["rows"] == 100
+        # The _persist_source_results CAS update was called once per page.
+        # We don't pin the exact call count to the mock here because the
+        # callback re-imports MaterializationRun via the module under test,
+        # not via our local patch — covered by the integration test below.
+
+    def test_resume_does_not_drop_table_when_start_cursor_present(self):
+        """The resumable writer skips DROP and uses CREATE IF NOT EXISTS."""
+        from mcp_server.services.materializer import _write_connect_completed_works
+
+        conn = MagicMock()
+        cur = MagicMock()
+        conn.cursor.return_value = cur
+        _write_connect_completed_works(
+            pages=iter([]),
+            schema_name="t_x",
+            conn=conn,
+            start_cursor=1234,
+        )
+        executed_sql = [str(c.args[0]) for c in cur.execute.call_args_list]
+        joined = "\n".join(executed_sql)
+        assert "DROP TABLE" not in joined, "Resume path must not DROP the partially-loaded table"
+        assert "CREATE TABLE IF NOT EXISTS" in joined or "IF NOT EXISTS" in joined
+
+    def test_no_prior_cursor_means_clean_start(self):
+        """First-ever run (no PARTIAL/FAILED history) behaves like pre-#187."""
+        from mcp_server.pipeline_registry import SourceConfig
+
+        cw_loader_cls = MagicMock()
+        cw_loader_cls.return_value.load_pages.return_value = iter([])
+
+        _, invocations = self._run_connect_pipeline(
+            sources=[SourceConfig(name="completed_works", resumable=True)],
+            loader_mocks={"completed_works": cw_loader_cls},
+            prior_run=None,
+        )
+
+        call = invocations["completed_works"].return_value.load_pages.call_args
+        # start_last_id is None on a clean run.
+        assert call.kwargs.get("start_last_id") is None
+
+    def test_failed_resumable_source_records_cursor_state_for_next_run(self):
+        """A resumable source that fails mid-load must preserve its cursor
+        watermark in MaterializationRun.result so the next run can resume.
+        """
+        from mcp_server.pipeline_registry import PipelineConfig, SourceConfig
+        from mcp_server.services.materializer import run_pipeline
+
+        pipeline_cfg_sources = [SourceConfig(name="completed_works", resumable=True)]
+
+        pipeline = PipelineConfig(
+            name="connect_sync",
+            description="",
+            version="1.0",
+            provider="commcare_connect",
+            sources=pipeline_cfg_sources,
+        )
+
+        def fake_writer_side_effect(*args, **kwargs):
+            # Simulate one successful page-commit then a failure.
+            cursor_callback = kwargs.get("cursor_callback")
+            if cursor_callback is not None:
+                cursor_callback(777, 42)
+            raise RuntimeError("Connect 500 mid-load")
+
+        with (
+            patch("mcp_server.services.materializer.SchemaManager") as mock_mgr,
+            patch("mcp_server.services.materializer.MaterializationRun") as mock_run_cls,
+            patch("mcp_server.services.materializer.TenantMetadata"),
+            patch("mcp_server.services.materializer.ConnectMetadataLoader") as mock_meta,
+            patch("mcp_server.services.materializer.ConnectCompletedWorkLoader") as mock_cw,
+            patch(
+                "mcp_server.services.materializer._write_connect_completed_works",
+                side_effect=fake_writer_side_effect,
+            ),
+            patch("mcp_server.services.materializer.get_managed_db_connection") as mock_conn,
+        ):
+            schema = self._make_schema()
+            mock_mgr.return_value.provision.return_value = schema
+            run = self._setup_run_mock(mock_run_cls)
+            mock_meta.return_value.load.return_value = {}
+            mock_cw.return_value.load_pages.return_value = iter([])
+            conn = MagicMock()
+            mock_conn.return_value = conn
+            conn.cursor.return_value = MagicMock()
+
+            with pytest.raises(RuntimeError, match="Connect 500"):
+                run_pipeline(self._make_tm(), {"type": "api_key", "value": "x"}, pipeline)
+
+        # The final saved result must show the source failed with cursor_state
+        # preserved so the next run resumes from id=777.
+        sources = run.result["sources"]
+        assert sources["completed_works"]["state"] == "failed"
+        assert sources["completed_works"]["cursor_state"]["last_id"] == 777
+        # And because the cursor advanced (some pages committed), the run is
+        # PARTIAL — not FAILED — so the next run knows it has resume work.
+        assert run.state == "partial"
+
+
 @pytest.mark.django_db
 class TestWriteCases:
     """Real DB tests for _write_cases using psycopg."""

--- a/tests/test_metadata_service.py
+++ b/tests/test_metadata_service.py
@@ -253,6 +253,62 @@ class TestPipelineListTables:
         names = {t["name"] for t in result}
         assert names == {"raw_users"}
 
+    @pytest.mark.asyncio
+    async def test_in_progress_source_not_listed(self):
+        """Issue #187: a source mid-resume (state="in_progress") must be
+        excluded from the catalog even if its physical table partly exists.
+        The table is only partially populated; surfacing it would let the
+        agent query incomplete data and produce wrong answers.
+        """
+        from mcp_server.services.metadata import pipeline_list_tables
+
+        mock_ts = MagicMock()
+        mock_ts.schema_name = "t_test"
+        pipeline_config = _make_pipeline_config(
+            sources=[
+                ("users", "Connect users"),
+                ("completed_works", "Connect completed works"),
+            ]
+        )
+
+        completed_at = datetime(2026, 5, 27, 10, 0, 0, tzinfo=UTC)
+        mock_run = MagicMock()
+        mock_run.completed_at = completed_at
+        mock_run.result = {
+            "sources": {
+                "users": {"state": "completed", "rows": 100},
+                "completed_works": {
+                    "state": "in_progress",
+                    "rows": 4700,
+                    "cursor_state": {
+                        "last_id": 1500,
+                        "last_committed_at": "2026-05-27T09:00:00Z",
+                    },
+                },
+            }
+        }
+        mock_run.state = "partial"
+
+        with (
+            patch("mcp_server.services.metadata.MaterializationRun") as mock_run_cls,
+            patch(
+                "mcp_server.services.metadata._live_tables_in_schema",
+                AsyncMock(return_value={"raw_users", "raw_completed_works"}),
+            ),
+        ):
+            mock_run_cls.RunState.COMPLETED = "completed"
+            mock_run_cls.RunState.PARTIAL = "partial"
+            qs = mock_run_cls.objects.filter.return_value.order_by.return_value
+            qs.afirst = AsyncMock(return_value=mock_run)
+
+            result = await pipeline_list_tables(mock_ts, pipeline_config)
+
+        names = {t["name"] for t in result}
+        assert names == {"raw_users"}, (
+            "in_progress source must not appear in the catalog, even if its "
+            "physical table partially exists"
+        )
+
 
 class TestPipelineDescribeTable:
     def _make_ctx(self, schema_name="test_schema"):

--- a/tests/test_pipeline_registry.py
+++ b/tests/test_pipeline_registry.py
@@ -121,6 +121,52 @@ relationships:
         assert all(t.startswith("raw_") for t in rel_from_tables)
         assert all(t.startswith("raw_") for t in rel_to_tables)
 
+    def test_source_config_resumable_defaults_to_true(self):
+        """Issue #187: ``resumable`` defaults to True so most append-mostly
+        sources opt in automatically; non-resumable ones set it false."""
+        from mcp_server.pipeline_registry import SourceConfig
+
+        assert SourceConfig(name="visits").resumable is True
+        assert SourceConfig(name="users", resumable=False).resumable is False
+
+    def test_pipeline_yaml_can_override_resumable(self, tmp_path):
+        """The YAML ``resumable: false`` key flows through to SourceConfig."""
+        yml = tmp_path / "pipeline.yml"
+        yml.write_text("""
+pipeline: test_pipeline
+description: ""
+version: "1.0"
+provider: commcare_connect
+sources:
+  - name: visits
+  - name: users
+    resumable: false
+""")
+        registry = PipelineRegistry(pipelines_dir=str(tmp_path))
+        config = registry.get("test_pipeline")
+        by_name = {s.name: s for s in config.sources}
+        assert by_name["visits"].resumable is True
+        assert by_name["users"].resumable is False
+
+    def test_connect_sync_users_is_non_resumable(self):
+        """The real connect_sync.yml must mark ``users`` non-resumable."""
+        registry = PipelineRegistry()
+        config = registry.get("connect_sync")
+        by_name = {s.name: s for s in config.sources}
+        assert by_name["users"].resumable is False
+        # The other six are resumable.
+        for src_name in (
+            "visits",
+            "completed_works",
+            "payments",
+            "invoices",
+            "assessments",
+            "completed_modules",
+        ):
+            assert by_name[src_name].resumable is True, (
+                f"{src_name} should default to resumable=True"
+            )
+
     def test_relationships_defaults_to_empty(self, tmp_path):
         yml = tmp_path / "no_rel.yml"
         yml.write_text(


### PR DESCRIPTION
Fixes #187

## Summary

- Resumable Connect sources (visits, completed_works, payments, invoices, assessments, completed_modules) commit per page and persist a `cursor_state.last_id` watermark to `MaterializationRun.result["sources"][name]`. A crash mid-source leaves the partial table intact; the next run skips DROP TABLE and resumes from the watermark via `last_id=N` query.
- New per-source state `"in_progress"` while a resumable source is mid-flight. `pipeline_list_tables` excludes it so the catalog never surfaces a partially-loaded table.
- Connect `users` is non-resumable (mutable rows): `pipelines/connect_sync.yml` marks it `resumable: false`; the writer keeps the full DROP/CREATE/INSERT path untouched.
- A failed resumable source whose cursor advanced lands as `PARTIAL` (not `FAILED`) so the next run inherits the watermark.
- `_aggregate_materialization_state` exposes `resume_last_id` per source so the resume-prompt body can tell the agent which sources are mid-resume.

## Strict dependency

This PR is **stacked on `materialization-atomicity-and-reconciliation`** (PR #198, issue #185). The base branch will need to be retargeted to `main` after #198 merges — GitHub does this automatically.

## Test plan

- [x] `tests/test_materializer.py::TestResumableMaterialization` — 6 new tests covering: resume from prior cursor, non-resumable ignores cursor, cursor advances per page, no-DROP on resume, clean start when no prior, failed resumable source preserves watermark and lands as PARTIAL.
- [x] `tests/test_connect_base_loader.py` — 3 new tests: `start_last_id` translates to `last_id=` query param, omitting it preserves default URL, merging with caller-supplied params doesn't mutate the caller's dict.
- [x] `tests/test_metadata_service.py::TestPipelineListTables::test_in_progress_source_not_listed` — verifies the catalog hides in_progress sources even if their physical table partly exists.
- [x] `tests/test_pipeline_registry.py` — 3 new tests: default `resumable=True`, YAML override, real `connect_sync.yml` marks `users` non-resumable.
- [x] All 1030 existing tests still pass.
- [x] `ruff check` clean; `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)