### PR TITLE
Apply ruff format pass to repo

### DIFF
--- a/apps/chat/migrations/0003_threadjob.py
+++ b/apps/chat/migrations/0003_threadjob.py
@@ -7,27 +7,58 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
-        ('chat', '0002_initial'),
+        ("chat", "0002_initial"),
     ]
 
     operations = [
         migrations.CreateModel(
-            name='ThreadJob',
+            name="ThreadJob",
             fields=[
-                ('id', models.UUIDField(default=uuid.uuid4, editable=False, primary_key=True, serialize=False)),
-                ('job_type', models.CharField(choices=[('materialization', 'Materialization')], max_length=32)),
-                ('procrastinate_job_id', models.BigIntegerField(db_index=True, unique=True)),
-                ('tool_call_id', models.CharField(max_length=64)),
-                ('state', models.CharField(choices=[('pending', 'Pending'), ('running', 'Running'), ('completed', 'Completed'), ('failed', 'Failed'), ('cancelled', 'Cancelled')], default='pending', max_length=16)),
-                ('created_at', models.DateTimeField(auto_now_add=True)),
-                ('completed_at', models.DateTimeField(blank=True, null=True)),
-                ('thread', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='jobs', to='chat.thread')),
+                (
+                    "id",
+                    models.UUIDField(
+                        default=uuid.uuid4, editable=False, primary_key=True, serialize=False
+                    ),
+                ),
+                (
+                    "job_type",
+                    models.CharField(
+                        choices=[("materialization", "Materialization")], max_length=32
+                    ),
+                ),
+                ("procrastinate_job_id", models.BigIntegerField(db_index=True, unique=True)),
+                ("tool_call_id", models.CharField(max_length=64)),
+                (
+                    "state",
+                    models.CharField(
+                        choices=[
+                            ("pending", "Pending"),
+                            ("running", "Running"),
+                            ("completed", "Completed"),
+                            ("failed", "Failed"),
+                            ("cancelled", "Cancelled"),
+                        ],
+                        default="pending",
+                        max_length=16,
+                    ),
+                ),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("completed_at", models.DateTimeField(blank=True, null=True)),
+                (
+                    "thread",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="jobs",
+                        to="chat.thread",
+                    ),
+                ),
             ],
             options={
-                'ordering': ['-created_at'],
-                'indexes': [models.Index(fields=['thread', 'state'], name='chat_threadjob_th_state')],
+                "ordering": ["-created_at"],
+                "indexes": [
+                    models.Index(fields=["thread", "state"], name="chat_threadjob_th_state")
+                ],
             },
         ),
     ]

--- a/apps/chat/migrations/0004_thread_last_viewed_at.py
+++ b/apps/chat/migrations/0004_thread_last_viewed_at.py
@@ -4,15 +4,14 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
-        ('chat', '0003_threadjob'),
+        ("chat", "0003_threadjob"),
     ]
 
     operations = [
         migrations.AddField(
-            model_name='thread',
-            name='last_viewed_at',
+            model_name="thread",
+            name="last_viewed_at",
             field=models.DateTimeField(blank=True, null=True),
         ),
     ]

--- a/apps/chat/models.py
+++ b/apps/chat/models.py
@@ -70,15 +70,11 @@ class ThreadJob(models.Model):
     ACTIVE_STATES = frozenset({State.PENDING, State.RUNNING})
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
-    thread = models.ForeignKey(
-        "chat.Thread", on_delete=models.CASCADE, related_name="jobs"
-    )
+    thread = models.ForeignKey("chat.Thread", on_delete=models.CASCADE, related_name="jobs")
     job_type = models.CharField(max_length=32, choices=JobType.choices)
     procrastinate_job_id = models.BigIntegerField(unique=True, db_index=True)
     tool_call_id = models.CharField(max_length=64)
-    state = models.CharField(
-        max_length=16, choices=State.choices, default=State.PENDING
-    )
+    state = models.CharField(max_length=16, choices=State.choices, default=State.PENDING)
     created_at = models.DateTimeField(auto_now_add=True)
     completed_at = models.DateTimeField(null=True, blank=True)
 

--- a/apps/chat/thread_views.py
+++ b/apps/chat/thread_views.py
@@ -207,7 +207,9 @@ async def thread_viewed_view(request, workspace_id, thread_id):
         return JsonResponse({"error": "Workspace not found or access denied"}, status=403)
 
     updated = await Thread.objects.filter(
-        id=thread_id, user=user, workspace=workspace,
+        id=thread_id,
+        user=user,
+        workspace=workspace,
     ).aupdate(last_viewed_at=datetime.now(UTC))
     if not updated:
         return JsonResponse({"error": "Thread not found"}, status=404)

--- a/apps/chat/views.py
+++ b/apps/chat/views.py
@@ -123,8 +123,7 @@ async def chat_view(request):
     except Exception:
         existing_thread = None
     if existing_thread is not None and (
-        existing_thread.user_id != user.pk
-        or existing_thread.workspace_id != workspace.pk
+        existing_thread.user_id != user.pk or existing_thread.workspace_id != workspace.pk
     ):
         return JsonResponse({"error": "Thread not found"}, status=404)
 

