### PR TITLE
feat: make agent LLM model configurable, default to claude-opus-4-8

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,10 @@ DB_CREDENTIAL_KEY=
 # LLM provider
 ANTHROPIC_API_KEY=
 
+# Override the default Claude model used by the agent (optional).
+# Defaults to claude-opus-4-8 when unset.
+# DEFAULT_LLM_MODEL=claude-opus-4-8
+
 # MCP server URL (data access layer for the agent)
 # MCP_SERVER_URL=http://localhost:8100/mcp
 

--- a/apps/agents/graph/base.py
+++ b/apps/agents/graph/base.py
@@ -25,6 +25,7 @@ import logging
 import time
 from typing import TYPE_CHECKING, Any, Literal
 
+from django.conf import settings
 from langchain_anthropic import ChatAnthropic
 from langchain_core.messages import AIMessage, SystemMessage, ToolMessage
 from langgraph.graph import END, StateGraph
@@ -513,7 +514,7 @@ async def build_agent_graph(
 
     # --- Build LLM with tools ---
     llm = ChatAnthropic(
-        model="claude-sonnet-4-5-20250929",
+        model=settings.DEFAULT_LLM_MODEL,
         max_tokens=DEFAULT_MAX_TOKENS,
         temperature=DEFAULT_TEMPERATURE,
     )

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -278,7 +278,7 @@ DB_CREDENTIAL_KEY = env("DB_CREDENTIAL_KEY", default="")
 
 # LLM settings
 ANTHROPIC_API_KEY = env("ANTHROPIC_API_KEY", default="")
-DEFAULT_LLM_MODEL = "claude-sonnet-4-5-20250929"
+DEFAULT_LLM_MODEL = env("DEFAULT_LLM_MODEL", default="claude-opus-4-8")
 
 # Hard ceiling on the materialization-resume agent.ainvoke. The agent's
 # recursion_limit is 50; 120s is generous for any sane follow-up response.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,7 @@ services:
       - DJANGO_SETTINGS_MODULE=config.settings.development
       - DB_CREDENTIAL_KEY=${DB_CREDENTIAL_KEY}
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+      - DEFAULT_LLM_MODEL=${DEFAULT_LLM_MODEL:-claude-opus-4-8}
       - DJANGO_SECRET_KEY=${DJANGO_SECRET_KEY:-dev-secret-key-change-in-production}
       - MCP_SERVER_URL=http://mcp-server:8100/mcp
       - MAX_CONNECTIONS_PER_PROJECT=5

--- a/tests/test_agent_graph_model_config.py
+++ b/tests/test_agent_graph_model_config.py
@@ -1,0 +1,41 @@
+"""The agent graph's LLM model is driven by settings.DEFAULT_LLM_MODEL.
+
+The setting previously existed but was unused while the model string was
+hardcoded in ``build_agent_graph``. These tests guard against that drift
+recurring and confirm the env-var override path works.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from django.conf import settings
+from django.test import override_settings
+
+from apps.agents.graph.base import build_agent_graph
+
+
+@pytest.mark.asyncio
+async def test_llm_model_comes_from_settings():
+    """ChatAnthropic is built with settings.DEFAULT_LLM_MODEL, not a hardcoded id."""
+    workspace = MagicMock()
+    workspace.id = "ws-1"
+    user = MagicMock()
+
+    with (
+        override_settings(DEFAULT_LLM_MODEL="sentinel-model-id"),
+        patch("apps.agents.graph.base.ChatAnthropic") as MockChat,
+        patch("apps.agents.graph.base._build_tools", return_value=[]),
+        patch(
+            "apps.agents.graph.base._build_system_prompt",
+            new=AsyncMock(return_value="prompt"),
+        ),
+    ):
+        await build_agent_graph(workspace, user)
+
+    assert MockChat.call_count == 1
+    assert MockChat.call_args.kwargs["model"] == "sentinel-model-id"
+
+
+def test_default_llm_model_is_opus_4_8():
+    """With DEFAULT_LLM_MODEL unset, the default resolves to claude-opus-4-8."""
+    assert settings.DEFAULT_LLM_MODEL == "claude-opus-4-8"


### PR DESCRIPTION
## Summary

Changes the agent's LLM model so it can be configured per-deployment via an environment variable, and bumps the default to `claude-opus-4-8`.

**The bug this fixes:** `config/settings/base.py` defined `DEFAULT_LLM_MODEL`, but nothing read it — the model string was hardcoded directly in `build_agent_graph` (`claude-sonnet-4-5-20250929`). The setting had no effect, and changing the model on a deployed system required a code edit + redeploy.

## Changes

- **`apps/agents/graph/base.py`** — `ChatAnthropic` is now built with `settings.DEFAULT_LLM_MODEL` instead of a hardcoded string.
- **`config/settings/base.py`** — `DEFAULT_LLM_MODEL` now reads from the `DEFAULT_LLM_MODEL` env var, defaulting to `claude-opus-4-8`.
- **`.env.example`** — documents the optional override.
- **`docker-compose.yml`** — passes `DEFAULT_LLM_MODEL` through to the `api` service (`${DEFAULT_LLM_MODEL:-claude-opus-4-8}`).
- **`tests/test_agent_graph_model_config.py`** — regression test proving the model is driven by the setting (and the override path works), so the setting can't silently drift out of use again.

## How to change the model on a deployed system

Set the `DEFAULT_LLM_MODEL` env var (e.g. `claude-sonnet-4-6`, `claude-haiku-4-5-20251001`) and restart. Unset → `claude-opus-4-8`.

> **Note:** the procrastinate worker also builds the agent graph, so production worker deployments need the same env var to be in scope (it falls back to the `claude-opus-4-8` default when unset, so behavior is safe either way — both the API and worker resolve to the same model).

## Testing

```
uv run pytest tests/test_agent_graph_model_config.py tests/test_agent_graph.py \
  tests/test_agent_graph_caching.py tests/test_agent_graph_injection.py
# 11 passed
```
`ruff check` / `ruff format --check` clean on all edited files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)