### PR TITLE
Workspace badge, chat empty state, and data-freshness line

### DIFF
--- a/apps/workspaces/api/workspace_views.py
+++ b/apps/workspaces/api/workspace_views.py
@@ -184,6 +184,17 @@ class WorkspaceDetailView(APIView):
             except WorkspaceViewSchema.DoesNotExist:
                 schema_status = "provisioning"
 
+        latest_completed = (
+            MaterializationRun.objects.filter(
+                state=MaterializationRun.RunState.COMPLETED,
+                tenant_schema__tenant__in=tenants,
+            )
+            .order_by("-completed_at")
+            .values_list("completed_at", flat=True)
+            .first()
+        )
+        last_synced_at = latest_completed.isoformat() if latest_completed else None
+
         first_tenant = tenants[0] if tenants else None
         display_name = (
             first_tenant.format_display_name(workspace.name) if first_tenant else workspace.name
@@ -201,6 +212,7 @@ class WorkspaceDetailView(APIView):
                 "member_count": workspace.memberships.count(),
                 "created_at": workspace.created_at.isoformat(),
                 "updated_at": workspace.updated_at.isoformat(),
+                "last_synced_at": last_synced_at,
             }
         )
 

--- a/apps/workspaces/api/workspace_views.py
+++ b/apps/workspaces/api/workspace_views.py
@@ -2,7 +2,7 @@
 
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
-from django.db.models import Count
+from django.db.models import Count, OuterRef, Subquery
 from rest_framework import status
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
@@ -11,6 +11,7 @@ from rest_framework.views import APIView
 from apps.chat.models import Thread
 from apps.users.models import Tenant, TenantMembership
 from apps.workspaces.models import (
+    MaterializationRun,
     SchemaState,
     TenantSchema,
     Workspace,
@@ -38,12 +39,22 @@ class WorkspaceListView(APIView):
     permission_classes = [IsAuthenticated]
 
     def get(self, request):
+        latest_run = (
+            MaterializationRun.objects.filter(
+                state=MaterializationRun.RunState.COMPLETED,
+                tenant_schema__tenant__workspace_tenants__workspace=OuterRef("workspace"),
+            )
+            .order_by("-completed_at")
+            .values("completed_at")[:1]
+        )
+
         memberships = (
             WorkspaceMembership.objects.filter(user=request.user)
             .select_related("workspace")
             .prefetch_related("workspace__workspace_tenants__tenant")
             .annotate(
                 member_count=Count("workspace__memberships", distinct=True),
+                last_synced_at=Subquery(latest_run),
             )
         )
         results = []
@@ -65,6 +76,7 @@ class WorkspaceListView(APIView):
                     "role": m.role,
                     "tenants": tenants,
                     "member_count": m.member_count,
+                    "last_synced_at": (m.last_synced_at.isoformat() if m.last_synced_at else None),
                     "created_at": m.workspace.created_at.isoformat(),
                 }
             )

