### PR TITLE
Fix Connect materialization loading + redesign progress banner

### DIFF
--- a/frontend/src/components/MaterializationStatus/MaterializationProgressBanner.tsx
+++ b/frontend/src/components/MaterializationStatus/MaterializationProgressBanner.tsx
@@ -1,4 +1,4 @@
-import { Square, Loader2 } from "lucide-react"
+import { Loader2, X } from "lucide-react"
 import { useState } from "react"
 import { api } from "@/api/client"
 import type { ActiveJob } from "@/api/jobs"
@@ -9,15 +9,14 @@ interface Props {
 }
 
 /**
- * Full-width sticky banner that appears at the bottom of the chat thread
- * whenever a materialization job is active. Designed to be impossible to miss:
- * solid amber background that pops against the neutral chat palette, large
- * percentage counter, thick progress bar, and a solid red Stop button with
- * maximum contrast.
+ * Slim status card shown above the chat input while a materialization job is
+ * active. Styled to read like a system chat message — light-blue fill, blue
+ * outline, rounded like a message bubble — rather than a full-bleed banner.
  *
- * Rendered by ChatPanel below the message list and above the input area.
- * The inline tool-call card still exists for history; this banner is the
- * primary real-time surface.
+ * The bar is determinate (filled to percent) only when the source reports a
+ * row total. Keyset-paginated sources (e.g. Connect visits) return no count,
+ * so there is no denominator: the bar sweeps indeterminately and we show the
+ * live row count instead of a fake fill.
  */
 export function MaterializationProgressBanner({ job, workspaceId }: Props) {
   const [cancelState, setCancelState] = useState<"idle" | "pending" | "error">("idle")
@@ -44,18 +43,16 @@ export function MaterializationProgressBanner({ job, workspaceId }: Props) {
   const sourceName = progress?.source ?? null
   const step = progress?.step ?? null
   const totalSteps = progress?.total_steps ?? null
+  const isDeterminate = percent != null
 
-  // Build the count display: "27,000 / 50,000 (54%)" or "27,000 rows"
+  // Count line: "27,000 of 50,000 rows" when a total is known, else "27,000 rows".
   let countText: string
   if (rowsLoaded > 0) {
     const rowsStr = rowsLoaded.toLocaleString()
-    if (rowsTotal != null && rowsTotal > 0 && percent != null) {
-      countText = `${rowsStr} / ${rowsTotal.toLocaleString()} (${percent}%)`
-    } else if (rowsTotal != null && rowsTotal > 0) {
-      countText = `${rowsStr} / ${rowsTotal.toLocaleString()}`
-    } else {
-      countText = `${rowsStr} rows`
-    }
+    countText =
+      rowsTotal != null && rowsTotal > 0
+        ? `${rowsStr} of ${rowsTotal.toLocaleString()} rows`
+        : `${rowsStr} rows`
   } else if (sourceName) {
     countText = `Loading ${sourceName}…`
   } else {
@@ -63,100 +60,100 @@ export function MaterializationProgressBanner({ job, workspaceId }: Props) {
   }
 
   const stepText = step != null && totalSteps != null ? `Step ${step} of ${totalSteps}` : null
+  const stopLabel =
+    cancelState === "pending" ? "Stopping…" : cancelState === "error" ? "Try again" : "Stop"
 
   return (
-    <div
-      className="bg-amber-500 shadow-lg px-5 py-4 flex items-center gap-4"
-      data-testid="materialization-progress-banner"
-      role="status"
-      aria-live="polite"
-    >
-      {/* Spinner */}
-      <Loader2
-        className="h-6 w-6 shrink-0 animate-spin text-amber-900"
-        aria-hidden="true"
-      />
+    <div className="px-4 pt-1 pb-2">
+      <div
+        className="flex items-center gap-3 rounded-lg border border-blue-600/40 bg-blue-50 px-4 py-2.5 dark:border-blue-400/30 dark:bg-blue-950/40"
+        data-testid="materialization-progress-banner"
+        role="status"
+        aria-live="polite"
+      >
+        <Loader2
+          className="h-4 w-4 shrink-0 animate-spin text-blue-600 dark:text-blue-400"
+          aria-hidden="true"
+        />
 
-      {/* Progress text block */}
-      <div className="flex-1 min-w-0">
-        {/* Source label + step info */}
-        <div className="flex items-baseline gap-2 flex-wrap">
-          <span
-            className="font-semibold text-base text-amber-950"
-            data-testid="materialization-banner-source"
-          >
-            {sourceName ? `Fetching ${sourceName}` : "Materializing data"}
-          </span>
-          {stepText && (
-            <span className="text-sm text-amber-800 font-medium opacity-80">
-              · {stepText}
-            </span>
-          )}
-        </div>
-
-        {/* Percentage (dominant) + count */}
-        <div className="flex items-baseline gap-3 mt-0.5 flex-wrap">
-          {percent != null && (
+        {/* Progress text block */}
+        <div className="flex-1 min-w-0">
+          <div className="flex items-baseline gap-2 flex-wrap">
             <span
-              className="text-2xl font-extrabold text-amber-950 leading-none"
-              data-testid="materialization-banner-percent"
+              className="text-sm font-medium text-blue-900 dark:text-blue-100"
+              data-testid="materialization-banner-source"
             >
-              {percent}%
+              {sourceName ? `Fetching ${sourceName}` : "Materializing data"}
             </span>
-          )}
-          <span
-            className="text-sm font-medium text-amber-900"
+            {stepText && (
+              <span className="text-xs text-blue-700/70 dark:text-blue-300/70">{stepText}</span>
+            )}
+            {percent != null && (
+              <span
+                className="text-xs font-semibold text-blue-700 dark:text-blue-300"
+                data-testid="materialization-banner-percent"
+              >
+                {percent}%
+              </span>
+            )}
+          </div>
+
+          <div
+            className="text-xs text-blue-700/90 dark:text-blue-300/90 mt-0.5"
             data-testid="materialization-banner-rows"
           >
             {countText}
-          </span>
-        </div>
+          </div>
 
-        {/* Progress bar — 5px tall, always visible, fills smoothly */}
-        <div
-          className="mt-2 h-[5px] rounded-full bg-amber-200 overflow-hidden"
-          data-testid="materialization-banner-progress-bar"
-        >
+          {/* Determinate fill when a total is known; otherwise an indeterminate
+              sweep — keyset-paginated sources report no total to fill against. */}
           <div
-            className="h-full rounded-full bg-amber-900 transition-all duration-500 ease-out"
-            style={{ width: percent != null ? `${Math.min(percent, 100)}%` : "100%" }}
-          />
+            className="relative mt-1.5 h-1 overflow-hidden rounded-full bg-blue-200/70 dark:bg-blue-900"
+            data-testid="materialization-banner-progress-bar"
+          >
+            {isDeterminate ? (
+              <div
+                className="h-full rounded-full bg-blue-600 transition-all duration-500 ease-out dark:bg-blue-400"
+                style={{ width: `${Math.min(percent, 100)}%` }}
+              />
+            ) : (
+              <div
+                className="absolute top-0 h-full rounded-full bg-blue-500 dark:bg-blue-400"
+                style={{ animation: "mat-indeterminate 1.5s ease-in-out infinite" }}
+              />
+            )}
+          </div>
         </div>
-      </div>
 
-      {/* Stop button — solid red fill, white text, large hit target */}
-      <button
-        type="button"
-        onClick={handleCancel}
-        disabled={cancelState === "pending"}
-        className={`flex items-center gap-2 rounded-lg px-5 py-2.5 text-base font-bold transition-colors shrink-0 shadow-md ${
-          cancelState === "error"
-            ? "bg-red-700 text-white cursor-default"
-            : cancelState === "pending"
-              ? "bg-red-300 text-white cursor-not-allowed"
-              : "bg-red-600 text-white hover:bg-red-700 active:bg-red-800"
-        }`}
-        data-testid="materialization-banner-stop-btn"
-        title={
-          cancelState === "error"
-            ? "Cancel failed — try again"
-            : cancelState === "pending"
-              ? "Cancelling…"
-              : "Stop data loading"
-        }
-      >
-        <Square
-          className={`h-4 w-4 ${cancelState === "pending" ? "animate-pulse" : ""}`}
-          aria-hidden="true"
-        />
-        <span>
-          {cancelState === "pending"
-            ? "Stopping…"
-            : cancelState === "error"
-              ? "Stop failed"
-              : "Stop"}
-        </span>
-      </button>
+        {/* Stop button — restrained by default, reveals a red destructive tone on hover */}
+        <button
+          type="button"
+          onClick={handleCancel}
+          disabled={cancelState === "pending"}
+          className={`flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-xs font-medium transition-colors shrink-0 ${
+            cancelState === "pending"
+              ? "border-blue-600/20 text-blue-400 cursor-not-allowed dark:border-blue-400/20 dark:text-blue-500"
+              : "border-blue-600/30 text-blue-700 hover:border-red-400 hover:bg-red-50 hover:text-red-600 dark:border-blue-400/30 dark:text-blue-300 dark:hover:border-red-400/50 dark:hover:bg-red-950/40 dark:hover:text-red-400"
+          }`}
+          data-testid="materialization-banner-stop-btn"
+          title={
+            cancelState === "error" ? "Cancel failed — try again" : "Stop data loading"
+          }
+        >
+          <X
+            className={`h-3.5 w-3.5 ${cancelState === "pending" ? "animate-pulse" : ""}`}
+            aria-hidden="true"
+          />
+          <span>{stopLabel}</span>
+        </button>
+
+        <style>{`
+          @keyframes mat-indeterminate {
+            0%   { left: -35%; width: 35%; }
+            100% { left: 100%; width: 35%; }
+          }
+        `}</style>
+      </div>
     </div>
   )
 }

--- a/mcp_server/services/materializer.py
+++ b/mcp_server/services/materializer.py
@@ -145,10 +145,14 @@ def run_pipeline(
                 }
             )
 
-    def make_on_page(source_name: str, message: str) -> OnPage:
+    def make_on_page(source_name: str, message: str, known_total: int | None = None) -> OnPage:
         def _on_page(rows_loaded: int, rows_total: int | None) -> None:
             if progress_updater is None:
                 return
+            # Prefer a total the loader itself reports (page envelope ``count``);
+            # otherwise fall back to a count discovered up front (e.g. the
+            # opportunity's ``visit_count``) so the bar can show a real percent.
+            effective_total = rows_total if rows_total is not None else known_total
             progress_updater(
                 {
                     "run_id": run_id_holder["id"],
@@ -157,7 +161,7 @@ def run_pipeline(
                     "source": source_name,
                     "message": message,
                     "rows_loaded": rows_loaded,
-                    "rows_total": rows_total,
+                    "rows_total": effective_total,
                 }
             )
 
@@ -186,7 +190,16 @@ def run_pipeline(
     try:
         # ── 2. DISCOVER ───────────────────────────────────────────────────────
         report(f"Discovering tenant metadata from {pipeline.provider}...")
-        _run_discover_phase(tenant_membership, credential, pipeline)
+        discovered_metadata = _run_discover_phase(tenant_membership, credential, pipeline)
+
+        # The visits export is keyset-paginated and returns no total, but the
+        # discovery payload already carries the opportunity's visit_count — use
+        # it as the visits progress denominator.
+        visit_total: int | None = None
+        if pipeline.provider == "commcare_connect":
+            visit_total = _connect_visit_total(
+                discovered_metadata, int(tenant_membership.tenant.external_id)
+            )
 
         # Generate system staging assets from discovered metadata.
         # Failures are logged but do not fail the pipeline — the discover phase
@@ -262,6 +275,12 @@ def run_pipeline(
                 if source_is_resumable
                 else None
             )
+            # The discovered visit_count counts *all* visits, so it's only a
+            # valid denominator on a fresh load. On resume, rows_loaded counts
+            # just this run's new rows, so leave the bar indeterminate.
+            source_total = (
+                visit_total if source.name == "visits" and start_cursor is None else None
+            )
             try:
                 rows = _load_and_commit_source(
                     source.name,
@@ -269,7 +288,7 @@ def run_pipeline(
                     credential,
                     schema_name,
                     provider=pipeline.provider,
-                    on_page=make_on_page(source.name, load_message),
+                    on_page=make_on_page(source.name, load_message, known_total=source_total),
                     resumable=source_is_resumable,
                     start_cursor=start_cursor,
                     cursor_callback=cursor_callback,
@@ -476,10 +495,15 @@ def run_pipeline(
 
 def _run_discover_phase(
     tenant_membership: Any, credential: dict[str, str], pipeline: PipelineConfig
-) -> None:
-    """Fetch provider metadata and upsert into TenantMetadata."""
+) -> dict | None:
+    """Fetch provider metadata, upsert into TenantMetadata, and return it.
+
+    The returned dict lets the LOAD phase read counts that the discovery
+    payload already carries (e.g. the opportunity's ``visit_count``) without a
+    second API call. Returns ``None`` when the pipeline has no discovery step.
+    """
     if not pipeline.has_metadata_discovery:
-        return
+        return None
 
     if pipeline.provider == "commcare_connect":
         loader = ConnectMetadataLoader(
@@ -502,6 +526,24 @@ def _run_discover_phase(
         defaults={"metadata": metadata, "discovered_at": timezone.now()},
     )
     logger.info("Stored metadata for tenant %s", tenant_membership.tenant.external_id)
+    return metadata
+
+
+def _connect_visit_total(metadata: dict | None, opportunity_id: int) -> int | None:
+    """Pull the opportunity's all-visits count from discovered Connect metadata.
+
+    ``/export/opp_org_program_list/`` (fetched during DISCOVER) annotates each
+    opportunity with ``visit_count``. We use it as the denominator for the
+    visits progress bar, since the keyset-paginated visits export returns no
+    total of its own. Returns ``None`` when the count is absent or non-positive.
+    """
+    if not metadata:
+        return None
+    for opp in metadata.get("all_opportunities", []) or []:
+        if isinstance(opp, dict) and opp.get("id") == opportunity_id:
+            count = opp.get("visit_count")
+            return count if isinstance(count, int) and count > 0 else None
+    return None
 
 
 def _load_prior_resume_cursors(tenant_schema: Any, exclude_run_id: Any) -> dict[str, int]:
@@ -1222,52 +1264,47 @@ _CONNECT_USERS_INSERT = psql.SQL(
 _CONNECT_COMPLETED_WORKS_INSERT = psql.SQL(
     """
     INSERT INTO {schema}.raw_completed_works
-        (id, username, opportunity_id, payment_unit_id, status, last_modified,
+        (username, opportunity_id, payment_unit_id, status, last_modified,
          entity_id, entity_name, reason, status_modified_date, payment_date,
          date_created, saved_completed_count, saved_approved_count,
          saved_payment_accrued, saved_payment_accrued_usd,
          saved_org_payment_accrued, saved_org_payment_accrued_usd)
-    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
-    ON CONFLICT (id) DO NOTHING
+    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
     """
 )
 
 _CONNECT_PAYMENTS_INSERT = psql.SQL(
     """
     INSERT INTO {schema}.raw_payments
-        (id, username, opportunity_id, created_at, amount, amount_usd, date_paid,
+        (username, opportunity_id, created_at, amount, amount_usd, date_paid,
          payment_unit, confirmed, confirmation_date, organization, invoice_id,
          payment_method, payment_operator)
-    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
-    ON CONFLICT (id) DO NOTHING
+    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
     """
 )
 
 _CONNECT_INVOICES_INSERT = psql.SQL(
     """
     INSERT INTO {schema}.raw_invoices
-        (id, opportunity_id, amount, amount_usd, date, invoice_number,
+        (opportunity_id, amount, amount_usd, date, invoice_number,
          service_delivery, exchange_rate)
-    VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
-    ON CONFLICT (id) DO NOTHING
+    VALUES (%s, %s, %s, %s, %s, %s, %s)
     """
 )
 
 _CONNECT_ASSESSMENTS_INSERT = psql.SQL(
     """
     INSERT INTO {schema}.raw_assessments
-        (id, username, app, opportunity_id, date, score, passing_score, passed)
-    VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
-    ON CONFLICT (id) DO NOTHING
+        (username, app, opportunity_id, date, score, passing_score, passed)
+    VALUES (%s, %s, %s, %s, %s, %s, %s)
     """
 )
 
 _CONNECT_COMPLETED_MODULES_INSERT = psql.SQL(
     """
     INSERT INTO {schema}.raw_completed_modules
-        (id, username, module, opportunity_id, date, duration)
-    VALUES (%s, %s, %s, %s, %s, %s)
-    ON CONFLICT (id) DO NOTHING
+        (username, module, opportunity_id, date, duration)
+    VALUES (%s, %s, %s, %s, %s)
     """
 )
 
@@ -1531,7 +1568,7 @@ def _write_connect_completed_works(
         psql.SQL(
             """
         CREATE TABLE IF NOT EXISTS {schema}.raw_completed_works (
-            id BIGINT PRIMARY KEY,
+            id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
             username TEXT,
             opportunity_id BIGINT,
             payment_unit_id BIGINT,
@@ -1565,7 +1602,6 @@ def _write_connect_completed_works(
             rows_total = page_total
         rows = [
             (
-                r.get("id"),
                 r.get("username", ""),
                 r.get("opportunity_id"),
                 r.get("payment_unit_id"),
@@ -1625,7 +1661,7 @@ def _write_connect_payments(
         psql.SQL(
             """
         CREATE TABLE IF NOT EXISTS {schema}.raw_payments (
-            id BIGINT PRIMARY KEY,
+            id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
             username TEXT,
             opportunity_id BIGINT,
             created_at TIMESTAMPTZ,
@@ -1655,7 +1691,6 @@ def _write_connect_payments(
             rows_total = page_total
         rows = [
             (
-                r.get("id"),
                 r.get("username", ""),
                 r.get("opportunity_id"),
                 r.get("created_at"),
@@ -1712,7 +1747,7 @@ def _write_connect_invoices(
         psql.SQL(
             """
         CREATE TABLE IF NOT EXISTS {schema}.raw_invoices (
-            id BIGINT PRIMARY KEY,
+            id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
             opportunity_id BIGINT,
             amount NUMERIC(14, 2),
             amount_usd NUMERIC(14, 2),
@@ -1736,7 +1771,6 @@ def _write_connect_invoices(
             rows_total = page_total
         rows = [
             (
-                r.get("id"),
                 r.get("opportunity_id"),
                 r.get("amount"),
                 r.get("amount_usd"),
@@ -1785,7 +1819,7 @@ def _write_connect_assessments(
         psql.SQL(
             """
         CREATE TABLE IF NOT EXISTS {schema}.raw_assessments (
-            id BIGINT PRIMARY KEY,
+            id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
             username TEXT,
             app BIGINT,
             opportunity_id BIGINT,
@@ -1809,7 +1843,6 @@ def _write_connect_assessments(
             rows_total = page_total
         rows = [
             (
-                r.get("id"),
                 r.get("username", ""),
                 r.get("app"),
                 r.get("opportunity_id"),
@@ -1858,7 +1891,7 @@ def _write_connect_completed_modules(
         psql.SQL(
             """
         CREATE TABLE IF NOT EXISTS {schema}.raw_completed_modules (
-            id BIGINT PRIMARY KEY,
+            id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
             username TEXT,
             module BIGINT,
             opportunity_id BIGINT,
@@ -1880,7 +1913,6 @@ def _write_connect_completed_modules(
             rows_total = page_total
         rows = [
             (
-                r.get("id"),
                 r.get("username", ""),
                 r.get("module"),
                 r.get("opportunity_id"),

--- a/pipelines/connect_sync.yml
+++ b/pipelines/connect_sync.yml
@@ -11,16 +11,24 @@ sources:
     # Mutable rows (usernames, suspension status) — full DROP/CREATE/INSERT
     # every run; do not resume from a partial-page watermark (issue #187).
     resumable: false
+  # The v2 export serializers for the resources below do not emit a per-row
+  # `id`, so there is no integer watermark to keyset-resume from. Like `users`,
+  # they do a full DROP/CREATE/INSERT every run and use a surrogate identity PK.
   - name: completed_works
     description: "Completed work records"
+    resumable: false
   - name: payments
     description: "Payment records"
+    resumable: false
   - name: invoices
     description: "Invoice records"
+    resumable: false
   - name: assessments
     description: "Assessment results"
+    resumable: false
   - name: completed_modules
     description: "Learn module completions"
+    resumable: false
 
 metadata_discovery:
   description: "Fetch opportunity detail and org/program structure from Connect API"

--- a/tests/test_materializer.py
+++ b/tests/test_materializer.py
@@ -2,6 +2,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from mcp_server.services.materializer import _connect_visit_total
+
 
 class TestRunPipeline:
     def _make_schema(self, name="dimagi"):
@@ -1169,11 +1171,17 @@ class TestWriteForms:
 
 @pytest.mark.django_db
 class TestConnectPageReplayIdempotency:
-    """Regression tests for bot comment #3315357471.
+    """Regression tests guarding against row duplication in the Connect writers.
 
-    Verifies that re-inserting the same page (simulating a crash between
-    conn.commit() and cursor_callback()) does NOT duplicate rows in the
-    five Connect tables that previously lacked a primary key.
+    ``visits`` is resumable (real integer ``visit_id`` PK) and dedupes a page
+    replay via ON CONFLICT DO UPDATE.
+
+    ``completed_works`` and ``payments`` are non-resumable: the v2 export
+    serializers omit a per-row ``id``, so they use a surrogate identity PK and
+    do a full DROP/CREATE/INSERT every run. The tests below feed **id-less**
+    records (matching the real serializer shape — see the production tenant-765
+    NotNullViolation on ``id``) and verify a re-run reloads cleanly without
+    duplication, rather than relying on a primary key the API never sends.
     """
 
     def _get_db_url(self):
@@ -1188,9 +1196,11 @@ class TestConnectPageReplayIdempotency:
             cur.execute(f"CREATE SCHEMA {schema_name}")
         conn.autocommit = False
 
-    def test_payments_page_replay_no_duplication(self, django_db_setup, db):
-        """Re-inserting a page of payments (simulating crash before watermark
-        persist) must not duplicate rows — ON CONFLICT (id) DO NOTHING applies.
+    def test_payments_idless_full_reload_no_duplication(self, django_db_setup, db):
+        """payments records carry no ``id`` in the v2 export. They must insert
+        via the surrogate identity PK (no NotNullViolation), and because the
+        source is non-resumable a re-run does a full DROP/CREATE/INSERT — so the
+        row count stays stable instead of duplicating.
         """
         import psycopg
 
@@ -1205,9 +1215,9 @@ class TestConnectPageReplayIdempotency:
         try:
             self._make_schema(conn, test_schema)
 
+            # id-less: mirrors PaymentDataSerializer, which omits `id`.
             page = [
                 {
-                    "id": 101,
                     "username": "user1",
                     "opportunity_id": 1,
                     "created_at": "2026-01-01T00:00:00Z",
@@ -1223,7 +1233,6 @@ class TestConnectPageReplayIdempotency:
                     "payment_operator": "op1",
                 },
                 {
-                    "id": 102,
                     "username": "user2",
                     "opportunity_id": 1,
                     "created_at": "2026-01-02T00:00:00Z",
@@ -1240,21 +1249,18 @@ class TestConnectPageReplayIdempotency:
                 },
             ]
 
-            # First write — clean run, no cursor yet.
+            # First full load (non-resumable → start_cursor is always None).
             _write_connect_payments(
                 pages=iter([(page, 2)]),
                 schema_name=test_schema,
                 conn=conn,
             )
 
-            # Simulate crash: conn already committed the page, but cursor_callback
-            # was never called. Re-run from the prior watermark by writing the
-            # same page again (start_cursor is set to skip DROP/CREATE).
+            # Re-run: a fresh full load drops and recreates the table.
             _write_connect_payments(
                 pages=iter([(page, 2)]),
                 schema_name=test_schema,
                 conn=conn,
-                start_cursor=100,  # any non-None value triggers the resume path
             )
 
             with conn.cursor() as cur:
@@ -1262,8 +1268,8 @@ class TestConnectPageReplayIdempotency:
                 (count,) = cur.fetchone()
 
             assert count == 2, (
-                f"Expected 2 rows after page replay, got {count} — "
-                "ON CONFLICT (id) DO NOTHING must be present"
+                f"Expected 2 rows after a full reload, got {count} — "
+                "non-resumable writers must DROP/CREATE each run"
             )
         finally:
             conn.rollback()
@@ -1272,8 +1278,11 @@ class TestConnectPageReplayIdempotency:
                 cur.execute(f"DROP SCHEMA IF EXISTS {test_schema} CASCADE")
             conn.close()
 
-    def test_completed_works_page_replay_no_duplication(self, django_db_setup, db):
-        """Re-inserting a page of completed_works must not duplicate rows."""
+    def test_completed_works_idless_full_reload_no_duplication(self, django_db_setup, db):
+        """completed_works records carry no ``id`` in the v2 export (the exact
+        production failure on tenant 765). They must insert via the surrogate
+        identity PK, and a non-resumable re-run reloads without duplication.
+        """
         import psycopg
 
         from mcp_server.services.materializer import _write_connect_completed_works
@@ -1287,9 +1296,9 @@ class TestConnectPageReplayIdempotency:
         try:
             self._make_schema(conn, test_schema)
 
+            # id-less: mirrors CompletedWorkDataSerializer, which omits `id`.
             page = [
                 {
-                    "id": 201,
                     "username": "user1",
                     "opportunity_id": 1,
                     "payment_unit_id": 10,
@@ -1310,19 +1319,18 @@ class TestConnectPageReplayIdempotency:
                 },
             ]
 
-            # First write — clean run.
+            # First full load.
             _write_connect_completed_works(
                 pages=iter([(page, 1)]),
                 schema_name=test_schema,
                 conn=conn,
             )
 
-            # Replay the same page (crash scenario — watermark not advanced).
+            # Re-run: fresh full load drops and recreates the table.
             _write_connect_completed_works(
                 pages=iter([(page, 1)]),
                 schema_name=test_schema,
                 conn=conn,
-                start_cursor=200,
             )
 
             with conn.cursor() as cur:
@@ -1330,8 +1338,8 @@ class TestConnectPageReplayIdempotency:
                 (count,) = cur.fetchone()
 
             assert count == 1, (
-                f"Expected 1 row after page replay, got {count} — "
-                "ON CONFLICT (id) DO NOTHING must be present"
+                f"Expected 1 row after a full reload, got {count} — "
+                "non-resumable writers must DROP/CREATE each run"
             )
         finally:
             conn.rollback()
@@ -1414,3 +1422,30 @@ class TestConnectPageReplayIdempotency:
             with conn.cursor() as cur:
                 cur.execute(f"DROP SCHEMA IF EXISTS {test_schema} CASCADE")
             conn.close()
+
+
+class TestConnectVisitTotal:
+    """`_connect_visit_total` pulls the opportunity's all-visits count from the
+    discovery payload so the keyset-paginated visits bar can show a real percent.
+    """
+
+    def test_returns_visit_count_for_matching_opportunity(self):
+        meta = {
+            "all_opportunities": [
+                {"id": 1, "visit_count": 5},
+                {"id": 765, "visit_count": 99130},
+            ]
+        }
+        assert _connect_visit_total(meta, 765) == 99130
+
+    def test_returns_none_when_opportunity_absent(self):
+        meta = {"all_opportunities": [{"id": 1, "visit_count": 5}]}
+        assert _connect_visit_total(meta, 765) is None
+
+    def test_returns_none_for_zero_or_missing_count(self):
+        assert _connect_visit_total({"all_opportunities": [{"id": 765, "visit_count": 0}]}, 765) is None
+        assert _connect_visit_total({"all_opportunities": [{"id": 765}]}, 765) is None
+
+    def test_returns_none_for_no_metadata(self):
+        assert _connect_visit_total(None, 765) is None
+        assert _connect_visit_total({}, 765) is None

--- a/tests/test_pipeline_registry.py
+++ b/tests/test_pipeline_registry.py
@@ -148,23 +148,25 @@ sources:
         assert by_name["visits"].resumable is True
         assert by_name["users"].resumable is False
 
-    def test_connect_sync_users_is_non_resumable(self):
-        """The real connect_sync.yml must mark ``users`` non-resumable."""
+    def test_connect_sync_resumability_flags(self):
+        """Only ``visits`` can keyset-resume: its v2 export carries an integer
+        ``id``. ``users`` is mutable (full reload), and the remaining sources'
+        v2 export serializers omit ``id`` entirely, so they have no watermark to
+        resume from and must be non-resumable (full DROP/CREATE/INSERT)."""
         registry = PipelineRegistry()
         config = registry.get("connect_sync")
         by_name = {s.name: s for s in config.sources}
-        assert by_name["users"].resumable is False
-        # The other six are resumable.
+        assert by_name["visits"].resumable is True
         for src_name in (
-            "visits",
+            "users",
             "completed_works",
             "payments",
             "invoices",
             "assessments",
             "completed_modules",
         ):
-            assert by_name[src_name].resumable is True, (
-                f"{src_name} should default to resumable=True"
+            assert by_name[src_name].resumable is False, (
+                f"{src_name} has no per-row id in the v2 export and must be non-resumable"
             )
 
     def test_relationships_defaults_to_empty(self, tmp_path):


### PR DESCRIPTION
## Summary

Follow-up to #204 (materialization UX) fixing a production loading bug and polishing the progress banner.

- **Fix the `completed_works`/`payments`/`invoices`/`assessments`/`completed_modules` writers.** The v2 Connect export serializers emit no per-row `id` for these resources, but the writers mapped a NOT NULL `id BIGINT PRIMARY KEY` from `r.get("id")` — so every insert raised `NotNullViolation` (the tenant-765 failure that left runs PARTIAL with those sources skipped). They now use a surrogate `GENERATED ALWAYS AS IDENTITY` key, drop the meaningless `ON CONFLICT (id)`, and are marked **non-resumable** (no integer id = no keyset watermark), matching the `users` precedent. Only `visits` (real `visit_id`) stays resumable.
- **Show a real percentage for visits.** Its export is keyset-paginated and returns no total, but `/export/opp_org_program_list/` (already fetched during discovery) carries `visit_count` per opportunity — threaded through as the progress denominator on fresh loads (indeterminate on resume). No extra API call.
- **Redesign the progress banner** to read like a system chat message: blue outline, light-blue fill, rounded, inset to the chat column. The bar animates indeterminately when there's no real total (instead of a misleading full bar), and the Stop button is simplified to an X + label that reddens on hover.

The synthetic id-bearing test fixtures that had masked the writer bug are reworked to mirror the real serializer shape.

## Verification
- Live re-materialization against real Connect: **status `completed`, all 7 sources loaded** (completed_works 95,557 rows ✅; previously failed), visits showed a real percentage.
- Real-Postgres writer tests + visit-count + resumability tests pass; ruff + eslint clean.

## Test plan
- [ ] `uv run pytest tests/test_materializer.py tests/test_pipeline_registry.py tests/test_connect_data_loaders.py`
- [ ] Run a Connect materialization and confirm all sources load and the banner shows a live percentage on visits

🤖 Generated with [Claude Code](https://claude.com/claude-code)