### PR TITLE
Stop agent panic loops on contradictory schema responses (#190)

### DIFF
--- a/apps/agents/graph/base.py
+++ b/apps/agents/graph/base.py
@@ -80,6 +80,49 @@ DEFAULT_MAX_TOKENS = 4096
 DEFAULT_TEMPERATURE = 0
 SCHEMA_CONTEXT_CHAR_BUDGET = 6000
 
+# Circuit-breaker thresholds for the escalation node. If the last N tool
+# messages all carry one of these error codes, the agent has drifted from
+# self-correction into a panic loop — route to the escalation node so the
+# turn ends with an explicit ask instead of consuming the recursion budget.
+ESCALATION_ERROR_CODES = ('"code": "NOT_FOUND"', '"code": "VALIDATION_ERROR"')
+ESCALATION_TRIGGER_COUNT = 3
+
+ESCALATION_MESSAGE = (
+    "I've encountered repeated schema errors — the tables I expected to "
+    "find aren't queryable. The data may need to be re-materialized. "
+    "Would you like me to run materialization?"
+)
+
+
+def _should_escalate(messages: list) -> bool:
+    """Detect a panic loop: last N tool messages all returned an error code.
+
+    Looks only at trailing ``ToolMessage``s — a successful tool call in
+    between resets the streak. Substring matches the error envelope's
+    ``"code": "..."`` field rather than parsing JSON, since tool content
+    may be a string, list of content blocks, or other shapes.
+    """
+    streak: list[ToolMessage] = []
+    for msg in reversed(messages):
+        if isinstance(msg, ToolMessage):
+            streak.append(msg)
+            if len(streak) >= ESCALATION_TRIGGER_COUNT:
+                break
+        elif isinstance(msg, AIMessage) and getattr(msg, "tool_calls", None):
+            continue
+        else:
+            break
+
+    if len(streak) < ESCALATION_TRIGGER_COUNT:
+        return False
+
+    for tm in streak:
+        content = tm.content if isinstance(tm.content, str) else str(tm.content)
+        if not any(code in content for code in ESCALATION_ERROR_CODES):
+            return False
+    return True
+
+
 # Simple TTL cache for system prompts
 _system_prompt_cache: dict[str, tuple[str, float]] = {}
 _SYSTEM_PROMPT_TTL = 60  # 60 seconds — short to limit staleness from knowledge/schema changes
@@ -556,12 +599,33 @@ async def build_agent_graph(
 
         return END
 
+    def post_tools_router(state: AgentState) -> Literal["agent", "escalate"]:
+        """Route post-tools: escalate if the agent is in a panic loop, else agent.
+
+        See ``_should_escalate`` for the loop-detection rule. The escalation
+        node ends the turn with a fixed message — no further tool calls.
+        """
+        if _should_escalate(state.get("messages", [])):
+            logger.warning(
+                "agent graph: routing to escalation node after %d consecutive "
+                "tool errors (workspace=%s)",
+                ESCALATION_TRIGGER_COUNT,
+                workspace.id,
+            )
+            return "escalate"
+        return "agent"
+
+    def escalation_node(state: AgentState) -> dict[str, Any]:
+        """Terminal node that emits a fixed escalation message and ends the turn."""
+        return {"messages": [AIMessage(content=ESCALATION_MESSAGE)]}
+
     # --- Build the graph ---
     graph = StateGraph(AgentState)
 
     # Add nodes
     graph.add_node("agent", agent_node)
     graph.add_node("tools", tool_node)
+    graph.add_node("escalate", escalation_node)
 
     # Set entry point
     graph.set_entry_point("agent")
@@ -577,8 +641,16 @@ async def build_agent_graph(
         },
     )
 
-    # tools -> agent (the LLM sees error ToolMessages and self-corrects)
-    graph.add_edge("tools", "agent")
+    # tools -> agent (normal) or -> escalate (panic loop detected, terminal)
+    graph.add_conditional_edges(
+        "tools",
+        post_tools_router,
+        {
+            "agent": "agent",
+            "escalate": "escalate",
+        },
+    )
+    graph.add_edge("escalate", END)
 
     # --- Compile and return ---
     compiled = graph.compile(checkpointer=checkpointer)
@@ -713,5 +785,8 @@ When results are truncated, suggest adding filters or using aggregations to redu
 
 
 __all__ = [
+    "ESCALATION_MESSAGE",
+    "ESCALATION_TRIGGER_COUNT",
+    "_should_escalate",
     "build_agent_graph",
 ]

--- a/apps/agents/prompts/base_system.py
+++ b/apps/agents/prompts/base_system.py
@@ -133,6 +133,29 @@ Rules:
 - Treat `materialized_row_count` as advisory only — useful for sizing
   expectations (small / medium / large), not as an answer.
 
+## When the Schema is Broken
+
+If `list_tables` reports a table but `describe_table` or a `query` against
+it returns `NOT_FOUND` or `VALIDATION_ERROR`, the catalog and the database
+have drifted. STOP exploring. Do exactly one of:
+
+1. Call `run_materialization` to rebuild the data.
+2. Tell the user the data isn't currently queryable and ask whether to
+   re-materialize.
+
+Do NOT:
+
+- Run more than two `query` attempts trying to reach the data through
+  alternate schema names, qualified paths, or variant spellings.
+- Query `pg_namespace`, `pg_class`, `pg_views`, `pg_tables`, or other
+  system catalogs to "investigate" where the data went. That's a
+  system-state question for the operator, not an answer to surface.
+- Quote `materialized_row_count` as a consolation answer (see Metadata
+  vs. Verified Counts above).
+
+A single `NOT_FOUND` can be a typo. Three of them in a row from the same
+schema means the catalog is wrong — escalate.
+
 ## Security Constraints
 
 Your access is strictly limited for safety:

--- a/apps/workspaces/tasks.py
+++ b/apps/workspaces/tasks.py
@@ -714,7 +714,7 @@ async def resume_thread_after_materialization(context, thread_job_id: str) -> di
         }
         config = {
             "configurable": {"thread_id": str(tj.thread.id)},
-            "recursion_limit": 50,
+            "recursion_limit": settings.AGENT_RESUME_RECURSION_LIMIT,
             "oauth_tokens": oauth_tokens,
         }
         await agent.ainvoke(input_state, config)

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -337,3 +337,9 @@ EMBED_ALLOWED_ORIGINS = env.list("EMBED_ALLOWED_ORIGINS", default=[])
 
 
 SCHEMA_TTL_HOURS = 24  # schemas inactive longer than this are expired
