### PR TITLE
Fix Langfuse SDK method name

### DIFF
--- a/apps/workspaces/tasks.py
+++ b/apps/workspaces/tasks.py
@@ -687,7 +687,7 @@ def _resume_langfuse_span(*, thread_job_id: str, thread_id: str, status: str):
         return contextlib.nullcontext()
     try:
         client = Langfuse(secret_key=secret_key, public_key=public_key, host=host)
-        return client.start_as_current_span(
+        return client.start_as_current_observation(
             name="resume_thread_after_materialization",
             input={
                 "thread_job_id": thread_job_id,


### PR DESCRIPTION
## Summary

Fixed the Langfuse SDK method call in task resumption instrumentation. The code was calling `start_as_current_span()` which doesn't exist in Langfuse v4. Replaced it with the correct method `start_as_current_observation()` from the current SDK.

This resolves the CloudWatch error:
```
AttributeError: 'Langfuse' object has no attribute 'start_as_current_span'. Did you mean: 'score_current_span'?
```

## Changes

- Replace `client.start_as_current_span()` with `client.start_as_current_observation()` in `_resume_langfuse_span()`
- The method signature and behavior remain the same as both are context managers
- Verified no other occurrences of the old method in the codebase

## Testing

- Verified Python file compiles correctly
- Confirmed no other occurrences of deprecated method

🤖 Generated with [Claude Code](https://claude.com/claude-code)