### PR TITLE
Bookmarkable workspace + chat-thread navigation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,6 @@ node_modules/
 bun.lockb
 .superpowers/
 .gstack/
+
+# playwright-cli session/config/output dirs
+.playwright*/

--- a/frontend/src/components/ChatPanel/ChatPanel.tsx
+++ b/frontend/src/components/ChatPanel/ChatPanel.tsx
@@ -14,10 +14,7 @@ import { SlashCommandMenu } from "./SlashCommandMenu"
 import { useWorkspaceJobs } from "@/contexts/WorkspaceJobsContext"
 import { ChatEmptyState } from "@/components/ChatEmptyState"
 import { TopBarSlot } from "@/components/TopBar"
-
-function threadStorageKey(domainId: string) {
-  return `scout:thread:${domainId}`
-}
+import { writeSavedThreadId } from "./threadStorage"
 
 function getPublicUrl(token: string): string {
   return `${window.location.origin}/shared/threads/${token}/`
@@ -119,7 +116,6 @@ function ShareMenu({
 export function ChatPanel() {
   const activeDomainId = useAppStore((s) => s.activeDomainId)
   const threadId = useAppStore((s) => s.threadId)
-  const selectThread = useAppStore((s) => s.uiActions.selectThread)
   const fetchThreads = useAppStore((s) => s.uiActions.fetchThreads)
   const scrollRef = useRef<HTMLDivElement>(null)
   const [input, setInput] = useState("")
@@ -170,23 +166,14 @@ export function ChatPanel() {
     setSlashMenuIndex(0)
   }
 
-  // Persist threadId to localStorage when it changes
+  // Persist threadId to localStorage when it changes, so a bare /chat visit can
+  // restore the last-viewed thread for this workspace. The URL is the source of
+  // truth for which thread is active; this is just a "last seen" fallback.
   useEffect(() => {
-    if (activeDomainId) {
-      localStorage.setItem(threadStorageKey(activeDomainId), threadId)
+    if (activeDomainId && threadId) {
+      writeSavedThreadId(activeDomainId, threadId)
     }
   }, [threadId, activeDomainId])
-
-  // Restore threadId from localStorage when domain changes
-  useEffect(() => {
-    if (!activeDomainId) return
-    const saved = localStorage.getItem(threadStorageKey(activeDomainId))
-    if (saved && saved !== threadId) {
-      selectThread(saved)
-    }
-    // Only run when domain changes
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeDomainId])
 
   // Load messages from backend when threadId changes (or after a background job completes)
   useEffect(() => {

--- a/frontend/src/components/ChatPanel/ChatRedirect.tsx
+++ b/frontend/src/components/ChatPanel/ChatRedirect.tsx
@@ -1,0 +1,38 @@
+import { useEffect } from "react"
+import { Navigate, useLocation } from "react-router-dom"
+import { useAppStore } from "@/store/store"
+import { ChatPanel } from "./ChatPanel"
+import { readSavedThreadId } from "./threadStorage"
+
+/**
+ * Entry point for the bare chat routes (`/` and `/chat`). Once the active
+ * workspace is known, redirects to the canonical, bookmarkable chat URL
+ * (`/workspaces/:workspaceId/chat[/:threadId]`). While domains are still
+ * loading — or the user has no workspace yet — it renders the chat panel
+ * directly so the existing empty/loading states still show.
+ */
+export function ChatRedirect() {
+  const location = useLocation()
+  const pathPrefix = location.pathname.startsWith("/embed") ? "/embed" : ""
+  const activeDomainId = useAppStore((s) => s.activeDomainId)
+  const threadId = useAppStore((s) => s.threadId)
+  const domainsStatus = useAppStore((s) => s.domainsStatus)
+  const fetchDomains = useAppStore((s) => s.domainActions.fetchDomains)
+
+  // Domains may not have been fetched yet if the chat route is the entry point.
+  useEffect(() => {
+    if (domainsStatus === "idle") fetchDomains()
+  }, [domainsStatus, fetchDomains])
+
+  if (activeDomainId) {
+    // Prefer the last thread the user viewed in this workspace (persisted in
+    // localStorage by ChatPanel); fall back to the store's current threadId.
+    const resolvedThreadId = readSavedThreadId(activeDomainId) || threadId
+    const target = resolvedThreadId
+      ? `${pathPrefix}/workspaces/${activeDomainId}/chat/${resolvedThreadId}`
+      : `${pathPrefix}/workspaces/${activeDomainId}/chat`
+    return <Navigate to={target} replace />
+  }
+
+  return <ChatPanel />
+}

--- a/frontend/src/components/ChatPanel/ChatRoute.tsx
+++ b/frontend/src/components/ChatPanel/ChatRoute.tsx
@@ -1,0 +1,14 @@
+import { useLocation } from "react-router-dom"
+import { ChatPanel } from "./ChatPanel"
+import { useWorkspaceThreadSync } from "@/hooks/useWorkspaceThreadSync"
+
+/**
+ * Chat route wrapper. Keeps the URL (`/workspaces/:workspaceId/chat/:threadId`)
+ * and the store's active workspace + thread in sync, then renders the chat UI.
+ */
+export function ChatRoute() {
+  const location = useLocation()
+  const pathPrefix = location.pathname.startsWith("/embed") ? "/embed" : ""
+  useWorkspaceThreadSync(pathPrefix)
+  return <ChatPanel />
+}

--- a/frontend/src/components/ChatPanel/threadStorage.ts
+++ b/frontend/src/components/ChatPanel/threadStorage.ts
@@ -1,0 +1,21 @@
+/** localStorage helpers for remembering the last-viewed thread per workspace. */
+
+function threadStorageKey(workspaceId: string): string {
+  return `scout:thread:${workspaceId}`
+}
+
+export function readSavedThreadId(workspaceId: string): string | null {
+  try {
+    return localStorage.getItem(threadStorageKey(workspaceId))
+  } catch {
+    return null
+  }
+}
+
+export function writeSavedThreadId(workspaceId: string, threadId: string): void {
+  try {
+    localStorage.setItem(threadStorageKey(workspaceId), threadId)
+  } catch {
+    // Storage may be unavailable (private mode, quota). Persistence is best-effort.
+  }
+}

--- a/frontend/src/components/Sidebar/NavItem.tsx
+++ b/frontend/src/components/Sidebar/NavItem.tsx
@@ -1,4 +1,4 @@
-import { NavLink } from "react-router-dom"
+import { NavLink, useLocation } from "react-router-dom"
 import { cn } from "@/lib/utils"
 import type { LucideIcon } from "lucide-react"
 
@@ -6,16 +6,23 @@ interface NavItemProps {
   to: string
   icon: LucideIcon
   label: string
+  /**
+   * Optional predicate to force the active state for paths that don't match
+   * `to` directly (e.g. the Chat item is active on `/workspaces/:id/chat`).
+   */
+  isActivePath?: (pathname: string) => boolean
 }
 
-export function NavItem({ to, icon: Icon, label }: NavItemProps) {
+export function NavItem({ to, icon: Icon, label, isActivePath }: NavItemProps) {
+  const location = useLocation()
+  const forceActive = isActivePath?.(location.pathname) ?? false
   return (
     <NavLink
       to={to}
       className={({ isActive }) =>
         cn(
           "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
-          isActive
+          isActive || forceActive
             ? "bg-accent text-accent-foreground"
             : "text-muted-foreground hover:bg-accent hover:text-accent-foreground"
         )

--- a/frontend/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/Sidebar/Sidebar.tsx
@@ -113,7 +113,12 @@ export function Sidebar() {
                   <button
                     key={d.id}
                     data-testid={`domain-item-${d.id}`}
-                    onClick={() => { setActiveDomain(d.id); newThread(); setSelectorOpen(false) }}
+                    onClick={() => {
+                      setActiveDomain(d.id)
+                      newThread()
+                      setSelectorOpen(false)
+                      navigate(`${pathPrefix}/workspaces/${d.id}/chat`)
+                    }}
                     className={`w-full rounded-sm px-2 py-1.5 text-left text-sm transition-colors hover:bg-accent hover:text-accent-foreground ${
                       d.id === activeDomainId ? "font-medium bg-accent" : ""
                     }`}
@@ -155,7 +160,12 @@ export function Sidebar() {
 
       {/* Navigation */}
       <nav className="space-y-1 p-4">
-        <NavItem to={`${pathPrefix}/`} icon={MessageSquare} label="Chat" />
+        <NavItem
+          to={activeDomainId ? `${pathPrefix}/workspaces/${activeDomainId}/chat` : `${pathPrefix}/`}
+          icon={MessageSquare}
+          label="Chat"
+          isActivePath={(p) => /\/workspaces\/[^/]+\/chat(\/|$)/.test(p)}
+        />
         <NavItem to={`${pathPrefix}/artifacts`} icon={LayoutDashboard} label="Artifacts" />
         <NavItem to={`${pathPrefix}/knowledge`} icon={BookOpen} label="Knowledge" />
         <NavItem to={`${pathPrefix}/recipes`} icon={ChefHat} label="Recipes" />
@@ -172,7 +182,14 @@ export function Sidebar() {
             variant="ghost"
             size="icon"
             className="h-6 w-6"
-            onClick={() => { newThread(); navigate(`${pathPrefix}/chat`) }}
+            onClick={() => {
+              newThread()
+              navigate(
+                activeDomainId
+                  ? `${pathPrefix}/workspaces/${activeDomainId}/chat`
+                  : `${pathPrefix}/chat`,
+              )
+            }}
             data-testid="sidebar-new-chat"
           >
             <Plus className="h-3.5 w-3.5" />
@@ -189,7 +206,14 @@ export function Sidebar() {
             return (
               <button
                 key={thread.id}
-                onClick={() => { selectThread(thread.id); navigate(`${pathPrefix}/chat`) }}
+                onClick={() => {
+                  selectThread(thread.id)
+                  navigate(
+                    activeDomainId
+                      ? `${pathPrefix}/workspaces/${activeDomainId}/chat/${thread.id}`
+                      : `${pathPrefix}/chat`,
+                  )
+                }}
                 data-testid={`sidebar-thread-${thread.id}`}
                 className={`flex w-full items-center gap-2 rounded-md px-3 py-1.5 text-left text-sm transition-colors ${
                   thread.id === threadId

--- a/frontend/src/hooks/useWorkspaceThreadSync.ts
+++ b/frontend/src/hooks/useWorkspaceThreadSync.ts
@@ -1,0 +1,88 @@
+import { useEffect, useRef } from "react"
+import { useNavigate, useParams } from "react-router-dom"
+import { useAppStore } from "@/store/store"
+
+/**
+ * Two-way bridge between the chat URL (`/workspaces/:workspaceId/chat/:threadId`)
+ * and the zustand store (`activeDomainId` / `threadId`).
+ *
+ * Direction 1 — URL → store: when the user navigates directly (bookmark, paste,
+ * back/forward), the params drive the store so the correct workspace + thread
+ * are restored.
+ *
+ * Direction 2 — store → URL: when the store changes from in-app actions (e.g.
+ * the workspace switcher or starting a new thread), the URL is updated so the
+ * current view is bookmarkable.
+ *
+ * A guard ref records the last (workspaceId, threadId) pair we reconciled so we
+ * never bounce an update back to its origin and never create a navigation loop.
+ *
+ * @param pathPrefix "" for the main app, "/embed" for the embedded app.
+ */
+export function useWorkspaceThreadSync(pathPrefix: string) {
+  const navigate = useNavigate()
+  const { workspaceId: urlWorkspaceId, threadId: urlThreadId } = useParams<{
+    workspaceId: string
+    threadId: string
+  }>()
+
+  const activeDomainId = useAppStore((s) => s.activeDomainId)
+  const threadId = useAppStore((s) => s.threadId)
+  const domainsStatus = useAppStore((s) => s.domainsStatus)
+  const domains = useAppStore((s) => s.domains)
+  const setActiveDomain = useAppStore((s) => s.domainActions.setActiveDomain)
+  const selectThread = useAppStore((s) => s.uiActions.selectThread)
+
+  // Last pair we reconciled, in either direction. Prevents ping-pong loops.
+  const syncedRef = useRef<{ workspaceId: string | null; threadId: string | null }>({
+    workspaceId: null,
+    threadId: null,
+  })
+
+  // Direction 1: URL → store
+  useEffect(() => {
+    if (!urlWorkspaceId) return
+    if (
+      syncedRef.current.workspaceId === urlWorkspaceId &&
+      syncedRef.current.threadId === (urlThreadId ?? null)
+    ) {
+      return
+    }
+
+    // Only adopt a workspace from the URL once domains have loaded and the id is
+    // valid for this user — otherwise leave the store alone (the redirect logic
+    // below or fetchDomains will pick a sensible default).
+    if (domainsStatus === "loaded" && !domains.some((d) => d.id === urlWorkspaceId)) {
+      return
+    }
+
+    if (urlWorkspaceId !== activeDomainId) {
+      setActiveDomain(urlWorkspaceId)
+    }
+    if (urlThreadId && urlThreadId !== threadId) {
+      void selectThread(urlThreadId)
+    }
+
+    syncedRef.current = { workspaceId: urlWorkspaceId, threadId: urlThreadId ?? null }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [urlWorkspaceId, urlThreadId, domainsStatus, domains])
+
+  // Direction 2: store → URL
+  useEffect(() => {
+    if (!activeDomainId) return
+    if (
+      syncedRef.current.workspaceId === activeDomainId &&
+      syncedRef.current.threadId === (threadId || null)
+    ) {
+      return
+    }
+
+    const target = threadId
+      ? `${pathPrefix}/workspaces/${activeDomainId}/chat/${threadId}`
+      : `${pathPrefix}/workspaces/${activeDomainId}/chat`
+
+    syncedRef.current = { workspaceId: activeDomainId, threadId: threadId || null }
+    navigate(target, { replace: false })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeDomainId, threadId])
+}

--- a/frontend/src/pages/EmbedPage.tsx
+++ b/frontend/src/pages/EmbedPage.tsx
@@ -5,7 +5,8 @@ import { useAppStore } from "@/store/store"
 import { LoginForm } from "@/components/LoginForm/LoginForm"
 import { Skeleton } from "@/components/ui/skeleton"
 import { EmbedLayout } from "@/components/EmbedLayout/EmbedLayout"
-import { ChatPanel } from "@/components/ChatPanel/ChatPanel"
+import { ChatRoute } from "@/components/ChatPanel/ChatRoute"
+import { ChatRedirect } from "@/components/ChatPanel/ChatRedirect"
 import { ArtifactsPage } from "@/pages/ArtifactsPage"
 import { DataDictionaryPage } from "@/pages/DataDictionaryPage"
 import { KnowledgePage } from "@/pages/KnowledgePage"
@@ -21,8 +22,10 @@ const embedRouter = createBrowserRouter([
     path: "/embed",
     element: <EmbedLayout />,
     children: [
-      { index: true, element: <ChatPanel /> },
-      { path: "chat", element: <ChatPanel /> },
+      { index: true, element: <ChatRedirect /> },
+      { path: "chat", element: <ChatRedirect /> },
+      { path: "workspaces/:workspaceId/chat", element: <ChatRoute /> },
+      { path: "workspaces/:workspaceId/chat/:threadId", element: <ChatRoute /> },
       { path: "artifacts", element: <ArtifactsPage /> },
       { path: "knowledge", element: <KnowledgePage /> },
       { path: "knowledge/new", element: <KnowledgePage /> },

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -1,7 +1,8 @@
 import { createBrowserRouter, Navigate } from "react-router-dom"
 import { BASE_PATH } from "@/config"
 import { AppLayout } from "@/components/AppLayout/AppLayout"
-import { ChatPanel } from "@/components/ChatPanel/ChatPanel"
+import { ChatRoute } from "@/components/ChatPanel/ChatRoute"
+import { ChatRedirect } from "@/components/ChatPanel/ChatRedirect"
 import { ArtifactsPage } from "@/pages/ArtifactsPage"
 import { DataDictionaryPage } from "@/pages/DataDictionaryPage"
 import { KnowledgePage } from "@/pages/KnowledgePage"
@@ -15,8 +16,10 @@ export const router = createBrowserRouter([
     path: "/",
     element: <AppLayout />,
     children: [
-      { index: true, element: <ChatPanel /> },
-      { path: "chat", element: <ChatPanel /> },
+      { index: true, element: <ChatRedirect /> },
+      { path: "chat", element: <ChatRedirect /> },
+      { path: "workspaces/:workspaceId/chat", element: <ChatRoute /> },
+      { path: "workspaces/:workspaceId/chat/:threadId", element: <ChatRoute /> },
       { path: "artifacts", element: <ArtifactsPage /> },
       { path: "knowledge", element: <KnowledgePage /> },
       { path: "knowledge/new", element: <KnowledgePage /> },


### PR DESCRIPTION
## Summary

Workspace switching and chat-thread selection are now **bookmarkable** — they sync to real URLs:

- `/workspaces/:workspaceId/chat` — a workspace's chat
- `/workspaces/:workspaceId/chat/:threadId` — a specific thread

`/` and `/chat` redirect to the active workspace's chat, restoring the last-viewed thread (tracked per-workspace in `localStorage`). Browser back/forward and pasted/bookmarked URLs restore the correct workspace **and** thread.

### How it works

- **`useWorkspaceThreadSync`** — a two-way store↔URL bridge hook. Direction 1 (URL → store) adopts the workspace/thread from route params on direct navigation; direction 2 (store → URL) pushes a canonical URL when in-app actions change the active workspace/thread. A `syncedRef` guard records the last reconciled `(workspaceId, threadId)` pair to prevent navigation ping-pong loops. URL → store only adopts a workspace once domains have loaded and the id is valid for the user.
- **`ChatRoute`** — wraps `ChatPanel`, runs the sync hook for the canonical routes.
- **`ChatRedirect`** — entry point for the bare `/` and `/chat` routes; once the active workspace is known it `<Navigate replace>`s to the canonical URL (preferring the saved last thread), otherwise renders `ChatPanel` so existing empty/loading states still show.
- **`threadStorage`** — small `readSavedThreadId` / `writeSavedThreadId` helpers (try/catch wrapped for private-mode/quota), replacing the inline localStorage logic that used to live in `ChatPanel`.
- **Routes** registered on both the main router and the embed router (`/embed/...`), with `pathPrefix` threading so embed URLs stay under `/embed`.
- **Sidebar** workspace switcher, thread buttons, and the new-chat button now navigate to canonical URLs; the Chat nav item stays highlighted on any `/workspaces/:id/chat` path via a new optional `isActivePath` predicate on `NavItem`.

Public (`/shared/...`) and embed pages are preserved.

## Test plan

- [ ] Switch workspaces via the sidebar switcher → URL becomes `/workspaces/:id/chat`, chat resets to a new thread.
- [ ] Click a thread in the sidebar → URL becomes `/workspaces/:id/chat/:threadId`; the Chat nav item stays highlighted.
- [ ] **Back/forward**: navigate across a couple of workspaces/threads, then use the browser back and forward buttons → the workspace + thread restore correctly, no redirect loop.
- [ ] **Paste / bookmark restore**: copy a `/workspaces/:id/chat/:threadId` URL, open it in a fresh tab → correct workspace and thread load (and an invalid/foreign workspace id falls back gracefully).
- [ ] Visit bare `/` or `/chat` → redirects to the active workspace's chat with the last-viewed thread.
- [ ] **Embed unaffected**: `/embed`, `/embed/chat`, and the new `/embed/workspaces/:id/chat[/:threadId]` routes behave the same with the `/embed` prefix preserved.
- [ ] Public pages `/shared/runs/...` and `/shared/threads/...` still render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)