+
+# Agent recursion limit for the post-materialization resume path. A healthy
+# resume is 2-5 tool calls; 20 leaves headroom for follow-up exploration
+# without giving a panic-looping agent runway for ~25 cycles. The user-facing
+# chat path keeps its own (higher) limit.
+AGENT_RESUME_RECURSION_LIMIT = env.int("AGENT_RESUME_RECURSION_LIMIT", default=20)

--- a/tests/agents/test_panic_loop_eval.py
+++ b/tests/agents/test_panic_loop_eval.py
@@ -1,0 +1,75 @@
+"""Golden eval for the panic-loop / escalation rule from base_system.py.
+
+Regression pin for issue #190: when ``list_tables`` and the database disagree
+(NOT_FOUND / VALIDATION_ERROR on the same table), the agent must stop
+exploring after a small number of attempts rather than ratholing into
+``pg_catalog`` and consuming the recursion budget.
+
+CI has no Anthropic API key, so these tests do NOT invoke a real LLM. They
+pin the structural pieces that make the bug impossible by construction:
+
+1. ``BASE_SYSTEM_PROMPT`` contains the explicit "When the Schema is Broken"
+   section, the STOP-exploring rule, and the explicit prohibition on
+   ``pg_catalog`` / ``pg_namespace`` exploration.
+2. ``_build_system_prompt`` includes the section end-to-end.
+"""
+
+import pytest
+
+from apps.agents.graph.base import _build_system_prompt
+from apps.agents.prompts.base_system import BASE_SYSTEM_PROMPT
+
+
+class TestBaseSystemPromptContainsEscalationSection:
+    """Pin the prompt wording so a future edit can't silently weaken it."""
+
+    def test_when_schema_is_broken_section_present(self):
+        assert "## When the Schema is Broken" in BASE_SYSTEM_PROMPT
+
+    def test_prompt_names_the_error_codes(self):
+        # The rule keys off these two MCP error codes. If they're ever
+        # renamed, the prompt must be updated in lockstep.
+        assert "NOT_FOUND" in BASE_SYSTEM_PROMPT
+        assert "VALIDATION_ERROR" in BASE_SYSTEM_PROMPT
+
+    def test_prompt_says_stop_exploring(self):
+        # The exact case is part of the contract — if a future edit tones
+        # it down to "consider stopping" or similar, we want to know.
+        assert "STOP exploring" in BASE_SYSTEM_PROMPT
+
+    def test_prompt_directs_to_run_materialization(self):
+        # The escalation path is to call run_materialization OR ask the
+        # user. Both must be reachable from the rule.
+        assert "run_materialization" in BASE_SYSTEM_PROMPT
+        assert "re-materialize" in BASE_SYSTEM_PROMPT
+
+
+class TestBaseSystemPromptForbidsPgCatalogExploration:
+    """The observed bug was the agent running 6+ pg_catalog queries. Pin the
+    explicit prohibition so a future "be more helpful" edit can't drop it.
+    """
+
+    def test_prompt_forbids_pg_catalog_tables(self):
+        # Each system catalog the agent reached for in the incident must be
+        # named explicitly. Naming them is what makes the rule enforceable.
+        for table in ("pg_namespace", "pg_class", "pg_views", "pg_tables"):
+            assert table in BASE_SYSTEM_PROMPT, f"Missing prohibition on {table}"
+
+    def test_prompt_limits_alternate_query_attempts(self):
+        # "More than two query attempts" is the operational rule — not
+        # "give up immediately" (one NOT_FOUND can be a typo).
+        assert "more than two" in BASE_SYSTEM_PROMPT.lower()
+
+
+class TestAssembledSystemPromptIncludesEscalationRule:
+    """End-to-end: when the agent is built for a workspace, the assembled
+    system prompt must contain the escalation rule.
+    """
+
+    @pytest.mark.django_db(transaction=True)
+    @pytest.mark.asyncio
+    async def test_assembled_prompt_contains_escalation_section(self, workspace, user):
+        prompt = await _build_system_prompt(workspace, user)
+        assert "## When the Schema is Broken" in prompt
+        assert "STOP exploring" in prompt
+        assert "pg_namespace" in prompt

