### PR TITLE
feat(ocs): materialize participants from dedicated participant API

### DIFF
--- a/mcp_server/loaders/ocs_participants.py
+++ b/mcp_server/loaders/ocs_participants.py
@@ -1,7 +1,30 @@
 """Participant loader for Open Chat Studio.
 
-No dedicated participants endpoint — extract unique participants from the
-session list.
+Uses the dedicated ``GET /api/participants`` endpoint (added in OCS PR
+dimagi/open-chat-studio#3334) to fetch rich participant records — including
+``name`` and per-chatbot custom ``data`` — rather than deriving a minimal
+participant list from the session endpoint.
+
+The endpoint is cursor-paginated (``{"next": ..., "previous": ...,
+"results": [...]}``) and returns ``ParticipantDetail`` objects shaped as::
+
+    {
+        "id": "<participant public uuid>",
+        "identifier": "part1",
+        "name": "John",
+        "platform": "api",
+        "remote_id": "",
+        "data": [
+            {
+                "chatbot": "Support Bot",
+                "chatbot_id": "<experiment public uuid>",
+                "data": {"name": "John", "timezone": "Africa/Johannesburg"},
+            },
+        ],
+    }
+
+We pass ``chatbot=<experiment_id>`` so the participant list (and each
+participant's ``data`` array) is scoped to this tenant's chatbot.
 """
 
 from __future__ import annotations
@@ -15,35 +38,38 @@ logger = logging.getLogger(__name__)
 
 
 class OCSParticipantLoader(OCSBaseLoader):
-    """Deduplicate participants from session list data."""
+    """Fetch participants from the dedicated OCS participant endpoint."""
 
     def load_pages(self) -> Iterator[tuple[list[dict], int | None]]:
-        url = f"{self.base_url}/api/sessions/"
-        params = {"experiment": self.experiment_id}
-        seen: set[str] = set()
-        # Participants are derived from sessions — no upstream count is meaningful.
-        for session_page, _session_total in self._paginate(url, params=params):
-            rows: list[dict] = []
-            for session in session_page:
-                participant = session.get("participant") or {}
-                identifier = participant.get("identifier")
-                if not identifier or identifier in seen:
-                    continue
-                seen.add(identifier)
-                rows.append(
-                    {
-                        "identifier": identifier,
-                        "platform": participant.get("platform") or "",
-                        "remote_id": participant.get("remote_id") or "",
-                    }
-                )
-            if rows:
-                yield rows, None
+        url = f"{self.base_url}/api/participants"
+        # Scope to this tenant's chatbot so the participant list and each
+        # participant's per-chatbot ``data`` array are limited to it.
+        params = {"chatbot": self.experiment_id}
+        total = 0
+        # Cursor pagination — no ``count`` field, so totals are always None.
+        for raw_page, _page_total in self._paginate(url, params=params):
+            rows = [_map_participant(item) for item in raw_page]
+            if not rows:
+                continue
+            total += len(rows)
+            yield rows, None
         logger.info(
-            "Fetched %d unique participants for experiment %s",
-            len(seen),
+            "Fetched %d participants for experiment %s",
+            total,
             self.experiment_id,
         )
 
     def load(self) -> list[dict]:
         return [row for page, _ in self.load_pages() for row in page]
+
+
+def _map_participant(raw: dict) -> dict:
+    return {
+        "participant_id": str(raw.get("id") or ""),
+        "identifier": raw.get("identifier") or "",
+        "name": raw.get("name") or "",
+        "platform": raw.get("platform") or "",
+        "remote_id": raw.get("remote_id") or "",
+        # Per-chatbot custom data entries: [{chatbot, chatbot_id, data}, ...].
+        "data": raw.get("data") or [],
+    }

