### PR TITLE
Remove public/share-creation UI (chat share menu + recipe public link)

### DIFF
--- a/frontend/src/components/ChatPanel/ChatPanel.tsx
+++ b/frontend/src/components/ChatPanel/ChatPanel.tsx
@@ -1,6 +1,6 @@
 import { useChat } from "@ai-sdk/react"
 import { DefaultChatTransport, type UIMessage } from "ai"
-import { useCallback, useEffect, useRef, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { getCsrfToken, api } from "@/api/client"
 import { BASE_PATH } from "@/config"
 import { useAppStore } from "@/store/store"
@@ -8,110 +8,12 @@ import { ChatMessage } from "@/components/ChatMessage/ChatMessage"
 import { MaterializationProgressBanner } from "@/components/MaterializationStatus/MaterializationProgressBanner"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
-import { Send, Square, Share2, Users, Globe, Link, Copy, Check } from "lucide-react"
+import { Send, Square } from "lucide-react"
 import { SLASH_COMMANDS, resolveSlashCommand } from "./slashCommands"
 import { SlashCommandMenu } from "./SlashCommandMenu"
 import { useWorkspaceJobs } from "@/contexts/WorkspaceJobsContext"
 import { ChatEmptyState } from "@/components/ChatEmptyState"
-import { TopBarSlot } from "@/components/TopBar"
 import { writeSavedThreadId } from "./threadStorage"
-
-function getPublicUrl(token: string): string {
-  return `${window.location.origin}/shared/threads/${token}/`
-}
-
-function ShareMenu({
-  threadId,
-  workspaceId,
-  onClose,
-}: {
-  threadId: string
-  workspaceId: string
-  onClose: () => void
-}) {
-  const threads = useAppStore((s) => s.threads)
-  const updateThreadSharing = useAppStore((s) => s.uiActions.updateThreadSharing)
-  const thread = threads.find((t) => t.id === threadId)
-  const [copied, setCopied] = useState(false)
-
-  const isShared = thread?.is_shared ?? false
-  const isPublic = thread?.is_public ?? false
-  const shareToken = thread?.share_token ?? null
-
-  const handleCopy = useCallback(async () => {
-    if (!shareToken) return
-    await navigator.clipboard.writeText(getPublicUrl(shareToken))
-    setCopied(true)
-    setTimeout(() => setCopied(false), 2000)
-  }, [shareToken])
-
-  return (
-    <div className="absolute right-0 top-full mt-1 z-50 w-72 rounded-lg border bg-popover p-3 shadow-md" data-testid="share-menu">
-      <div className="space-y-3">
-        <label
-          className="flex items-center gap-2 cursor-pointer text-sm"
-          data-testid="thread-sharing-project"
-        >
-          <input
-            type="checkbox"
-            checked={isShared}
-            onChange={(e) => updateThreadSharing(threadId, { is_shared: e.target.checked }, workspaceId)}
-            className="h-4 w-4 rounded border-gray-300"
-          />
-          <Users className="h-4 w-4 text-muted-foreground" />
-          <span>Share with project</span>
-        </label>
-        <label
-          className="flex items-center gap-2 cursor-pointer text-sm"
-          data-testid="thread-sharing-public"
-        >
-          <input
-            type="checkbox"
-            checked={isPublic}
-            onChange={(e) => updateThreadSharing(threadId, { is_public: e.target.checked }, workspaceId)}
-            className="h-4 w-4 rounded border-gray-300"
-          />
-          <Globe className="h-4 w-4 text-muted-foreground" />
-          <span>Public link</span>
-        </label>
-        {isPublic && shareToken && (
-          <div
-            className="flex items-center gap-2 rounded-md border bg-muted/50 p-2"
-            data-testid="thread-share-url"
-          >
-            <Link className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-            <code className="flex-1 truncate text-xs">
-              {getPublicUrl(shareToken)}
-            </code>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={handleCopy}
-              data-testid="copy-thread-share-link"
-              className="h-7 px-2"
-            >
-              {copied ? (
-                <Check className="h-3 w-3" />
-              ) : (
-                <Copy className="h-3 w-3" />
-              )}
-            </Button>
-          </div>
-        )}
-      </div>
-      <button
-        type="button"
-        onClick={onClose}
-        className="absolute -top-2 -right-2 rounded-full border bg-background p-1 text-muted-foreground hover:text-foreground"
-      >
-        <span className="sr-only">Close</span>
-        <svg className="h-3 w-3" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="2">
-          <path d="M2 2l8 8M10 2l-8 8" />
-        </svg>
-      </button>
-    </div>
-  )
-}
 
 export function ChatPanel() {
   const activeDomainId = useAppStore((s) => s.activeDomainId)
@@ -120,7 +22,6 @@ export function ChatPanel() {
   const scrollRef = useRef<HTMLDivElement>(null)
   const [input, setInput] = useState("")
   const [slashMenuIndex, setSlashMenuIndex] = useState(0)
-  const [showShareMenu, setShowShareMenu] = useState(false)
   const [messageReloadKey, setMessageReloadKey] = useState(0)
   const prevStatusRef = useRef<string>("")
 
@@ -272,27 +173,6 @@ export function ChatPanel() {
 
   return (
     <div className="flex flex-col h-full">
-      <TopBarSlot>
-        <div className="relative">
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => setShowShareMenu(!showShareMenu)}
-            data-testid="chat-share-btn"
-          >
-            <Share2 className="mr-1 h-4 w-4" />
-            Share
-          </Button>
-          {showShareMenu && activeDomainId && (
-            <ShareMenu
-              threadId={threadId}
-              workspaceId={activeDomainId}
-              onClose={() => setShowShareMenu(false)}
-            />
-          )}
-        </div>
-      </TopBarSlot>
-
       {/* Message list */}
       <div ref={scrollRef} className="flex-1 overflow-y-auto p-4 space-y-4">
         {messages.map((msg: UIMessage, msgIdx: number) => (

--- a/frontend/src/pages/RecipesPage/RecipeDetail.tsx
+++ b/frontend/src/pages/RecipesPage/RecipeDetail.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from "react"
-import { ArrowLeft, Save, Play, Loader2, Clock, CheckCircle, XCircle, AlertCircle, Copy, Check, Users, Globe, Eye } from "lucide-react"
+import { ArrowLeft, Save, Play, Loader2, Clock, CheckCircle, XCircle, AlertCircle, Users, Eye } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
@@ -60,36 +60,6 @@ function getStatusIcon(status: RecipeRun["status"]) {
     default:
       return <AlertCircle className="h-4 w-4 text-muted-foreground" />
   }
-}
-
-function CopyButton({ text }: { text: string }) {
-  const [copied, setCopied] = useState(false)
-
-  const handleCopy = useCallback(async () => {
-    await navigator.clipboard.writeText(text)
-    setCopied(true)
-    setTimeout(() => setCopied(false), 2000)
-  }, [text])
-
-  return (
-    <Button
-      variant="outline"
-      size="sm"
-      onClick={handleCopy}
-      data-testid="copy-share-link"
-    >
-      {copied ? (
-        <Check className="mr-1 h-3 w-3" />
-      ) : (
-        <Copy className="mr-1 h-3 w-3" />
-      )}
-      {copied ? "Copied" : "Copy"}
-    </Button>
-  )
-}
-
-function getPublicUrl(path: string, token: string): string {
-  return `${window.location.origin}${path}${token}/`
 }
 
 export function RecipeDetail({ recipe, runs, onBack, onSave, onRun, onUpdateRun, onViewRun }: RecipeDetailProps) {
@@ -371,26 +341,6 @@ export function RecipeDetail({ recipe, runs, onBack, onSave, onRun, onUpdateRun,
                             <Users className="h-3 w-3 text-muted-foreground" />
                             <span className="text-muted-foreground">Project</span>
                           </label>
-                          <label className="flex items-center gap-1.5 cursor-pointer text-xs">
-                            <input
-                              type="checkbox"
-                              checked={run.is_public}
-                              onChange={(e) =>
-                                onUpdateRun(run.id, { is_public: e.target.checked })
-                              }
-                              className="h-3.5 w-3.5 rounded border-gray-300"
-                            />
-                            <Globe className="h-3 w-3 text-muted-foreground" />
-                            <span className="text-muted-foreground">Public</span>
-                          </label>
-                          {run.is_public && run.share_token && (
-                            <CopyButton
-                              text={getPublicUrl(
-                                "/shared/runs/",
-                                run.share_token,
-                              )}
-                            />
-                          )}
                         </div>
                       </div>
                     ))}

--- a/frontend/src/pages/RecipesPage/RecipeRunDetail.tsx
+++ b/frontend/src/pages/RecipesPage/RecipeRunDetail.tsx
@@ -1,4 +1,3 @@
-import { useState, useCallback } from "react"
 import Markdown from "react-markdown"
 import remarkGfm from "remark-gfm"
 import {
@@ -8,11 +7,7 @@ import {
   Loader2,
   Clock,
   AlertCircle,
-  Copy,
-  Check,
-  Link,
   Users,
-  Globe,
   FileBarChart,
 } from "lucide-react"
 import { Button } from "@/components/ui/button"
@@ -67,36 +62,6 @@ function getStatusBadgeClass(status: RecipeRun["status"]): string {
     case "pending":
       return "bg-gray-100 text-gray-800 dark:bg-gray-900/30 dark:text-gray-400"
   }
-}
-
-function getPublicUrl(path: string, token: string): string {
-  return `${window.location.origin}${path}${token}/`
-}
-
-function CopyButton({ text }: { text: string }) {
-  const [copied, setCopied] = useState(false)
-
-  const handleCopy = useCallback(async () => {
-    await navigator.clipboard.writeText(text)
-    setCopied(true)
-    setTimeout(() => setCopied(false), 2000)
-  }, [text])
-
-  return (
-    <Button
-      variant="outline"
-      size="sm"
-      onClick={handleCopy}
-      data-testid="copy-share-link"
-    >
-      {copied ? (
-        <Check className="mr-1 h-3 w-3" />
-      ) : (
-        <Copy className="mr-1 h-3 w-3" />
-      )}
-      {copied ? "Copied" : "Copy"}
-    </Button>
-  )
 }
 
 export function RecipeRunDetail({ recipe, run, onBack, onUpdateRun }: RecipeRunDetailProps) {
@@ -248,35 +213,6 @@ export function RecipeRunDetail({ recipe, run, onBack, onUpdateRun }: RecipeRunD
             <Users className="h-4 w-4 text-muted-foreground" />
             <span>Share with project</span>
           </label>
-          <label
-            className="flex items-center gap-1.5 cursor-pointer text-sm"
-            data-testid="run-sharing-public"
-          >
-            <input
-              type="checkbox"
-              checked={run.is_public}
-              onChange={(e) =>
-                onUpdateRun(run.id, { is_public: e.target.checked })
-              }
-              className="h-4 w-4 rounded border-gray-300"
-            />
-            <Globe className="h-4 w-4 text-muted-foreground" />
-            <span>Public link</span>
-          </label>
-          {run.is_public && run.share_token && (
-            <div
-              className="flex items-center gap-2 rounded-md border bg-muted/50 p-2"
-              data-testid="run-share-url"
-            >
-              <Link className="h-4 w-4 shrink-0 text-muted-foreground" />
-              <code className="flex-1 truncate text-xs">
-                {getPublicUrl("/shared/runs/", run.share_token)}
-              </code>
-              <CopyButton
-                text={getPublicUrl("/shared/runs/", run.share_token)}
-              />
-            </div>
-          )}
         </CardContent>
       </Card>
     </div>


### PR DESCRIPTION
UI-only removal of share-**creation** affordances. No backend endpoints, models, serializers, or public viewer routes/pages were touched; **existing shared links keep working**.

**Chat threads** — remove the entire Share menu from `ChatPanel` (Share button, `ShareMenu`, `showShareMenu` state, `getPublicUrl`, and the now-empty `TopBarSlot`). These minted public unauthenticated links / a non-functional `is_public` toggle.

**Recipe runs** — remove only the "Public link" (`is_public`) affordances (checkbox, public share-URL display, CopyButton, `getPublicUrl`) in `RecipeRunDetail` and `RecipeDetail`. **"Share with project" (`is_shared`) — real internal sharing — is kept intact.**

The shared store/prop types still carry an optional `is_public` field; no UI control sends it anymore. Lint and tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