--- a/tests/agents/test_panic_loop_graph.py
+++ b/tests/agents/test_panic_loop_graph.py
@@ -1,0 +1,138 @@
+"""Unit tests for the graph-level panic-loop circuit breaker.
+
+These exercise ``_should_escalate`` directly — the helper that decides
+whether the post-tools router should hand off to the terminal escalation
+node. They use bare ``ToolMessage`` / ``AIMessage`` objects (no DB, no LLM)
+so they're cheap and deterministic.
+"""
+
+import json
+
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+
+from apps.agents.graph.base import _should_escalate
+
+
+def _err_tool_message(code: str, tool_call_id: str = "tc", name: str = "query") -> ToolMessage:
+    """Build a ToolMessage with a JSON-encoded error envelope, matching the
+    shape ``mcp_server.envelope.error_response`` produces.
+    """
+    body = json.dumps({"success": False, "error": {"code": code, "message": f"simulated {code}"}})
+    return ToolMessage(content=body, tool_call_id=tool_call_id, name=name)
+
+
+def _ok_tool_message(tool_call_id: str = "tc", name: str = "query") -> ToolMessage:
+    body = json.dumps({"success": True, "data": {"rows": [[1]]}})
+    return ToolMessage(content=body, tool_call_id=tool_call_id, name=name)
+
+
+def _ai_with_tool_call(tool_call_id: str = "tc", name: str = "query") -> AIMessage:
+    return AIMessage(
+        content="",
+        tool_calls=[{"id": tool_call_id, "name": name, "args": {}}],
+    )
+
+
+class TestShouldEscalate:
+    def test_three_consecutive_not_found_triggers_escalation(self):
+        messages = [
+            HumanMessage(content="how many users?"),
+            _ai_with_tool_call("a"),
+            _err_tool_message("NOT_FOUND", "a"),
+            _ai_with_tool_call("b"),
+            _err_tool_message("NOT_FOUND", "b"),
+            _ai_with_tool_call("c"),
+            _err_tool_message("NOT_FOUND", "c"),
+        ]
+        assert _should_escalate(messages) is True
+
+    def test_three_consecutive_validation_error_triggers_escalation(self):
+        messages = [
+            HumanMessage(content="how many users?"),
+            _ai_with_tool_call("a"),
+            _err_tool_message("VALIDATION_ERROR", "a"),
+            _ai_with_tool_call("b"),
+            _err_tool_message("VALIDATION_ERROR", "b"),
+            _ai_with_tool_call("c"),
+            _err_tool_message("VALIDATION_ERROR", "c"),
+        ]
+        assert _should_escalate(messages) is True
+
+    def test_three_mixed_errors_trigger_escalation(self):
+        # NOT_FOUND, VALIDATION_ERROR, NOT_FOUND in sequence — the rule is
+        # "all errors", not "all the same error code".
+        messages = [
+            HumanMessage(content="how many users?"),
+            _ai_with_tool_call("a"),
+            _err_tool_message("NOT_FOUND", "a"),
+            _ai_with_tool_call("b"),
+            _err_tool_message("VALIDATION_ERROR", "b"),
+            _ai_with_tool_call("c"),
+            _err_tool_message("NOT_FOUND", "c"),
+        ]
+        assert _should_escalate(messages) is True
+
+    def test_single_not_found_does_not_trigger_escalation(self):
+        # One transient error is normal. The agent should still get a turn
+        # to self-correct.
+        messages = [
+            HumanMessage(content="how many users?"),
+            _ai_with_tool_call("a"),
+            _err_tool_message("NOT_FOUND", "a"),
+        ]
+        assert _should_escalate(messages) is False
+
+    def test_two_errors_does_not_trigger_escalation(self):
+        # Threshold is 3 — two errors is "trying twice" which the prompt
+        # explicitly allows.
+        messages = [
+            HumanMessage(content="how many users?"),
+            _ai_with_tool_call("a"),
+            _err_tool_message("NOT_FOUND", "a"),
+            _ai_with_tool_call("b"),
+            _err_tool_message("NOT_FOUND", "b"),
+        ]
+        assert _should_escalate(messages) is False
+
+    def test_success_between_errors_resets_streak(self):
+        # If the agent successfully recovered at some point, the streak is
+        # broken — we only look at the trailing run of tool messages.
+        messages = [
+            HumanMessage(content="how many users?"),
+            _ai_with_tool_call("a"),
+            _err_tool_message("NOT_FOUND", "a"),
+            _ai_with_tool_call("b"),
+            _err_tool_message("NOT_FOUND", "b"),
+            _ai_with_tool_call("c"),
+            _ok_tool_message("c"),
+        ]
+        assert _should_escalate(messages) is False
+
+    def test_other_error_codes_do_not_trigger_escalation(self):
+        # The breaker is scoped to schema-drift signals. A query timeout
+        # or auth error is not a panic-loop pattern.
+        messages = [
+            HumanMessage(content="how many users?"),
+            _ai_with_tool_call("a"),
+            ToolMessage(
+                content='{"success": false, "error": {"code": "QUERY_TIMEOUT"}}',
+                tool_call_id="a",
+                name="query",
+            ),
+            _ai_with_tool_call("b"),
+            ToolMessage(
+                content='{"success": false, "error": {"code": "QUERY_TIMEOUT"}}',
+                tool_call_id="b",
+                name="query",
+            ),
+            _ai_with_tool_call("c"),
+            ToolMessage(
+                content='{"success": false, "error": {"code": "QUERY_TIMEOUT"}}',
+                tool_call_id="c",
+                name="query",
+            ),
+        ]
+        assert _should_escalate(messages) is False
+
+    def test_empty_message_list_does_not_trigger_escalation(self):
+        assert _should_escalate([]) is False

