### PR TITLE
Give materialization progress bars real denominators (#221)

### DIFF
--- a/apps/workspaces/api/jobs_views.py
+++ b/apps/workspaces/api/jobs_views.py
@@ -33,6 +33,9 @@ def _job_to_dict(job: ThreadJob, run_progress: dict | None) -> dict:
             "percent": percent,
             "rows_loaded": rows_loaded,
             "rows_total": rows_total,
+            # Display unit for the counts ("rows" for most sources; OCS
+            # messages report per-session progress as "sessions").
+            "unit": run_progress.get("unit") or "rows",
             "message": run_progress.get("message"),
             "source": run_progress.get("source"),
             "step": run_progress.get("step"),

--- a/frontend/src/api/jobs.ts
+++ b/frontend/src/api/jobs.ts
@@ -8,6 +8,9 @@ export interface JobProgress {
   percent: number | null
   rows_loaded: number
   rows_total: number | null
+  /** Display unit for the counts — "rows" for most sources; OCS messages
+   *  report per-session progress as "sessions". */
+  unit?: string
   message: string | null
   source: string | null
   step: number | null

--- a/frontend/src/components/MaterializationStatus/MaterializationProgressBanner.tsx
+++ b/frontend/src/components/MaterializationStatus/MaterializationProgressBanner.tsx
@@ -43,16 +43,19 @@ export function MaterializationProgressBanner({ job, workspaceId }: Props) {
   const sourceName = progress?.source ?? null
   const step = progress?.step ?? null
   const totalSteps = progress?.total_steps ?? null
+  const unit = progress?.unit ?? "rows"
   const isDeterminate = percent != null
 
-  // Count line: "27,000 of 50,000 rows" when a total is known, else "27,000 rows".
+  // Count line: "27,000 of 50,000 rows" when a total is known, else "27,000
+  // rows". The unit comes from the backend — OCS messages count "sessions"
+  // (one detail fetch per session) rather than rows.
   let countText: string
   if (rowsLoaded > 0) {
     const rowsStr = rowsLoaded.toLocaleString()
     countText =
       rowsTotal != null && rowsTotal > 0
-        ? `${rowsStr} of ${rowsTotal.toLocaleString()} rows`
-        : `${rowsStr} rows`
+        ? `${rowsStr} of ${rowsTotal.toLocaleString()} ${unit}`
+        : `${rowsStr} ${unit}`
   } else if (sourceName) {
     countText = `Loading ${sourceName}…`
   } else {

--- a/mcp_server/loaders/commcare_cases.py
+++ b/mcp_server/loaders/commcare_cases.py
@@ -39,8 +39,9 @@ class CommCareCaseLoader(CommCareBaseLoader):
         """Yield ``(page, total_count)`` one page at a time.
 
         Each ``page`` is a list of normalised case dicts. ``total_count`` is
-        the API's ``meta.total_count`` from the first response only;
-        subsequent pages yield ``None``.
+        the API's ``matching_records`` from the first response only;
+        subsequent pages yield ``None``. (Case API v2 has no tastypie
+        ``meta`` envelope — the total lives in ``matching_records``.)
         """
         url = f"{_BASE_URL}/a/{self.domain}/api/case/v2/"
         params: dict = {"limit": self.page_size}
@@ -51,9 +52,9 @@ class CommCareCaseLoader(CommCareBaseLoader):
             cases = [_normalize_case(c) for c in data.get("cases", [])]
             page_total: int | None = None
             if first_page:
-                meta_total = data.get("meta", {}).get("total_count")
-                if isinstance(meta_total, int):
-                    page_total = meta_total
+                matching = data.get("matching_records")
+                if isinstance(matching, int):
+                    page_total = matching
                 first_page = False
             if cases:
                 total_loaded += len(cases)

--- a/mcp_server/loaders/ocs_messages.py
+++ b/mcp_server/loaders/ocs_messages.py
@@ -17,27 +17,39 @@ logger = logging.getLogger(__name__)
 
 
 class OCSMessageLoader(OCSBaseLoader):
-    """Fetch messages for every session in an experiment."""
+    """Fetch messages for every session in an experiment.
+
+    Two-pass: first walk the (cheap) session list collecting session ids,
+    then fetch each session's detail. The list walk costs the same requests
+    as the old interleaved approach but lets us know the session count up
+    front, so the expensive detail-fetch phase can report determinate
+    progress (issue #221).
+
+    ``load_pages`` yields exactly one ``(rows, total_sessions)`` tuple per
+    session — ``rows`` may be empty — where the total is denominated in
+    **sessions**, not message rows (OCS' cursor pagination exposes no
+    message count). The writer counts tuples to report per-session progress.
+    """
 
     def load_pages(self) -> Iterator[tuple[list[dict], int | None]]:
         list_url = f"{self.base_url}/api/sessions/"
         params = {"experiment": self.experiment_id}
-        total_sessions = 0
-        total_messages = 0
-        # No reliable total for messages — they're nested per-session.
+        session_ids: list[str] = []
         for session_page, _session_total in self._paginate(list_url, params=params):
             for session in session_page:
                 session_id = str(session.get("id") or "")
-                if not session_id:
-                    continue
-                total_sessions += 1
-                detail_url = f"{self.base_url}/api/sessions/{session_id}/"
-                detail_resp = self._get(detail_url)
-                messages = detail_resp.json().get("messages") or []
-                rows = [_map_message(session_id, idx, msg) for idx, msg in enumerate(messages)]
-                if rows:
-                    total_messages += len(rows)
-                    yield rows, None
+                if session_id:
+                    session_ids.append(session_id)
+
+        total_sessions = len(session_ids)
+        total_messages = 0
+        for session_id in session_ids:
+            detail_url = f"{self.base_url}/api/sessions/{session_id}/"
+            detail_resp = self._get(detail_url)
+            messages = detail_resp.json().get("messages") or []
+            rows = [_map_message(session_id, idx, msg) for idx, msg in enumerate(messages)]
+            total_messages += len(rows)
+            yield rows, total_sessions
         logger.info(
             "Fetched %d messages across %d sessions for experiment %s",
             total_messages,

--- a/mcp_server/loaders/ocs_sessions.py
+++ b/mcp_server/loaders/ocs_sessions.py
@@ -11,7 +11,14 @@ logger = logging.getLogger(__name__)
 
 
 class OCSSessionLoader(OCSBaseLoader):
-    """Fetch chat sessions for this experiment (paginated)."""
+    """Fetch chat sessions for this experiment (paginated).
+
+    Verified against the OCS OpenAPI schema (2026-06, issue #221):
+    ``PaginatedExperimentSessionList`` carries only ``next``/``previous``/
+    ``results`` — cursor pagination with no ``count`` — so ``page_total``
+    is always ``None`` today and the progress bar stays indeterminate.
+    ``_paginate`` will pick a ``count`` up automatically if OCS ever adds one.
+    """
 
     def load_pages(self) -> Iterator[tuple[list[dict], int | None]]:
         url = f"{self.base_url}/api/sessions/"

--- a/mcp_server/pipeline_registry.py
+++ b/mcp_server/pipeline_registry.py
@@ -23,6 +23,10 @@ class SourceConfig:
     # default True. Mutable rows like Connect ``users`` set this to False so
     # the writer always does a full DROP/CREATE/INSERT.
     resumable: bool = True
+    # Display unit for progress counts (issue #221). Most sources page through
+    # the rows they write ("rows"); OCS messages advance one session-detail
+    # fetch at a time, so their progress is denominated in "sessions".
+    progress_unit: str = "rows"
 
     @property
     def physical_table_name(self) -> str:
@@ -118,6 +122,7 @@ def _parse_pipeline(data: dict) -> PipelineConfig:
             description=s.get("description", ""),
             table_name=s.get("table_name", ""),
             resumable=s.get("resumable", True),
+            progress_unit=s.get("progress_unit", "rows"),
         )
         for s in data.get("sources", [])
     ]

--- a/mcp_server/services/materializer.py
+++ b/mcp_server/services/materializer.py
@@ -145,7 +145,12 @@ def run_pipeline(
                 }
             )
 
-    def make_on_page(source_name: str, message: str, known_total: int | None = None) -> OnPage:
+    def make_on_page(
+        source_name: str,
+        message: str,
+        known_total: int | None = None,
+        unit: str = "rows",
+    ) -> OnPage:
         def _on_page(rows_loaded: int, rows_total: int | None) -> None:
             if progress_updater is None:
                 return
@@ -162,6 +167,11 @@ def run_pipeline(
                     "message": message,
                     "rows_loaded": rows_loaded,
                     "rows_total": effective_total,
+                    # Unit of rows_loaded/rows_total for display. OCS messages
+                    # report progress in "sessions" — the API exposes no
+                    # message count, but the per-session detail fetches are
+                    # the work, so sessions are an honest denominator.
+                    "unit": unit,
                 }
             )
 
@@ -288,7 +298,12 @@ def run_pipeline(
                     credential,
                     schema_name,
                     provider=pipeline.provider,
-                    on_page=make_on_page(source.name, load_message, known_total=source_total),
+                    on_page=make_on_page(
+                        source.name,
+                        load_message,
+                        known_total=source_total,
+                        unit=source.progress_unit,
+                    ),
                     resumable=source_is_resumable,
                     start_cursor=start_cursor,
                     cursor_callback=cursor_callback,
@@ -933,7 +948,13 @@ def _write_ocs_messages(
     conn: Any,
     on_page: OnPage | None = None,
 ) -> int:
-    """Create the messages table and bulk-insert all pages."""
+    """Create the messages table and bulk-insert all pages.
+
+    The loader yields one ``(rows, total_sessions)`` tuple per session (rows
+    may be empty), so progress here is denominated in sessions — the unit the
+    N+1 detail fetches actually advance in — not message rows. The return
+    value is still the number of message rows written.
+    """
     sid = psql.Identifier(schema_name)
     cur = conn.cursor()
 
@@ -957,29 +978,28 @@ def _write_ocs_messages(
 
     ins_sql = _OCS_MESSAGES_INSERT.format(schema=sid)
     total = 0
-    rows_total: int | None = None
-    for page, page_total in pages:
-        if not page:
-            continue
-        if rows_total is None and page_total is not None:
-            rows_total = page_total
-        rows = [
-            (
-                r.get("message_id", ""),
-                r.get("session_id", ""),
-                r.get("message_index", 0),
-                r.get("role", ""),
-                r.get("content", ""),
-                r.get("created_at"),
-                json.dumps(r.get("metadata") or {}),
-                json.dumps(r.get("tags") or []),
-            )
-            for r in page
-        ]
-        cur.executemany(ins_sql, rows)
-        total += len(page)
+    sessions_total: int | None = None
+    for sessions_done, (page, page_total) in enumerate(pages, start=1):
+        if sessions_total is None and page_total is not None:
+            sessions_total = page_total
+        if page:
+            rows = [
+                (
+                    r.get("message_id", ""),
+                    r.get("session_id", ""),
+                    r.get("message_index", 0),
+                    r.get("role", ""),
+                    r.get("content", ""),
+                    r.get("created_at"),
+                    json.dumps(r.get("metadata") or {}),
+                    json.dumps(r.get("tags") or []),
+                )
+                for r in page
+            ]
+            cur.executemany(ins_sql, rows)
+            total += len(page)
         if on_page is not None:
-            on_page(total, rows_total)
+            on_page(sessions_done, sessions_total)
 
     return total
 

--- a/pipelines/ocs_sync.yml
+++ b/pipelines/ocs_sync.yml
@@ -10,6 +10,9 @@ sources:
     description: "Chat sessions with timestamps, tags, and participant info"
   - name: messages
     description: "Individual messages within sessions"
+    # Messages are fetched one session-detail request at a time; progress is
+    # counted in sessions because OCS exposes no message total (issue #221).
+    progress_unit: sessions
   - name: participants
     description: "Participants with name, platform, and per-chatbot custom data (from the dedicated participant API)"
 

--- a/tests/test_commcare_loader.py
+++ b/tests/test_commcare_loader.py
@@ -1,5 +1,7 @@
 from unittest.mock import MagicMock, patch
 
+from mcp_server.loaders.commcare_cases import CommCareCaseLoader
+
 
 class TestCommCareCaseLoader:
     def test_fetches_and_returns_cases(self):
@@ -18,8 +20,6 @@ class TestCommCareCaseLoader:
             session = MagicMock()
             mock_session_cls.return_value = session
             session.get.return_value = mock_response
-            from mcp_server.loaders.commcare_cases import CommCareCaseLoader
-
             loader = CommCareCaseLoader(domain="dimagi", access_token="fake-token")
             cases = loader.load()
 
@@ -46,8 +46,6 @@ class TestCommCareCaseLoader:
             session = MagicMock()
             mock_session_cls.return_value = session
             session.get.side_effect = [page1, page2]
-            from mcp_server.loaders.commcare_cases import CommCareCaseLoader
-
             loader = CommCareCaseLoader(domain="dimagi", access_token="fake-token")
             cases = loader.load()
 
@@ -80,18 +78,21 @@ class TestCaseLoaderLoadPages:
         page1.status_code = 200
         page1.json.return_value = {
             "next": "https://www.commcarehq.org/a/dimagi/api/case/v2/?cursor=x",
+            "matching_records": 3,
             "cases": [{"case_id": "c1"}, {"case_id": "c2"}],
         }
         page2 = MagicMock()
         page2.status_code = 200
-        page2.json.return_value = {"next": None, "cases": [{"case_id": "c3"}]}
+        page2.json.return_value = {
+            "next": None,
+            "matching_records": 3,
+            "cases": [{"case_id": "c3"}],
+        }
 
         with patch("mcp_server.loaders.commcare_base.requests.Session") as mock_session_cls:
             session = MagicMock()
             mock_session_cls.return_value = session
             session.get.side_effect = [page1, page2]
-
-            from mcp_server.loaders.commcare_cases import CommCareCaseLoader
 
             loader = CommCareCaseLoader(
                 domain="dimagi", credential={"type": "api_key", "value": "u:k"}
@@ -99,12 +100,29 @@ class TestCaseLoaderLoadPages:
             pages = list(loader.load_pages())
 
         assert len(pages) == 2
-        # load_pages now yields (page, total_count) tuples; total is None
-        # because the test mock omits ``meta.total_count``.
+        # load_pages yields (page, total_count) tuples; the total comes from
+        # Case API v2's ``matching_records`` on the first page only.
         assert len(pages[0][0]) == 2
         assert len(pages[1][0]) == 1
-        assert pages[0][1] is None
+        assert pages[0][1] == 3
         assert pages[1][1] is None
+
+    def test_load_pages_total_none_when_matching_records_missing(self):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {"next": None, "cases": [{"case_id": "c1"}]}
+
+        with patch("mcp_server.loaders.commcare_base.requests.Session") as mock_session_cls:
+            session = MagicMock()
+            mock_session_cls.return_value = session
+            session.get.return_value = resp
+
+            loader = CommCareCaseLoader(
+                domain="dimagi", credential={"type": "api_key", "value": "u:k"}
+            )
+            pages = list(loader.load_pages())
+
+        assert pages[0][1] is None
 
     def test_load_is_flat_list(self):
         mock_resp = MagicMock()
@@ -118,8 +136,6 @@ class TestCaseLoaderLoadPages:
             session = MagicMock()
             mock_session_cls.return_value = session
             session.get.return_value = mock_resp
-
-            from mcp_server.loaders.commcare_cases import CommCareCaseLoader
 
             loader = CommCareCaseLoader(
                 domain="dimagi", credential={"type": "api_key", "value": "u:k"}

--- a/tests/test_jobs_endpoints.py
+++ b/tests/test_jobs_endpoints.py
@@ -552,6 +552,61 @@ async def test_active_jobs_exposes_rows_total_for_percentage():
     # percent is pre-computed server-side (50%)
     assert p["percent"] == 50
     assert p["source"] == "visits"
+    # Progress dicts written before the unit field existed default to "rows".
+    assert p["unit"] == "rows"
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_active_jobs_passes_through_progress_unit():
+    """OCS messages report progress in sessions (issue #221); the unit is
+    surfaced so the banner can label the counts honestly."""
+    user = await sync_to_async(User.objects.create_user)(email="unit@rows.test", password="x")
+    ws = await sync_to_async(Workspace.objects.create)(name="WUnit", created_by=user)
+    await sync_to_async(WorkspaceMembership.objects.create)(
+        workspace=ws, user=user, role=WorkspaceRole.READ_WRITE
+    )
+    tenant = await sync_to_async(Tenant.objects.create)(
+        external_id="exp-uuid-unit",
+        provider="ocs",
+        canonical_name="OCS Test",
+    )
+    await sync_to_async(WorkspaceTenant.objects.create)(workspace=ws, tenant=tenant)
+    schema = await sync_to_async(TenantSchema.objects.create)(
+        tenant=tenant, schema_name="s_ocs_unit"
+    )
+    thread = await sync_to_async(Thread.objects.create)(workspace=ws, user=user)
+    await sync_to_async(ThreadJob.objects.create)(
+        thread=thread,
+        job_type="materialization",
+        procrastinate_job_id=7778,
+        tool_call_id="tc-unit",
+    )
+    await sync_to_async(MaterializationRun.objects.create)(
+        tenant_schema=schema,
+        pipeline="ocs_sync",
+        state=MaterializationRun.RunState.LOADING,
+        procrastinate_job_id=7778,
+        progress={
+            "run_id": str(schema.id),
+            "step": 4,
+            "total_steps": 7,
+            "source": "messages",
+            "message": "Loading messages from ocs API...",
+            "rows_loaded": 120,
+            "rows_total": 480,
+            "unit": "sessions",
+        },
+    )
+
+    client = AsyncClient()
+    await sync_to_async(client.login)(email="unit@rows.test", password="x")
+    resp = await client.get(f"/api/workspaces/{ws.id}/jobs/active/")
+    assert resp.status_code == 200
+    body = resp.json()
+    p = body["jobs"][0]["progress"]
+    assert p["unit"] == "sessions"
+    assert p["percent"] == 25
 
 
 @pytest.mark.asyncio

--- a/tests/test_ocs_data_loaders.py
+++ b/tests/test_ocs_data_loaders.py
@@ -125,7 +125,8 @@ def test_message_loader_flattens_messages_with_composite_pk():
         ],
     }
     with patch.object(loader._session, "get", side_effect=[sessions_page, detail]):
-        rows = [r for pg, _ in loader.load_pages() for r in pg]
+        pages = list(loader.load_pages())
+        rows = [r for pg, _ in pages for r in pg]
         assert rows == [
             {
                 "message_id": "sess-1:0",
@@ -148,6 +149,53 @@ def test_message_loader_flattens_messages_with_composite_pk():
                 "tags": ["greeting"],
             },
         ]
+        # Every per-session tuple carries the session count as its total —
+        # message progress is denominated in sessions (issue #221).
+        assert [total for _, total in pages] == [1]
+
+
+def test_message_loader_indexes_sessions_before_fetching_details():
+    """Two-pass: the full session list is walked first, then one tuple is
+    yielded per session — including sessions with no messages — each carrying
+    the total session count so the writer can report determinate progress."""
+    loader = OCSMessageLoader(experiment_id="exp-1", credential=CREDENTIAL, base_url=BASE_URL)
+    list_page1 = MagicMock(status_code=200)
+    list_page1.json.return_value = {
+        "results": [{"id": "sess-1"}],
+        "next": f"{BASE_URL}/api/sessions/?cursor=abc",
+    }
+    list_page2 = MagicMock(status_code=200)
+    list_page2.json.return_value = {
+        "results": [{"id": "sess-2"}],
+        "next": None,
+    }
+    detail_1 = MagicMock(status_code=200)
+    detail_1.json.return_value = {
+        "id": "sess-1",
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+    detail_2 = MagicMock(status_code=200)
+    detail_2.json.return_value = {"id": "sess-2", "messages": []}
+
+    with patch.object(
+        loader._session, "get", side_effect=[list_page1, list_page2, detail_1, detail_2]
+    ) as mock_get:
+        pages = list(loader.load_pages())
+
+    # Both list pages are fetched before the first session detail.
+    urls = [call.args[0] for call in mock_get.call_args_list]
+    assert urls == [
+        f"{BASE_URL}/api/sessions/",
+        f"{BASE_URL}/api/sessions/?cursor=abc",
+        f"{BASE_URL}/api/sessions/sess-1/",
+        f"{BASE_URL}/api/sessions/sess-2/",
+    ]
+    # One tuple per session, each with total_sessions=2; the empty session
+    # still yields so the writer can advance the progress bar.
+    assert len(pages) == 2
+    assert [total for _, total in pages] == [2, 2]
+    assert len(pages[0][0]) == 1
+    assert pages[1][0] == []
 
 
 def test_participant_loader_maps_dedicated_endpoint_fields():

--- a/tests/test_ocs_materializer.py
+++ b/tests/test_ocs_materializer.py
@@ -150,6 +150,50 @@ def test_write_ocs_messages_creates_table_and_rows(tenant_schema):
         conn.close()
 
 
+def test_write_ocs_messages_reports_session_progress(tenant_schema):
+    """The messages writer reports progress in sessions (one yielded tuple
+    per session, empty or not) against the loader's session-count total,
+    while still returning the number of message rows written."""
+    conn = get_managed_db_connection()
+    conn.autocommit = False
+    progress: list[tuple[int, int | None]] = []
+
+    def on_page(loaded: int, total: int | None) -> None:
+        progress.append((loaded, total))
+
+    def msg(session_id: str, idx: int) -> dict:
+        return {
+            "message_id": f"{session_id}:{idx}",
+            "session_id": session_id,
+            "message_index": idx,
+            "role": "user",
+            "content": "hi",
+            "created_at": "2026-04-01T00:00:00Z",
+            "metadata": {},
+            "tags": [],
+        }
+
+    try:
+        n = _write_ocs_messages(
+            iter(
+                [
+                    ([msg("s1", 0), msg("s1", 1)], 3),
+                    ([], 3),  # session with no messages still advances the bar
+                    ([msg("s3", 0)], 3),
+                ]
+            ),
+            tenant_schema.schema_name,
+            conn,
+            on_page=on_page,
+        )
+        conn.commit()
+        assert n == 3
+        assert _row_count(conn, tenant_schema.schema_name, "raw_messages") == 3
+        assert progress == [(1, 3), (2, 3), (3, 3)]
+    finally:
+        conn.close()
+
+
 def test_write_ocs_participants_creates_table_and_rows(tenant_schema):
     conn = get_managed_db_connection()
     conn.autocommit = False

--- a/tests/test_pipeline_registry.py
+++ b/tests/test_pipeline_registry.py
@@ -169,6 +169,32 @@ sources:
                 f"{src_name} has no per-row id in the v2 export and must be non-resumable"
             )
 
+    def test_progress_unit_defaults_to_rows_and_parses_from_yaml(self, tmp_path):
+        """Issue #221: ``progress_unit`` labels the progress counts; OCS
+        messages report per-session progress as "sessions"."""
+        yml = tmp_path / "pipeline.yml"
+        yml.write_text("""
+pipeline: test_pipeline
+description: ""
+version: "1.0"
+provider: ocs
+sources:
+  - name: sessions
+  - name: messages
+    progress_unit: sessions
+""")
+        registry = PipelineRegistry(pipelines_dir=str(tmp_path))
+        config = registry.get("test_pipeline")
+        by_name = {s.name: s for s in config.sources}
+        assert by_name["sessions"].progress_unit == "rows"
+        assert by_name["messages"].progress_unit == "sessions"
+
+    def test_ocs_sync_messages_progress_unit_is_sessions(self):
+        registry = PipelineRegistry()
+        config = registry.get("ocs_sync")
+        by_name = {s.name: s for s in config.sources}
+        assert by_name["messages"].progress_unit == "sessions"
+
     def test_relationships_defaults_to_empty(self, tmp_path):
         yml = tmp_path / "no_rel.yml"
         yml.write_text(


### PR DESCRIPTION
## Summary

Resolves #221 — and extends it to CommCare, where the same bug existed unnoticed.

| Source | Before | After |
|---|---|---|
| OCS messages | indeterminate | **determinate, in sessions** (e.g. "120 of 480 sessions") |
| CommCare cases | indeterminate (read non-existent `meta.total_count`) | **determinate** via v2 `matching_records` |
| OCS sessions / participants | indeterminate | unchanged — API exposes no count (verified, see below) |
| OCS experiments, CommCare forms, Connect (all) | determinate | unchanged |

## Verification against the APIs

- **OCS OpenAPI schema** (per the issue): all paginated list schemas (`PaginatedExperimentSessionList`, `PaginatedParticipantDetailList`, …) carry only `next`/`previous`/`results` — DRF cursor pagination with **no `count` field**. So no OCS list endpoint can give an up-front total.
- **CommCare Case API v2** (`corehq/apps/hqcase/api/get_list.py`): the envelope is `{"matching_records": <es total>, "cases": [...], "next": <abs url>}` — there is no tastypie `meta`. Scout was reading `meta.total_count`, which never exists in v2, so the cases bar was always indeterminate.
- **CommCare Forms v0.5** is tastypie and does return `meta.total_count`; Connect returns `count` on the first page — both already worked.

## How OCS messages get a denominator without API support

Messages are fetched N+1 style (session list, then one detail request per session) — the detail fetches are ~all the wall time. The loader now indexes the full session list first (same total request count as the old interleaved walk, just reordered), then yields exactly one page per session, so the writer reports `sessions_done / total_sessions`. That's an honest denominator for the work actually being done, surfaced with a new `progress_unit` field (pipelines YAML → progress dict → jobs API → banner) so the banner reads "120 of 480 sessions" instead of mislabeling them as rows.

OCS sessions and participants stay honestly indeterminate (running count, sweeping bar): their list fetch *is* the materialization, so a pre-count pass would double the requests. If OCS ever adds `count` to its paginated envelopes upstream, `OCSBaseLoader._paginate` picks it up automatically with no Scout change.

## Test plan

- [x] `uv run pytest` — full suite; only pre-existing flaky failures also present on `main` (social login reconciliation, resume-thread bookends, agent-graph injection)
- [x] New tests: two-pass message loader ordering + empty-session yields; session-unit writer progress (incl. empty sessions advancing the bar); `matching_records` totals; `progress_unit` YAML parsing; jobs API `unit` passthrough + default
- [x] `uv run ruff check .` clean; frontend `bun run lint` and `bun run build` (tsc) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)