### PR TITLE
Rename Tenants to Data sources + lazy-load and cache the Data sources tab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,6 @@ node_modules/
 bun.lockb
 .superpowers/
 .gstack/
+
+# playwright-cli session/config/output dirs
+.playwright*/

--- a/frontend/src/api/userTenantsCache.ts
+++ b/frontend/src/api/userTenantsCache.ts
@@ -1,0 +1,60 @@
+import { authApi, type UserTenant } from "./auth"
+
+// ── User-tenants session cache ───────────────────────────────────────────────
+//
+// GET /api/auth/tenants/ synchronously refreshes the user's opportunities,
+// domains, and chatbots from the live CommCare / Connect / OCS APIs whenever the
+// server-side TTL cache is cold. That external round-trip can take ~20s on the
+// first call of a session. We never want to pay that cost more than once, so we
+// memoize the in-flight promise per user for the lifetime of the page session.
+//
+// The cache is keyed by user id so that switching accounts (logout/login within
+// the same tab) does not surface a stale list.
+
+let cachedUserId: string | null = null
+let cachedPromise: Promise<UserTenant[]> | null = null
+
+/**
+ * Returns the user's tenant memberships, memoizing the (potentially slow) fetch
+ * for the rest of the session. Subsequent calls resolve instantly. A failed
+ * fetch is not cached, so the next call retries.
+ */
+export function getUserTenantsCached(userId: string): Promise<UserTenant[]> {
+  if (cachedUserId !== userId || !cachedPromise) {
+    cachedUserId = userId
+    cachedPromise = authApi.getUserTenants().catch((err) => {
+      // Don't cache failures — allow the next caller to retry.
+      if (cachedUserId === userId) cachedPromise = null
+      throw err
+    })
+  }
+  return cachedPromise
+}
+
+/**
+ * Forces a fresh fetch, replacing the cached promise. Use for an explicit
+ * "Refresh" affordance.
+ */
+export function refreshUserTenants(userId: string): Promise<UserTenant[]> {
+  cachedUserId = userId
+  cachedPromise = authApi.getUserTenants().catch((err) => {
+    if (cachedUserId === userId) cachedPromise = null
+    throw err
+  })
+  return cachedPromise
+}
+
+/**
+ * Synchronously rewrites the cached list. Used after add/remove mutations so the
+ * cache stays consistent without a network round-trip.
+ */
+export function setCachedUserTenants(userId: string, tenants: UserTenant[]): void {
+  cachedUserId = userId
+  cachedPromise = Promise.resolve(tenants)
+}
+
+/** Drops the cache entirely (e.g. on logout). */
+export function clearUserTenantsCache(): void {
+  cachedUserId = null
+  cachedPromise = null
+}

--- a/frontend/src/components/CreateWorkspaceModal/CreateWorkspaceModal.tsx
+++ b/frontend/src/components/CreateWorkspaceModal/CreateWorkspaceModal.tsx
@@ -2,7 +2,8 @@ import { useState, useEffect, useMemo } from "react"
 import { useNavigate } from "react-router-dom"
 import { useAppStore } from "@/store/store"
 import { workspaceApi } from "@/api/workspaces"