--- a/docs/superpowers/plans/2026-05-28-ui-tweaks.md
+++ b/docs/superpowers/plans/2026-05-28-ui-tweaks.md
@@ -1,0 +1,1114 @@
+# Scout UI Tweaks Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a global workspace badge, a tailored welcome/empty-state in the chat panel with provider-specific starter questions, and a "last synced" freshness line.
+
+**Architecture:** New `TopBar` slot in `AppLayout` hosts a non-interactive `WorkspaceBadge` (provider icon + workspace `display_name` + multi-tenant subtext). `ChatPanel` branches on `messages.length`: empty threads render a new `ChatEmptyState` with provider-specific starter cards and a prominent textarea; non-empty threads keep the existing compact layout. Backend adds one `last_synced_at` field to the workspace list/detail responses, sourced from the latest completed `MaterializationRun` across the workspace's tenants.
+
+**Tech Stack:** Django 5 + DRF (sync APIView), React 19 + Vite + TypeScript, Tailwind CSS 4, Zustand store, AI SDK v6 `useChat`. Backend tests via `pytest-django`; frontend has no unit tests — coverage via `data-testid`s and manual smoke.
+
+**Spec:** `docs/superpowers/specs/2026-05-28-ui-tweaks-design.md`
+
+---
+
+## Conventions
+
+- Commit messages: imperative subject, short body if needed. Co-author trailer is added by the commit hook in this repo — don't add it manually.
+- Run frontend lint with `cd frontend && bun run lint` before every commit that touches frontend files.
+- Run backend lint and tests with `uv run ruff check .` and `uv run pytest <path>` from repo root.
+- Always use `pathlib`, async ORM, and `typing.Callable` (not `callable`) when adding Python — but this plan only adds sync DRF code, so `Callable` and async ORM don't apply.
+- The repo uses `import` statements at module level only — don't add inline imports.
+
+---
+
+## Task 1: Backend — annotate `last_synced_at` on workspace list
+
+**Files:**
+- Modify: `apps/workspaces/api/workspace_views.py` (around `WorkspaceListView.get`, lines 40-71)
+- Test: `tests/test_workspace_last_synced.py` (new file)
+
+The list endpoint must include a `last_synced_at` ISO string (or `null`) on each workspace entry, computed as the max `completed_at` of all `MaterializationRun` rows in state `COMPLETED` for any of the workspace's tenants' schemas.
+
+- [ ] **Step 1: Write the failing test for the list endpoint**
+
+Create `tests/test_workspace_last_synced.py`:
+
+```python
+"""Tests for the last_synced_at field on workspace endpoints."""
+
+from datetime import timedelta
+
+import pytest
+from django.test import Client
+from django.utils import timezone
+
+from apps.users.models import Tenant
+from apps.workspaces.models import (
+    MaterializationRun,
+    SchemaState,
+    TenantSchema,
+    Workspace,
+    WorkspaceMembership,
+    WorkspaceRole,
+    WorkspaceTenant,
+)
+
+
+@pytest.fixture
+def client():
+    return Client(enforce_csrf_checks=False)
+
+
+@pytest.fixture
+def tenant_schema(db, tenant):
+    return TenantSchema.objects.create(
+        tenant=tenant, schema_name="test_schema", state=SchemaState.ACTIVE
+    )
+
+
+def _make_run(schema, state, completed_at):
+    run = MaterializationRun.objects.create(
+        tenant_schema=schema, pipeline="commcare", state=state
+    )
+    run.completed_at = completed_at
+    run.save(update_fields=["completed_at"])
+    return run
+
+
+@pytest.mark.django_db
+def test_list_returns_null_when_no_completed_runs(client, user, workspace):
+    client.force_login(user)
+    resp = client.get("/api/workspaces/")
+    assert resp.status_code == 200
+    entry = next(w for w in resp.json() if w["id"] == str(workspace.id))
+    assert entry["last_synced_at"] is None
+
+
+@pytest.mark.django_db
+def test_list_returns_latest_completed_run(client, user, workspace, tenant_schema):
+    now = timezone.now()
+    older = now - timedelta(hours=2)
+    _make_run(tenant_schema, MaterializationRun.RunState.COMPLETED, older)
+    latest = _make_run(tenant_schema, MaterializationRun.RunState.COMPLETED, now)
+
+    client.force_login(user)
+    resp = client.get("/api/workspaces/")
+    entry = next(w for w in resp.json() if w["id"] == str(workspace.id))
+    assert entry["last_synced_at"] == latest.completed_at.isoformat()
+
+
+@pytest.mark.django_db
+def test_list_ignores_in_flight_and_failed_runs(client, user, workspace, tenant_schema):
+    now = timezone.now()
+    completed = _make_run(
+        tenant_schema, MaterializationRun.RunState.COMPLETED, now - timedelta(hours=1)
+    )
+    _make_run(tenant_schema, MaterializationRun.RunState.LOADING, now)
+    _make_run(tenant_schema, MaterializationRun.RunState.FAILED, now)
+
+    client.force_login(user)
+    resp = client.get("/api/workspaces/")
+    entry = next(w for w in resp.json() if w["id"] == str(workspace.id))
+    assert entry["last_synced_at"] == completed.completed_at.isoformat()
+
+
+@pytest.mark.django_db
+def test_list_multi_tenant_returns_max_across_tenants(client, user, workspace, tenant_schema):
+    # Add a second tenant with a more-recent completed run
+    second = Tenant.objects.create(
+        provider="commcare", external_id="second-domain", canonical_name="Second"
+    )
+    WorkspaceTenant.objects.create(workspace=workspace, tenant=second)
+    second_schema = TenantSchema.objects.create(
+        tenant=second, schema_name="second_schema", state=SchemaState.ACTIVE
+    )
+
+    now = timezone.now()
+    _make_run(
+        tenant_schema,
+        MaterializationRun.RunState.COMPLETED,
+        now - timedelta(hours=3),
+    )
+    latest = _make_run(
+        second_schema, MaterializationRun.RunState.COMPLETED, now
+    )
+
+    client.force_login(user)
+    resp = client.get("/api/workspaces/")
+    entry = next(w for w in resp.json() if w["id"] == str(workspace.id))
+    assert entry["last_synced_at"] == latest.completed_at.isoformat()
+
+
+@pytest.mark.django_db
+def test_list_only_users_workspaces_get_field(client, user, workspace, tenant_schema):
+    # Sibling workspace this user does not belong to
+    other_owner_email = "stranger@example.com"
+    from django.contrib.auth import get_user_model
+    other = get_user_model().objects.create_user(email=other_owner_email, password="pass")
+    other_ws = Workspace.objects.create(name="Other", created_by=other)
+    WorkspaceMembership.objects.create(workspace=other_ws, user=other, role=WorkspaceRole.MANAGE)
+
+    client.force_login(user)
+    resp = client.get("/api/workspaces/")
+    ids = [w["id"] for w in resp.json()]
+    assert str(other_ws.id) not in ids
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_workspace_last_synced.py -v`
+Expected: All four tests FAIL with `KeyError: 'last_synced_at'` (the field doesn't exist yet).
+
+- [ ] **Step 3: Implement the annotation on the list view**
+
+Modify `apps/workspaces/api/workspace_views.py`. Add the imports near the top (alongside the existing `Count`):
+
+```python
+from django.db.models import Count, Max, OuterRef, Subquery
+```
+
+Then in `WorkspaceListView.get`, replace the body with the version below. The change: build a per-workspace subquery that returns the latest `completed_at` across all of the workspace's tenants' completed runs, annotate the queryset with it, and include it in each result dict.
+
+```python
+def get(self, request):
+    latest_run = (
+        MaterializationRun.objects.filter(
+            state=MaterializationRun.RunState.COMPLETED,
+            tenant_schema__tenant__workspace_tenants__workspace=OuterRef("workspace"),
+        )
+        .order_by("-completed_at")
+        .values("completed_at")[:1]
+    )
+
+    memberships = (
+        WorkspaceMembership.objects.filter(user=request.user)
+        .select_related("workspace")
+        .prefetch_related("workspace__workspace_tenants__tenant")
+        .annotate(
+            member_count=Count("workspace__memberships", distinct=True),
+            last_synced_at=Subquery(latest_run),
+        )
+    )
+    results = []
+    for m in memberships:
+        tenants = [
+            {
+                "id": str(wt.tenant.id),
+                "tenant_name": wt.tenant.canonical_name,
+                "provider": wt.tenant.provider,
+            }
+            for wt in m.workspace.workspace_tenants.all()
+        ]
+        results.append(
+            {
+                "id": str(m.workspace.id),
+                "name": m.workspace.name,
+                "display_name": m.workspace.display_name,
+                "is_auto_created": m.workspace.is_auto_created,
+                "role": m.role,
+                "tenants": tenants,
+                "member_count": m.member_count,
+                "last_synced_at": (
+                    m.last_synced_at.isoformat() if m.last_synced_at else None
+                ),
+                "created_at": m.workspace.created_at.isoformat(),
+            }
+        )
+    return Response(results)
+```
+
+Also add `MaterializationRun` to the imports at the top of the file (it isn't imported there yet):
+
+```python
+from apps.workspaces.models import (
+    MaterializationRun,
+    SchemaState,
+    TenantSchema,
+    Workspace,
+    WorkspaceMembership,
+    WorkspaceRole,
+    WorkspaceTenant,
+    WorkspaceViewSchema,
+)
+```
+
+`Max` is imported but unused for now — keep `OuterRef` and `Subquery` only. Remove `Max` from the import line if you added it; the final imports line should read:
+
+```python
+from django.db.models import Count, OuterRef, Subquery
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_workspace_last_synced.py -v`
+Expected: All 5 tests PASS.
+
+Run the existing workspace tests too to make sure nothing else broke:
+Run: `uv run pytest tests/test_workspace_management.py tests/test_workspace_permissions.py -v`
+Expected: PASS (no regressions).
+
+- [ ] **Step 5: Lint**
+
+Run: `uv run ruff check apps/workspaces/api/workspace_views.py tests/test_workspace_last_synced.py`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/workspaces/api/workspace_views.py tests/test_workspace_last_synced.py
+git commit -m "Add last_synced_at to workspace list API"
+```
+
+---
+
+## Task 2: Backend — add `last_synced_at` to workspace detail
+
+**Files:**
+- Modify: `apps/workspaces/api/workspace_views.py` (`WorkspaceDetailView.get`, lines 146-193)
+- Test: `tests/test_workspace_last_synced.py` (extend)
+
+Detail uses the resolver, not the same queryset — compute inline from `MaterializationRun`.
+
+- [ ] **Step 1: Add detail-endpoint tests**
+
+Append to `tests/test_workspace_last_synced.py`:
+
+```python
+@pytest.mark.django_db
+def test_detail_returns_null_when_no_completed_runs(client, user, workspace):
+    client.force_login(user)
+    resp = client.get(f"/api/workspaces/{workspace.id}/")
+    assert resp.status_code == 200
+    assert resp.json()["last_synced_at"] is None
+
+
+@pytest.mark.django_db
+def test_detail_returns_latest_completed_run(client, user, workspace, tenant_schema):
+    now = timezone.now()
+    older = now - timedelta(hours=2)
+    _make_run(tenant_schema, MaterializationRun.RunState.COMPLETED, older)
+    latest = _make_run(tenant_schema, MaterializationRun.RunState.COMPLETED, now)
+
+    client.force_login(user)
+    resp = client.get(f"/api/workspaces/{workspace.id}/")
+    assert resp.json()["last_synced_at"] == latest.completed_at.isoformat()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_workspace_last_synced.py::test_detail_returns_null_when_no_completed_runs tests/test_workspace_last_synced.py::test_detail_returns_latest_completed_run -v`
+Expected: FAIL with `KeyError: 'last_synced_at'`.
+
+- [ ] **Step 3: Implement in `WorkspaceDetailView.get`**
+
+In `apps/workspaces/api/workspace_views.py`, inside `WorkspaceDetailView.get` (after computing `tenants` and `schema_status` and before the `Response(...)` call), add:
+
+```python
+        latest_completed = (
+            MaterializationRun.objects.filter(
+                state=MaterializationRun.RunState.COMPLETED,
+                tenant_schema__tenant__in=tenants,
+            )
+            .order_by("-completed_at")
+            .values_list("completed_at", flat=True)
+            .first()
+        )
+        last_synced_at = latest_completed.isoformat() if latest_completed else None
+```
+
+Then add `"last_synced_at": last_synced_at,` to the response dict (place it next to `"updated_at"`).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_workspace_last_synced.py -v`
+Expected: all PASS.
+
+- [ ] **Step 5: Lint**
+
+Run: `uv run ruff check apps/workspaces/api/workspace_views.py`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/workspaces/api/workspace_views.py tests/test_workspace_last_synced.py
+git commit -m "Add last_synced_at to workspace detail API"
+```
+
+---
+
+## Task 3: Frontend — extend `WorkspaceListItem` and `WorkspaceDetail` types
+
+**Files:**
+- Modify: `frontend/src/api/workspaces.ts` (lines 11-37)
+
+- [ ] **Step 1: Add the new field to both interfaces**
+
+In `frontend/src/api/workspaces.ts`, add `last_synced_at: string | null` to `WorkspaceListItem` and `WorkspaceDetail`:
+
+```ts
+export interface WorkspaceListItem {
+  id: string
+  name: string
+  display_name: string
+  is_auto_created: boolean
+  role: "read" | "read_write" | "manage"
+  tenants: WorkspaceListTenant[]
+  member_count: number
+  last_synced_at: string | null
+  created_at: string
+}
+
+export interface WorkspaceDetail {
+  id: string
+  name: string
+  display_name: string
+  is_auto_created: boolean
+  role: "read" | "read_write" | "manage"
+  system_prompt: string
+  schema_status: "available" | "provisioning" | "unavailable"
+  tenant_count: number
+  member_count: number
+  last_synced_at: string | null
+  created_at: string
+  updated_at: string
+}
+```
+
+- [ ] **Step 2: Verify frontend typechecks**
+
+Run: `cd frontend && bun run lint`
+Expected: clean.
+
+Run: `cd frontend && bunx tsc --noEmit`
+Expected: clean (no callers strict-require the new field, so adding it is safe).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/api/workspaces.ts
+git commit -m "Add last_synced_at to workspace API types"
+```
+
+---
+
+## Task 4: Frontend — `formatRelativeTime` helper
+
+**Files:**
+- Create: `frontend/src/lib/relativeTime.ts`
+
+Reusable helper used by the freshness line. Uses `Intl.RelativeTimeFormat`, bucketing by minute / hour / day.
+
+- [ ] **Step 1: Create the file**
+
+```ts
+// frontend/src/lib/relativeTime.ts
+
+const SECOND = 1
+const MINUTE = 60
+const HOUR = 60 * MINUTE
+const DAY = 24 * HOUR
+
+const rtf = new Intl.RelativeTimeFormat("en", { numeric: "auto" })
+
+/**
+ * Format an ISO timestamp as a relative phrase like "12 minutes ago".
+ * Returns "just now" for differences under 30 seconds, falls back to a date
+ * string for differences over ~30 days.
+ */
+export function formatRelativeTime(iso: string, now: Date = new Date()): string {
+  const then = new Date(iso)
+  const deltaSeconds = Math.round((then.getTime() - now.getTime()) / 1000)
+  const abs = Math.abs(deltaSeconds)
+
+  if (abs < 30 * SECOND) return "just now"
+  if (abs < HOUR) return rtf.format(Math.round(deltaSeconds / MINUTE), "minute")
+  if (abs < DAY) return rtf.format(Math.round(deltaSeconds / HOUR), "hour")
+  if (abs < 30 * DAY) return rtf.format(Math.round(deltaSeconds / DAY), "day")
+  return then.toLocaleDateString()
+}
+```
+
+- [ ] **Step 2: Quick sanity check**
+
+Run: `cd frontend && bunx tsc --noEmit`
+Expected: clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/lib/relativeTime.ts
+git commit -m "Add formatRelativeTime helper"
+```
+
+---
+
+## Task 5: Frontend — `providerMeta` and provider icons
+
+**Files:**
+- Create: `frontend/src/components/WorkspaceBadge/providerMeta.tsx`
+
+We're using lucide-react icons (already a dep) rather than committing SVG files — they tint with `currentColor`, match the rest of the UI, and avoid asset noise. Each provider gets a label and an icon component.
+
+- [ ] **Step 1: Create the file**
+
+```tsx
+// frontend/src/components/WorkspaceBadge/providerMeta.tsx
+import { Database, Smartphone, Briefcase, MessageSquare } from "lucide-react"
+import type { ComponentType, SVGProps } from "react"
+
+type IconComponent = ComponentType<SVGProps<SVGSVGElement>>
+
+export interface ProviderMeta {
+  label: string
+  Icon: IconComponent
+}
+
+const META: Record<string, ProviderMeta> = {
+  commcare: { label: "CommCare", Icon: Smartphone },
+  commcare_connect: { label: "CommCare Connect", Icon: Briefcase },
+  ocs: { label: "Open Chat Studio", Icon: MessageSquare },
+}
+
+const FALLBACK: ProviderMeta = { label: "Workspace", Icon: Database }
+
+export function getProviderMeta(provider: string | undefined): ProviderMeta {
+  if (!provider) return FALLBACK
+  return META[provider] ?? FALLBACK
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add frontend/src/components/WorkspaceBadge/providerMeta.tsx
+git commit -m "Add provider metadata for workspace badge"
+```
+
+---
+
+## Task 6: Frontend — `WorkspaceBadge` component
+
+**Files:**
+- Create: `frontend/src/components/WorkspaceBadge/WorkspaceBadge.tsx`
+- Create: `frontend/src/components/WorkspaceBadge/index.ts`
+
+Non-interactive badge: provider icon + workspace `display_name`, with tenant subtext when the workspace spans multiple tenants.
+
+- [ ] **Step 1: Create the badge component**
+
+```tsx
+// frontend/src/components/WorkspaceBadge/WorkspaceBadge.tsx
+import { useAppStore } from "@/store/store"
+import { getProviderMeta } from "./providerMeta"
+
+export function WorkspaceBadge() {
+  const activeDomainId = useAppStore((s) => s.activeDomainId)
+  const workspace = useAppStore((s) =>
+    s.domains.find((d) => d.id === s.activeDomainId),
+  )
+
+  if (!activeDomainId || !workspace) return null
+
+  const firstProvider = workspace.tenants[0]?.provider
+  const { label, Icon } = getProviderMeta(firstProvider)
+  const isMultiTenant = workspace.tenants.length > 1
+  const tenantNames = workspace.tenants
+    .map((t) => t.tenant_name)
+    .join(", ")
+
+  return (
+    <div
+      className="inline-flex items-center gap-2 rounded-full border bg-background px-3 py-1.5 text-sm shadow-sm"
+      data-testid="workspace-badge"
+      data-provider={firstProvider ?? "unknown"}
+      title={isMultiTenant ? `${label} • ${tenantNames}` : label}
+    >
+      <Icon className="h-4 w-4 text-muted-foreground" aria-hidden />
+      <div className="flex flex-col leading-tight">
+        <span className="font-medium">{workspace.display_name}</span>
+        {isMultiTenant && (
+          <span className="text-xs text-muted-foreground truncate max-w-[24ch]">
+            {tenantNames}
+          </span>
+        )}
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Create the barrel export**
+
+```ts
+// frontend/src/components/WorkspaceBadge/index.ts
+export { WorkspaceBadge } from "./WorkspaceBadge"
+```
+
+- [ ] **Step 3: Verify typecheck**
+
+Run: `cd frontend && bunx tsc --noEmit`
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/components/WorkspaceBadge/
+git commit -m "Add WorkspaceBadge component"
+```
+
+---
+
+## Task 7: Frontend — `TopBar` (with portal slot) and integrate into `AppLayout`
+
+**Files:**
+- Create: `frontend/src/components/TopBar/TopBar.tsx`
+- Create: `frontend/src/components/TopBar/TopBarSlot.tsx`
+- Create: `frontend/src/components/TopBar/index.ts`
+- Modify: `frontend/src/components/AppLayout/AppLayout.tsx`
+
+Slim header above the main content column. Right-aligned WorkspaceBadge plus a portal slot that pages (specifically ChatPanel) can fill with route-specific actions like the Share button. The portal pattern lets pages own their action state while rendering the markup into the global header — keeping Share's `showShareMenu`, `threadId`, and `messages.length > 0` checks in ChatPanel without cross-component prop drilling.
+
+- [ ] **Step 1: Create the TopBar with a slot DOM element exposed via context**
+
+```tsx
+// frontend/src/components/TopBar/TopBar.tsx
+import { createContext, useState } from "react"
+import type { ReactNode } from "react"
+import { WorkspaceBadge } from "@/components/WorkspaceBadge"
+
+export const TopBarSlotContext = createContext<HTMLElement | null>(null)
+
+export function TopBarProvider({ children }: { children: ReactNode }) {
+  const [slotEl, setSlotEl] = useState<HTMLElement | null>(null)
+
+  return (
+    <TopBarSlotContext.Provider value={slotEl}>
+      <div
+        className="flex h-11 shrink-0 items-center justify-between border-b px-4"
+        data-testid="top-bar"
+      >
+        <div className="flex items-center gap-2" />
+        <div className="flex items-center gap-2">
+          <div
+            ref={setSlotEl}
+            className="flex items-center gap-2"
+            data-testid="top-bar-slot"
+          />
+          <WorkspaceBadge />
+        </div>
+      </div>
+      {children}
+    </TopBarSlotContext.Provider>
+  )
+}
+```
+
+- [ ] **Step 2: Create the `TopBarSlot` portal helper**
+
+```tsx
+// frontend/src/components/TopBar/TopBarSlot.tsx
+import { useContext } from "react"
+import type { ReactNode } from "react"
+import { createPortal } from "react-dom"
+import { TopBarSlotContext } from "./TopBar"
+
+/**
+ * Renders children into the global TopBar's trailing slot.
+ * No-op until the TopBar has mounted (slot element exists).
+ */
+export function TopBarSlot({ children }: { children: ReactNode }) {
+  const slotEl = useContext(TopBarSlotContext)
+  if (!slotEl) return null
+  return createPortal(children, slotEl)
+}
+```
+
+- [ ] **Step 3: Create the barrel export**
+
+```ts
+// frontend/src/components/TopBar/index.ts
+export { TopBarProvider } from "./TopBar"
+export { TopBarSlot } from "./TopBarSlot"
+```
+
+- [ ] **Step 4: Slot TopBarProvider into AppLayout**
+
+Replace `AppLayout.tsx`'s return statement so the main column is a flex-column with the TopBar on top and the Outlet flex-1 below. The provider wraps the main column so the slot context is in scope for everything rendered inside the Outlet:
+
+```tsx
+  return (
+    <WorkspaceJobsProvider workspaceId={activeDomainId}>
+      <div className="flex h-screen">
+        <Sidebar />
+        <div className="flex flex-1 min-w-0 flex-col">
+          <TopBarProvider>
+            <main className="flex-1 min-w-0 overflow-auto">
+              <ErrorBoundary>
+                <Outlet />
+              </ErrorBoundary>
+            </main>
+          </TopBarProvider>
+        </div>
+        <ArtifactPanel />
+        <OfflineBanner />
+      </div>
+    </WorkspaceJobsProvider>
+  )
+```
+
+Add the import to the top of `AppLayout.tsx`:
+
+```tsx
+import { TopBarProvider } from "@/components/TopBar"
+```
+
+- [ ] **Step 5: Verify typecheck and lint**
+
+Run: `cd frontend && bunx tsc --noEmit && bun run lint`
+Expected: clean.
+
+- [ ] **Step 6: Manual smoke**
+
+Run: `cd frontend && bun dev`
+- Open the app, log in, pick a workspace.
+- Verify the workspace badge appears in the top-right on Chat, Knowledge, Recipes, Connections, Data Dictionary.
+- Verify a single-tenant workspace shows only the display name; a multi-tenant workspace (if available) also shows the comma-separated tenant names below.
+- Verify the badge does not respond to clicks.
+- The slot is empty for now — that's fine.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/src/components/TopBar/ frontend/src/components/AppLayout/AppLayout.tsx
+git commit -m "Add TopBar with WorkspaceBadge and portal slot to AppLayout"
+```
+
+---
+
+## Task 8: Frontend — `starterQuestions.ts`
+
+**Files:**
+- Create: `frontend/src/components/ChatEmptyState/starterQuestions.ts`
+
+- [ ] **Step 1: Create the file**
+
+```ts
+// frontend/src/components/ChatEmptyState/starterQuestions.ts
+
+type Provider = "commcare" | "commcare_connect" | "ocs" | "default"
+
+export const STARTER_QUESTIONS: Record<Provider, readonly string[]> = {
+  commcare: [
+    "How many cases were opened last month?",
+    "Which mobile workers haven't submitted a form in the last week?",
+    "Compare form submission volume this quarter vs last quarter.",
+  ],
+  commcare_connect: [
+    "How many workers completed verified visits this week?",
+    "Which opportunities have the highest payment volume this month?",
+    "Compare average payment per worker across opportunities.",
+  ],
+  ocs: [
+    "How many conversations did the bot handle in the last 7 days?",
+    "What are the most common user messages this week?",
+    "Compare session counts across bots this month vs last month.",
+  ],
+  default: [
+    "What tables are available in my data?",
+    "Show me a high-level overview of the schema.",
+    "What are the most recently updated records?",
+  ],
+}
+
+export function getStarterQuestions(provider: string | undefined): readonly string[] {
+  if (!provider) return STARTER_QUESTIONS.default
+  const key = provider as Provider
+  return STARTER_QUESTIONS[key] ?? STARTER_QUESTIONS.default
+}
+```
+
+- [ ] **Step 2: Verify typecheck**
+
+Run: `cd frontend && bunx tsc --noEmit`
+Expected: clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/components/ChatEmptyState/starterQuestions.ts
+git commit -m "Add provider-specific starter questions"
+```
+
+---
+
+## Task 9: Frontend — `ChatEmptyState` component
+
+**Files:**
+- Create: `frontend/src/components/ChatEmptyState/ChatEmptyState.tsx`
+- Create: `frontend/src/components/ChatEmptyState/index.ts`
+
+Owns the welcome heading, starter cards, prominent textarea form, and freshness line. Receives input state and the send callback from `ChatPanel`.
+
+- [ ] **Step 1: Create the component**
+
+```tsx
+// frontend/src/components/ChatEmptyState/ChatEmptyState.tsx
+import { ArrowUp, ArrowRight } from "lucide-react"
+import { useAppStore } from "@/store/store"
+import { Button } from "@/components/ui/button"
+import { Textarea } from "@/components/ui/textarea"
+import { formatRelativeTime } from "@/lib/relativeTime"
+import { getStarterQuestions } from "./starterQuestions"
+
+interface ChatEmptyStateProps {
+  input: string
+  setInput: (value: string) => void
+  onSend: (text: string) => void
+  disabled?: boolean
+}
+
+export function ChatEmptyState({
+  input,
+  setInput,
+  onSend,
+  disabled = false,
+}: ChatEmptyStateProps) {
+  const workspace = useAppStore((s) =>
+    s.domains.find((d) => d.id === s.activeDomainId),
+  )
+
+  const provider = workspace?.tenants[0]?.provider
+  const starters = getStarterQuestions(provider)
+  const lastSyncedAt = workspace?.last_synced_at ?? null
+
+  function submit(text: string) {
+    const trimmed = text.trim()
+    if (!trimmed || disabled) return
+    setInput("")
+    onSend(trimmed)
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    submit(input)
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault()
+      submit(input)
+    }
+  }
+
+  return (
+    <div
+      className="flex h-full flex-col items-center justify-center px-6 py-10"
+      data-testid="chat-empty-state"
+    >
+      <div className="w-full max-w-3xl">
+        <h1 className="text-center text-2xl font-medium leading-snug md:text-3xl">
+          I&apos;m Scout! Your AI-powered Data Analyst.
+          <br />
+          How can I assist you today?
+        </h1>
+
+        <div className="mt-10 grid grid-cols-1 gap-3 md:grid-cols-3">
+          {starters.map((question, idx) => (
+            <button
+              key={idx}
+              type="button"
+              onClick={() => submit(question)}
+              disabled={disabled}
+              className="group flex items-start justify-between gap-2 rounded-lg border bg-card p-4 text-left text-sm transition hover:bg-accent disabled:opacity-50"
+              data-testid={`starter-question-${idx}`}
+            >
+              <span>{question}</span>
+              <ArrowRight
+                className="h-4 w-4 shrink-0 text-muted-foreground transition group-hover:text-foreground"
+                aria-hidden
+              />
+            </button>
+          ))}
+        </div>
+
+        <form onSubmit={handleSubmit} className="relative mt-10">
+          <Textarea
+            data-testid="chat-input-prominent"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Ask about your data..."
+            disabled={disabled}
+            rows={3}
+            className="resize-none rounded-xl border bg-background px-4 py-3 pr-14 text-base shadow-sm"
+          />
+          <Button
+            type="submit"
+            size="icon"
+            disabled={disabled || !input.trim()}
+            className="absolute bottom-3 right-3"
+          >
+            <ArrowUp className="h-4 w-4" />
+          </Button>
+        </form>
+
+        <p
+          className="mt-3 text-center text-xs text-muted-foreground"
+          data-testid="data-freshness"
+        >
+          Scout can only read your data — never modify or delete it.
+          {lastSyncedAt && (
+            <> Data last synced {formatRelativeTime(lastSyncedAt)}.</>
+          )}
+        </p>
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Create the barrel export**
+
+```ts
+// frontend/src/components/ChatEmptyState/index.ts
+export { ChatEmptyState } from "./ChatEmptyState"
+```
+
+- [ ] **Step 3: Verify typecheck**
+
+Run: `cd frontend && bunx tsc --noEmit`
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/components/ChatEmptyState/
+git commit -m "Add ChatEmptyState component"
+```
+
+---
+
+## Task 10: Frontend — wire `ChatEmptyState` and portal Share into TopBar
+
+**Files:**
+- Modify: `frontend/src/components/ChatPanel/ChatPanel.tsx`
+
+Three changes:
+
+1. Render `ChatEmptyState` when `messages.length === 0`. The compact-input layout renders once any message exists.
+2. Remove ChatPanel's own header strip (the `border-b px-4 py-2` div). Move the Share button (and its `ShareMenu` popover) into a `<TopBarSlot>` portal so it appears in the global TopBar next to the WorkspaceBadge. Visibility rule stays the same: only render when `messages.length > 0`.
+3. Update the empty-state placeholder removal inside the message-list div (since the empty branch returns early).
+
+- [ ] **Step 1: Update imports in ChatPanel.tsx**
+
+Near the top of `frontend/src/components/ChatPanel/ChatPanel.tsx`, add:
+
+```tsx
+import { ChatEmptyState } from "@/components/ChatEmptyState"
+import { TopBarSlot } from "@/components/TopBar"
+```
+
+- [ ] **Step 2: Replace the render block**
+
+Replace lines 271-362 (everything from `if (!activeDomainId)` to the closing `)` of the return statement) with:
+
+```tsx
+  if (!activeDomainId) {
+    return (
+      <div className="flex-1 flex items-center justify-center text-muted-foreground">
+        Select a domain to start chatting
+      </div>
+    )
+  }
+
+  if (messages.length === 0) {
+    return (
+      <ChatEmptyState
+        input={input}
+        setInput={setInput}
+        onSend={(text) => sendMessage({ text })}
+        disabled={isStreaming}
+      />
+    )
+  }
+
+  return (
+    <div className="flex flex-col h-full">
+      <TopBarSlot>
+        <div className="relative">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setShowShareMenu(!showShareMenu)}
+            data-testid="chat-share-btn"
+          >
+            <Share2 className="mr-1 h-4 w-4" />
+            Share
+          </Button>
+          {showShareMenu && activeDomainId && (
+            <ShareMenu
+              threadId={threadId}
+              workspaceId={activeDomainId}
+              onClose={() => setShowShareMenu(false)}
+            />
+          )}
+        </div>
+      </TopBarSlot>
+
+      {/* Message list */}
+      <div ref={scrollRef} className="flex-1 overflow-y-auto p-4 space-y-4">
+        {messages.map((msg: UIMessage, msgIdx: number) => (
+          <ChatMessage
+            key={msg.id}
+            message={msg}
+            isActiveMessage={isStreaming && msgIdx === messages.length - 1}
+            workspaceId={activeDomainId ?? undefined}
+            activeMaterializationJob={activeMaterializationJob}
+          />
+        ))}
+        {isStreaming && <ThinkingIndicator />}
+        {error && (
+          <div className="text-sm text-destructive bg-destructive/10 rounded-lg px-4 py-2">
+            {error.message}
+          </div>
+        )}
+      </div>
+
+      {/* Input area */}
+      <div className="border-t p-4">
+        <form onSubmit={handleSubmit} className="relative flex gap-2">
+          <SlashCommandMenu
+            query={slashQuery}
+            onSelect={selectSlashCommand}
+            visible={showSlashMenu}
+            selectedIndex={slashMenuIndex}
+          />
+          <Input
+            data-testid="chat-input"
+            value={input}
+            onChange={(e) => {
+              setInput(e.target.value)
+              setSlashMenuIndex(0)
+            }}
+            onKeyDown={handleKeyDown}
+            placeholder="Ask about your data..."
+            disabled={isStreaming}
+            className="flex-1"
+          />
+          {isStreaming ? (
+            <Button type="button" variant="outline" size="icon" onClick={() => stop()}>
+              <Square className="w-4 h-4" />
+            </Button>
+          ) : (
+            <Button type="submit" size="icon" disabled={!input.trim()}>
+              <Send className="w-4 h-4" />
+            </Button>
+          )}
+        </form>
+      </div>
+    </div>
+  )
+```
+
+Notes:
+- The old `border-b px-4 py-2` chat header div is gone — Share lives in the TopBar slot.
+- The empty-state `<div>Ask a question…</div>` placeholder is gone — the empty branch returns early.
+- The `TopBarSlot` is a no-op until TopBar mounts; on chat routes that happens immediately (AppLayout wraps the Outlet in `TopBarProvider`).
+
+- [ ] **Step 3: Verify typecheck and lint**
+
+Run: `cd frontend && bunx tsc --noEmit && bun run lint`
+Expected: clean.
+
+- [ ] **Step 4: Manual smoke**
+
+Run: `cd frontend && bun dev`
+- New chat → see welcome heading, 3 starter cards, large textarea, freshness line. No Share button in the TopBar (thread has no messages).
+- Click a starter card → sends immediately, layout swaps to compact, Share appears in the TopBar to the left of the WorkspaceBadge.
+- Type a question and press Enter → sends, same flip.
+- Shift+Enter in the textarea inserts a newline rather than submitting.
+- Click the Share button in the TopBar → menu opens; toggles work; copy-link works.
+- Navigate to Knowledge → Share button disappears (it only mounts when ChatPanel renders).
+- Back to Chat → Share reappears for non-empty threads.
+- Refresh the page mid-thread → existing messages reload, Share visible in TopBar.
+- Click "New Chat" in sidebar → returns to empty state, Share disappears from TopBar.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/ChatPanel/ChatPanel.tsx
+git commit -m "Render ChatEmptyState for empty threads; move Share to TopBar"
+```
+
+---
+
+## Task 11: Frontend — sanity-check freshness line with a known workspace
+
+**Files:**
+- (no code changes — verification only)
+
+- [ ] **Step 1: Confirm last_synced_at flows to the empty state**
+
+Pre-req: a workspace with at least one completed `MaterializationRun`. If none exists in your local dev DB, create one by either running a refresh from the UI or with:
+
+```bash
+uv run python manage.py shell -c "
+from apps.workspaces.models import MaterializationRun, TenantSchema, SchemaState
+from django.utils import timezone
+ts = TenantSchema.objects.filter(state=SchemaState.ACTIVE).first()
+MaterializationRun.objects.create(
+    tenant_schema=ts,
+    pipeline='manual-smoke',
+    state=MaterializationRun.RunState.COMPLETED,
+    completed_at=timezone.now(),
+)
+"
+```
+
+Reload the app. Open the empty-state for that workspace. Expected: the freshness line reads `Scout can only read your data — never modify or delete it. Data last synced just now.` (or similar relative phrase).
+
+- [ ] **Step 2: Confirm absence of last_synced_at hides the timestamp**
+
+Pick a workspace with no completed runs (or temporarily delete the `MaterializationRun` you just created). Expected: only `Scout can only read your data — never modify or delete it.` shows; no "Data last synced" tail.
+
+No commit — this is verification only.
+
+---
+
+## Task 12: Final integration check
+
+**Files:**
+- (no code changes — full-flow verification)
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `uv run pytest`
+Expected: PASS.
+
+Run: `cd frontend && bun run lint && bunx tsc --noEmit`
+Expected: clean.
+
+- [ ] **Step 2: Walk every workspace state**
+
+Spin up `cd frontend && bun dev` and a backend (`uv run honcho -f Procfile.dev start` or whatever the maintainer prefers). Verify:
+
+1. **Single-tenant CommCare workspace** → badge shows phone icon + "[CC] {name}", no subtext.
+2. **Multi-tenant workspace** → badge shows tenant subtext.
+3. **Workspace with unknown provider** → badge falls back to database icon + "Workspace" label hover.
+4. **Empty thread** → welcome + 3 CommCare starters + prominent input + freshness line.
+5. **Click starter** → instant send, layout flips to compact.
+6. **Send manual message** → same flip.
+7. **Switch to Knowledge / Recipes / Connections** → badge stays visible in TopBar; pages render below it without overflow.
+8. **`last_synced_at = null` workspace** → freshness line shows safety message only.
+9. **`last_synced_at` set** → freshness line includes relative time.
+
+- [ ] **Step 3: Sanity-check git history**
+
+Run: `git log --oneline main..HEAD`
+Expected: one commit per task, all imperative subject lines, no fixup commits.
+
+- [ ] **Step 4: Ready for review**
+
+Push the branch and open a PR linking to the spec at `docs/superpowers/specs/2026-05-28-ui-tweaks-design.md`.

--- a/docs/superpowers/specs/2026-05-28-ui-tweaks-design.md
+++ b/docs/superpowers/specs/2026-05-28-ui-tweaks-design.md
@@ -1,0 +1,241 @@
+# Scout UI Tweaks — Design
+
+**Date:** 2026-05-28
+**Branch:** `sk/ui-tweaks`
+**Status:** draft
+
+## Goal
+
+Three discrete UI changes to make Scout easier to use, all driven from a mockup:
+
+1. **Welcome + starter questions** in the chat empty state, tailored to the active workspace's tenant provider (CommCare HQ / CommCare Connect / OCS).
+2. **Workspace badge in the top-right** so users can always see which workspace they're operating in — visible on every page, not just chat.
+3. **Prominent chat bar** in the empty state with a safety line and (when known) a data-freshness timestamp.
+
+## Non-goals
+
+- Recipe / Knowledge chips inside the chat input — the existing slash-command menu (`/recipe`, `/knowledge`) already covers this.
+- Editing starter questions without a code deploy.
+- Animated transitions between empty-state and compact-input layouts.
+- A general top-header system (page titles, breadcrumbs). The new top bar has only a workspace badge on the right; the left half stays empty.
+
+## Architecture
+
+Three new frontend components, one backend serializer change.
+
+```
+AppLayout (changed: adds top bar slot above main content)
+└── TopBar (new) — slim header, right-aligned WorkspaceBadge, hosts chat Share button on chat routes
+└── WorkspaceBadge (new) — provider icon + display_name; tenant list subtext when multi-tenant
+└── ChatPanel (changed: branch on messages.length, drops its own header strip)
+    ├── ChatEmptyState (new) — welcome heading + starter cards + prominent input + freshness line
+    │   └── starterQuestions.ts (new) — provider → string[3]
+    └── (existing compact input layout) — unchanged for non-empty threads
+```
+
+`ChatEmptyState` does not own chat state; `ChatPanel` keeps `input`, `setInput`, `sendMessage`, `status`, and the slash-command menu, and passes the handlers in as props. This avoids duplicating form/slash logic across the two layouts.
+
+## Component design
+
+### TopBar
+
+- Lives inside `AppLayout`, in the right column above `<Outlet />` and above `<ArtifactPanel />`.
+- Height ~44px, bottom border (`border-b`), transparent background.
+- Right-aligned slot for `<WorkspaceBadge />`.
+- On chat routes, also renders the `Share` button (moved out of `ChatPanel`).
+- Left half is empty for now; reserved for future page-title / breadcrumb use.
+
+```
+┌────────┬───────────────────────────────┬──────────┐
+│        │  TopBar       [WorkspaceBadge]│          │
+│ Sidebar├───────────────────────────────┤ Artifact │
+│        │  <Outlet />                   │ Panel    │
+└────────┴───────────────────────────────┴──────────┘
+```
+
+The Share button moves into the TopBar to avoid two stacked header strips on chat routes. It's only rendered when the current route is a chat route AND the active thread has messages — same visibility rule as today.
+
+### WorkspaceBadge
+
+- Pill-shaped non-interactive `<div>` (no chevron — explicitly not a selector; the sidebar selector remains the way to switch workspaces).
+- Reads `activeDomainId` from the Zustand store, looks up the workspace in `state.domains`.
+- Renders:
+  - **Provider icon** from a `providerMeta` map: `commcare`, `commcare_connect`, `ocs`, plus a generic database icon for unknown.
+  - **Workspace `display_name`** (already provider-formatted by backend — e.g. `[CC] Hello World`).
+  - **Tenant subtext** (small, muted) listing tenant `tenant_name`s comma-separated, truncated. Only rendered when `tenants.length > 1`.
+- `data-testid="workspace-badge"`, plus `data-provider="<provider>"` for QA targeting.
+- Provider icons: new SVGs under `frontend/src/assets/providers/{commcare,commcare-connect,ocs}.svg`. (I'll check `frontend/src/assets/` first and reuse anything already there.)
+
+### ChatEmptyState
+
+Triggered inside `ChatPanel` when `messages.length === 0` and not streaming. Renders inside the chat pane, vertically and horizontally centered in a `max-w-3xl mx-auto` container. The page-level full-width rule still holds because the chat pane *is* the full-width page content; the centering is internal to the empty state.
+
+Layout:
+
+```
+              I'm Scout! Your AI-powered Data Analyst.
+              How can I assist you today?
+
+   ┌────────────────┐ ┌────────────────┐ ┌────────────────┐
+   │ Starter Q 1  → │ │ Starter Q 2  → │ │ Starter Q 3  → │
+   └────────────────┘ └────────────────┘ └────────────────┘
+
+   ┌────────────────────────────────────────────────────┐
+   │  Ask about your data...                            │
+   │                                                  ↑ │
+   └────────────────────────────────────────────────────┘
+   Scout can only read your data — never modify or delete it.
+   [Data last synced 12 minutes ago.]
+```
+
+- **Heading**: `text-2xl`/`text-3xl`, two lines.
+- **Starter cards**: 3-column grid (collapses to 1 column below `md`). Each card uses existing card / border tokens. Click → calls `props.onSubmit(question)` which calls `sendMessage({ text: question })` — sends immediately, no edit step.
+- **Prominent input**: `<textarea>` styled as a card with a send button absolutely positioned in the bottom-right corner. Enter submits, Shift+Enter newline. Distinct from the compact `<Input>` used mid-chat. Shares `input`/`setInput`/slash-menu state with `ChatPanel`.
+- **Freshness subtext**: always renders the safety line. If `workspace.last_synced_at` is set, appends `Data last synced {relativeTime(last_synced_at)}.`
+- `data-testid`s: `chat-empty-state`, `starter-question-0|1|2`, `chat-input-prominent`, `data-freshness`.
+
+Provider lookup: `workspace.tenants[0]?.provider`. If missing or unknown, falls through to the `default` starter set.
+
+### starterQuestions.ts
+
+```ts
+type Provider = "commcare" | "commcare_connect" | "ocs" | "default"
+
+export const STARTER_QUESTIONS: Record<Provider, string[]> = {
+  commcare: [
+    "How many cases were opened last month?",
+    "Which mobile workers haven't submitted a form in the last week?",
+    "Compare form submission volume this quarter vs last quarter.",
+  ],
+  commcare_connect: [
+    "How many workers completed verified visits this week?",
+    "Which opportunities have the highest payment volume this month?",
+    "Compare average payment per worker across opportunities.",
+  ],
+  ocs: [
+    "How many conversations did the bot handle in the last 7 days?",
+    "What are the most common user messages this week?",
+    "Compare session counts across bots this month vs last month.",
+  ],
+  default: [
+    "What tables are available in my data?",
+    "Show me a high-level overview of the schema.",
+    "What are the most recently updated records?",
+  ],
+}
+```
+
+The CommCare three come from the mockup. CommCare Connect / OCS are reasonable starters informed by each product's domain (payments/opportunities for Connect; conversations/bots for OCS) — they exist to be replaced by anyone with deeper product knowledge during code review.
+
+## Backend: freshness
+
+Add `last_synced_at: datetime | null` to the workspace list and detail responses in `apps/workspaces/api/views.py`.
+
+**Definition.** The `completed_at` of the most recent `MaterializationRun` whose `state == COMPLETED` and whose `tenant_schema.tenant_id` is in the workspace's tenants. `null` if no completed run exists.
+
+**Implementation.** A single annotated subquery on the workspace queryset, returning `MAX(completed_at)` across the workspace's tenants. Conceptually:
+
+```python
+latest_run = MaterializationRun.objects.filter(
+    state=MaterializationRun.RunState.COMPLETED,
+    tenant_schema__tenant__in=OuterRef("tenants"),
+).order_by("-completed_at").values("completed_at")[:1]
+
+queryset.annotate(last_synced_at=Subquery(latest_run))
+```
+
+Avoids N+1 on the list endpoint. Per-workspace tenant counts are typically small, and list pages return <100 workspaces.
+
+**Trade-off considered**: a separate `/api/workspaces/{id}/freshness/` endpoint. Rejected — every page wanting freshness would need a second fetch, and the payload is one timestamp.
+
+## Frontend types
+
+In `frontend/src/api/workspaces.ts`:
+
+```ts
+interface WorkspaceListItem {
+  ...
+  last_synced_at: string | null   // ISO-8601, new
+}
+
+interface WorkspaceDetail {
+  ...
+  last_synced_at: string | null   // ISO-8601, new
+}
+```
+
+The store's `domains` slice picks up the new field for free; no slice changes required.
+
+## Helpers
+
+`frontend/src/lib/relativeTime.ts`:
+
+```ts
+export function formatRelativeTime(iso: string): string
+```
+
+Uses `Intl.RelativeTimeFormat`, bucketing to seconds/minutes/hours/days. Returns strings like `"12 minutes ago"`, `"2 hours ago"`. Only consumer for now is `ChatEmptyState`'s freshness line, but it's general-purpose.
+
+## Data flow
+
+1. App load → `domainSlice.fetchDomains()` → `GET /api/workspaces/` → each workspace now has `last_synced_at`.
+2. `WorkspaceBadge` reads `state.domains.find(d => d.id === activeDomainId)` and renders.
+3. `ChatPanel` mounts. If `messages.length === 0`: renders `<ChatEmptyState workspace={activeWorkspace} input={input} setInput={setInput} onSubmit={onSubmit} />`. Otherwise renders the existing compact layout.
+4. User clicks a starter card → `onSubmit(question)` → `sendMessage({ text: question })` → first message lands → re-render → compact layout.
+
+## Testing
+
+### Frontend
+
+No new unit-test infrastructure. Coverage via:
+
+- **QA scenarios** in `tests/qa/` — new `data-testid`s (`workspace-badge`, `chat-empty-state`, `starter-question-0|1|2`, `chat-input-prominent`, `data-freshness`) let showboat/rodney target the new elements. Scenarios likely needing updates: empty-state assertions, starter-click flow, badge presence on non-chat pages, freshness presence when sync data exists.
+- **Manual smoke** before merge:
+  - Empty state renders with welcome + 3 starters + prominent input.
+  - Clicking a starter immediately sends and transitions to compact layout.
+  - Badge shows correct provider icon + name on Chat / Knowledge / Recipes / Connections / Data Dictionary.
+  - Multi-tenant workspace shows tenant subtext.
+  - Freshness line shows the safety message always, and appends the timestamp only when `last_synced_at` is set.
+
+### Backend
+
+One pytest in `apps/workspaces/tests/` (existing API test file if there's a natural home; new file otherwise). Cases:
+
+1. `last_synced_at` is `null` when no completed `MaterializationRun` exists.
+2. Returns the latest completed run's `completed_at` when one exists.
+3. Ignores in-flight / failed runs.
+4. On a multi-tenant workspace, returns the max `completed_at` across all tenants.
+
+Sync DRF endpoint — standard `pytest-django` + DRF test client, no async client needed.
+
+## File-by-file change list
+
+**New files**
+- `frontend/src/components/TopBar/TopBar.tsx`
+- `frontend/src/components/TopBar/index.ts`
+- `frontend/src/components/WorkspaceBadge/WorkspaceBadge.tsx`
+- `frontend/src/components/WorkspaceBadge/index.ts`
+- `frontend/src/components/WorkspaceBadge/providerMeta.ts` (icon + label map)
+- `frontend/src/components/ChatEmptyState/ChatEmptyState.tsx`
+- `frontend/src/components/ChatEmptyState/starterQuestions.ts`
+- `frontend/src/components/ChatEmptyState/index.ts`
+- `frontend/src/lib/relativeTime.ts`
+- `frontend/src/assets/providers/commcare.svg` (and connect / ocs, if no existing assets)
+
+**Changed files**
+- `frontend/src/components/AppLayout/AppLayout.tsx` — wrap main column with TopBar
+- `frontend/src/components/ChatPanel/ChatPanel.tsx` — branch on `messages.length`, drop own header strip (move Share into TopBar), pass handlers to `ChatEmptyState`
+- `frontend/src/api/workspaces.ts` — add `last_synced_at: string | null` to list and detail types
+- `apps/workspaces/api/views.py` — annotate workspace queryset with `last_synced_at`; include in serialized output
+- `apps/workspaces/tests/...` — new test cases for `last_synced_at`
+
+## Risks & mitigations
+
+- **Subquery cost on workspace list.** One correlated subquery per workspace row. Acceptable for typical user list sizes (<100). If profile shows it as a regression, fold into a single GROUP BY query.
+- **Provider mismatch on multi-tenant workspaces.** A workspace can span multiple tenants of different providers. Using `tenants[0]?.provider` picks the first. Acceptable: it matches how `display_name` already resolves provider, and the tenant subtext makes the multi-tenant nature visible.
+- **Empty-state flicker on first send.** When `messages.length` flips from 0 to 1, the layout swaps instantly. Verify the textarea's focus and any in-flight slash-command state don't break the transition.
+- **Top bar layout shift on pages that previously had no chrome.** The 44px addition is consistent across all pages, so no individual page is uniquely affected. Verify scrollable pages (`ConnectionsPage`, `KnowledgePage`) still position content correctly under the bar.
+
+## Open questions
+
+None — all design decisions resolved during brainstorming.

--- a/frontend/src/api/workspaces.ts
+++ b/frontend/src/api/workspaces.ts
@@ -19,6 +19,7 @@ export interface WorkspaceListItem {
   role: "read" | "read_write" | "manage"
   tenants: WorkspaceListTenant[]
   member_count: number
+  last_synced_at: string | null
   created_at: string
 }
 
@@ -32,6 +33,7 @@ export interface WorkspaceDetail {
   schema_status: "available" | "provisioning" | "unavailable"
   tenant_count: number
   member_count: number
+  last_synced_at: string | null
   created_at: string
   updated_at: string
 }

--- a/frontend/src/components/AppLayout/AppLayout.tsx
+++ b/frontend/src/components/AppLayout/AppLayout.tsx
@@ -7,6 +7,7 @@ import { OfflineBanner } from "@/components/OfflineBanner/OfflineBanner"
 import { useNetworkStatus } from "@/hooks/useNetworkStatus"
 import { useAppStore } from "@/store/store"
 import { WorkspaceJobsProvider } from "@/contexts/WorkspaceJobsContext"
+import { TopBarProvider } from "@/components/TopBar"
 
 export function AppLayout() {
   const { isOnline } = useNetworkStatus()
@@ -50,11 +51,15 @@ export function AppLayout() {
     <WorkspaceJobsProvider workspaceId={activeDomainId}>
       <div className="flex h-screen">
         <Sidebar />
-        <main className="flex-1 min-w-0 overflow-auto">
-          <ErrorBoundary>
-            <Outlet />
-          </ErrorBoundary>
-        </main>
+        <div className="flex flex-1 min-w-0 flex-col">
+          <TopBarProvider>
+            <main className="flex-1 min-w-0 overflow-auto">
+              <ErrorBoundary>
+                <Outlet />
+              </ErrorBoundary>
+            </main>
+          </TopBarProvider>
+        </div>
         <ArtifactPanel />
         <OfflineBanner />
       </div>

--- a/frontend/src/components/ChatEmptyState/ChatEmptyState.tsx
+++ b/frontend/src/components/ChatEmptyState/ChatEmptyState.tsx
@@ -34,7 +34,7 @@ export function ChatEmptyState({
     onSend(trimmed)
   }
 
-  function handleSubmit(e: React.FormEvent) {
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault()
     submit(input)
   }

--- a/frontend/src/components/ChatEmptyState/ChatEmptyState.tsx
+++ b/frontend/src/components/ChatEmptyState/ChatEmptyState.tsx
@@ -1,0 +1,113 @@
+// frontend/src/components/ChatEmptyState/ChatEmptyState.tsx
+import { ArrowUp, ArrowRight } from "lucide-react"
+import { useAppStore } from "@/store/store"
+import { Button } from "@/components/ui/button"
+import { Textarea } from "@/components/ui/textarea"
+import { formatRelativeTime } from "@/lib/relativeTime"
+import { getStarterQuestions } from "./starterQuestions"
+
+interface ChatEmptyStateProps {
+  input: string
+  setInput: (value: string) => void
+  onSend: (text: string) => void
+  disabled?: boolean
+}
+
+export function ChatEmptyState({
+  input,
+  setInput,
+  onSend,
+  disabled = false,
+}: ChatEmptyStateProps) {
+  const workspace = useAppStore((s) =>
+    s.domains.find((d) => d.id === s.activeDomainId),
+  )
+
+  const provider = workspace?.tenants[0]?.provider
+  const starters = getStarterQuestions(provider)
+  const lastSyncedAt = workspace?.last_synced_at ?? null
+
+  function submit(text: string) {
+    const trimmed = text.trim()
+    if (!trimmed || disabled) return
+    setInput("")
+    onSend(trimmed)
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    submit(input)
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault()
+      submit(input)
+    }
+  }
+
+  return (
+    <div
+      className="flex h-full flex-col items-center justify-center px-6 py-10"
+      data-testid="chat-empty-state"
+    >
+      <div className="w-full max-w-3xl">
+        <h1 className="text-center text-2xl font-medium leading-snug md:text-3xl">
+          I&apos;m Scout! Your AI-powered Data Analyst.
+          <br />
+          How can I assist you today?
+        </h1>
+
+        <div className="mt-10 grid grid-cols-1 gap-3 md:grid-cols-3">
+          {starters.map((question, idx) => (
+            <button
+              key={idx}
+              type="button"
+              onClick={() => submit(question)}
+              disabled={disabled}
+              className="group flex items-start justify-between gap-2 rounded-lg border bg-card p-4 text-left text-sm transition hover:bg-accent disabled:opacity-50"
+              data-testid={`starter-question-${idx}`}
+            >
+              <span>{question}</span>
+              <ArrowRight
+                className="h-4 w-4 shrink-0 text-muted-foreground transition group-hover:text-foreground"
+                aria-hidden
+              />
+            </button>
+          ))}
+        </div>
+
+        <form onSubmit={handleSubmit} className="relative mt-10">
+          <Textarea
+            data-testid="chat-input-prominent"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Ask about your data..."
+            disabled={disabled}
+            rows={3}
+            className="resize-none rounded-xl border bg-background px-4 py-3 pr-14 text-base shadow-sm"
+          />
+          <Button
+            type="submit"
+            size="icon"
+            disabled={disabled || !input.trim()}
+            className="absolute bottom-3 right-3"
+          >
+            <ArrowUp className="h-4 w-4" />
+          </Button>
+        </form>
+
+        <p
+          className="mt-3 text-center text-xs text-muted-foreground"
+          data-testid="data-freshness"
+        >
+          Scout can only read your data — never modify or delete it.
+          {lastSyncedAt && (
+            <> Data last synced {formatRelativeTime(lastSyncedAt)}.</>
+          )}
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/ChatEmptyState/index.ts
+++ b/frontend/src/components/ChatEmptyState/index.ts
@@ -1,0 +1,1 @@
+export { ChatEmptyState } from "./ChatEmptyState"

--- a/frontend/src/components/ChatEmptyState/starterQuestions.ts
+++ b/frontend/src/components/ChatEmptyState/starterQuestions.ts
@@ -1,0 +1,32 @@
+// frontend/src/components/ChatEmptyState/starterQuestions.ts
+
+type Provider = "commcare" | "commcare_connect" | "ocs" | "default"
+
+export const STARTER_QUESTIONS: Record<Provider, readonly string[]> = {
+  commcare: [
+    "How many cases were opened last month?",
+    "Which mobile workers haven't submitted a form in the last week?",
+    "Compare form submission volume this quarter vs last quarter.",
+  ],
+  commcare_connect: [
+    "How many workers completed verified visits this week?",
+    "Which opportunities have the highest payment volume this month?",
+    "Compare average payment per worker across opportunities.",
+  ],
+  ocs: [
+    "How many conversations did the bot handle in the last 7 days?",
+    "What are the most common user messages this week?",
+    "Compare session counts across bots this month vs last month.",
+  ],
+  default: [
+    "What tables are available in my data?",
+    "Show me a high-level overview of the schema.",
+    "What are the most recently updated records?",
+  ],
+}
+
+export function getStarterQuestions(provider: string | undefined): readonly string[] {
+  if (!provider) return STARTER_QUESTIONS.default
+  const key = provider as Provider
+  return STARTER_QUESTIONS[key] ?? STARTER_QUESTIONS.default
+}

--- a/frontend/src/components/ChatPanel/ChatPanel.tsx
+++ b/frontend/src/components/ChatPanel/ChatPanel.tsx
@@ -11,6 +11,8 @@ import { Send, Square, Share2, Users, Globe, Link, Copy, Check } from "lucide-re
 import { SLASH_COMMANDS } from "./slashCommands"
 import { SlashCommandMenu } from "./SlashCommandMenu"
 import { useWorkspaceJobs } from "@/contexts/WorkspaceJobsContext"
+import { ChatEmptyState } from "@/components/ChatEmptyState"
+import { TopBarSlot } from "@/components/TopBar"
 
 function threadStorageKey(domainId: string) {
   return `scout:thread:${domainId}`
@@ -276,39 +278,42 @@ export function ChatPanel() {
     )
   }
 
+  if (messages.length === 0) {
+    return (
+      <ChatEmptyState
+        input={input}
+        setInput={setInput}
+        onSend={(text) => sendMessage({ text })}
+        disabled={isStreaming}
+      />
+    )
+  }
+
   return (
     <div className="flex flex-col h-full">
-      {/* Header with share */}
-      {messages.length > 0 && (
-        <div className="flex items-center justify-end border-b px-4 py-2">
-          <div className="relative">
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() => setShowShareMenu(!showShareMenu)}
-              data-testid="chat-share-btn"
-            >
-              <Share2 className="mr-1 h-4 w-4" />
-              Share
-            </Button>
-            {showShareMenu && activeDomainId && (
-              <ShareMenu
-                threadId={threadId}
-                workspaceId={activeDomainId}
-                onClose={() => setShowShareMenu(false)}
-              />
-            )}
-          </div>
+      <TopBarSlot>
+        <div className="relative">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setShowShareMenu(!showShareMenu)}
+            data-testid="chat-share-btn"
+          >
+            <Share2 className="mr-1 h-4 w-4" />
+            Share
+          </Button>
+          {showShareMenu && activeDomainId && (
+            <ShareMenu
+              threadId={threadId}
+              workspaceId={activeDomainId}
+              onClose={() => setShowShareMenu(false)}
+            />
+          )}
         </div>
-      )}
+      </TopBarSlot>
 
       {/* Message list */}
       <div ref={scrollRef} className="flex-1 overflow-y-auto p-4 space-y-4">
-        {messages.length === 0 && (
-          <div className="text-center text-muted-foreground mt-20">
-            Ask a question about your data to get started.
-          </div>
-        )}
         {messages.map((msg: UIMessage, msgIdx: number) => (
           <ChatMessage
             key={msg.id}

--- a/frontend/src/components/TopBar/TopBar.tsx
+++ b/frontend/src/components/TopBar/TopBar.tsx
@@ -1,0 +1,29 @@
+// frontend/src/components/TopBar/TopBar.tsx
+import { useState } from "react"
+import type { ReactNode } from "react"
+import { WorkspaceBadge } from "@/components/WorkspaceBadge"
+import { TopBarSlotContext } from "./TopBarContext"
+
+export function TopBarProvider({ children }: { children: ReactNode }) {
+  const [slotEl, setSlotEl] = useState<HTMLElement | null>(null)
+
+  return (
+    <TopBarSlotContext.Provider value={slotEl}>
+      <div
+        className="flex h-11 shrink-0 items-center justify-between border-b px-4"
+        data-testid="top-bar"
+      >
+        <div className="flex items-center gap-2" />
+        <div className="flex items-center gap-2">
+          <div
+            ref={setSlotEl}
+            className="flex items-center gap-2"
+            data-testid="top-bar-slot"
+          />
+          <WorkspaceBadge />
+        </div>
+      </div>
+      {children}
+    </TopBarSlotContext.Provider>
+  )
+}

--- a/frontend/src/components/TopBar/TopBarContext.ts
+++ b/frontend/src/components/TopBar/TopBarContext.ts
@@ -1,0 +1,4 @@
+// frontend/src/components/TopBar/TopBarContext.ts
+import { createContext } from "react"
+
+export const TopBarSlotContext = createContext<HTMLElement | null>(null)

--- a/frontend/src/components/TopBar/TopBarSlot.tsx
+++ b/frontend/src/components/TopBar/TopBarSlot.tsx
@@ -1,0 +1,15 @@
+// frontend/src/components/TopBar/TopBarSlot.tsx
+import { useContext } from "react"
+import type { ReactNode } from "react"
+import { createPortal } from "react-dom"
+import { TopBarSlotContext } from "./TopBarContext"
+
+/**
+ * Renders children into the global TopBar's trailing slot.
+ * No-op until the TopBar has mounted (slot element exists).
+ */
+export function TopBarSlot({ children }: { children: ReactNode }) {
+  const slotEl = useContext(TopBarSlotContext)
+  if (!slotEl) return null
+  return createPortal(children, slotEl)
+}

--- a/frontend/src/components/TopBar/index.ts
+++ b/frontend/src/components/TopBar/index.ts
@@ -1,0 +1,2 @@
+export { TopBarProvider } from "./TopBar"
+export { TopBarSlot } from "./TopBarSlot"

--- a/frontend/src/components/WorkspaceBadge/WorkspaceBadge.tsx
+++ b/frontend/src/components/WorkspaceBadge/WorkspaceBadge.tsx
@@ -1,0 +1,38 @@
+// frontend/src/components/WorkspaceBadge/WorkspaceBadge.tsx
+import { useAppStore } from "@/store/store"
+import { getProviderMeta } from "./providerMeta"
+
+export function WorkspaceBadge() {
+  const activeDomainId = useAppStore((s) => s.activeDomainId)
+  const workspace = useAppStore((s) =>
+    s.domains.find((d) => d.id === s.activeDomainId),
+  )
+
+  if (!activeDomainId || !workspace) return null
+
+  const firstProvider = workspace.tenants[0]?.provider
+  const { label, Icon } = getProviderMeta(firstProvider)
+  const isMultiTenant = workspace.tenants.length > 1
+  const tenantNames = workspace.tenants
+    .map((t) => t.tenant_name)
+    .join(", ")
+
+  return (
+    <div
+      className="inline-flex items-center gap-2 rounded-full border bg-background px-3 py-1.5 text-sm shadow-sm"
+      data-testid="workspace-badge"
+      data-provider={firstProvider ?? "unknown"}
+      title={isMultiTenant ? `${label} • ${tenantNames}` : label}
+    >
+      <Icon className="h-4 w-4 text-muted-foreground" aria-hidden />
+      <div className="flex flex-col leading-tight">
+        <span className="font-medium">{workspace.display_name}</span>
+        {isMultiTenant && (
+          <span className="text-xs text-muted-foreground truncate max-w-[24ch]">
+            {tenantNames}
+          </span>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/WorkspaceBadge/index.ts
+++ b/frontend/src/components/WorkspaceBadge/index.ts
@@ -1,0 +1,1 @@
+export { WorkspaceBadge } from "./WorkspaceBadge"

--- a/frontend/src/components/WorkspaceBadge/providerMeta.tsx
+++ b/frontend/src/components/WorkspaceBadge/providerMeta.tsx
@@ -1,0 +1,23 @@
+// frontend/src/components/WorkspaceBadge/providerMeta.tsx
+import { Database, Smartphone, Briefcase, MessageSquare } from "lucide-react"
+import type { ComponentType, SVGProps } from "react"
+
+type IconComponent = ComponentType<SVGProps<SVGSVGElement>>
+
+export interface ProviderMeta {
+  label: string
+  Icon: IconComponent
+}
+
+const META: Record<string, ProviderMeta> = {
+  commcare: { label: "CommCare", Icon: Smartphone },
+  commcare_connect: { label: "CommCare Connect", Icon: Briefcase },
+  ocs: { label: "Open Chat Studio", Icon: MessageSquare },
+}
+
+const FALLBACK: ProviderMeta = { label: "Workspace", Icon: Database }
+
+export function getProviderMeta(provider: string | undefined): ProviderMeta {
+  if (!provider) return FALLBACK
+  return META[provider] ?? FALLBACK
+}

--- a/frontend/src/lib/relativeTime.ts
+++ b/frontend/src/lib/relativeTime.ts
@@ -1,0 +1,25 @@
+// frontend/src/lib/relativeTime.ts
+
+const SECOND = 1
+const MINUTE = 60
+const HOUR = 60 * MINUTE
+const DAY = 24 * HOUR
+
+const rtf = new Intl.RelativeTimeFormat("en", { numeric: "auto" })
+
+/**
+ * Format an ISO timestamp as a relative phrase like "12 minutes ago".
+ * Returns "just now" for differences under 30 seconds, falls back to a date
+ * string for differences over ~30 days.
+ */
+export function formatRelativeTime(iso: string, now: Date = new Date()): string {
+  const then = new Date(iso)
+  const deltaSeconds = Math.round((then.getTime() - now.getTime()) / 1000)
+  const abs = Math.abs(deltaSeconds)
+
+  if (abs < 30 * SECOND) return "just now"
+  if (abs < HOUR) return rtf.format(Math.round(deltaSeconds / MINUTE), "minute")
+  if (abs < DAY) return rtf.format(Math.round(deltaSeconds / HOUR), "hour")
+  if (abs < 30 * DAY) return rtf.format(Math.round(deltaSeconds / DAY), "day")
+  return then.toLocaleDateString()
+}

--- a/tests/test_workspace_last_synced.py
+++ b/tests/test_workspace_last_synced.py
@@ -132,3 +132,17 @@ def test_detail_returns_latest_completed_run(client, user, workspace, tenant_sch
     client.force_login(user)
     resp = client.get(f"/api/workspaces/{workspace.id}/")
     assert resp.json()["last_synced_at"] == latest.completed_at.isoformat()
+
+
+@pytest.mark.django_db
+def test_detail_ignores_in_flight_and_failed_runs(client, user, workspace, tenant_schema):
+    now = timezone.now()
+    completed = _make_run(
+        tenant_schema, MaterializationRun.RunState.COMPLETED, now - timedelta(hours=1)
+    )
+    _make_run(tenant_schema, MaterializationRun.RunState.LOADING, now)
+    _make_run(tenant_schema, MaterializationRun.RunState.FAILED, now)
+
+    client.force_login(user)
+    resp = client.get(f"/api/workspaces/{workspace.id}/")
+    assert resp.json()["last_synced_at"] == completed.completed_at.isoformat()

--- a/tests/test_workspace_last_synced.py
+++ b/tests/test_workspace_last_synced.py
@@ -112,3 +112,23 @@ def test_list_only_users_workspaces_get_field(client, user, workspace, tenant_sc
     resp = client.get("/api/workspaces/")
     ids = [w["id"] for w in resp.json()]
     assert str(other_ws.id) not in ids
+
+
+@pytest.mark.django_db
+def test_detail_returns_null_when_no_completed_runs(client, user, workspace):
+    client.force_login(user)
+    resp = client.get(f"/api/workspaces/{workspace.id}/")
+    assert resp.status_code == 200
+    assert resp.json()["last_synced_at"] is None
+
+
+@pytest.mark.django_db
+def test_detail_returns_latest_completed_run(client, user, workspace, tenant_schema):
+    now = timezone.now()
+    older = now - timedelta(hours=2)
+    _make_run(tenant_schema, MaterializationRun.RunState.COMPLETED, older)
+    latest = _make_run(tenant_schema, MaterializationRun.RunState.COMPLETED, now)
+
+    client.force_login(user)
+    resp = client.get(f"/api/workspaces/{workspace.id}/")
+    assert resp.json()["last_synced_at"] == latest.completed_at.isoformat()

--- a/tests/test_workspace_last_synced.py
+++ b/tests/test_workspace_last_synced.py
@@ -1,0 +1,114 @@
+"""Tests for the last_synced_at field on workspace endpoints."""
+
+from datetime import timedelta
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import Client
+from django.utils import timezone
+
+from apps.users.models import Tenant
+from apps.workspaces.models import (
+    MaterializationRun,
+    SchemaState,
+    TenantSchema,
+    Workspace,
+    WorkspaceMembership,
+    WorkspaceRole,
+    WorkspaceTenant,
+)
+
+
+@pytest.fixture
+def client():
+    return Client(enforce_csrf_checks=False)
+
+
+@pytest.fixture
+def tenant_schema(db, tenant):
+    return TenantSchema.objects.create(
+        tenant=tenant, schema_name="test_schema", state=SchemaState.ACTIVE
+    )
+
+
+def _make_run(schema, state, completed_at):
+    run = MaterializationRun.objects.create(tenant_schema=schema, pipeline="commcare", state=state)
+    run.completed_at = completed_at
+    run.save(update_fields=["completed_at"])
+    return run
+
+
+@pytest.mark.django_db
+def test_list_returns_null_when_no_completed_runs(client, user, workspace):
+    client.force_login(user)
+    resp = client.get("/api/workspaces/")
+    assert resp.status_code == 200
+    entry = next(w for w in resp.json() if w["id"] == str(workspace.id))
+    assert entry["last_synced_at"] is None
+
+
+@pytest.mark.django_db
+def test_list_returns_latest_completed_run(client, user, workspace, tenant_schema):
+    now = timezone.now()
+    older = now - timedelta(hours=2)
+    _make_run(tenant_schema, MaterializationRun.RunState.COMPLETED, older)
+    latest = _make_run(tenant_schema, MaterializationRun.RunState.COMPLETED, now)
+
+    client.force_login(user)
+    resp = client.get("/api/workspaces/")
+    entry = next(w for w in resp.json() if w["id"] == str(workspace.id))
+    assert entry["last_synced_at"] == latest.completed_at.isoformat()
+
+
+@pytest.mark.django_db
+def test_list_ignores_in_flight_and_failed_runs(client, user, workspace, tenant_schema):
+    now = timezone.now()
+    completed = _make_run(
+        tenant_schema, MaterializationRun.RunState.COMPLETED, now - timedelta(hours=1)
+    )
+    _make_run(tenant_schema, MaterializationRun.RunState.LOADING, now)
+    _make_run(tenant_schema, MaterializationRun.RunState.FAILED, now)
+
+    client.force_login(user)
+    resp = client.get("/api/workspaces/")
+    entry = next(w for w in resp.json() if w["id"] == str(workspace.id))
+    assert entry["last_synced_at"] == completed.completed_at.isoformat()
+
+
+@pytest.mark.django_db
+def test_list_multi_tenant_returns_max_across_tenants(client, user, workspace, tenant_schema):
+    # Add a second tenant with a more-recent completed run
+    second = Tenant.objects.create(
+        provider="commcare", external_id="second-domain", canonical_name="Second"
+    )
+    WorkspaceTenant.objects.create(workspace=workspace, tenant=second)
+    second_schema = TenantSchema.objects.create(
+        tenant=second, schema_name="second_schema", state=SchemaState.ACTIVE
+    )
+
+    now = timezone.now()
+    _make_run(
+        tenant_schema,
+        MaterializationRun.RunState.COMPLETED,
+        now - timedelta(hours=3),
+    )
+    latest = _make_run(second_schema, MaterializationRun.RunState.COMPLETED, now)
+
+    client.force_login(user)
+    resp = client.get("/api/workspaces/")
+    entry = next(w for w in resp.json() if w["id"] == str(workspace.id))
+    assert entry["last_synced_at"] == latest.completed_at.isoformat()
+
+
+@pytest.mark.django_db
+def test_list_only_users_workspaces_get_field(client, user, workspace, tenant_schema):
+    # Sibling workspace this user does not belong to
+    other_owner_email = "stranger@example.com"
+    other = get_user_model().objects.create_user(email=other_owner_email, password="pass")
+    other_ws = Workspace.objects.create(name="Other", created_by=other)
+    WorkspaceMembership.objects.create(workspace=other_ws, user=other, role=WorkspaceRole.MANAGE)
+
+    client.force_login(user)
+    resp = client.get("/api/workspaces/")
+    ids = [w["id"] for w in resp.json()]
+    assert str(other_ws.id) not in ids


### PR DESCRIPTION
A few UX tweaks to make the active workspace and the data behind it more visible:

- Global workspace badge in a new TopBar (provider icon + display_name, with a tenant subtext line for multi-tenant workspaces). Replaces "which workspace am I in?" guesswork on Knowledge / Recipes / Connections etc.
- Chat empty state: welcome heading + 3 starter cards keyed off the workspace's first tenant provider (CommCare / Connect / OCS / fallback), prominent textarea, and a "Data last synced N minutes ago" line driven by a new `last_synced_at` field on the workspaces API.
- Chat **Share** moves out of its own header strip and into the TopBar via a small portal pattern (`TopBarSlot`), so chat no longer stacks two header strips.

Spec at `docs/superpowers/specs/2026-05-28-ui-tweaks-design.md`, plan at `docs/superpowers/plans/2026-05-28-ui-tweaks.md` (both live on this branch for posterity).

Worth a closer look:
- The portal pattern in `frontend/src/components/TopBar/` — `TopBarProvider` owns a `useState<HTMLElement | null>` set via a callback ref so consumers re-render once the slot DOM mounts. `TopBarSlotContext` is in its own file because `react-refresh/only-export-components` rejects mixing a context export with a component export.
- The `last_synced_at` subquery on the list endpoint (`apps/workspaces/api/workspace_views.py`) — one correlated subquery per workspace row rather than an N+1 follow-up query.
- Starter questions for CommCare Connect and OCS are reasonable starters informed by each product's domain; happy to take edits from anyone with deeper product knowledge.

Out of scope (called out in the spec):
- Recipe / Knowledge chips inside the chat input — slash commands already cover this.
- Editing starter questions without a code deploy.
- Animation for the empty-state → compact-input transition.

To verify locally: open the app on a CommCare workspace, see the welcome state with three CommCare starters; click one and it sends immediately and flips to the compact layout. Badge should appear in the top-right on every page. Multi-tenant workspaces (if you have one) show a comma-separated tenant subtext under the display name.