--- a/mcp_server/services/materializer.py
+++ b/mcp_server/services/materializer.py
@@ -999,9 +999,12 @@ def _write_ocs_participants(
         psql.SQL(
             """
         CREATE TABLE {schema}.raw_participants (
-            identifier TEXT PRIMARY KEY,
+            participant_id TEXT PRIMARY KEY,
+            identifier TEXT,
+            name TEXT,
             platform TEXT,
-            remote_id TEXT
+            remote_id TEXT,
+            data JSONB
         )
         """
         ).format(schema=sid)
@@ -1017,9 +1020,12 @@ def _write_ocs_participants(
             rows_total = page_total
         rows = [
             (
+                r.get("participant_id", ""),
                 r.get("identifier", ""),
+                r.get("name", ""),
                 r.get("platform", ""),
                 r.get("remote_id", ""),
+                json.dumps(r.get("data") or []),
             )
             for r in page
         ]
@@ -1348,10 +1354,12 @@ _OCS_MESSAGES_INSERT = psql.SQL(
 _OCS_PARTICIPANTS_INSERT = psql.SQL(
     """
     INSERT INTO {schema}.raw_participants
-        (identifier, platform, remote_id)
-    VALUES (%s, %s, %s)
-    ON CONFLICT (identifier) DO UPDATE SET
-        platform=EXCLUDED.platform, remote_id=EXCLUDED.remote_id
+        (participant_id, identifier, name, platform, remote_id, data)
+    VALUES (%s, %s, %s, %s, %s, %s)
+    ON CONFLICT (participant_id) DO UPDATE SET
+        identifier=EXCLUDED.identifier, name=EXCLUDED.name,
+        platform=EXCLUDED.platform, remote_id=EXCLUDED.remote_id,
+        data=EXCLUDED.data
     """
 )
 

--- a/pipelines/ocs_sync.yml
+++ b/pipelines/ocs_sync.yml
@@ -11,7 +11,7 @@ sources:
   - name: messages
     description: "Individual messages within sessions"
   - name: participants
-    description: "Unique participants extracted from sessions"
+    description: "Participants with name, platform, and per-chatbot custom data (from the dedicated participant API)"
 
 metadata_discovery:
   description: "Fetch experiment detail from OCS API"

--- a/tests/test_ocs_data_loaders.py
+++ b/tests/test_ocs_data_loaders.py
@@ -150,29 +150,72 @@ def test_message_loader_flattens_messages_with_composite_pk():
         ]
 
 
-def test_participant_loader_dedupes_by_identifier():
+def test_participant_loader_maps_dedicated_endpoint_fields():
+    """Uses the dedicated /api/participants endpoint with rich fields + custom data."""
     loader = OCSParticipantLoader(experiment_id="exp-1", credential=CREDENTIAL, base_url=BASE_URL)
     page = MagicMock(status_code=200)
     page.json.return_value = {
         "results": [
             {
-                "id": "sess-1",
-                "participant": {"identifier": "p1", "platform": "web", "remote_id": "r1"},
+                "id": "11111111-1111-1111-1111-111111111111",
+                "identifier": "p1",
+                "name": "John",
+                "platform": "api",
+                "remote_id": "r1",
+                "data": [
+                    {
+                        "chatbot": "Support Bot",
+                        "chatbot_id": "exp-1",
+                        "data": {"name": "John", "timezone": "Africa/Johannesburg"},
+                    }
+                ],
             },
             {
-                "id": "sess-2",
-                "participant": {"identifier": "p1", "platform": "web", "remote_id": "r1"},
-            },
-            {
-                "id": "sess-3",
-                "participant": {"identifier": "p2", "platform": "whatsapp", "remote_id": "r2"},
+                "id": "22222222-2222-2222-2222-222222222222",
+                "identifier": "p2",
+                "name": "",
+                "platform": "whatsapp",
+                "remote_id": "",
+                "data": [],
             },
         ],
         "next": None,
     }
     with patch.object(loader._session, "get", return_value=page):
         rows = [r for pg, _ in loader.load_pages() for r in pg]
-        assert sorted(rows, key=lambda r: r["identifier"]) == [
-            {"identifier": "p1", "platform": "web", "remote_id": "r1"},
-            {"identifier": "p2", "platform": "whatsapp", "remote_id": "r2"},
+        assert rows == [
+            {
+                "participant_id": "11111111-1111-1111-1111-111111111111",
+                "identifier": "p1",
+                "name": "John",
+                "platform": "api",
+                "remote_id": "r1",
+                "data": [
+                    {
+                        "chatbot": "Support Bot",
+                        "chatbot_id": "exp-1",
+                        "data": {"name": "John", "timezone": "Africa/Johannesburg"},
+                    }
+                ],
+            },
+            {
+                "participant_id": "22222222-2222-2222-2222-222222222222",
+                "identifier": "p2",
+                "name": "",
+                "platform": "whatsapp",
+                "remote_id": "",
+                "data": [],
+            },
         ]
+
+
+def test_participant_loader_queries_chatbot_scoped_endpoint():
+    """The loader hits /api/participants filtered by the tenant's chatbot."""
+    loader = OCSParticipantLoader(experiment_id="exp-1", credential=CREDENTIAL, base_url=BASE_URL)
+    page = MagicMock(status_code=200)
+    page.json.return_value = {"results": [], "next": None}
+    with patch.object(loader._session, "get", return_value=page) as mock_get:
+        list(loader.load_pages())
+    args, kwargs = mock_get.call_args
+    assert args[0] == f"{BASE_URL}/api/participants"
+    assert kwargs["params"] == {"chatbot": "exp-1"}

--- a/tests/test_ocs_materializer.py
+++ b/tests/test_ocs_materializer.py
@@ -155,12 +155,54 @@ def test_write_ocs_participants_creates_table_and_rows(tenant_schema):
     conn.autocommit = False
     try:
         n = _write_ocs_participants(
-            iter([([{"identifier": "p1", "platform": "web", "remote_id": "r1"}], None)]),
+            iter(
+                [
+                    (
+                        [
+                            {
+                                "participant_id": "11111111-1111-1111-1111-111111111111",
+                                "identifier": "p1",
+                                "name": "John",
+                                "platform": "api",
+                                "remote_id": "r1",
+                                "data": [
+                                    {
+                                        "chatbot": "Support Bot",
+                                        "chatbot_id": "exp-uuid-1",
+                                        "data": {"timezone": "Africa/Johannesburg"},
+                                    }
+                                ],
+                            }
+                        ],
+                        None,
+                    )
+                ]
+            ),
             tenant_schema.schema_name,
             conn,
         )
         conn.commit()
         assert n == 1
         assert _row_count(conn, tenant_schema.schema_name, "raw_participants") == 1
+        with conn.cursor() as cur:
+            cur.execute(
+                psql.SQL(
+                    "SELECT participant_id, identifier, name, platform, remote_id, data "
+                    "FROM {}.raw_participants"
+                ).format(psql.Identifier(tenant_schema.schema_name))
+            )
+            row = cur.fetchone()
+        assert row[0] == "11111111-1111-1111-1111-111111111111"
+        assert row[1] == "p1"
+        assert row[2] == "John"
+        assert row[3] == "api"
+        assert row[4] == "r1"
+        assert row[5] == [
+            {
+                "chatbot": "Support Bot",
+                "chatbot_id": "exp-uuid-1",
+                "data": {"timezone": "Africa/Johannesburg"},
+            }
+        ]
     finally:
         conn.close()


### PR DESCRIPTION
Replaces the session-derived participant list with the new dedicated `GET /api/participants` endpoint (OCS PR dimagi/open-chat-studio#3334). The endpoint is cursor-paginated and returns `ParticipantDetail` objects — `id`, `identifier`, `name`, `platform`, `remote_id`, and a `data` array of per-chatbot entries. We pass `chatbot=<experiment_id>` so both the participant set and each participant's `data` are scoped to this tenant's chatbot.

**Changes**
- `OCSParticipantLoader`: fetch `/api/participants` (chatbot-scoped) via the shared cursor `_paginate` helper instead of deriving from `/api/sessions/`; map the richer fields including the custom `data` JSON.
- materializer: `raw_participants` now keyed on `participant_id` (TEXT PK) with `identifier`, `name`, `platform`, `remote_id`, `data` (JSONB); upsert `ON CONFLICT (participant_id)`. `identifier` retained so `raw_sessions.participant_identifier` still joins.
- `ocs_sync.yml`: updated participants source description.
- tests: loader field-mapping + chatbot-scoped query; writer columns + JSONB round-trip.

**Assumption:** the new endpoint is treated as primary (no version-negotiation/fallback pattern exists for OCS sources). Backend-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