-import { authApi, type UserTenant } from "@/api/auth"
+import { type UserTenant } from "@/api/auth"
+import { getUserTenantsCached } from "@/api/userTenantsCache"
 import { ApiError } from "@/api/client"
 import {
   Dialog,
@@ -29,6 +30,7 @@ export function CreateWorkspaceModal({ onClose }: Props) {
   const navigate = useNavigate()
   const fetchDomains = useAppStore((s) => s.domainActions.fetchDomains)
   const setActiveDomain = useAppStore((s) => s.domainActions.setActiveDomain)
+  const userId = useAppStore((s) => s.user?.id)
 
   const [name, setName] = useState("")
   const [loading, setLoading] = useState(false)
@@ -42,11 +44,12 @@ export function CreateWorkspaceModal({ onClose }: Props) {
   const [providerFilter, setProviderFilter] = useState<string | null>(null)
 
   useEffect(() => {
+    if (!userId) return
     let cancelled = false
     async function loadSources() {
       setSourcesLoading(true)
       try {
-        const data = await authApi.getUserTenants()
+        const data = await getUserTenantsCached(userId!)
         if (!cancelled) setSources(data)
       } catch {
         // Non-fatal: workspace can still be created without a data source.
@@ -59,7 +62,7 @@ export function CreateWorkspaceModal({ onClose }: Props) {
     return () => {
       cancelled = true
     }
-  }, [])
+  }, [userId])
 
   const providerFilterGroups = useMemo((): FilterGroup[] => {
     const counts = new Map<string, number>()

--- a/frontend/src/components/CreateWorkspaceModal/CreateWorkspaceModal.tsx
+++ b/frontend/src/components/CreateWorkspaceModal/CreateWorkspaceModal.tsx
@@ -1,7 +1,8 @@
-import { useState } from "react"
+import { useState, useEffect, useMemo } from "react"
 import { useNavigate } from "react-router-dom"
 import { useAppStore } from "@/store/store"
 import { workspaceApi } from "@/api/workspaces"
+import { authApi, type UserTenant } from "@/api/auth"
 import { ApiError } from "@/api/client"
 import {
   Dialog,
@@ -13,6 +14,12 @@ import {
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { Check } from "lucide-react"
+import {
+  SearchFilterBar,
+  type FilterGroup,
+} from "@/components/SearchFilterBar/SearchFilterBar"
+import { getProviderMeta } from "@/components/WorkspaceBadge/providerMeta"
 
 interface Props {
   onClose: () => void
@@ -27,13 +34,82 @@ export function CreateWorkspaceModal({ onClose }: Props) {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
+  // Data-source picker state
+  const [sources, setSources] = useState<UserTenant[]>([])
+  const [sourcesLoading, setSourcesLoading] = useState(true)
+  const [selected, setSelected] = useState<Set<string>>(new Set())
+  const [search, setSearch] = useState("")
+  const [providerFilter, setProviderFilter] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    async function loadSources() {
+      setSourcesLoading(true)
+      try {
+        const data = await authApi.getUserTenants()
+        if (!cancelled) setSources(data)
+      } catch {
+        // Non-fatal: workspace can still be created without a data source.
+        if (!cancelled) setSources([])
+      } finally {
+        if (!cancelled) setSourcesLoading(false)
+      }
+    }
+    void loadSources()
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const providerFilterGroups = useMemo((): FilterGroup[] => {
+    const counts = new Map<string, number>()
+    for (const t of sources) {
+      counts.set(t.provider, (counts.get(t.provider) ?? 0) + 1)
+    }
+    if (counts.size <= 1) return []
+    return [
+      {
+        name: "provider",
+        options: [...counts.entries()]
+          .sort(([a], [b]) => a.localeCompare(b))
+          .map(([value, count]) => ({
+            value,
+            label: getProviderMeta(value).label,
+            count,
+          })),
+      },
+    ]
+  }, [sources])
+
+  const normalizedSearch = search.trim().replace(/^#/, "").toLowerCase()
+  const filteredSources = sources.filter((t) => {
+    if (providerFilter && t.provider !== providerFilter) return false
+    if (
+      normalizedSearch &&
+      !t.tenant_name.toLowerCase().includes(normalizedSearch) &&
+      !t.tenant_id.toLowerCase().includes(normalizedSearch)
+    ) {
+      return false
+    }
+    return true
+  })
+
+  function toggleSource(uuid: string) {
+    setSelected((prev) => {
+      const next = new Set(prev)
+      if (next.has(uuid)) next.delete(uuid)
+      else next.add(uuid)
+      return next
+    })
+  }
+
   async function handleSubmit(e: React.SyntheticEvent<HTMLFormElement>) {
     e.preventDefault()
     if (!name.trim()) return
     setLoading(true)
     setError(null)
     try {
-      const workspace = await workspaceApi.create(name.trim())
+      const workspace = await workspaceApi.create(name.trim(), [...selected])
       await fetchDomains()
       setActiveDomain(workspace.id)
       onClose()
@@ -47,23 +123,107 @@ export function CreateWorkspaceModal({ onClose }: Props) {
 
   return (
     <Dialog open onOpenChange={(open) => { if (!open) onClose() }}>
-      <DialogContent className="sm:max-w-md" data-testid="create-workspace-modal">
+      <DialogContent className="sm:max-w-lg" data-testid="create-workspace-modal">
         <DialogHeader>
           <DialogTitle>New Workspace</DialogTitle>
         </DialogHeader>
         <form onSubmit={handleSubmit}>
-          <div className="py-4">
-            <Label htmlFor="workspace-name">Name</Label>
-            <Input
-              id="workspace-name"
-              data-testid="workspace-name-input"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              placeholder="e.g. Acme Corp"
-              className="mt-1"
-              autoFocus
-            />
-            {error && <p className="mt-2 text-sm text-destructive">{error}</p>}
+          <div className="space-y-4 py-4">
+            <div>
+              <Label htmlFor="workspace-name">Name</Label>
+              <Input
+                id="workspace-name"
+                data-testid="workspace-name-input"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="e.g. Acme Corp"
+                className="mt-1"
+                autoFocus
+              />
+            </div>
+
+            {/* Data sources */}
+            <div>
+              <div className="mb-1 flex items-center justify-between">
+                <Label>Data sources</Label>
+                <span className="text-xs text-muted-foreground">
+                  {selected.size > 0
+                    ? `${selected.size} selected`
+                    : "Optional"}
+                </span>
+              </div>
+              <p className="mb-2 text-xs text-muted-foreground">
+                Add at least one data source so your workspace isn&rsquo;t empty.
+              </p>
+
+              {sourcesLoading ? (
+                <p className="py-4 text-center text-sm text-muted-foreground">
+                  Loading data sources…
+                </p>
+              ) : sources.length === 0 ? (
+                <p
+                  className="rounded-md border border-dashed py-4 text-center text-sm text-muted-foreground"
+                  data-testid="create-no-sources"
+                >
+                  No data sources available to add.
+                </p>
+              ) : (
+                <div className="space-y-3">
+                  <SearchFilterBar
+                    search={search}
+                    onSearchChange={setSearch}
+                    placeholder="Search by name or opportunity ID…"
+                    filters={providerFilterGroups}
+                    activeFilters={{ provider: providerFilter }}
+                    onFilterChange={(_group, value) => setProviderFilter(value)}
+                  />
+                  <div
+                    className="max-h-56 space-y-1 overflow-y-auto rounded-md border p-1"
+                    data-testid="create-sources-list"
+                  >
+                    {filteredSources.length === 0 ? (
+                      <p className="py-3 text-center text-sm text-muted-foreground">
+                        No data sources match your filters.
+                      </p>
+                    ) : (
+                      filteredSources.map((t) => {
+                        const isSelected = selected.has(t.tenant_uuid)
+                        return (
+                          <button
+                            type="button"
+                            key={t.tenant_uuid}
+                            onClick={() => toggleSource(t.tenant_uuid)}
+                            aria-pressed={isSelected}
+                            data-testid={`create-source-${t.tenant_uuid}`}
+                            className={`flex w-full items-center justify-between rounded-md px-3 py-2 text-left transition-colors ${
+                              isSelected ? "bg-accent" : "hover:bg-accent/50"
+                            }`}
+                          >
+                            <div className="min-w-0">
+                              <div className="truncate text-sm font-medium">{t.tenant_name}</div>
+                              <div className="truncate text-xs text-muted-foreground">
+                                #{t.tenant_id} · {getProviderMeta(t.provider).label}
+                              </div>
+                            </div>
+                            <span
+                              className={`flex h-5 w-5 shrink-0 items-center justify-center rounded-full border ${
+                                isSelected
+                                  ? "border-primary bg-primary text-primary-foreground"
+                                  : "border-muted-foreground/30"
+                              }`}
+                            >
+                              {isSelected && <Check className="h-3 w-3" />}
+                            </span>
+                          </button>
+                        )
+                      })
+                    )}
+                  </div>
+                </div>
+              )}
+            </div>
+
+            {error && <p className="text-sm text-destructive">{error}</p>}
           </div>
           <DialogFooter>
             <Button type="button" variant="outline" onClick={onClose}>

--- a/frontend/src/pages/ConnectionsPage/ConnectionsPage.tsx
+++ b/frontend/src/pages/ConnectionsPage/ConnectionsPage.tsx
@@ -264,7 +264,7 @@ export function ConnectionsPage() {
               <SearchFilterBar
                 search={search}
                 onSearchChange={setSearch}
-                placeholder="Search tenants..."
+                placeholder="Search data sources..."
                 filters={
                   providerFilterGroup.options.length > 1 ? [providerFilterGroup] : []
                 }
@@ -278,7 +278,7 @@ export function ConnectionsPage() {
                 <p className="text-muted-foreground">
                   {connections.length === 0
                     ? "No API key connections."
-                    : "No tenants match your search."}
+                    : "No data sources match your search."}
                 </p>
               </div>
             ) : (
@@ -287,7 +287,7 @@ export function ConnectionsPage() {
                   <TableRow>
                     <TableHead>Name</TableHead>
                     <TableHead>Provider</TableHead>
-                    <TableHead>Tenant ID</TableHead>
+                    <TableHead>Data source ID</TableHead>
                     <TableHead className="text-right">Actions</TableHead>
                   </TableRow>
                 </TableHeader>

--- a/frontend/src/pages/WorkspaceDetailPage/WorkspaceDetailPage.tsx
+++ b/frontend/src/pages/WorkspaceDetailPage/WorkspaceDetailPage.tsx
@@ -1,13 +1,17 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from "react"
 import { Link, useParams, useNavigate } from "react-router-dom"
 import { workspaceApi } from "@/api/workspaces"
-import { authApi } from "@/api/auth"
+import {
+  getUserTenantsCached,
+  refreshUserTenants,
+} from "@/api/userTenantsCache"
 import type { WorkspaceDetail, WorkspaceMember, WorkspaceTenant, UserTenant } from "@/api/workspaces"
 import { ApiError } from "@/api/client"
 import { useAppStore } from "@/store/store"
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
+import { Skeleton } from "@/components/ui/skeleton"
 import {
   Select,
   SelectContent,
@@ -15,7 +19,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
-import { ChevronLeft } from "lucide-react"
+import { ChevronLeft, Plus, RefreshCw } from "lucide-react"
 import { RoleBadge } from "@/components/RoleBadge"
 import { SearchFilterBar, type FilterGroup } from "@/components/SearchFilterBar/SearchFilterBar"
 import { getProviderMeta } from "@/components/WorkspaceBadge/providerMeta"
@@ -292,11 +296,23 @@ function MembersTab({ workspaceId, isManager }: { workspaceId: string; isManager
 
 // ── Tenants Tab ─────────────────────────────────────────────────────────────
 
+type AvailableStatus = "idle" | "loading" | "ready" | "error"
+
 function TenantsTab({ workspaceId, isManager }: { workspaceId: string; isManager: boolean }) {
+  const userId = useAppStore((s) => s.user?.id)
+
+  // Connected sources — fast local-DB query, gates only its own section.
   const [tenants, setTenants] = useState<WorkspaceTenant[]>([])
+  const [connectedLoading, setConnectedLoading] = useState(true)
+  const [connectedError, setConnectedError] = useState<string | null>(null)
+
+  // Available sources — lazily fetched (potentially slow external refresh),
+  // memoized for the session via the user-tenants cache.
   const [userTenants, setUserTenants] = useState<UserTenant[]>([])
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
+  const [availableStatus, setAvailableStatus] = useState<AvailableStatus>("idle")
+  const [availableError, setAvailableError] = useState<string | null>(null)
+  const [refreshing, setRefreshing] = useState(false)
+
   const [addingId, setAddingId] = useState<string | null>(null)
   const [removingId, setRemovingId] = useState<string | null>(null)
   const [showAdd, setShowAdd] = useState(false)
@@ -313,24 +329,61 @@ function TenantsTab({ workspaceId, isManager }: { workspaceId: string; isManager
     }
   }, [showAdd])
 
-  const load = useCallback(async () => {
-    setLoading(true)
-    setError(null)
+  // Load the connected sources (fast). Never blocked on the available list.
+  const loadConnected = useCallback(async () => {
+    setConnectedLoading(true)
+    setConnectedError(null)
     try {
-      const [wsTenants, allTenants] = await Promise.all([
-        workspaceApi.getTenants(workspaceId),
-        authApi.getUserTenants(),
-      ])
+      const wsTenants = await workspaceApi.getTenants(workspaceId)
       setTenants(wsTenants)
-      setUserTenants(allTenants)
     } catch (err) {
-      setError(err instanceof ApiError ? err.message : "Failed to load data sources")
+      setConnectedError(err instanceof ApiError ? err.message : "Failed to load data sources")
     } finally {
-      setLoading(false)
+      setConnectedLoading(false)
     }
   }, [workspaceId])
 
-  useEffect(() => { load() }, [load])
+  useEffect(() => { void loadConnected() }, [loadConnected])
+
+  // Load the available list from the session cache. Resolves instantly after
+  // the first successful fetch (the first fetch may take a moment because the
+  // server refreshes from the external provider APIs).
+  const loadAvailable = useCallback(async () => {
+    if (!userId) return
+    setAvailableStatus("loading")
+    setAvailableError(null)
+    try {
+      const all = await getUserTenantsCached(userId)
+      setUserTenants(all)
+      setAvailableStatus("ready")
+    } catch (err) {
+      setAvailableError(err instanceof ApiError ? err.message : "Failed to load available sources")
+      setAvailableStatus("error")
+    }
+  }, [userId])
+
+  // Kick off the available-list fetch in the background after first paint so a
+  // session cache is warm by the time the user opens the add panel — but the
+  // connected-sources view is never blocked on it.
+  useEffect(() => {
+    if (isManager) void loadAvailable()
+  }, [isManager, loadAvailable])
+
+  async function handleRefreshAvailable() {
+    if (!userId) return
+    setRefreshing(true)
+    setAvailableError(null)
+    try {
+      const all = await refreshUserTenants(userId)
+      setUserTenants(all)
+      setAvailableStatus("ready")
+    } catch (err) {
+      setAvailableError(err instanceof ApiError ? err.message : "Failed to refresh available sources")
+      setAvailableStatus("error")
+    } finally {
+      setRefreshing(false)
+    }
+  }
 
   // Tenants the user has access to that are not already in this workspace
   const inWorkspaceIds = new Set(tenants.map((t) => t.tenant_id))
@@ -340,6 +393,8 @@ function TenantsTab({ workspaceId, isManager }: { workspaceId: string; isManager
   const externalIdByUuid = new Map(userTenants.map((t) => [t.tenant_uuid, t.tenant_id]))
 
   // Provider filter pills, reusing the Workspaces page filter design.
+  // Only shown when more than one provider is present in the available set;
+  // a single-provider set renders just the search box (no "All" + one pill).
   const providerFilterGroups = useMemo((): FilterGroup[] => {
     const counts = new Map<string, number>()
     for (const t of available) {
@@ -373,11 +428,22 @@ function TenantsTab({ workspaceId, isManager }: { workspaceId: string; isManager
     return true
   })
 
-  async function handleAdd(tenantUuid: string) {
-    setAddingId(tenantUuid)
+  async function handleAdd(tenant: UserTenant) {
+    setAddingId(tenant.tenant_uuid)
+    setMutationError(null)
     try {
-      await workspaceApi.addTenant(workspaceId, tenantUuid)
-      await load()
+      const created = await workspaceApi.addTenant(workspaceId, tenant.tenant_uuid)
+      // Optimistically reflect the new connection without a round-trip; the
+      // backend returns the internal tenant UUID as `tenant_id`.
+      setTenants((prev) => [
+        ...prev,
+        {
+          id: created.id,
+          tenant_id: tenant.tenant_uuid,
+          tenant_name: tenant.tenant_name,
+          provider: tenant.provider,
+        },
+      ])
     } catch (err) {
       setMutationError(err instanceof ApiError ? err.message : "Failed to add data source")
     } finally {
@@ -387,9 +453,10 @@ function TenantsTab({ workspaceId, isManager }: { workspaceId: string; isManager
 
   async function handleRemove(wt: WorkspaceTenant) {
     setRemovingId(wt.id)
+    setMutationError(null)
     try {
       await workspaceApi.removeTenant(workspaceId, wt.id)
-      await load()  // consistent with handleAdd
+      setTenants((prev) => prev.filter((t) => t.id !== wt.id))
       setConfirmRemoveId(null)
     } catch (err) {
       setMutationError(err instanceof ApiError ? err.message : "Failed to remove data source")
@@ -398,60 +465,140 @@ function TenantsTab({ workspaceId, isManager }: { workspaceId: string; isManager
     }
   }
 
-  if (loading) return <div className="py-8 text-center text-muted-foreground">Loading…</div>
-  if (error) return <div className="py-8 text-center text-destructive">{error}</div>
+  const canShowAddButton = isManager && (availableStatus !== "ready" || available.length > 0)
 
   return (
     <div data-testid="tenants-tab">
       <div className="mb-4 flex items-center justify-between">
         <span className="text-sm text-muted-foreground">
-          {tenants.length} connected {tenants.length === 1 ? "source" : "sources"}
+          {connectedLoading
+            ? "Loading data sources…"
+            : `${tenants.length} connected ${tenants.length === 1 ? "source" : "sources"}`}
         </span>
-        {isManager && available.length > 0 && (
-          <Button size="sm" variant="outline" onClick={() => setShowAdd((v) => !v)} data-testid="add-tenant-btn">
-            + Add data source
+        {canShowAddButton && (
+          <Button
+            size="sm"
+            variant={showAdd ? "secondary" : "outline"}
+            onClick={() => setShowAdd((v) => !v)}
+            data-testid="add-tenant-btn"
+          >
+            <Plus className="mr-1 h-4 w-4" />
+            Add data source
           </Button>
         )}
       </div>
 
-      {showAdd && available.length > 0 && (
-        <div className="mb-4 rounded-lg border bg-muted/30 p-4">
-          <p className="mb-3 text-sm font-medium">Available data sources</p>
-          <div className="mb-3">
-            <SearchFilterBar
-              search={query}
-              onSearchChange={setQuery}
-              placeholder="Search by name or opportunity ID…"
-              filters={providerFilterGroups}
-              activeFilters={{ provider: providerFilter }}
-              onFilterChange={(_group, value) => setProviderFilter(value)}
-            />
+      {showAdd && isManager && (
+        <div className="mb-4 rounded-lg border bg-muted/30 p-4" data-testid="add-tenant-panel">
+          <div className="mb-3 flex items-center justify-between">
+            <p className="text-sm font-medium">Available data sources</p>
+            {availableStatus === "ready" && (
+              <button
+                type="button"
+                onClick={handleRefreshAvailable}
+                disabled={refreshing}
+                className="inline-flex items-center gap-1 text-xs text-muted-foreground transition-colors hover:text-foreground disabled:opacity-50"
+                data-testid="refresh-available-sources"
+              >
+                <RefreshCw className={`h-3 w-3 ${refreshing ? "animate-spin" : ""}`} />
+                {refreshing ? "Refreshing…" : "Refresh"}
+              </button>
+            )}
           </div>
-          {filteredAvailable.length === 0 ? (
-            <p className="text-sm text-muted-foreground" data-testid="available-sources-empty">
-              No data sources match your filters.
+
+          {availableStatus === "loading" ? (
+            <div data-testid="available-sources-loading">
+              <p className="mb-3 text-xs text-muted-foreground">
+                Fetching available sources from CommCare, Connect &amp; OCS — the first load can
+                take a moment.
+              </p>
+              <div className="space-y-2">
+                {[0, 1, 2].map((i) => (
+                  <div
+                    key={i}
+                    className="flex items-center justify-between rounded-md border bg-background px-3 py-2.5"
+                  >
+                    <div className="space-y-1.5">
+                      <Skeleton className="h-4 w-40" />
+                      <Skeleton className="h-3 w-24" />
+                    </div>
+                    <Skeleton className="h-8 w-16 rounded-md" />
+                  </div>
+                ))}
+              </div>
+            </div>
+          ) : availableStatus === "error" ? (
+            <div className="rounded-md border border-destructive/30 bg-background p-4 text-center">
+              <p className="text-sm text-destructive">{availableError}</p>
+              <button
+                type="button"
+                onClick={() => void loadAvailable()}
+                className="mt-2 text-sm text-muted-foreground underline hover:text-foreground"
+                data-testid="retry-available-sources"
+              >
+                Try again
+              </button>
+            </div>
+          ) : available.length === 0 ? (
+            <p
+              className="rounded-md border border-dashed bg-background py-6 text-center text-sm text-muted-foreground"
+              data-testid="available-sources-none"
+            >
+              All of your data sources are already connected.
             </p>
           ) : (
-            <div className="space-y-2" data-testid="available-sources-list">
-              {filteredAvailable.map((t) => (
-                <div key={t.tenant_uuid} className="flex items-center justify-between">
-                  <div>
-                    <div className="text-sm font-medium">{t.tenant_name}</div>
-                    <div className="text-xs text-muted-foreground">
-                      #{t.tenant_id} · {getProviderMeta(t.provider).label}
-                    </div>
-                  </div>
-                  <Button
-                    size="sm"
-                    onClick={() => handleAdd(t.tenant_uuid)}
-                    disabled={addingId === t.tenant_uuid}
-                    data-testid={`add-tenant-${t.tenant_uuid}`}
-                  >
-                    {addingId === t.tenant_uuid ? "Adding…" : "Add"}
-                  </Button>
+            <>
+              <div className="mb-3">
+                <SearchFilterBar
+                  search={query}
+                  onSearchChange={setQuery}
+                  placeholder="Search by name or opportunity ID…"
+                  filters={providerFilterGroups}
+                  activeFilters={{ provider: providerFilter }}
+                  onFilterChange={(_group, value) => setProviderFilter(value)}
+                />
+              </div>
+              {filteredAvailable.length === 0 ? (
+                <p
+                  className="rounded-md border border-dashed bg-background py-6 text-center text-sm text-muted-foreground"
+                  data-testid="available-sources-empty"
+                >
+                  No data sources match your filters.
+                </p>
+              ) : (
+                <div className="space-y-1.5" data-testid="available-sources-list">
+                  {filteredAvailable.map((t) => {
+                    const { label, Icon } = getProviderMeta(t.provider)
+                    return (
+                      <div
+                        key={t.tenant_uuid}
+                        className="flex items-center justify-between gap-3 rounded-md border bg-background px-3 py-2.5"
+                      >
+                        <div className="flex min-w-0 items-center gap-3">
+                          <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
+                            <Icon className="h-4 w-4" />
+                          </span>
+                          <div className="min-w-0">
+                            <div className="truncate text-sm font-medium">{t.tenant_name}</div>
+                            <div className="truncate text-xs text-muted-foreground">
+                              #{t.tenant_id} · {label}
+                            </div>
+                          </div>
+                        </div>
+                        <Button
+                          size="sm"
+                          onClick={() => handleAdd(t)}
+                          disabled={addingId === t.tenant_uuid}
+                          data-testid={`add-tenant-${t.tenant_uuid}`}
+                        >
+                          {addingId === t.tenant_uuid ? "Adding…" : "Add"}
+                        </Button>
+                      </div>
+                    )
+                  })}
                 </div>
-              ))}
-            </div>
+              )}
+            </>
           )}
         </div>
       )}
@@ -460,57 +607,102 @@ function TenantsTab({ workspaceId, isManager }: { workspaceId: string; isManager
         <p className="mb-3 text-sm text-destructive">{mutationError}</p>
       )}
 
-      {tenants.length === 0 ? (
-        <div className="rounded-lg border border-dashed p-8 text-center text-muted-foreground">
-          No data sources connected.
-        </div>
-      ) : (
-        <div className="rounded-lg border">
-          {tenants.map((t, i) => (
+      {connectedLoading ? (
+        <div className="rounded-lg border" data-testid="connected-sources-loading">
+          {[0, 1, 2].map((i) => (
             <div
-              key={t.id}
-              className={`flex items-center justify-between px-4 py-3 ${i < tenants.length - 1 ? "border-b" : ""}`}
-              data-testid={`tenant-row-${t.id}`}
+              key={i}
+              className={`flex items-center justify-between px-4 py-3 ${i < 2 ? "border-b" : ""}`}
             >
-              <div>
-                <div className="font-medium">{t.tenant_name}</div>
-                <div className="text-xs text-muted-foreground">
-                  {externalIdByUuid.has(t.tenant_id)
-                    ? `#${externalIdByUuid.get(t.tenant_id)} · ${getProviderMeta(t.provider).label}`
-                    : getProviderMeta(t.provider).label}
-                </div>
+              <div className="space-y-1.5">
+                <Skeleton className="h-4 w-44" />
+                <Skeleton className="h-3 w-28" />
               </div>
-              {isManager && tenants.length > 1 && (
-                confirmRemoveId === t.id ? (
-                  <div className="flex items-center justify-end gap-2">
-                    <span className="text-xs text-muted-foreground">Remove?</span>
-                    <Button variant="ghost" size="sm" onClick={() => setConfirmRemoveId(null)}>
-                      Cancel
-                    </Button>
-                    <Button
-                      variant="destructive"
-                      size="sm"
-                      onClick={() => handleRemove(t)}
-                      disabled={removingId === t.id}
-                      data-testid={`confirm-remove-tenant-${t.id}`}
-                    >
-                      {removingId === t.id ? "Removing…" : "Confirm"}
-                    </Button>
-                  </div>
-                ) : (
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="text-destructive hover:text-destructive"
-                    onClick={() => setConfirmRemoveId(t.id)}
-                    data-testid={`remove-tenant-${t.id}`}
-                  >
-                    Remove
-                  </Button>
-                )
-              )}
             </div>
           ))}
+        </div>
+      ) : connectedError ? (
+        <div className="rounded-lg border border-destructive/30 p-6 text-center">
+          <p className="text-sm text-destructive">{connectedError}</p>
+          <button
+            type="button"
+            onClick={() => void loadConnected()}
+            className="mt-2 text-sm text-muted-foreground underline hover:text-foreground"
+            data-testid="retry-connected-sources"
+          >
+            Try again
+          </button>
+        </div>
+      ) : tenants.length === 0 ? (
+        <div className="rounded-lg border border-dashed p-10 text-center" data-testid="connected-sources-empty">
+          <p className="text-sm text-muted-foreground">No data sources connected yet.</p>
+          {isManager && (
+            <Button
+              size="sm"
+              variant="outline"
+              className="mt-4"
+              onClick={() => setShowAdd(true)}
+              data-testid="add-tenant-empty-btn"
+            >
+              <Plus className="mr-1 h-4 w-4" />
+              Add data source
+            </Button>
+          )}
+        </div>
+      ) : (
+        <div className="overflow-hidden rounded-lg border">
+          {tenants.map((t, i) => {
+            const { label, Icon } = getProviderMeta(t.provider)
+            const externalId = externalIdByUuid.get(t.tenant_id)
+            return (
+              <div
+                key={t.id}
+                className={`flex items-center justify-between gap-3 px-4 py-3 transition-colors hover:bg-muted/40 ${i < tenants.length - 1 ? "border-b" : ""}`}
+                data-testid={`tenant-row-${t.id}`}
+              >
+                <div className="flex min-w-0 items-center gap-3">
+                  <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
+                    <Icon className="h-4 w-4" />
+                  </span>
+                  <div className="min-w-0">
+                    <div className="truncate font-medium">{t.tenant_name}</div>
+                    <div className="truncate text-xs text-muted-foreground">
+                      {externalId ? `#${externalId} · ${label}` : label}
+                    </div>
+                  </div>
+                </div>
+                {isManager && tenants.length > 1 && (
+                  confirmRemoveId === t.id ? (
+                    <div className="flex items-center justify-end gap-2">
+                      <span className="text-xs text-muted-foreground">Remove?</span>
+                      <Button variant="ghost" size="sm" onClick={() => setConfirmRemoveId(null)}>
+                        Cancel
+                      </Button>
+                      <Button
+                        variant="destructive"
+                        size="sm"
+                        onClick={() => handleRemove(t)}
+                        disabled={removingId === t.id}
+                        data-testid={`confirm-remove-tenant-${t.id}`}
+                      >
+                        {removingId === t.id ? "Removing…" : "Confirm"}
+                      </Button>
+                    </div>
+                  ) : (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="text-destructive hover:text-destructive"
+                      onClick={() => setConfirmRemoveId(t.id)}
+                      data-testid={`remove-tenant-${t.id}`}
+                    >
+                      Remove
+                    </Button>
+                  )
+                )}
+              </div>
+            )
+          })}
         </div>
       )}
     </div>

--- a/frontend/src/pages/WorkspaceDetailPage/WorkspaceDetailPage.tsx
+++ b/frontend/src/pages/WorkspaceDetailPage/WorkspaceDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from "react"
+import { useState, useEffect, useCallback, useRef, useMemo } from "react"
 import { Link, useParams, useNavigate } from "react-router-dom"
 import { workspaceApi } from "@/api/workspaces"
 import { authApi } from "@/api/auth"
@@ -17,6 +17,8 @@ import {
 } from "@/components/ui/select"
 import { ChevronLeft } from "lucide-react"
 import { RoleBadge } from "@/components/RoleBadge"
+import { SearchFilterBar, type FilterGroup } from "@/components/SearchFilterBar/SearchFilterBar"
+import { getProviderMeta } from "@/components/WorkspaceBadge/providerMeta"
 
 // ── Members Tab ─────────────────────────────────────────────────────────────
 
@@ -299,12 +301,16 @@ function TenantsTab({ workspaceId, isManager }: { workspaceId: string; isManager
   const [removingId, setRemovingId] = useState<string | null>(null)
   const [showAdd, setShowAdd] = useState(false)
   const [query, setQuery] = useState("")
+  const [providerFilter, setProviderFilter] = useState<string | null>(null)
   const [confirmRemoveId, setConfirmRemoveId] = useState<string | null>(null)
   const [mutationError, setMutationError] = useState<string | null>(null)
 
-  // Reset search when the add panel is closed manually.
+  // Reset search + filter when the add panel is closed manually.
   useEffect(() => {
-    if (!showAdd) setQuery("")
+    if (!showAdd) {
+      setQuery("")
+      setProviderFilter(null)
+    }
   }, [showAdd])
 
   const load = useCallback(async () => {
@@ -318,7 +324,7 @@ function TenantsTab({ workspaceId, isManager }: { workspaceId: string; isManager
       setTenants(wsTenants)
       setUserTenants(allTenants)
     } catch (err) {
-      setError(err instanceof ApiError ? err.message : "Failed to load tenants")
+      setError(err instanceof ApiError ? err.message : "Failed to load data sources")
     } finally {
       setLoading(false)
     }
@@ -333,14 +339,39 @@ function TenantsTab({ workspaceId, isManager }: { workspaceId: string; isManager
   // Internal-UUID → external opportunity ID, for the connected list display.
   const externalIdByUuid = new Map(userTenants.map((t) => [t.tenant_uuid, t.tenant_id]))
 
+  // Provider filter pills, reusing the Workspaces page filter design.
+  const providerFilterGroups = useMemo((): FilterGroup[] => {
+    const counts = new Map<string, number>()
+    for (const t of available) {
+      counts.set(t.provider, (counts.get(t.provider) ?? 0) + 1)
+    }
+    if (counts.size <= 1) return []
+    return [
+      {
+        name: "provider",
+        options: [...counts.entries()]
+          .sort(([a], [b]) => a.localeCompare(b))
+          .map(([value, count]) => ({
+            value,
+            label: getProviderMeta(value).label,
+            count,
+          })),
+      },
+    ]
+  }, [available])
+
   const normalizedQuery = query.trim().replace(/^#/, "").toLowerCase()
-  const filteredAvailable = normalizedQuery
-    ? available.filter(
-        (t) =>
-          t.tenant_name.toLowerCase().includes(normalizedQuery) ||
-          t.tenant_id.toLowerCase().includes(normalizedQuery),
-      )
-    : available
+  const filteredAvailable = available.filter((t) => {
+    if (providerFilter && t.provider !== providerFilter) return false
+    if (
+      normalizedQuery &&
+      !t.tenant_name.toLowerCase().includes(normalizedQuery) &&
+      !t.tenant_id.toLowerCase().includes(normalizedQuery)
+    ) {
+      return false
+    }
+    return true
+  })
 
   async function handleAdd(tenantUuid: string) {
     setAddingId(tenantUuid)
@@ -385,27 +416,29 @@ function TenantsTab({ workspaceId, isManager }: { workspaceId: string; isManager
 
       {showAdd && available.length > 0 && (
         <div className="mb-4 rounded-lg border bg-muted/30 p-4">
-          <p className="mb-2 text-sm font-medium">Available data sources</p>
-          <Input
-            type="search"
-            placeholder="Search by name or opportunity ID…"
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            className="mb-3"
-            data-testid="tenant-search-input"
-          />
+          <p className="mb-3 text-sm font-medium">Available data sources</p>
+          <div className="mb-3">
+            <SearchFilterBar
+              search={query}
+              onSearchChange={setQuery}
+              placeholder="Search by name or opportunity ID…"
+              filters={providerFilterGroups}
+              activeFilters={{ provider: providerFilter }}
+              onFilterChange={(_group, value) => setProviderFilter(value)}
+            />
+          </div>
           {filteredAvailable.length === 0 ? (
-            <p className="text-sm text-muted-foreground">
-              No data sources match &ldquo;{normalizedQuery}&rdquo;.
+            <p className="text-sm text-muted-foreground" data-testid="available-sources-empty">
+              No data sources match your filters.
             </p>
           ) : (
-            <div className="space-y-2">
+            <div className="space-y-2" data-testid="available-sources-list">
               {filteredAvailable.map((t) => (
                 <div key={t.tenant_uuid} className="flex items-center justify-between">
                   <div>
                     <div className="text-sm font-medium">{t.tenant_name}</div>
                     <div className="text-xs text-muted-foreground">
-                      #{t.tenant_id} · {t.provider}
+                      #{t.tenant_id} · {getProviderMeta(t.provider).label}
                     </div>
                   </div>
                   <Button
@@ -443,8 +476,8 @@ function TenantsTab({ workspaceId, isManager }: { workspaceId: string; isManager
                 <div className="font-medium">{t.tenant_name}</div>
                 <div className="text-xs text-muted-foreground">
                   {externalIdByUuid.has(t.tenant_id)
-                    ? `#${externalIdByUuid.get(t.tenant_id)} · ${t.provider}`
-                    : t.provider}
+                    ? `#${externalIdByUuid.get(t.tenant_id)} · ${getProviderMeta(t.provider).label}`
+                    : getProviderMeta(t.provider).label}
                 </div>
               </div>
               {isManager && tenants.length > 1 && (
@@ -712,7 +745,7 @@ export function WorkspaceDetailPage() {
       <Tabs defaultValue="members">
         <TabsList data-testid="workspace-tabs">
           <TabsTrigger value="members" data-testid="tab-members">Members</TabsTrigger>
-          <TabsTrigger value="tenants" data-testid="tab-tenants">Tenants</TabsTrigger>
+          <TabsTrigger value="tenants" data-testid="tab-tenants">Data sources</TabsTrigger>
           <TabsTrigger value="settings" data-testid="tab-settings">Settings</TabsTrigger>
         </TabsList>
 

--- a/frontend/src/store/authSlice.ts
+++ b/frontend/src/store/authSlice.ts
@@ -1,5 +1,6 @@
 import type { StateCreator } from "zustand"
 import { api, ApiError } from "@/api/client"
+import { clearUserTenantsCache } from "@/api/userTenantsCache"
 
 export type AuthStatus = "idle" | "loading" | "authenticated" | "unauthenticated"
 
@@ -61,6 +62,7 @@ export const createAuthSlice: StateCreator<AuthSlice, [], [], AuthSlice> = (set)
       try {
         await api.post("/api/auth/logout/")
       } finally {
+        clearUserTenantsCache()
         set({ user: null, authStatus: "unauthenticated", authError: null })
       }
     },


### PR DESCRIPTION
## Summary

UI-level rename of **Tenants → Data sources** plus a performance/UX overhaul of the Data sources tab. Frontend-only — no data-model or API changes (API paths, fields, and postMessage event types are unchanged).

- **Rename**: All user-visible "Tenant(s)" copy becomes "Data source(s)" (Connections page, Workspace detail tab, create-workspace modal). API endpoints (`/api/auth/tenant-credentials/`, `/api/auth/tenants/`), model field names (`tenant_id`, `tenant_uuid`, `tenant_name`), tab values, and `data-testid`s are intentionally left untouched.
- **Create-workspace data-source picker**: The New Workspace modal now lets you select one or more data sources up front, with search and (when 2+ providers are present) provider filter pills.
- **Provider filter pills**: The add-data-source list reuses `SearchFilterBar` (same component/design as the Workspaces page). Pills only appear when the available set spans more than one provider.
- **Data sources tab overhaul**:
  - Connected sources render immediately from the fast local-DB query — never blocked on the slow external list.
  - The available list lazy-loads behind the "+ Add data source" panel with a skeleton placeholder, warmed in the background after first paint.
  - `getUserTenants()` (which can take ~20s on a cold session because the backend synchronously refreshes from the live CommCare / Connect / OCS APIs) is memoized in a per-user session cache (`userTenantsCache.ts`), keyed by user id, cleared on logout. Failed fetches are not cached so the next call retries. Add/remove mutations update state optimistically.
  - Bare "Loading…" placeholders replaced with skeletons; design-polish pass throughout.

## Test plan

- [ ] **Rename**: Connections page, Workspace → Data sources tab, and the New Workspace modal all read "Data source(s)" with no stray "Tenant" copy.
- [ ] **Create with source**: Open New Workspace, pick one or more data sources, create — the new workspace has those sources connected.
- [ ] **Filters**: With 2+ providers available, provider pills appear and filter the list (both in the modal and the add panel); with a single provider, only the search box shows.
- [ ] **Fast tab load**: Opening a workspace's Data sources tab renders connected sources immediately without waiting on the external refresh.
- [ ] **Lazy available list + cache**: Opening "+ Add data source" shows a skeleton on first load, then the list; reopening (or revisiting within the session) resolves instantly from cache. Logout clears the cache. The "Refresh" affordance forces a live re-fetch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)