### PR TITLE
Fix SynchronousOnlyOperation in refresh_tenant_schema credential resolution

### DIFF
--- a/apps/workspaces/tasks.py
+++ b/apps/workspaces/tasks.py
@@ -18,7 +18,7 @@ from apps.chat.checkpointer import ensure_checkpointer
 from apps.chat.constants import SYSTEM_RESUME_MARKER
 from apps.chat.models import Thread, ThreadJob
 from apps.users.models import TenantMembership
-from apps.users.services.credential_resolver import aresolve_credential, resolve_credential
+from apps.users.services.credential_resolver import aresolve_credential
 from apps.workspaces.models import (
     MaterializationRun,
     SchemaState,
@@ -149,8 +149,10 @@ async def refresh_tenant_schema(schema_id: str, membership_id: str) -> dict:
         await new_schema.asave(update_fields=["state"])
         return {"error": "Failed to create schema"}
 
-    # Step 2: Resolve credential and run materialization pipeline
-    credential = resolve_credential(membership)
+    # Step 2: Resolve credential and run materialization pipeline. This task
+    # runs as an async job, so it must use the async resolver — the sync one
+    # issues ORM queries that raise SynchronousOnlyOperation here.
+    credential = await aresolve_credential(membership)
     if credential is None:
         await _drop_schema_and_fail(new_schema)
         return {"error": "No credential available"}

--- a/tests/test_refresh_task.py
+++ b/tests/test_refresh_task.py
@@ -4,6 +4,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from apps.users.adapters import encrypt_credential
+from apps.users.models import TenantCredential
 from apps.workspaces.models import SchemaState, TenantSchema
 
 
@@ -61,8 +63,8 @@ async def test_refresh_task_marks_schema_active_on_success(
             return_value=_mock_conn(),
         ),
         patch(
-            "apps.workspaces.tasks.resolve_credential",
-            return_value={"type": "api_key", "value": "tok"},
+            "apps.workspaces.tasks.aresolve_credential",
+            new=AsyncMock(return_value={"type": "api_key", "value": "tok"}),
         ),
         patch(
             "apps.workspaces.tasks.get_registry",
@@ -97,8 +99,8 @@ async def test_refresh_task_schedules_old_schema_teardown(
             return_value=_mock_conn(),
         ),
         patch(
-            "apps.workspaces.tasks.resolve_credential",
-            return_value={"type": "api_key", "value": "tok"},
+            "apps.workspaces.tasks.aresolve_credential",
+            new=AsyncMock(return_value={"type": "api_key", "value": "tok"}),
         ),
         patch(
             "apps.workspaces.tasks.get_registry",
@@ -154,7 +156,7 @@ async def test_refresh_task_marks_failed_on_no_credential(
             "apps.workspaces.services.schema_manager.get_managed_db_connection",
             return_value=_mock_conn(),
         ),
-        patch("apps.workspaces.tasks.resolve_credential", return_value=None),
+        patch("apps.workspaces.tasks.aresolve_credential", new=AsyncMock(return_value=None)),
         patch("apps.workspaces.services.schema_manager.SchemaManager.teardown"),
     ):
         from apps.workspaces.tasks import refresh_tenant_schema
@@ -180,8 +182,8 @@ async def test_refresh_task_marks_failed_on_materialization_error(
             return_value=_mock_conn(),
         ),
         patch(
-            "apps.workspaces.tasks.resolve_credential",
-            return_value={"type": "api_key", "value": "tok"},
+            "apps.workspaces.tasks.aresolve_credential",
+            new=AsyncMock(return_value={"type": "api_key", "value": "tok"}),
         ),
         patch(
             "apps.workspaces.tasks.get_registry",
@@ -203,6 +205,48 @@ async def test_refresh_task_marks_failed_on_materialization_error(
     await provisioning_schema.arefresh_from_db()
     assert provisioning_schema.state == SchemaState.FAILED
     assert "error" in result
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_refresh_task_resolves_credential_in_async_context(
+    provisioning_schema, tenant_membership_obj
+):
+    """Regression: the task must resolve credentials via the async ORM path.
+
+    The task runs as an ``async def`` procrastinate job, so it must use
+    ``aresolve_credential``. Calling the sync ``resolve_credential`` here ran
+    sync ORM queries in an async context and raised ``SynchronousOnlyOperation``
+    in production. This test exercises the *real* resolver (no mock) against a
+    stored API-key credential to catch that regression.
+    """
+    await TenantCredential.objects.acreate(
+        tenant_membership=tenant_membership_obj,
+        credential_type=TenantCredential.API_KEY,
+        encrypted_credential=encrypt_credential("secret-key"),
+    )
+
+    with (
+        patch(
+            "apps.workspaces.services.schema_manager.get_managed_db_connection",
+            return_value=_mock_conn(),
+        ),
+        patch(
+            "apps.workspaces.tasks.get_registry",
+            return_value=_mock_registry(),
+        ),
+        patch("apps.workspaces.tasks.run_pipeline"),
+    ):
+        from apps.workspaces.tasks import refresh_tenant_schema
+
+        result = await refresh_tenant_schema(
+            schema_id=str(provisioning_schema.id),
+            membership_id=str(tenant_membership_obj.id),
+        )
+
+    await provisioning_schema.arefresh_from_db()
+    assert provisioning_schema.state == SchemaState.ACTIVE
+    assert result["status"] == "active"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes `SynchronousOnlyOperation` crashing the `refresh_tenant_schema` background job in production (Sentry **SCOUT-DJANGO-14**).

`refresh_tenant_schema` is an `async def` procrastinate job, but it called the **sync** `resolve_credential(membership)`, which issues ORM queries (`TenantCredential.objects.get`, `get_social_token`) directly. Django forbids sync ORM from an async context, so the job raised `SynchronousOnlyOperation: You cannot call this from an async context`.

The sibling task `materialize_workspace` already resolves credentials correctly via `await aresolve_credential(...)`; this brings `refresh_tenant_schema` in line.

## Changes

- `apps/workspaces/tasks.py`: call `await aresolve_credential(membership)` instead of the sync `resolve_credential(membership)`; drop the now-unused sync import.
- `tests/test_refresh_task.py`:
  - The existing tests masked this bug by mocking `apps.workspaces.tasks.resolve_credential`, so the sync ORM path never ran. Updated those mocks to the async resolver (`AsyncMock`).
  - Added `test_refresh_task_resolves_credential_in_async_context`, a regression test that exercises the **real** resolver against a stored API-key `TenantCredential` (no resolver mock). It reproduces `SynchronousOnlyOperation` on the old code and passes after the fix.

## Testing

- `uv run pytest tests/test_refresh_task.py tests/test_materialize_workspace_task.py` → 25 passed
- `uv run pytest tests/ -k "credential or refresh"` → 60 passed
- `uv run ruff check` clean
- Confirmed the new regression test fails (raising `SynchronousOnlyOperation`) against the unfixed code before applying the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)