### PR TITLE
Add Export to PDF for artifacts via browser print-to-PDF

### DIFF
--- a/apps/artifacts/views.py
+++ b/apps/artifacts/views.py
@@ -174,6 +174,42 @@ SANDBOX_HTML_TEMPLATE = """<!DOCTYPE html>
             white-space: pre-wrap;
             text-align: left;
         }
+        /* Print-to-PDF styling: white background, full content (no clipping),
+           sensible page margins, and visible chart SVGs. */
+        @media print {
+            @page {
+                size: auto;
+                margin: 16mm;
+            }
+            html, body {
+                height: auto;
+                overflow: visible;
+                background: #ffffff;
+            }
+            #root {
+                height: auto;
+                display: block;
+            }
+            #artifact-container {
+                overflow: visible;
+                height: auto;
+                padding: 0;
+            }
+            /* The loading spinner is non-content chrome; never print it. */
+            .loading-state {
+                display: none !important;
+            }
+            /* Ensure chart colors/backgrounds render instead of being stripped. */
+            * {
+                -webkit-print-color-adjust: exact !important;
+                print-color-adjust: exact !important;
+            }
+            /* Recharts/Plotly draw into SVG/canvas; keep them visible and unclipped. */
+            svg, canvas {
+                max-width: 100% !important;
+                overflow: visible !important;
+            }
+        }
     </style>
 </head>
 <body>
@@ -619,6 +655,16 @@ SANDBOX_HTML_TEMPLATE = """<!DOCTYPE html>
         } else {
             ArtifactRenderer.init().catch(console.error);
         }
+
+        // Print-to-PDF: the parent frame posts {type: 'scout-print'} to print
+        // only the artifact (not the surrounding app). Triggering print inside
+        // the sandboxed iframe scopes the print job to the artifact content.
+        window.addEventListener('message', (event) => {
+            if (event.origin !== window.location.origin) return;
+            if (event.data && event.data.type === 'scout-print') {
+                window.print();
+            }
+        });
     </script>
 </body>
 </html>"""

--- a/frontend/src/components/ArtifactPanel/ArtifactPanel.tsx
+++ b/frontend/src/components/ArtifactPanel/ArtifactPanel.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from "react"
 import { useAppStore } from "@/store/store"
-import { X, Eye, Database, RefreshCw, Loader2 } from "lucide-react"
+import { X, Eye, Database, RefreshCw, Loader2, FileDown } from "lucide-react"
 import { api } from "@/api/client"
 
 interface QueryResult {
@@ -37,6 +37,17 @@ export function ArtifactPanel() {
   const [panelWidth, setPanelWidth] = useState(DEFAULT_WIDTH)
   const [isResizing, setIsResizing] = useState(false)
   const panelRef = useRef<HTMLElement>(null)
+  const iframeRef = useRef<HTMLIFrameElement>(null)
+
+  const handleExportPdf = useCallback(() => {
+    // Trigger print inside the sandboxed iframe so the print job is scoped to
+    // the artifact content, not the surrounding app. The sandbox HTML listens
+    // for this message and calls window.print() (browser "Save as PDF").
+    iframeRef.current?.contentWindow?.postMessage(
+      { type: "scout-print" },
+      window.location.origin,
+    )
+  }, [])
 
   const fetchQueryData = useCallback(async (id: string) => {
     if (!activeDomainId) return
@@ -151,22 +162,36 @@ export function ArtifactPanel() {
                 Data
               </button>
             </div>
-            <button
-              onClick={closeArtifact}
-              className="rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
-              title="Close"
-            >
-              <X className="h-4 w-4" />
-            </button>
+            <div className="flex items-center gap-1">
+              <button
+                onClick={handleExportPdf}
+                disabled={activeTab !== "view"}
+                className="flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-40 disabled:hover:bg-transparent transition-colors"
+                title={activeTab === "view" ? "Export to PDF" : "Switch to the View tab to export"}
+                data-testid="artifact-export-pdf"
+              >
+                <FileDown className="h-3.5 w-3.5" />
+                Export PDF
+              </button>
+              <button
+                onClick={closeArtifact}
+                className="rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+                title="Close"
+                data-testid="artifact-close"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </div>
           </div>
 
           {/* View tab: iframe */}
           {activeTab === "view" && (
             <iframe
+              ref={iframeRef}
               key={artifactId}
               src={activeDomainId ? `/api/workspaces/${activeDomainId}/artifacts/${artifactId}/sandbox/` : ""}
               className="flex-1 w-full"
-              sandbox="allow-scripts allow-same-origin"
+              sandbox="allow-scripts allow-same-origin allow-modals"
               title="Artifact"
             />
           )}

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -214,6 +214,21 @@ class TestArtifactSandboxView:
         assert "React" in content or "react" in content
         assert "root" in content
 
+    def test_sandbox_supports_print_to_pdf(self, authenticated_client, artifact, workspace):
+        """Sandbox HTML wires up print-to-PDF: print CSS and a scout-print listener."""
+        response = authenticated_client.get(
+            f"/api/workspaces/{workspace.id}/artifacts/{artifact.id}/sandbox/"
+        )
+
+        assert response.status_code == 200
+        content = response.content.decode()
+
+        # Print-optimized styling is present.
+        assert "@media print" in content
+        # Parent frame triggers print via a postMessage handler scoped to origin.
+        assert "scout-print" in content
+        assert "window.print()" in content
+
     def test_sandbox_csp_headers(self, authenticated_client, artifact, workspace):
         """Test that CSP headers are set correctly for security."""
         response = authenticated_client.get(


### PR DESCRIPTION
Adds an **Export PDF** button to the artifact toolbar that triggers the native browser print dialog scoped to the artifact content, so users can "Save as PDF" with selectable text and no heavy client deps.

Because the artifact renders in a sandboxed iframe, the parent posts a `{type:'scout-print'}` message (origin-checked) to the iframe, and the server-rendered sandbox HTML calls `window.print()` in response. The iframe sandbox now includes `allow-modals` so the dialog can open. The sandbox HTML gains an `@media print` block (white bg, unclipped container, page margins, `color-adjust:exact`, visible SVG/canvas) so Recharts/Plotly charts render in the print preview.

Button has `data-testid="artifact-export-pdf"`, enabled only on the View tab. Adds a test asserting the print CSS and `scout-print` listener are present in the sandbox HTML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
