### PR TITLE
Make workspace detail page full width

### DIFF
--- a/frontend/src/pages/WorkspaceDetailPage/WorkspaceDetailPage.tsx
+++ b/frontend/src/pages/WorkspaceDetailPage/WorkspaceDetailPage.tsx
@@ -547,7 +547,7 @@ function SettingsTab({
   }
 
   return (
-    <div className="space-y-8" data-testid="settings-tab">
+    <div className="max-w-2xl space-y-8" data-testid="settings-tab">
       {/* Rename */}
       <section>
         <h3 className="mb-3 text-sm font-medium">Workspace name</h3>
@@ -689,7 +689,7 @@ export function WorkspaceDetailPage() {
   const isManager = workspace.role === "manage"
 
   return (
-    <div className="mx-auto max-w-2xl px-6 py-8">
+    <div className="p-6">
       {/* Header */}
       <div className="mb-6">
         <Link


### PR DESCRIPTION
## Summary

The workspace detail page was constrained to a narrow centered column (`mx-auto max-w-2xl`) instead of using the full-width layout that every other top-level page uses. This made the Members and Data-sources (Tenants) tables feel cramped and inconsistent with the rest of the app.

- Changed the page root from `mx-auto max-w-2xl px-6 py-8` to `p-6`, following the documented full-width layout convention in `.claude/rules/frontend-layout.md`. The Members / Data-sources tables now fill the available width.
- Kept `max-w-2xl` on the Settings tab only, since its text form fields read better when not stretched across a wide viewport.
- No other pages affected.

## Test plan

- `bun run lint` (eslint) — clean
- `bun run build` (tsc + vite) — passes
- `uv run --extra dev ruff check .` — clean
- Visual: workspace detail page now spans full width like Knowledge/Recipes/Connections; Settings text form remains constrained for readability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)