--- a/apps/workspaces/api/materialization_views.py
+++ b/apps/workspaces/api/materialization_views.py
@@ -42,9 +42,7 @@ async def materialization_cancel_view(request, workspace_id):
 
     active_runs = [
         r
-        async for r in MaterializationRun.objects.select_related(
-            "tenant_schema__tenant"
-        ).filter(
+        async for r in MaterializationRun.objects.select_related("tenant_schema__tenant").filter(
             tenant_schema__tenant__in=workspace.tenants.all(),
             state__in=list(MaterializationRun.ACTIVE_STATES),
         )
@@ -105,11 +103,13 @@ async def materialization_cancel_view(request, workspace_id):
         for procrastinate_job_id in orphan_job_ids:
             try:
                 await current_app.job_manager.cancel_job_by_id_async(
-                    procrastinate_job_id, abort=True,
+                    procrastinate_job_id,
+                    abort=True,
                 )
             except Exception:
                 logger.warning(
-                    "Failed to abort procrastinate job %s", procrastinate_job_id,
+                    "Failed to abort procrastinate job %s",
+                    procrastinate_job_id,
                     exc_info=True,
                 )
 

--- a/apps/workspaces/tasks.py
+++ b/apps/workspaces/tasks.py
@@ -139,9 +139,9 @@ async def materialize_workspace(
         qs = TenantMembership.objects.select_related("user", "tenant").filter(
             tenant_id__in=[
                 wt.tenant_id
-                async for wt in WorkspaceTenant.objects.filter(
-                    workspace=workspace
-                ).select_related("tenant")
+                async for wt in WorkspaceTenant.objects.filter(workspace=workspace).select_related(
+                    "tenant"
+                )
             ]
         )
         if user_id:
@@ -195,9 +195,7 @@ async def materialize_workspace(
                 break
             except Exception as e:
                 logger.exception("Materialization failed for tenant %s", tenant_id)
-                tenant_results.append(
-                    {"tenant": tenant_id, "success": False, "error": str(e)}
-                )
+                tenant_results.append({"tenant": tenant_id, "success": False, "error": str(e)})
 
         all_succeeded = all(r.get("success") for r in tenant_results)
 
@@ -479,7 +477,8 @@ async def expire_stale_thread_jobs(timestamp: int = 0) -> dict:
             # Marking FAILED directly avoids deferring a duplicate resume that
             # could race with a still-running first invocation.
             updated = await ThreadJob.objects.filter(
-                id=tj.id, state=ThreadJob.State.RUNNING,
+                id=tj.id,
+                state=ThreadJob.State.RUNNING,
             ).aupdate(state=ThreadJob.State.FAILED, completed_at=timezone.now())
             if updated:
                 flipped += 1
@@ -496,7 +495,8 @@ async def expire_stale_thread_jobs(timestamp: int = 0) -> dict:
         except Exception:
             logger.exception("Janitor: failed to defer resume for %s", tj.id)
             await ThreadJob.objects.filter(id=tj.id).aupdate(
-                state=ThreadJob.State.FAILED, completed_at=timezone.now(),
+                state=ThreadJob.State.FAILED,
+                completed_at=timezone.now(),
             )
     return {"flipped": flipped}
 
@@ -540,11 +540,13 @@ async def _aggregate_materialization_state(procrastinate_job_id: int) -> tuple[s
             for source, info in (r.result.get("sources") or {}).items():
                 if isinstance(info, dict) and "rows" in info:
                     row_counts[source] = info["rows"]
-        summary.append({
-            "tenant": tenant_id,
-            "state": r.state,
-            "row_counts": row_counts,
-        })
+        summary.append(
+            {
+                "tenant": tenant_id,
+                "state": r.state,
+                "row_counts": row_counts,
+            }
+        )
         if r.state == MaterializationRun.RunState.CANCELLED:
             any_cancelled = True
             all_completed = False
@@ -554,7 +556,8 @@ async def _aggregate_materialization_state(procrastinate_job_id: int) -> tuple[s
         elif r.state != MaterializationRun.RunState.COMPLETED:
             all_completed = False
     status = (
-        "cancelled" if any_cancelled
+        "cancelled"
+        if any_cancelled
         else ("failed" if any_failed else ("completed" if all_completed else "partial"))
     )
     return status, summary
@@ -586,7 +589,8 @@ async def resume_thread_after_materialization(context, thread_job_id: str) -> di
     # message even for cancelled materializations.
     CLAIMABLE_STATES = [ThreadJob.State.PENDING, ThreadJob.State.CANCELLED]
     claimed = await ThreadJob.objects.filter(
-        id=tj.id, state__in=CLAIMABLE_STATES,
+        id=tj.id,
+        state__in=CLAIMABLE_STATES,
     ).aupdate(state=ThreadJob.State.RUNNING)
     if not claimed:
         logger.info("resume: ThreadJob %s already claimed; no-op", thread_job_id)
@@ -607,7 +611,8 @@ async def resume_thread_after_materialization(context, thread_job_id: str) -> di
         logger.warning(
             "resume: no MaterializationRun rows for ThreadJob %s job_id=%s; "
             "invoking agent with explanation so the user is not left with a spinner",
-            thread_job_id, tj.procrastinate_job_id,
+            thread_job_id,
+            tj.procrastinate_job_id,
         )
         body = (
             f"{SYSTEM_RESUME_MARKER} Materialization finished without running any "
@@ -641,9 +646,7 @@ async def resume_thread_after_materialization(context, thread_job_id: str) -> di
         }
         await agent.ainvoke(input_state, config)
     except Exception:
-        logger.exception(
-            "resume: agent build or invoke failed for thread_job %s", thread_job_id
-        )
+        logger.exception("resume: agent build or invoke failed for thread_job %s", thread_job_id)
         await ThreadJob.objects.filter(id=tj.id).aupdate(
             state=ThreadJob.State.FAILED,
             completed_at=timezone.now(),
@@ -658,15 +661,17 @@ async def resume_thread_after_materialization(context, thread_job_id: str) -> di
         await Thread.objects.filter(id=tj.thread_id).aupdate(updated_at=timezone.now())
     except Exception:
         logger.warning(
-            "resume: Thread.updated_at bump failed for thread %s; "
-            "green-dot indicator may not fire",
-            tj.thread_id, exc_info=True,
+            "resume: Thread.updated_at bump failed for thread %s; green-dot indicator may not fire",
+            tj.thread_id,
+            exc_info=True,
         )
 
     terminal = (
-        ThreadJob.State.CANCELLED if status == "cancelled"
+        ThreadJob.State.CANCELLED
+        if status == "cancelled"
         else (
-            ThreadJob.State.FAILED if status in ("failed", "partial", "no_runs")
+            ThreadJob.State.FAILED
+            if status in ("failed", "partial", "no_runs")
             else ThreadJob.State.COMPLETED
         )
     )
@@ -677,16 +682,24 @@ async def resume_thread_after_materialization(context, thread_job_id: str) -> di
     # actual persisted state so the return value reflects reality, not the
     # value we *would have* written.
     updated = await ThreadJob.objects.filter(
-        id=tj.id, state=ThreadJob.State.RUNNING,
+        id=tj.id,
+        state=ThreadJob.State.RUNNING,
     ).aupdate(state=terminal, completed_at=timezone.now())
     if not updated:
-        actual_state = await ThreadJob.objects.filter(id=tj.id).values_list(
-            "state", flat=True,
-        ).afirst()
+        actual_state = (
+            await ThreadJob.objects.filter(id=tj.id)
+            .values_list(
+                "state",
+                flat=True,
+            )
+            .afirst()
+        )
         logger.info(
             "resume: ThreadJob %s state changed during ainvoke; not clobbering "
             "(intended terminal=%s, actual=%s)",
-            thread_job_id, terminal, actual_state,
+            thread_job_id,
+            terminal,
+            actual_state,
         )
         return {"status": "resumed", "terminal_state": actual_state or terminal}
     return {"status": "resumed", "terminal_state": terminal}

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -508,7 +508,6 @@ async def _resolve_workspace_memberships(workspace_id, user_id):
     return memberships, None
 
 
-
 @mcp.tool()
 async def run_materialization(
     workspace_id: str = "",
@@ -602,9 +601,7 @@ async def run_materialization(
             )
         except Exception:
             logger.exception("Failed to dispatch materialize_workspace task")
-            tc["result"] = error_response(
-                INTERNAL_ERROR, "Failed to dispatch materialization task"
-            )
+            tc["result"] = error_response(INTERNAL_ERROR, "Failed to dispatch materialization task")
             return tc["result"]
         job_id = getattr(job, "id", job) if not isinstance(job, int) else job
 
@@ -633,8 +630,7 @@ async def run_materialization(
                 "status": "started",
                 "thread_job_id": str(tj.id),
                 "message": (
-                    "Materialization started in background. "
-                    "I'll continue when it finishes."
+                    "Materialization started in background. I'll continue when it finishes."
                 ),
             },
             schema="",

--- a/tests/test_chat_thread_ownership.py
+++ b/tests/test_chat_thread_ownership.py
@@ -36,35 +36,38 @@ async def _csrf_client(email, password):
 async def test_chat_rejects_foreign_thread_id():
     """A user cannot inject content into another user's thread by passing
     that thread's UUID in the request body."""
-    owner = await sync_to_async(User.objects.create_user)(
-        email="owner-oth@b.c", password="x"
-    )
-    attacker = await sync_to_async(User.objects.create_user)(
-        email="attacker-oth@b.c", password="x"
-    )
+    owner = await sync_to_async(User.objects.create_user)(email="owner-oth@b.c", password="x")
+    attacker = await sync_to_async(User.objects.create_user)(email="attacker-oth@b.c", password="x")
     ws = await sync_to_async(Workspace.objects.create)(name="W-attack", created_by=owner)
     tenant = await sync_to_async(Tenant.objects.create)(
         external_id="t-attack", provider="commcare", canonical_name="Attack Tenant"
     )
     await sync_to_async(WorkspaceTenant.objects.create)(workspace=ws, tenant=tenant)
     await sync_to_async(WorkspaceMembership.objects.create)(
-        workspace=ws, user=owner, role=WorkspaceRole.READ_WRITE,
+        workspace=ws,
+        user=owner,
+        role=WorkspaceRole.READ_WRITE,
     )
     await sync_to_async(WorkspaceMembership.objects.create)(
-        workspace=ws, user=attacker, role=WorkspaceRole.READ_WRITE,
+        workspace=ws,
+        user=attacker,
+        role=WorkspaceRole.READ_WRITE,
     )
     owners_thread = await sync_to_async(Thread.objects.create)(
-        workspace=ws, user=owner,
+        workspace=ws,
+        user=owner,
     )
 
     client = await _csrf_client("attacker-oth@b.c", "x")
     resp = await client.post(
         "/api/chat/",
-        data=json.dumps({
-            "messages": [{"role": "user", "content": "inject content"}],
-            "workspaceId": str(ws.id),
-            "threadId": str(owners_thread.id),
-        }),
+        data=json.dumps(
+            {
+                "messages": [{"role": "user", "content": "inject content"}],
+                "workspaceId": str(ws.id),
+                "threadId": str(owners_thread.id),
+            }
+        ),
         content_type="application/json",
     )
     # Must be rejected — 404 hides thread existence, 403 from earlier guards also acceptable
@@ -78,16 +81,16 @@ async def test_chat_rejects_foreign_thread_id():
 @pytest.mark.django_db(transaction=True)
 async def test_chat_allows_own_thread_id():
     """A user can attach a turn to their own thread without rejection."""
-    user = await sync_to_async(User.objects.create_user)(
-        email="own-thread@b.c", password="x"
-    )
+    user = await sync_to_async(User.objects.create_user)(email="own-thread@b.c", password="x")
     ws = await sync_to_async(Workspace.objects.create)(name="W-own", created_by=user)
     tenant = await sync_to_async(Tenant.objects.create)(
         external_id="t-own", provider="commcare", canonical_name="Own Tenant"
     )
     await sync_to_async(WorkspaceTenant.objects.create)(workspace=ws, tenant=tenant)
     await sync_to_async(WorkspaceMembership.objects.create)(
-        workspace=ws, user=user, role=WorkspaceRole.READ_WRITE,
+        workspace=ws,
+        user=user,
+        role=WorkspaceRole.READ_WRITE,
     )
     own_thread = await sync_to_async(Thread.objects.create)(workspace=ws, user=user)
 
@@ -96,11 +99,15 @@ async def test_chat_allows_own_thread_id():
     # on the ownership check.
     resp = await client.post(
         "/api/chat/",
-        data=json.dumps({
-            "messages": [{"role": "user", "content": "hello"},],
-            "workspaceId": str(ws.id),
-            "threadId": str(own_thread.id),
-        }),
+        data=json.dumps(
+            {
+                "messages": [
+                    {"role": "user", "content": "hello"},
+                ],
+                "workspaceId": str(ws.id),
+                "threadId": str(own_thread.id),
+            }
+        ),
         content_type="application/json",
     )
     # Must NOT be 404 from thread-ownership check
@@ -116,11 +123,14 @@ async def test_upsert_thread_bumps_updated_at_on_subsequent_turn():
     updated_at frozen at thread creation — breaking sidebar ordering and
     the "newer than last_viewed" green-dot indicator."""
     user = await sync_to_async(User.objects.create_user)(
-        email="updated-at@b.c", password="x",
+        email="updated-at@b.c",
+        password="x",
     )
     ws = await sync_to_async(Workspace.objects.create)(name="W-updated", created_by=user)
     tenant = await sync_to_async(Tenant.objects.create)(
-        external_id="t-up", provider="commcare", canonical_name="Up Tenant",
+        external_id="t-up",
+        provider="commcare",
+        canonical_name="Up Tenant",
     )
     await sync_to_async(WorkspaceTenant.objects.create)(workspace=ws, tenant=tenant)
 

--- a/tests/test_jobs_endpoints.py
+++ b/tests/test_jobs_endpoints.py
@@ -26,28 +26,39 @@ async def test_active_jobs_returns_pending_job_with_progress():
     user = await sync_to_async(User.objects.create_user)(email="a@b.c", password="x")
     ws = await sync_to_async(Workspace.objects.create)(name="W", created_by=user)
     await sync_to_async(WorkspaceMembership.objects.create)(
-        workspace=ws, user=user, role=WorkspaceRole.READ_WRITE,
+        workspace=ws,
+        user=user,
+        role=WorkspaceRole.READ_WRITE,
     )
     tenant = await sync_to_async(Tenant.objects.create)(
-        external_id="t1", provider="commcare", canonical_name="Test Tenant",
+        external_id="t1",
+        provider="commcare",
+        canonical_name="Test Tenant",
     )
     await sync_to_async(WorkspaceTenant.objects.create)(workspace=ws, tenant=tenant)
     schema = await sync_to_async(TenantSchema.objects.create)(
-        tenant=tenant, schema_name="s_t1",
+        tenant=tenant,
+        schema_name="s_t1",
     )
     thread = await sync_to_async(Thread.objects.create)(workspace=ws, user=user)
     await sync_to_async(ThreadJob.objects.create)(
-        thread=thread, job_type="materialization",
-        procrastinate_job_id=1001, tool_call_id="tc1",
+        thread=thread,
+        job_type="materialization",
+        procrastinate_job_id=1001,
+        tool_call_id="tc1",
     )
     await sync_to_async(MaterializationRun.objects.create)(
-        tenant_schema=schema, pipeline="commcare_sync",
+        tenant_schema=schema,
+        pipeline="commcare_sync",
         state=MaterializationRun.RunState.LOADING,
         procrastinate_job_id=1001,
         progress={
-            "step": 3, "total_steps": 5,
-            "source": "cases", "message": "Loading cases...",
-            "rows_loaded": 64000, "rows_total": 100000,
+            "step": 3,
+            "total_steps": 5,
+            "source": "cases",
+            "message": "Loading cases...",
+            "rows_loaded": 64000,
+            "rows_total": 100000,
             "run_id": str(schema.id),
         },
     )
@@ -73,7 +84,9 @@ async def test_active_jobs_empty_when_none_running():
     user = await sync_to_async(User.objects.create_user)(email="a@b.c", password="x")
     ws = await sync_to_async(Workspace.objects.create)(name="W", created_by=user)
     await sync_to_async(WorkspaceMembership.objects.create)(
-        workspace=ws, user=user, role=WorkspaceRole.READ_WRITE,
+        workspace=ws,
+        user=user,
+        role=WorkspaceRole.READ_WRITE,
     )
     client = AsyncClient()
     await sync_to_async(client.login)(email="a@b.c", password="x")
@@ -110,30 +123,35 @@ async def test_cancel_job_flips_state_and_aborts_procrastinate():
     user = await sync_to_async(User.objects.create_user)(email="a@b.c", password="x")
     ws = await sync_to_async(Workspace.objects.create)(name="W", created_by=user)
     await sync_to_async(WorkspaceMembership.objects.create)(
-        workspace=ws, user=user, role=WorkspaceRole.READ_WRITE,
+        workspace=ws,
+        user=user,
+        role=WorkspaceRole.READ_WRITE,
     )
     tenant = await sync_to_async(Tenant.objects.create)(
-        external_id="t1", provider="commcare", canonical_name="Test Tenant",
+        external_id="t1",
+        provider="commcare",
+        canonical_name="Test Tenant",
     )
     await sync_to_async(WorkspaceTenant.objects.create)(workspace=ws, tenant=tenant)
     schema = await sync_to_async(TenantSchema.objects.create)(tenant=tenant, schema_name="s_t1")
     thread = await sync_to_async(Thread.objects.create)(workspace=ws, user=user)
     tj = await sync_to_async(ThreadJob.objects.create)(
-        thread=thread, job_type="materialization",
-        procrastinate_job_id=2002, tool_call_id="tc2",
+        thread=thread,
+        job_type="materialization",
+        procrastinate_job_id=2002,
+        tool_call_id="tc2",
         state=ThreadJob.State.RUNNING,
     )
     await sync_to_async(MaterializationRun.objects.create)(
-        tenant_schema=schema, pipeline="commcare_sync",
+        tenant_schema=schema,
+        pipeline="commcare_sync",
         state=MaterializationRun.RunState.LOADING,
         procrastinate_job_id=2002,
     )
     client = AsyncClient()
     await sync_to_async(client.login)(email="a@b.c", password="x")
 
-    with patch(
-        "apps.workspaces.api.jobs_cancel.current_app"
-    ) as mock_app:
+    with patch("apps.workspaces.api.jobs_cancel.current_app") as mock_app:
         mock_app.job_manager.cancel_job_by_id_async = AsyncMock(return_value=None)
         resp = await client.post(f"/api/workspaces/{ws.id}/jobs/{tj.id}/cancel/")
     assert resp.status_code == 200
@@ -153,15 +171,21 @@ async def test_cancel_job_cross_user_blocked():
     ws = await sync_to_async(Workspace.objects.create)(name="W", created_by=owner)
     # Both users are workspace members so aresolve_workspace lets them through.
     await sync_to_async(WorkspaceMembership.objects.create)(
-        workspace=ws, user=owner, role=WorkspaceRole.READ_WRITE,
+        workspace=ws,
+        user=owner,
+        role=WorkspaceRole.READ_WRITE,
     )
     await sync_to_async(WorkspaceMembership.objects.create)(
-        workspace=ws, user=other, role=WorkspaceRole.READ,
+        workspace=ws,
+        user=other,
+        role=WorkspaceRole.READ,
     )
     thread = await sync_to_async(Thread.objects.create)(workspace=ws, user=owner)
     tj = await sync_to_async(ThreadJob.objects.create)(
-        thread=thread, job_type="materialization",
-        procrastinate_job_id=3030, tool_call_id="tcX",
+        thread=thread,
+        job_type="materialization",
+        procrastinate_job_id=3030,
+        tool_call_id="tcX",
         state=ThreadJob.State.RUNNING,
     )
     client = AsyncClient()
@@ -178,12 +202,16 @@ async def test_cancel_job_double_cancel_is_idempotent():
     user = await sync_to_async(User.objects.create_user)(email="a@b.c", password="x")
     ws = await sync_to_async(Workspace.objects.create)(name="W", created_by=user)
     await sync_to_async(WorkspaceMembership.objects.create)(
-        workspace=ws, user=user, role=WorkspaceRole.READ_WRITE,
+        workspace=ws,
+        user=user,
+        role=WorkspaceRole.READ_WRITE,
     )
     thread = await sync_to_async(Thread.objects.create)(workspace=ws, user=user)
     tj = await sync_to_async(ThreadJob.objects.create)(
-        thread=thread, job_type="materialization",
-        procrastinate_job_id=4040, tool_call_id="tc4",
+        thread=thread,
+        job_type="materialization",
+        procrastinate_job_id=4040,
+        tool_call_id="tc4",
         state=ThreadJob.State.CANCELLED,
     )
     client = AsyncClient()
@@ -201,18 +229,20 @@ async def test_cancel_does_not_overwrite_terminal_threadjob():
     user = await sync_to_async(User.objects.create_user)(email="cancel-race@b.c", password="x")
     ws = await sync_to_async(Workspace.objects.create)(name="W-race", created_by=user)
     await sync_to_async(WorkspaceMembership.objects.create)(
-        workspace=ws, user=user, role=WorkspaceRole.READ_WRITE,
+        workspace=ws,
+        user=user,
+        role=WorkspaceRole.READ_WRITE,
     )
     thread = await sync_to_async(Thread.objects.create)(workspace=ws, user=user)
     tj = await sync_to_async(ThreadJob.objects.create)(
-        thread=thread, job_type="materialization",
-        procrastinate_job_id=9090, tool_call_id="tc-race",
+        thread=thread,
+        job_type="materialization",
+        procrastinate_job_id=9090,
+        tool_call_id="tc-race",
         state=ThreadJob.State.COMPLETED,  # Already terminal — resume just finished
     )
     # Call cancel_thread_job directly to exercise the race window
-    with patch(
-        "apps.workspaces.api.jobs_cancel.current_app"
-    ) as mock_app:
+    with patch("apps.workspaces.api.jobs_cancel.current_app") as mock_app:
         mock_app.job_manager.cancel_job_by_id_async = AsyncMock(return_value=None)
         await cancel_thread_job(tj)
 

--- a/tests/test_materialize_workspace_task.py
+++ b/tests/test_materialize_workspace_task.py
@@ -434,7 +434,9 @@ async def test_cancel_endpoint_requires_workspace_membership(workspace, other_us
 @pytest.mark.asyncio
 @pytest.mark.django_db(transaction=True)
 async def test_materialize_workspace_defers_resume_on_no_memberships_early_return(
-    workspace, user, context_with_job_id,
+    workspace,
+    user,
+    context_with_job_id,
 ):
     """Finding #4: the early-return path (no memberships) must still defer
     the resume task. Otherwise the user is left with a phantom spinner —
@@ -442,7 +444,8 @@ async def test_materialize_workspace_defers_resume_on_no_memberships_early_retur
     # Workspace exists, but the workspace has no tenants → no memberships.
     # Build a fresh workspace with no tenants/memberships.
     bare_ws = await sync_to_async(Workspace.objects.create)(
-        name="bare-no-memberships", created_by=user,
+        name="bare-no-memberships",
+        created_by=user,
     )
     # Create a ThreadJob bound to context_with_job_id.job.id so the resume
     # finally-block can locate it.
@@ -471,7 +474,9 @@ async def test_materialize_workspace_defers_resume_on_no_memberships_early_retur
 @pytest.mark.asyncio
 @pytest.mark.django_db(transaction=True)
 async def test_materialize_workspace_defers_resume_on_workspace_not_found(
-    workspace, user, context_with_job_id,
+    workspace,
+    user,
+    context_with_job_id,
 ):
     """Even when the workspace lookup fails, the resume must be deferred so
     the user is not stuck with a spinner. The _defer_resume_for_job helper
@@ -502,7 +507,8 @@ async def test_materialize_workspace_defers_resume_on_workspace_not_found(
 @pytest.mark.asyncio
 @pytest.mark.django_db(transaction=True)
 async def test_defer_resume_for_job_retries_when_threadjob_not_yet_committed(
-    workspace, user,
+    workspace,
+    user,
 ):
     """Finding #11: MCP commits the ThreadJob after defer_async returns the
     procrastinate job id; under load the worker can finish before the row
@@ -611,8 +617,10 @@ async def test_legacy_cancel_handles_mixed_tracked_and_orphan_runs(workspace, us
     client = AsyncClient()
     await sync_to_async(client.login)(email=user.email, password="testpass123")
 
-    with patch("apps.workspaces.api.jobs_cancel.current_app") as mock_tracked_app, \
-         patch("apps.workspaces.api.materialization_views.current_app") as mock_orphan_app:
+    with (
+        patch("apps.workspaces.api.jobs_cancel.current_app") as mock_tracked_app,
+        patch("apps.workspaces.api.materialization_views.current_app") as mock_orphan_app,
+    ):
         mock_tracked_app.job_manager.cancel_job_by_id_async = AsyncMock(return_value=1)
         mock_orphan_app.job_manager.cancel_job_by_id_async = AsyncMock(return_value=1)
         resp = await client.post(f"/api/workspaces/{workspace.id}/materialization/cancel/")
@@ -633,7 +641,10 @@ async def test_legacy_cancel_handles_mixed_tracked_and_orphan_runs(workspace, us
 @pytest.mark.asyncio
 @pytest.mark.django_db(transaction=True)
 async def test_legacy_cancel_does_not_cancel_other_users_threadjob(
-    workspace, user, other_user, tenant,
+    workspace,
+    user,
+    other_user,
+    tenant,
 ):
     """A workspace member must NOT be able to cancel another member's
     chat-driven materialization via the legacy
@@ -645,10 +656,14 @@ async def test_legacy_cancel_does_not_cancel_other_users_threadjob(
     filter so only the caller's own ThreadJobs are cancelled."""
     # Make other_user a member of the workspace (peer with access).
     await sync_to_async(WorkspaceMembership.objects.create)(
-        workspace=workspace, user=other_user, role=WorkspaceRole.READ_WRITE,
+        workspace=workspace,
+        user=other_user,
+        role=WorkspaceRole.READ_WRITE,
     )
     schema = await TenantSchema.objects.acreate(
-        tenant=tenant, schema_name="test_xuser_cancel", state=SchemaState.ACTIVE,
+        tenant=tenant,
+        schema_name="test_xuser_cancel",
+        state=SchemaState.ACTIVE,
     )
     # Active run owned by `user`'s thread.
     active_run = await MaterializationRun.objects.acreate(
@@ -669,8 +684,10 @@ async def test_legacy_cancel_does_not_cancel_other_users_threadjob(
     # other_user (a workspace peer) attempts to cancel via the legacy endpoint.
     client = AsyncClient()
     await sync_to_async(client.login)(email=other_user.email, password="otherpass123")
-    with patch("apps.workspaces.api.jobs_cancel.current_app") as mock_tracked_app, \
-         patch("apps.workspaces.api.materialization_views.current_app") as mock_orphan_app:
+    with (
+        patch("apps.workspaces.api.jobs_cancel.current_app") as mock_tracked_app,
+        patch("apps.workspaces.api.materialization_views.current_app") as mock_orphan_app,
+    ):
         mock_tracked_app.job_manager.cancel_job_by_id_async = AsyncMock(return_value=1)
         mock_orphan_app.job_manager.cancel_job_by_id_async = AsyncMock(return_value=1)
         resp = await client.post(f"/api/workspaces/{workspace.id}/materialization/cancel/")
@@ -702,7 +719,10 @@ async def test_legacy_cancel_does_not_cancel_other_users_threadjob(
 @pytest.mark.asyncio
 @pytest.mark.django_db(transaction=True)
 async def test_legacy_cancel_orphan_path_skips_other_users_runs(
-    workspace, user, other_user, tenant,
+    workspace,
+    user,
+    other_user,
+    tenant,
 ):
     """When user A calls the legacy cancel endpoint and user B has a
     chat-driven materialization (with ThreadJob) in the same workspace, only
@@ -713,10 +733,14 @@ async def test_legacy_cancel_orphan_path_skips_other_users_runs(
     computed against the caller-scoped tracked set, so other users' jobs
     leaked into the orphan branch and were aborted."""
     await sync_to_async(WorkspaceMembership.objects.create)(
-        workspace=workspace, user=other_user, role=WorkspaceRole.READ_WRITE,
+        workspace=workspace,
+        user=other_user,
+        role=WorkspaceRole.READ_WRITE,
     )
     schema = await TenantSchema.objects.acreate(
-        tenant=tenant, schema_name="test_orphan_skip_other", state=SchemaState.ACTIVE,
+        tenant=tenant,
+        schema_name="test_orphan_skip_other",
+        state=SchemaState.ACTIVE,
     )
 
     # Run #1: belongs to user B's chat (has a ThreadJob).
@@ -746,8 +770,10 @@ async def test_legacy_cancel_orphan_path_skips_other_users_runs(
     # User A (other_user) calls cancel.
     client = AsyncClient()
     await sync_to_async(client.login)(email=other_user.email, password="otherpass123")
-    with patch("apps.workspaces.api.jobs_cancel.current_app") as mock_tracked_app, \
-         patch("apps.workspaces.api.materialization_views.current_app") as mock_orphan_app:
+    with (
+        patch("apps.workspaces.api.jobs_cancel.current_app") as mock_tracked_app,
+        patch("apps.workspaces.api.materialization_views.current_app") as mock_orphan_app,
+    ):
         mock_tracked_app.job_manager.cancel_job_by_id_async = AsyncMock(return_value=1)
         mock_orphan_app.job_manager.cancel_job_by_id_async = AsyncMock(return_value=1)
         resp = await client.post(f"/api/workspaces/{workspace.id}/materialization/cancel/")
@@ -770,5 +796,6 @@ async def test_legacy_cancel_orphan_path_skips_other_users_runs(
     assert orphan_run.state == MaterializationRun.RunState.CANCELLED
     assert orphan_run.completed_at is not None
     mock_orphan_app.job_manager.cancel_job_by_id_async.assert_awaited_once_with(
-        1002, abort=True,
+        1002,
+        abort=True,
     )

--- a/tests/test_materializer.py
+++ b/tests/test_materializer.py
@@ -264,9 +264,7 @@ class TestRunPipeline:
             patch("mcp_server.services.materializer.CommCareMetadataLoader") as mock_meta,
             patch("mcp_server.services.materializer.CommCareCaseLoader") as mock_cases,
             patch("mcp_server.services.materializer.get_managed_db_connection") as mock_conn,
-            patch(
-                "mcp_server.services.materializer._run_transform_phase"
-            ) as mock_transform,
+            patch("mcp_server.services.materializer._run_transform_phase") as mock_transform,
         ):
             schema = self._make_schema()
             mock_mgr.return_value.provision.return_value = schema

--- a/tests/test_resume_thread_task.py
+++ b/tests/test_resume_thread_task.py
@@ -29,12 +29,15 @@ async def test_resume_appends_system_message_and_invokes_agent():
     schema = await sync_to_async(TenantSchema.objects.create)(tenant=tenant, schema_name="s_t1")
     thread = await sync_to_async(Thread.objects.create)(workspace=ws, user=user)
     tj = await sync_to_async(ThreadJob.objects.create)(
-        thread=thread, job_type="materialization",
-        procrastinate_job_id=3003, tool_call_id="tc3",
+        thread=thread,
+        job_type="materialization",
+        procrastinate_job_id=3003,
+        tool_call_id="tc3",
         state=ThreadJob.State.PENDING,
     )
     await sync_to_async(MaterializationRun.objects.create)(
-        tenant_schema=schema, pipeline="commcare_sync",
+        tenant_schema=schema,
+        pipeline="commcare_sync",
         state=MaterializationRun.RunState.COMPLETED,
         procrastinate_job_id=3003,
         result={"rows": 50000},
@@ -47,7 +50,8 @@ async def test_resume_appends_system_message_and_invokes_agent():
         AsyncMock(return_value=(mock_agent, {})),
     ):
         result = await resume_thread_after_materialization(
-            None, thread_job_id=str(tj.id),
+            None,
+            thread_job_id=str(tj.id),
         )
 
     assert result["status"] == "resumed"
@@ -73,18 +77,23 @@ async def test_resume_is_idempotent_when_already_claimed():
     user = await sync_to_async(User.objects.create_user)(email="b@b.c", password="x")
     ws = await sync_to_async(Workspace.objects.create)(name="W2", created_by=user)
     tenant = await sync_to_async(Tenant.objects.create)(
-        external_id="t2", provider="commcare", canonical_name="Test Tenant 2",
+        external_id="t2",
+        provider="commcare",
+        canonical_name="Test Tenant 2",
     )
     await sync_to_async(WorkspaceTenant.objects.create)(workspace=ws, tenant=tenant)
     schema = await sync_to_async(TenantSchema.objects.create)(tenant=tenant, schema_name="s_t2")
     thread = await sync_to_async(Thread.objects.create)(workspace=ws, user=user)
     tj = await sync_to_async(ThreadJob.objects.create)(
-        thread=thread, job_type="materialization",
-        procrastinate_job_id=4040, tool_call_id="tc4",
+        thread=thread,
+        job_type="materialization",
+        procrastinate_job_id=4040,
+        tool_call_id="tc4",
         state=ThreadJob.State.COMPLETED,  # already terminal
     )
     await sync_to_async(MaterializationRun.objects.create)(
-        tenant_schema=schema, pipeline="commcare_sync",
+        tenant_schema=schema,
+        pipeline="commcare_sync",
         state=MaterializationRun.RunState.COMPLETED,
         procrastinate_job_id=4040,
     )
@@ -103,8 +112,10 @@ async def test_resume_no_runs_still_invokes_agent_with_explanation():
     ws = await sync_to_async(Workspace.objects.create)(name="W3", created_by=user)
     thread = await sync_to_async(Thread.objects.create)(workspace=ws, user=user)
     tj = await sync_to_async(ThreadJob.objects.create)(
-        thread=thread, job_type="materialization",
-        procrastinate_job_id=5050, tool_call_id="tc5",
+        thread=thread,
+        job_type="materialization",
+        procrastinate_job_id=5050,
+        tool_call_id="tc5",
         state=ThreadJob.State.PENDING,
     )
     # No MaterializationRun rows for procrastinate_job_id=5050.
@@ -139,19 +150,24 @@ async def test_resume_partial_maps_to_failed():
     user = await sync_to_async(User.objects.create_user)(email="d@b.c", password="x")
     ws = await sync_to_async(Workspace.objects.create)(name="W4", created_by=user)
     tenant = await sync_to_async(Tenant.objects.create)(
-        external_id="t4", provider="commcare", canonical_name="Test Tenant 4",
+        external_id="t4",
+        provider="commcare",
+        canonical_name="Test Tenant 4",
     )
     await sync_to_async(WorkspaceTenant.objects.create)(workspace=ws, tenant=tenant)
     schema = await sync_to_async(TenantSchema.objects.create)(tenant=tenant, schema_name="s_t4")
     thread = await sync_to_async(Thread.objects.create)(workspace=ws, user=user)
     tj = await sync_to_async(ThreadJob.objects.create)(
-        thread=thread, job_type="materialization",
-        procrastinate_job_id=6060, tool_call_id="tc6",
+        thread=thread,
+        job_type="materialization",
+        procrastinate_job_id=6060,
+        tool_call_id="tc6",
         state=ThreadJob.State.PENDING,
     )
     # One run still in LOADING — triggers "partial" aggregate status.
     await sync_to_async(MaterializationRun.objects.create)(
-        tenant_schema=schema, pipeline="commcare_sync",
+        tenant_schema=schema,
+        pipeline="commcare_sync",
         state=MaterializationRun.RunState.LOADING,
         procrastinate_job_id=6060,
     )
@@ -178,20 +194,26 @@ async def test_resume_invokes_agent_for_cancelled_threadjob():
     user = await sync_to_async(User.objects.create_user)(email="f@b.c", password="x")
     ws = await sync_to_async(Workspace.objects.create)(name="W-cancel-resume", created_by=user)
     tenant = await sync_to_async(Tenant.objects.create)(
-        external_id="t-cancel", provider="commcare", canonical_name="Cancel Tenant",
+        external_id="t-cancel",
+        provider="commcare",
+        canonical_name="Cancel Tenant",
     )
     await sync_to_async(WorkspaceTenant.objects.create)(workspace=ws, tenant=tenant)
     schema = await sync_to_async(TenantSchema.objects.create)(
-        tenant=tenant, schema_name="s_cancel",
+        tenant=tenant,
+        schema_name="s_cancel",
     )
     thread = await sync_to_async(Thread.objects.create)(workspace=ws, user=user)
     tj = await sync_to_async(ThreadJob.objects.create)(
-        thread=thread, job_type="materialization",
-        procrastinate_job_id=7777, tool_call_id="tc-cancel",
+        thread=thread,
+        job_type="materialization",
+        procrastinate_job_id=7777,
+        tool_call_id="tc-cancel",
         state=ThreadJob.State.CANCELLED,  # Cancelled BEFORE resume runs
     )
     await sync_to_async(MaterializationRun.objects.create)(
-        tenant_schema=schema, pipeline="commcare_sync",
+        tenant_schema=schema,
+        pipeline="commcare_sync",
         state=MaterializationRun.RunState.CANCELLED,
         procrastinate_job_id=7777,
     )
@@ -203,7 +225,8 @@ async def test_resume_invokes_agent_for_cancelled_threadjob():
         AsyncMock(return_value=(mock_agent, {})),
     ):
         result = await resume_thread_after_materialization(
-            None, thread_job_id=str(tj.id),
+            None,
+            thread_job_id=str(tj.id),
         )
 
     assert result["status"] == "resumed"
@@ -231,12 +254,15 @@ async def test_resume_bumps_thread_updated_at_on_success():
     schema = await sync_to_async(TenantSchema.objects.create)(tenant=tenant, schema_name="s_t5")
     thread = await sync_to_async(Thread.objects.create)(workspace=ws, user=user)
     tj = await sync_to_async(ThreadJob.objects.create)(
-        thread=thread, job_type="materialization",
-        procrastinate_job_id=7070, tool_call_id="tc7",
+        thread=thread,
+        job_type="materialization",
+        procrastinate_job_id=7070,
+        tool_call_id="tc7",
         state=ThreadJob.State.PENDING,
     )
     await sync_to_async(MaterializationRun.objects.create)(
-        tenant_schema=schema, pipeline="commcare_sync",
+        tenant_schema=schema,
+        pipeline="commcare_sync",
         state=MaterializationRun.RunState.COMPLETED,
         procrastinate_job_id=7070,
         result={"rows": 1000},
@@ -273,18 +299,23 @@ async def test_resume_does_not_clobber_concurrent_cancel_during_ainvoke():
     user = await sync_to_async(User.objects.create_user)(email="race@b.c", password="x")
     ws = await sync_to_async(Workspace.objects.create)(name="W-race", created_by=user)
     tenant = await sync_to_async(Tenant.objects.create)(
-        external_id="t-race", provider="commcare", canonical_name="Race Tenant",
+        external_id="t-race",
+        provider="commcare",
+        canonical_name="Race Tenant",
     )
     await sync_to_async(WorkspaceTenant.objects.create)(workspace=ws, tenant=tenant)
     schema = await sync_to_async(TenantSchema.objects.create)(tenant=tenant, schema_name="s_race")
     thread = await sync_to_async(Thread.objects.create)(workspace=ws, user=user)
     tj = await sync_to_async(ThreadJob.objects.create)(
-        thread=thread, job_type="materialization",
-        procrastinate_job_id=8484, tool_call_id="tc-race",
+        thread=thread,
+        job_type="materialization",
+        procrastinate_job_id=8484,
+        tool_call_id="tc-race",
         state=ThreadJob.State.PENDING,
     )
     await sync_to_async(MaterializationRun.objects.create)(
-        tenant_schema=schema, pipeline="commcare_sync",
+        tenant_schema=schema,
+        pipeline="commcare_sync",
         state=MaterializationRun.RunState.COMPLETED,
         procrastinate_job_id=8484,
     )
@@ -324,20 +355,25 @@ async def test_resume_does_not_force_cancelled_status_when_runs_completed():
     user = await sync_to_async(User.objects.create_user)(email="stale@b.c", password="x")
     ws = await sync_to_async(Workspace.objects.create)(name="W-stale", created_by=user)
     tenant = await sync_to_async(Tenant.objects.create)(
-        external_id="t-stale", provider="commcare", canonical_name="Stale Tenant",
+        external_id="t-stale",
+        provider="commcare",
+        canonical_name="Stale Tenant",
     )
     await sync_to_async(WorkspaceTenant.objects.create)(workspace=ws, tenant=tenant)
     schema = await sync_to_async(TenantSchema.objects.create)(tenant=tenant, schema_name="s_stale")
     thread = await sync_to_async(Thread.objects.create)(workspace=ws, user=user)
     tj = await sync_to_async(ThreadJob.objects.create)(
-        thread=thread, job_type="materialization",
-        procrastinate_job_id=9595, tool_call_id="tc-stale",
+        thread=thread,
+        job_type="materialization",
+        procrastinate_job_id=9595,
+        tool_call_id="tc-stale",
         # ThreadJob got flipped to CANCELLED by a late Stop click,
         # but the runs already completed before the cancel landed.
         state=ThreadJob.State.CANCELLED,
     )
     await sync_to_async(MaterializationRun.objects.create)(
-        tenant_schema=schema, pipeline="commcare_sync",
+        tenant_schema=schema,
+        pipeline="commcare_sync",
         state=MaterializationRun.RunState.COMPLETED,
         procrastinate_job_id=9595,
         result={"rows": 1234},
@@ -368,18 +404,23 @@ async def test_resume_cas_rejects_already_running_threadjob():
     user = await sync_to_async(User.objects.create_user)(email="cas@b.c", password="x")
     ws = await sync_to_async(Workspace.objects.create)(name="W-cas", created_by=user)
     tenant = await sync_to_async(Tenant.objects.create)(
-        external_id="t-cas", provider="commcare", canonical_name="CAS Tenant",
+        external_id="t-cas",
+        provider="commcare",
+        canonical_name="CAS Tenant",
     )
     await sync_to_async(WorkspaceTenant.objects.create)(workspace=ws, tenant=tenant)
     schema = await sync_to_async(TenantSchema.objects.create)(tenant=tenant, schema_name="s_cas")
     thread = await sync_to_async(Thread.objects.create)(workspace=ws, user=user)
     tj = await sync_to_async(ThreadJob.objects.create)(
-        thread=thread, job_type="materialization",
-        procrastinate_job_id=24680, tool_call_id="tc-cas",
+        thread=thread,
+        job_type="materialization",
+        procrastinate_job_id=24680,
+        tool_call_id="tc-cas",
         state=ThreadJob.State.RUNNING,  # already-running; simulates a concurrent claim
     )
     await sync_to_async(MaterializationRun.objects.create)(
-        tenant_schema=schema, pipeline="commcare_sync",
+        tenant_schema=schema,
+        pipeline="commcare_sync",
         state=MaterializationRun.RunState.COMPLETED,
         procrastinate_job_id=24680,
     )
@@ -391,7 +432,8 @@ async def test_resume_cas_rejects_already_running_threadjob():
         AsyncMock(return_value=(mock_agent, {})),
     ):
         result = await resume_thread_after_materialization(
-            None, thread_job_id=str(tj.id),
+            None,
+            thread_job_id=str(tj.id),
         )
 
     assert result["status"] == "already_claimed"

--- a/tests/test_run_materialization_fire_and_ack.py
+++ b/tests/test_run_materialization_fire_and_ack.py
@@ -64,9 +64,11 @@ async def test_run_materialization_rolls_back_dispatch_when_threadjob_create_fai
     job_mock = MagicMock(id=8888)
     cancel_mock = AsyncMock(return_value=None)
 
-    with patch("mcp_server.server.materialize_workspace") as mw, \
-         patch("mcp_server.server.ThreadJob.objects.acreate", side_effect=Exception("DB down")), \
-         patch("mcp_server.server._procrastinate_app") as proc_app:
+    with (
+        patch("mcp_server.server.materialize_workspace") as mw,
+        patch("mcp_server.server.ThreadJob.objects.acreate", side_effect=Exception("DB down")),
+        patch("mcp_server.server._procrastinate_app") as proc_app,
+    ):
         mw.defer_async = AsyncMock(return_value=job_mock)
         proc_app.job_manager.cancel_job_by_id_async = cancel_mock
         result = await run_materialization(
@@ -95,13 +97,16 @@ async def test_run_materialization_rejects_thread_owned_by_other_user():
     user_b = await sync_to_async(User.objects.create_user)(email="userb@b.c", password="x")
     ws = await sync_to_async(Workspace.objects.create)(name="W-cross", created_by=user_a)
     tenant = await sync_to_async(Tenant.objects.create)(
-        external_id="tx", provider="commcare", canonical_name="X Tenant",
+        external_id="tx",
+        provider="commcare",
+        canonical_name="X Tenant",
     )
     await sync_to_async(WorkspaceTenant.objects.create)(workspace=ws, tenant=tenant)
     await sync_to_async(TenantMembership.objects.create)(tenant=tenant, user=user_a)
     await sync_to_async(TenantMembership.objects.create)(tenant=tenant, user=user_b)
     foreign_thread = await sync_to_async(Thread.objects.create)(
-        workspace=ws, user=user_a,
+        workspace=ws,
+        user=user_a,
     )
 
     result = await run_materialization(
@@ -125,7 +130,9 @@ async def test_run_materialization_returns_already_in_progress_if_active_in_same
     user = await sync_to_async(User.objects.create_user)(email="dup@b.c", password="x")
     ws = await sync_to_async(Workspace.objects.create)(name="W-dup", created_by=user)
     tenant = await sync_to_async(Tenant.objects.create)(
-        external_id="tdup", provider="commcare", canonical_name="Dup Tenant",
+        external_id="tdup",
+        provider="commcare",
+        canonical_name="Dup Tenant",
     )
     await sync_to_async(WorkspaceTenant.objects.create)(workspace=ws, tenant=tenant)
     await sync_to_async(TenantMembership.objects.create)(tenant=tenant, user=user)
@@ -133,8 +140,10 @@ async def test_run_materialization_returns_already_in_progress_if_active_in_same
     # Same thread holds the in-progress job and is also the caller.
     thread = await sync_to_async(Thread.objects.create)(workspace=ws, user=user)
     existing_tj = await sync_to_async(ThreadJob.objects.create)(
-        thread=thread, job_type="materialization",
-        procrastinate_job_id=11111, tool_call_id="tc-existing",
+        thread=thread,
+        job_type="materialization",
+        procrastinate_job_id=11111,
+        tool_call_id="tc-existing",
         state=ThreadJob.State.PENDING,
     )
 
@@ -161,7 +170,9 @@ async def test_run_materialization_allows_dispatch_from_different_thread_in_same
     user = await sync_to_async(User.objects.create_user)(email="parallel@b.c", password="x")
     ws = await sync_to_async(Workspace.objects.create)(name="W-parallel", created_by=user)
     tenant = await sync_to_async(Tenant.objects.create)(
-        external_id="tparallel", provider="commcare", canonical_name="Parallel Tenant",
+        external_id="tparallel",
+        provider="commcare",
+        canonical_name="Parallel Tenant",
     )
     await sync_to_async(WorkspaceTenant.objects.create)(workspace=ws, tenant=tenant)
     await sync_to_async(TenantMembership.objects.create)(tenant=tenant, user=user)
@@ -169,8 +180,10 @@ async def test_run_materialization_allows_dispatch_from_different_thread_in_same
     # Thread 1 has an in-progress job.
     thread1 = await sync_to_async(Thread.objects.create)(workspace=ws, user=user)
     await sync_to_async(ThreadJob.objects.create)(
-        thread=thread1, job_type="materialization",
-        procrastinate_job_id=22222, tool_call_id="tc-thread1",
+        thread=thread1,
+        job_type="materialization",
+        procrastinate_job_id=22222,
+        tool_call_id="tc-thread1",
         state=ThreadJob.State.PENDING,
     )
 

--- a/tests/test_social_login_reconciliation.py
+++ b/tests/test_social_login_reconciliation.py
@@ -70,7 +70,10 @@ def test_no_collision_backfills_user_email():
 def test_collision_merges_user_and_redirects_session():
     canonical = User.objects.create(email="brian@y.com", username="canon")
     EmailAddress.objects.create(
-        user=canonical, email="brian@y.com", verified=True, primary=True,
+        user=canonical,
+        email="brian@y.com",
+        verified=True,
+        primary=True,
     )
     duplicate = User.objects.create(email=None, username="connect-user")
     dup_account = SocialAccount.objects.create(
@@ -97,7 +100,10 @@ def test_collision_merges_user_and_redirects_session():
 def test_collision_match_is_case_insensitive():
     canonical = User.objects.create(email="Brian@Y.com", username="canon")
     EmailAddress.objects.create(
-        user=canonical, email="Brian@Y.com", verified=True, primary=True,
+        user=canonical,
+        email="Brian@Y.com",
+        verified=True,
+        primary=True,
     )
     duplicate = User.objects.create(email=None, username="dup")
     dup_account = SocialAccount.objects.create(
@@ -118,7 +124,10 @@ def test_collision_match_is_case_insensitive():
 def test_merge_failure_does_not_break_login(caplog):
     canonical = User.objects.create(email="brian@y.com", username="canon")
     EmailAddress.objects.create(
-        user=canonical, email="brian@y.com", verified=True, primary=True,
+        user=canonical,
+        email="brian@y.com",
+        verified=True,
+        primary=True,
     )
     duplicate = User.objects.create(email=None, username="connect-user")
     dup_account = SocialAccount.objects.create(
@@ -152,7 +161,9 @@ def test_collision_refuses_merge_when_canonical_email_not_verified(caplog):
     canonical = User.objects.create(email="brian@y.com", username="canon")
     duplicate = User.objects.create(email=None, username="connect-user")
     dup_account = SocialAccount.objects.create(
-        user=duplicate, provider="commcare_connect", uid="999",
+        user=duplicate,
+        provider="commcare_connect",
+        uid="999",
         extra_data={"email": "brian@y.com"},
     )
     sl = SimpleNamespace(user=duplicate, account=dup_account)
@@ -165,8 +176,7 @@ def test_collision_refuses_merge_when_canonical_email_not_verified(caplog):
     assert sl.user == duplicate
     # Logged at WARNING
     assert any(
-        r.levelname == "WARNING" and "Refusing auto-merge" in r.message
-        for r in caplog.records
+        r.levelname == "WARNING" and "Refusing auto-merge" in r.message for r in caplog.records
     )
 
 
@@ -176,11 +186,16 @@ def test_collision_allows_merge_when_canonical_email_verified(caplog):
     proceeds as normal."""
     canonical = User.objects.create(email="brian@y.com", username="canon")
     EmailAddress.objects.create(
-        user=canonical, email="brian@y.com", verified=True, primary=True,
+        user=canonical,
+        email="brian@y.com",
+        verified=True,
+        primary=True,
     )
     duplicate = User.objects.create(email=None, username="connect-user")
     dup_account = SocialAccount.objects.create(
-        user=duplicate, provider="commcare_connect", uid="999",
+        user=duplicate,
+        provider="commcare_connect",
+        uid="999",
         extra_data={"email": "brian@y.com"},
     )
     sl = SimpleNamespace(user=duplicate, account=dup_account)

--- a/tests/test_thread_viewed_endpoint.py
+++ b/tests/test_thread_viewed_endpoint.py
@@ -21,15 +21,15 @@ async def test_thread_viewed_sets_last_viewed_at():
     user = await sync_to_async(User.objects.create_user)(email="a@b.c", password="x")
     ws = await sync_to_async(Workspace.objects.create)(name="W", created_by=user)
     await sync_to_async(WorkspaceMembership.objects.create)(
-        workspace=ws, user=user, role=WorkspaceRole.READ_WRITE,
+        workspace=ws,
+        user=user,
+        role=WorkspaceRole.READ_WRITE,
     )
     thread = await sync_to_async(Thread.objects.create)(workspace=ws, user=user)
     client = AsyncClient()
     await sync_to_async(client.login)(email="a@b.c", password="x")
 
-    resp = await client.post(
-        f"/api/workspaces/{ws.id}/threads/{thread.id}/viewed/"
-    )
+    resp = await client.post(f"/api/workspaces/{ws.id}/threads/{thread.id}/viewed/")
     assert resp.status_code == 200
     assert resp.json() == {"status": "ok"}
     await sync_to_async(thread.refresh_from_db)()
@@ -43,15 +43,15 @@ async def test_thread_viewed_returns_403_for_non_member():
     await sync_to_async(User.objects.create_user)(email="c@b.c", password="x")
     ws = await sync_to_async(Workspace.objects.create)(name="W2", created_by=user)
     await sync_to_async(WorkspaceMembership.objects.create)(
-        workspace=ws, user=user, role=WorkspaceRole.READ_WRITE,
+        workspace=ws,
+        user=user,
+        role=WorkspaceRole.READ_WRITE,
     )
     thread = await sync_to_async(Thread.objects.create)(workspace=ws, user=user)
     client = AsyncClient()
     await sync_to_async(client.login)(email="c@b.c", password="x")
 
-    resp = await client.post(
-        f"/api/workspaces/{ws.id}/threads/{thread.id}/viewed/"
-    )
+    resp = await client.post(f"/api/workspaces/{ws.id}/threads/{thread.id}/viewed/")
     assert resp.status_code == 403
 
 
@@ -61,12 +61,12 @@ async def test_thread_viewed_returns_404_for_unknown_thread():
     user = await sync_to_async(User.objects.create_user)(email="d@b.c", password="x")
     ws = await sync_to_async(Workspace.objects.create)(name="W3", created_by=user)
     await sync_to_async(WorkspaceMembership.objects.create)(
-        workspace=ws, user=user, role=WorkspaceRole.READ_WRITE,
+        workspace=ws,
+        user=user,
+        role=WorkspaceRole.READ_WRITE,
     )
     client = AsyncClient()
     await sync_to_async(client.login)(email="d@b.c", password="x")
 
-    resp = await client.post(
-        f"/api/workspaces/{ws.id}/threads/{uuid.uuid4()}/viewed/"
-    )
+    resp = await client.post(f"/api/workspaces/{ws.id}/threads/{uuid.uuid4()}/viewed/")
     assert resp.status_code == 404

--- a/tests/test_threadjob_janitor.py
+++ b/tests/test_threadjob_janitor.py
@@ -23,19 +23,20 @@ async def test_janitor_defers_resume_for_stale_threadjobs():
     ws = await sync_to_async(Workspace.objects.create)(name="W", created_by=user)
     thread = await sync_to_async(Thread.objects.create)(workspace=ws, user=user)
     tj = await sync_to_async(ThreadJob.objects.create)(
-        thread=thread, job_type="materialization",
-        procrastinate_job_id=9999, tool_call_id="tc9",
+        thread=thread,
+        job_type="materialization",
+        procrastinate_job_id=9999,
+        tool_call_id="tc9",
         state=ThreadJob.State.PENDING,
     )
     # Backdate to before the threshold (cron runs every 15 min;
     # STALE_JOB_THRESHOLD is 1 hour per the plan).
-    await ThreadJob.objects.filter(id=tj.id).aupdate(
-        created_at=timezone.now() - timedelta(hours=2)
-    )
+    await ThreadJob.objects.filter(id=tj.id).aupdate(created_at=timezone.now() - timedelta(hours=2))
 
-    with patch("apps.workspaces.tasks._procrastinate_job_active",
-               new=AsyncMock(return_value=False)), \
-         patch("apps.workspaces.tasks.resume_thread_after_materialization") as resume:
+    with (
+        patch("apps.workspaces.tasks._procrastinate_job_active", new=AsyncMock(return_value=False)),
+        patch("apps.workspaces.tasks.resume_thread_after_materialization") as resume,
+    ):
         resume.defer_async = AsyncMock(return_value=None)
         result = await expire_stale_thread_jobs()
 
@@ -56,17 +57,18 @@ async def test_janitor_fallback_flips_to_failed_when_defer_raises():
     ws = await sync_to_async(Workspace.objects.create)(name="W2", created_by=user)
     thread = await sync_to_async(Thread.objects.create)(workspace=ws, user=user)
     tj = await sync_to_async(ThreadJob.objects.create)(
-        thread=thread, job_type="materialization",
-        procrastinate_job_id=8888, tool_call_id="tc8",
+        thread=thread,
+        job_type="materialization",
+        procrastinate_job_id=8888,
+        tool_call_id="tc8",
         state=ThreadJob.State.PENDING,
     )
-    await ThreadJob.objects.filter(id=tj.id).aupdate(
-        created_at=timezone.now() - timedelta(hours=2)
-    )
+    await ThreadJob.objects.filter(id=tj.id).aupdate(created_at=timezone.now() - timedelta(hours=2))
 
-    with patch("apps.workspaces.tasks._procrastinate_job_active",
-               new=AsyncMock(return_value=False)), \
-         patch("apps.workspaces.tasks.resume_thread_after_materialization") as resume:
+    with (
+        patch("apps.workspaces.tasks._procrastinate_job_active", new=AsyncMock(return_value=False)),
+        patch("apps.workspaces.tasks.resume_thread_after_materialization") as resume,
+    ):
         resume.defer_async = AsyncMock(side_effect=RuntimeError("queue unavailable"))
         result = await expire_stale_thread_jobs()
 
@@ -89,18 +91,23 @@ async def test_janitor_skips_threadjob_when_procrastinate_status_unknown():
     ws = await sync_to_async(Workspace.objects.create)(name="W-unknown", created_by=user)
     thread = await sync_to_async(Thread.objects.create)(workspace=ws, user=user)
     tj = await sync_to_async(ThreadJob.objects.create)(
-        thread=thread, job_type="materialization",
-        procrastinate_job_id=24242, tool_call_id="tc-unknown",
+        thread=thread,
+        job_type="materialization",
+        procrastinate_job_id=24242,
+        tool_call_id="tc-unknown",
         state=ThreadJob.State.PENDING,
     )
     await ThreadJob.objects.filter(id=tj.id).aupdate(
         created_at=timezone.now() - timedelta(hours=2),
     )
 
-    with patch(
-        "apps.workspaces.tasks._procrastinate_job_active",
-        new=AsyncMock(return_value=None),  # status unknown
-    ), patch("apps.workspaces.tasks.resume_thread_after_materialization") as resume:
+    with (
+        patch(
+            "apps.workspaces.tasks._procrastinate_job_active",
+            new=AsyncMock(return_value=None),  # status unknown
+        ),
+        patch("apps.workspaces.tasks.resume_thread_after_materialization") as resume,
+    ):
         resume.defer_async = AsyncMock(return_value=None)
         result = await expire_stale_thread_jobs()
 
@@ -122,17 +129,20 @@ async def test_janitor_marks_stuck_running_failed_without_deferring_resume():
     ws = await sync_to_async(Workspace.objects.create)(name="W-stuck", created_by=user)
     thread = await sync_to_async(Thread.objects.create)(workspace=ws, user=user)
     tj = await sync_to_async(ThreadJob.objects.create)(
-        thread=thread, job_type="materialization",
-        procrastinate_job_id=12345, tool_call_id="tc-stuck",
+        thread=thread,
+        job_type="materialization",
+        procrastinate_job_id=12345,
+        tool_call_id="tc-stuck",
         state=ThreadJob.State.RUNNING,
     )
     await ThreadJob.objects.filter(id=tj.id).aupdate(
         created_at=timezone.now() - timedelta(hours=2),
     )
 
-    with patch("apps.workspaces.tasks._procrastinate_job_active",
-               new=AsyncMock(return_value=False)), \
-         patch("apps.workspaces.tasks.resume_thread_after_materialization") as resume:
+    with (
+        patch("apps.workspaces.tasks._procrastinate_job_active", new=AsyncMock(return_value=False)),
+        patch("apps.workspaces.tasks.resume_thread_after_materialization") as resume,
+    ):
         resume.defer_async = AsyncMock(return_value=None)
         result = await expire_stale_thread_jobs()
 


### PR DESCRIPTION
## Summary

- Pure formatting commit — zero logic changes
- Reformats 17 files that had drifted from ruff's canonical style (line-length wrapping, trailing-comma expansion, quote normalization in migrations)
- Multiple subagents previously had to explicitly skip reformatting unrelated files to keep their diffs clean; merging this eliminates that noise and keeps future agent diffs minimal
- `ruff check .` passes cleanly after formatting (no new lint violations)
- All 1007 tests pass (1015 collected, 8 skipped, 22 deselected QA tests) with no failures

## Files changed (17)

- `apps/chat/migrations/0003_threadjob.py`
- `apps/chat/migrations/0004_thread_last_viewed_at.py`
- `apps/chat/models.py`
- `apps/chat/thread_views.py`
- `apps/chat/views.py`
- `apps/workspaces/api/materialization_views.py`
- `apps/workspaces/tasks.py`
- `mcp_server/server.py`
- `tests/test_chat_thread_ownership.py`
- `tests/test_jobs_endpoints.py`
- `tests/test_materialize_workspace_task.py`
- `tests/test_materializer.py`
- `tests/test_resume_thread_task.py`
- `tests/test_run_materialization_fire_and_ack.py`
- `tests/test_social_login_reconciliation.py`
- `tests/test_thread_viewed_endpoint.py`
- `tests/test_threadjob_janitor.py`

## Test plan

- [x] `uv run ruff format .` — 17 files reformatted, 316 unchanged
- [x] `uv run ruff check .` — All checks passed
- [x] `uv run pytest -x --ignore=tests/qa` — 1007 passed, 8 skipped, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)