--- a/tests/test_resume_thread_task.py
+++ b/tests/test_resume_thread_task.py
@@ -2,6 +2,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from asgiref.sync import sync_to_async
+from django.conf import settings as dj_settings
 from django.contrib.auth import get_user_model
 
 from apps.chat.models import Thread, ThreadJob
@@ -503,3 +504,48 @@ async def test_resume_cas_rejects_already_running_threadjob():
 
     assert result["status"] == "already_claimed"
     mock_agent.ainvoke.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_resume_recursion_limit_is_lowered_from_default():
+    """Regression pin for issue #190: the resume path's recursion_limit must
+    be lower than the chat default (50) so a panic-looping agent gets cut
+    off before it can run 18+ tool calls."""
+    user = await sync_to_async(User.objects.create_user)(email="rl@b.c", password="x")
+    ws = await sync_to_async(Workspace.objects.create)(name="W-rl", created_by=user)
+    tenant = await sync_to_async(Tenant.objects.create)(
+        external_id="t-rl", provider="commcare", canonical_name="RL Tenant"
+    )
+    await sync_to_async(WorkspaceTenant.objects.create)(workspace=ws, tenant=tenant)
+    schema = await sync_to_async(TenantSchema.objects.create)(tenant=tenant, schema_name="s_rl")
+    thread = await sync_to_async(Thread.objects.create)(workspace=ws, user=user)
+    tj = await sync_to_async(ThreadJob.objects.create)(
+        thread=thread,
+        job_type="materialization",
+        procrastinate_job_id=9999,
+        tool_call_id="tc-rl",
+        state=ThreadJob.State.PENDING,
+    )
+    await sync_to_async(MaterializationRun.objects.create)(
+        tenant_schema=schema,
+        pipeline="commcare_sync",
+        state=MaterializationRun.RunState.COMPLETED,
+        procrastinate_job_id=9999,
+        result={"rows": 100},
+    )
+
+    mock_agent = MagicMock()
+    mock_agent.ainvoke = AsyncMock(return_value={"messages": []})
+    with patch(
+        "apps.workspaces.tasks._build_agent_for_resume",
+        AsyncMock(return_value=(mock_agent, {})),
+    ):
+        await resume_thread_after_materialization(None, thread_job_id=str(tj.id))
+
+    config = mock_agent.ainvoke.await_args.args[1]
+    # Must read from the AGENT_RESUME_RECURSION_LIMIT setting (so ops can
+    # tune it without code change) and must be lower than the chat default
+    # of 50.
+    assert config["recursion_limit"] == dj_settings.AGENT_RESUME_RECURSION_LIMIT
+    assert config["recursion_limit"] < 50


