### PR TITLE
Fix New Workspace modal layout, post-create nav, and duplicate warning

### DIFF
--- a/frontend/src/components/CreateWorkspaceModal/CreateWorkspaceModal.tsx
+++ b/frontend/src/components/CreateWorkspaceModal/CreateWorkspaceModal.tsx
@@ -15,7 +15,7 @@ import {
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
-import { Check } from "lucide-react"
+import { AlertTriangle, Check } from "lucide-react"
 import {
   SearchFilterBar,
   type FilterGroup,
@@ -31,6 +31,8 @@ export function CreateWorkspaceModal({ onClose }: Props) {
   const fetchDomains = useAppStore((s) => s.domainActions.fetchDomains)
   const setActiveDomain = useAppStore((s) => s.domainActions.setActiveDomain)
   const userId = useAppStore((s) => s.user?.id)
+  const domains = useAppStore((s) => s.domains)
+  const domainsStatus = useAppStore((s) => s.domainsStatus)
 
   const [name, setName] = useState("")
   const [loading, setLoading] = useState(false)
@@ -42,6 +44,8 @@ export function CreateWorkspaceModal({ onClose }: Props) {
   const [selected, setSelected] = useState<Set<string>>(new Set())
   const [search, setSearch] = useState("")
   const [providerFilter, setProviderFilter] = useState<string | null>(null)
+  // Set once the user opts to "Create anyway" past the duplicate warning.
+  const [duplicateAcknowledged, setDuplicateAcknowledged] = useState(false)
 
   useEffect(() => {
     if (!userId) return
@@ -64,6 +68,12 @@ export function CreateWorkspaceModal({ onClose }: Props) {
     }
   }, [userId])
 
+  // Ensure the user's workspace list is loaded so duplicate detection has data
+  // to compare against, even if the modal is opened before the list is fetched.
+  useEffect(() => {
+    if (domainsStatus === "idle") void fetchDomains()
+  }, [domainsStatus, fetchDomains])
+
   const providerFilterGroups = useMemo((): FilterGroup[] => {
     const counts = new Map<string, number>()
     for (const t of sources) {
@@ -84,6 +94,21 @@ export function CreateWorkspaceModal({ onClose }: Props) {
     ]
   }, [sources])
 
+  // A workspace is an exact duplicate when its set of tenant ids matches the
+  // currently selected set, order-independent. Only meaningful for a non-empty
+  // selection — an empty pick shouldn't flag every empty workspace. Detection
+  // is purely client-side: the workspace list already carries each tenant's id.
+  const duplicateWorkspace = useMemo(() => {
+    if (selected.size === 0) return null
+    return (
+      domains.find((ws) => {
+        const ids = ws.tenants?.map((t) => t.id) ?? []
+        if (ids.length !== selected.size) return false
+        return ids.every((id) => selected.has(id))
+      }) ?? null
+    )
+  }, [domains, selected])
+
   const normalizedSearch = search.trim().replace(/^#/, "").toLowerCase()
   const filteredSources = sources.filter((t) => {
     if (providerFilter && t.provider !== providerFilter) return false
@@ -98,6 +123,9 @@ export function CreateWorkspaceModal({ onClose }: Props) {
   })
 
   function toggleSource(uuid: string) {
+    // Changing the selection invalidates a prior "create anyway" decision: the
+    // new set may match a different existing workspace (or none).
+    setDuplicateAcknowledged(false)
     setSelected((prev) => {
       const next = new Set(prev)
       if (next.has(uuid)) next.delete(uuid)
@@ -106,9 +134,19 @@ export function CreateWorkspaceModal({ onClose }: Props) {
     })
   }
 
+  function goToExistingWorkspace() {
+    if (!duplicateWorkspace) return
+    setActiveDomain(duplicateWorkspace.id)
+    onClose()
+    navigate(`/workspaces/${duplicateWorkspace.id}`)
+  }
+
   async function handleSubmit(e: React.SyntheticEvent<HTMLFormElement>) {
     e.preventDefault()
     if (!name.trim()) return
+    // Hold for an explicit decision when this exact data-source set already
+    // exists, unless the user has chosen to create anyway.
+    if (duplicateWorkspace && !duplicateAcknowledged) return
     setLoading(true)
     setError(null)
     try {
@@ -126,12 +164,12 @@ export function CreateWorkspaceModal({ onClose }: Props) {
 
   return (
     <Dialog open onOpenChange={(open) => { if (!open) onClose() }}>
-      <DialogContent className="sm:max-w-lg" data-testid="create-workspace-modal">
+      <DialogContent className="w-[calc(100vw-2rem)] sm:max-w-lg" data-testid="create-workspace-modal">
         <DialogHeader>
           <DialogTitle>New Workspace</DialogTitle>
         </DialogHeader>
-        <form onSubmit={handleSubmit}>
-          <div className="space-y-4 py-4">
+        <form onSubmit={handleSubmit} className="min-w-0">
+          <div className="min-w-0 space-y-4 py-4">
             <div>
               <Label htmlFor="workspace-name">Name</Label>
               <Input
@@ -179,6 +217,7 @@ export function CreateWorkspaceModal({ onClose }: Props) {
                     filters={providerFilterGroups}
                     activeFilters={{ provider: providerFilter }}
                     onFilterChange={(_group, value) => setProviderFilter(value)}
+                    orientation="stacked"
                   />
                   <div
                     className="max-h-56 space-y-1 overflow-y-auto rounded-md border p-1"
@@ -226,6 +265,45 @@ export function CreateWorkspaceModal({ onClose }: Props) {
               )}
             </div>
 
+            {duplicateWorkspace && !duplicateAcknowledged && (
+              <div
+                className="flex gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 p-3 text-sm text-amber-700 dark:text-amber-400"
+                data-testid="create-workspace-duplicate-warning"
+              >
+                <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+                <div className="min-w-0 space-y-2">
+                  <p>
+                    You already have a workspace with this exact set of data
+                    sources:{" "}
+                    <span className="font-medium">
+                      {duplicateWorkspace.display_name || duplicateWorkspace.name}
+                    </span>
+                    .
+                  </p>
+                  <div className="flex flex-wrap gap-2">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      onClick={goToExistingWorkspace}
+                      data-testid="create-workspace-duplicate-goto"
+                    >
+                      Go to that workspace
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => setDuplicateAcknowledged(true)}
+                      data-testid="create-workspace-duplicate-continue"
+                    >
+                      Create anyway
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            )}
+
             {error && <p className="text-sm text-destructive">{error}</p>}
           </div>
           <DialogFooter>
@@ -234,7 +312,11 @@ export function CreateWorkspaceModal({ onClose }: Props) {
             </Button>
             <Button
               type="submit"
-              disabled={!name.trim() || loading}
+              disabled={
+                !name.trim() ||
+                loading ||
+                (!!duplicateWorkspace && !duplicateAcknowledged)
+              }
               data-testid="create-workspace-submit"
             >
               {loading ? "Creating…" : "Create Workspace"}

--- a/frontend/src/components/SearchFilterBar/SearchFilterBar.tsx
+++ b/frontend/src/components/SearchFilterBar/SearchFilterBar.tsx
@@ -20,6 +20,15 @@ interface SearchFilterBarProps {
   filters: FilterGroup[]
   activeFilters: Record<string, string | null>
   onFilterChange: (group: string, value: string | null) => void
+  /**
+   * Layout of the search box relative to the filter chips.
+   * - "responsive" (default): stacked on mobile, single row at `sm`+. Suits
+   *   full-width page contexts.
+   * - "stacked": search always above the chips. Use inside narrow containers
+   *   (e.g. a modal) where the viewport is wide but the available width isn't,
+   *   so the row layout would cramp the search box.
+   */
+  orientation?: "responsive" | "stacked"
 }
 
 export function SearchFilterBar({
@@ -29,10 +38,18 @@ export function SearchFilterBar({
   filters,
   activeFilters,
   onFilterChange,
+  orientation = "responsive",
 }: SearchFilterBarProps) {
+  const stacked = orientation === "stacked"
   return (
-    <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
-      <div className="relative flex-1">
+    <div
+      className={
+        stacked
+          ? "flex min-w-0 flex-col gap-3"
+          : "flex min-w-0 flex-col gap-4 sm:flex-row sm:items-center"
+      }
+    >
+      <div className="relative min-w-0 flex-1">
         <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
         <Input
           placeholder={placeholder}
@@ -43,29 +60,45 @@ export function SearchFilterBar({
         />
       </div>
       {filters.map((group) => (
-        <div key={group.name} className="flex flex-wrap gap-2">
+        <div
+          key={group.name}
+          // Chips never wrap and never shrink, so toggling a filter can't push
+          // them onto a new row or collapse the search box. If they ever exceed
+          // the available width they scroll horizontally — honest and contained.
+          className="flex shrink-0 gap-2 overflow-x-auto"
+        >
           <Button
             variant={activeFilters[group.name] == null ? "default" : "outline"}
             size="sm"
+            // The `default` (active) variant has no border while `outline`
+            // (inactive) carries a 1px border, so toggling state would change
+            // the chip's box width and reflow the whole row. Reserve a 1px
+            // transparent border on the active chip so its width is identical
+            // to the inactive state. Width stays constant — no reflow.
+            className={activeFilters[group.name] == null ? "border border-transparent" : ""}
             onClick={() => onFilterChange(group.name, null)}
             data-testid={`filter-${group.name}-all`}
           >
             All
           </Button>
-          {group.options.map((opt) => (
-            <Button
-              key={opt.value}
-              variant={activeFilters[group.name] === opt.value ? "default" : "outline"}
-              size="sm"
-              onClick={() => onFilterChange(group.name, opt.value)}
-              data-testid={`filter-${group.name}-${opt.value}`}
-            >
-              {opt.label}
-              {opt.count != null && (
-                <span className="ml-1 text-xs opacity-60">{opt.count}</span>
-              )}
-            </Button>
-          ))}
+          {group.options.map((opt) => {
+            const isActive = activeFilters[group.name] === opt.value
+            return (
+              <Button
+                key={opt.value}
+                variant={isActive ? "default" : "outline"}
+                size="sm"
+                className={isActive ? "border border-transparent" : ""}
+                onClick={() => onFilterChange(group.name, opt.value)}
+                data-testid={`filter-${group.name}-${opt.value}`}
+              >
+                {opt.label}
+                {opt.count != null && (
+                  <span className="ml-1 text-xs opacity-60">{opt.count}</span>
+                )}
+              </Button>
+            )
+          })}
         </div>
       ))}
     </div>


### PR DESCRIPTION
Fixes three issues in the New Workspace modal.

**(A) Layout** — data-source filter chips reflowed/jumped on click and the modal cramped/overflowed. Active chip (`default` variant, no border) vs inactive (`outline`, 1px border) differed in width by ~1px, tipping the `flex-wrap` row over its wrap boundary against a `flex-1` search box. Fix: reserve a transparent 1px border on the active chip so widths match; chip group is `shrink-0` + no-wrap + `overflow-x-auto`; add `min-w-0` so flex children can shrink; new opt-in `orientation="stacked"` prop used only by the modal (page usages keep the responsive row layout).

**(B) Post-create nav** — on success, set the new workspace active, refresh the list, close, and navigate to `/workspaces/:id`.

**(C) Duplicate-tenant warning** — detected entirely client-side from the existing list payload; when the selected tenant set matches an existing workspace (order-independent), an inline warning offers "Go to that workspace" or "Create anyway". No backend change.

`SearchFilterBar` is shared — all 4 usages verified. data-testids added for the duplicate warning controls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