### PR DESCRIPTION
Fixes #190

## Summary

When `list_tables` reports a table but `describe_table` or `query` returns `NOT_FOUND` / `VALIDATION_ERROR`, the catalog and the database have drifted. The agent had no rule for "this means the schema is broken" and would loop through pg_catalog queries trying to find the data (observed: 18 SQL queries across 25 LangGraph turns).

## Stack

This PR is stacked on top of #200 → #198. GitHub will retarget through the chain as parents merge:

- #198 — materialization atomicity (already merged into the chain base)
- #200 — `materialized_row_count` rename + provenance flag
- **this PR (#190)** — panic-loop escalation rule + graph circuit breaker

## Changes

**1. Prompt rule** (`apps/agents/prompts/base_system.py`)

New `## When the Schema is Broken` section, placed between "Metadata vs. Verified Counts" and "Security Constraints" (same family of metadata-vs-reality rules):

- STOP exploring on the first NOT_FOUND/VALIDATION_ERROR contradiction
- Call `run_materialization` or ask the user — no other paths
- Explicit prohibition on `pg_namespace`, `pg_class`, `pg_views`, `pg_tables` exploration

**2. Graph-level circuit breaker** (`apps/agents/graph/base.py`)

Post-tools router: if the last 3 trailing `ToolMessage`s all contain `"code": "NOT_FOUND"` or `"code": "VALIDATION_ERROR"`, route to a new terminal `escalate` node that emits a fixed message and ends the turn. A successful tool call between errors resets the streak. Belt-and-suspenders against prompt drift.

**3. Lower resume-path `recursion_limit`** (`apps/workspaces/tasks.py` + `config/settings/base.py`)

`AGENT_RESUME_RECURSION_LIMIT = 20` (was 50). Tunable via env var. Chat path keeps 50 since user-initiated exploration can legitimately need depth.

## Tests

- `tests/agents/test_panic_loop_eval.py` — 7 tests pinning the prompt wording (section header, error code names, STOP wording, pg_catalog prohibition, run_materialization direction, "more than two" attempt limit, end-to-end assembled prompt).
- `tests/agents/test_panic_loop_graph.py` — 8 tests for `_should_escalate`: three-consecutive-NOT_FOUND triggers, three-VALIDATION_ERROR triggers, mixed triggers, single error does not, two errors do not, success-in-between resets streak, other error codes do not trigger, empty message list safe.
- `tests/test_resume_thread_task.py` — `test_resume_recursion_limit_is_lowered_from_default` asserts the resume config uses `AGENT_RESUME_RECURSION_LIMIT` and that the value is < 50.

26 new/extended tests, all passing; full agent suite (82 tests) green.

## Test plan

- [x] `uv run pytest tests/agents/ tests/test_resume_thread_task.py tests/test_mcp_chat_integration.py` — all pass
- [x] `uv run ruff check` + `uv run ruff format --check` on touched files — clean
- [ ] Manual smoke: trigger NOT_FOUND in chat 3x → escalation node emits the fixed ask