### PR TITLE
fix(workspaces): truncation-safe view names and idempotent view schema rebuild

### DIFF
--- a/apps/workspaces/services/schema_manager.py
+++ b/apps/workspaces/services/schema_manager.py
@@ -7,6 +7,7 @@ Creates and tears down tenant-scoped PostgreSQL schemas.
 from __future__ import annotations
 
 import contextlib
+import hashlib
 import logging
 import re
 import uuid
@@ -15,9 +16,17 @@ import psycopg
 import psycopg.sql
 from django.conf import settings
 
+from apps.users.models import Tenant
 from apps.workspaces.models import SchemaState, TenantSchema, WorkspaceViewSchema
 
 logger = logging.getLogger(__name__)
+
+# PostgreSQL truncates identifiers to 63 bytes (NAMEDATALEN - 1). Tenant view
+# names are composed as ``{prefix}__{table}``; we cap the prefix well below this
+# so a generous table-name budget remains, and hard-fail if a final name still
+# exceeds the limit.
+_PG_MAX_IDENTIFIER_BYTES = 63
+_MAX_VIEW_PREFIX_LEN = 32
 
 
 def readonly_role_name(schema_name: str) -> str:
@@ -199,12 +208,42 @@ class SchemaManager:
         hex_id = str(workspace_id).replace("-", "")[:16]
         return f"ws_{hex_id}"
 
-    def build_view_schema(self, workspace) -> WorkspaceViewSchema:
-        """Create (or replace) the PostgreSQL view schema for a multi-tenant workspace.
+    def _view_prefix(self, tenant) -> str:
+        """Derive the per-tenant view-name prefix, bounded to a safe length.
 
-        Fetches all active TenantSchema objects for the workspace's tenants,
-        collects their tables and columns, then creates UNION ALL views in a
-        dedicated schema. Raises ValueError if any tenant has no active schema.
+        Single source of truth for the ``{prefix}__{table}`` namespacing used by
+        ``build_view_schema``. PostgreSQL silently truncates identifiers to 63
+        bytes, so an unbounded prefix can make two distinct tenants' views
+        collapse to the same physical name. We therefore cap the prefix:
+
+        - If the sanitized canonical name is short (<= 32 chars), use it as-is so
+          human-readable names stay intact.
+        - Otherwise, use the first 23 sanitized chars plus ``_`` plus an 8-char
+          hex digest of ``tenant.external_id``. The digest is deterministic and
+          stable across builds and distinct for distinct tenants, so the prefix
+          is reproducible (same on rebuild) and collision-resistant.
+
+        The result is always a valid PG identifier and at most 32 chars long.
+        """
+        sanitized = self._sanitize_schema_name(tenant.canonical_name)
+        if len(sanitized) <= _MAX_VIEW_PREFIX_LEN:
+            return sanitized
+        digest = hashlib.sha256(str(tenant.external_id).encode("utf-8")).hexdigest()[:8]
+        # 23 (head) + 1 ("_") + 8 (digest) = 32
+        return f"{sanitized[:23]}_{digest}"
+
+    def build_view_schema(self, workspace) -> WorkspaceViewSchema:
+        """(Re)build the PostgreSQL view schema for a multi-tenant workspace.
+
+        Fetches all active TenantSchema objects for the workspace's tenants and
+        creates one namespaced ``{prefix}__{table}`` view per tenant table in a
+        dedicated schema. The build is idempotent: the view schema is dropped and
+        recreated from scratch each call, so a rebuild after an underlying table's
+        columns changed succeeds rather than failing on view-column mismatches.
+
+        Raises ValueError if any tenant has no active schema, if two tenants
+        produce the same view prefix or full view name, or if a composed view
+        name would exceed PostgreSQL's 63-byte identifier limit.
 
         Returns the WorkspaceViewSchema model instance with state=ACTIVE on success.
         """
@@ -247,24 +286,17 @@ class SchemaManager:
             if not re.match(r"^ws_[a-f0-9]{16}$", view_schema_name):
                 raise ValueError(f"Invalid view schema name: {view_schema_name!r}")
 
-            # Step 1: Create the physical schema
-            cursor.execute(
-                psycopg.sql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(
-                    psycopg.sql.Identifier(view_schema_name)
-                )
-            )
-
-            # Step 2+3: Create per-tenant namespaced views
-            from apps.users.models import Tenant
-
-            # Pre-compute prefixes and detect collisions before creating any views
+            # Step 1: Compute per-tenant prefixes and detect collisions on the
+            # FINAL (bounded) prefixes — _view_prefix caps each prefix to <= 32
+            # chars so distinct long-named tenants don't collapse to the same
+            # truncated identifier.
             prefix_to_tenant: dict[str, str] = {}
             tenant_prefixes: list[
                 tuple[str, str, str]
             ] = []  # (schema_name, tenant_external_id, prefix)
             for schema_name, tenant_external_id in tenant_schemas:
                 tenant_obj = Tenant.objects.get(external_id=tenant_external_id)
-                prefix = self._sanitize_schema_name(tenant_obj.canonical_name)
+                prefix = self._view_prefix(tenant_obj)
                 if prefix in prefix_to_tenant:
                     raise ValueError(
                         f"Canonical name collision: tenants '{prefix_to_tenant[prefix]}' and "
@@ -273,12 +305,17 @@ class SchemaManager:
                 prefix_to_tenant[prefix] = tenant_external_id
                 tenant_prefixes.append((schema_name, tenant_external_id, prefix))
 
-            # Collect all (view_name, schema_name, table_name) and detect full
-            # view name collisions before executing any DDL. This catches cases
-            # where the __ delimiter is ambiguous (e.g. prefix "foo__bar" + table
-            # "baz" vs prefix "foo" + table "bar__baz").
+            # Step 2: Collect all (view_name, schema_name, table_name), then run
+            # the defensive length check and the full view-name collision check
+            # on the FINAL names before executing any DDL. The collision check
+            # catches ambiguous __ delimiters (e.g. prefix "foo__bar" + table
+            # "baz" vs prefix "foo" + table "bar__baz"). The length check guards
+            # against table names growing the composed name past PostgreSQL's
+            # 63-byte identifier limit (where it would silently truncate and two
+            # distinct views could collapse into one).
             planned_views: list[tuple[str, str, str]] = []
             seen_view_names: dict[str, str] = {}  # view_name → tenant_external_id
+            oversized_views: list[str] = []
             for schema_name, tenant_external_id, prefix in tenant_prefixes:
                 cursor.execute(
                     "SELECT table_name FROM information_schema.tables "
@@ -287,6 +324,9 @@ class SchemaManager:
                 )
                 for (table_name,) in cursor.fetchall():
                     view_name = f"{prefix}__{table_name}"
+                    if len(view_name.encode("utf-8")) > _PG_MAX_IDENTIFIER_BYTES:
+                        oversized_views.append(view_name)
+                        continue
                     if view_name in seen_view_names:
                         raise ValueError(
                             f"View name collision: '{view_name}' produced by both "
@@ -295,9 +335,30 @@ class SchemaManager:
                     seen_view_names[view_name] = tenant_external_id
                     planned_views.append((view_name, schema_name, table_name))
 
+            if oversized_views:
+                raise ValueError(
+                    "View name(s) exceed PostgreSQL's 63-byte identifier limit and "
+                    f"would be truncated: {', '.join(sorted(oversized_views))}"
+                )
+
+            # Step 3: Rebuild the view schema from scratch for idempotency. We
+            # DROP and recreate the schema (rather than CREATE OR REPLACE VIEW
+            # in place) so that a rebuild after an underlying table's columns
+            # changed never hits "cannot change name of view column" — and so
+            # any unexpected duplicate name becomes a hard error (plain CREATE
+            # VIEW) instead of a silent redefinition.
+            cursor.execute(
+                psycopg.sql.SQL("DROP SCHEMA IF EXISTS {} CASCADE").format(
+                    psycopg.sql.Identifier(view_schema_name)
+                )
+            )
+            cursor.execute(
+                psycopg.sql.SQL("CREATE SCHEMA {}").format(psycopg.sql.Identifier(view_schema_name))
+            )
+
             for view_name, schema_name, table_name in planned_views:
                 cursor.execute(
-                    psycopg.sql.SQL("CREATE OR REPLACE VIEW {}.{} AS SELECT * FROM {}.{}").format(
+                    psycopg.sql.SQL("CREATE VIEW {}.{} AS SELECT * FROM {}.{}").format(
                         psycopg.sql.Identifier(view_schema_name),
                         psycopg.sql.Identifier(view_name),
                         psycopg.sql.Identifier(schema_name),

--- a/tests/test_schema_manager.py
+++ b/tests/test_schema_manager.py
@@ -447,3 +447,78 @@ class TestReadonlyRoleName:
 
     def test_refresh_schema(self):
         assert readonly_role_name("test_domain_r1a2b3c4") == "test_domain_r1a2b3c4_ro"
+
+
+class _FakeTenant:
+    """Lightweight stand-in for a Tenant — _view_prefix only reads two attrs."""
+
+    def __init__(self, canonical_name: str, external_id: str):
+        self.canonical_name = canonical_name
+        self.external_id = external_id
+
+
+class TestViewPrefix:
+    """Pure-logic coverage for the bounded per-tenant view prefix (no DB)."""
+
+    PIPN_NAME = "Kangaroo Mother Care- Preterm Infants Parents Network (PIPN)"
+
+    def test_short_name_used_verbatim(self):
+        mgr = SchemaManager()
+        # _sanitize_schema_name lowercases, maps "-" -> "_", strips other
+        # non-alphanumerics (spaces dropped). "domain_a" stays verbatim.
+        t = _FakeTenant("domain_a", "ext-a")
+        assert mgr._view_prefix(t) == "domain_a"
+
+    def test_name_at_32_char_boundary_used_verbatim(self):
+        mgr = SchemaManager()
+        # 32 sanitized chars exactly -> used as-is (no digest)
+        name = "a" * 32
+        t = _FakeTenant(name, "ext-32")
+        prefix = mgr._view_prefix(t)
+        assert prefix == name
+        assert len(prefix) == 32
+
+    def test_long_name_is_bounded_and_hashed(self):
+        mgr = SchemaManager()
+        t = _FakeTenant(self.PIPN_NAME, "pipn-001")
+        prefix = mgr._view_prefix(t)
+        assert len(prefix) == 32
+        # 23-char sanitized head + "_" + 8 hex chars
+        assert prefix == "kangaroomothercare_pret_" + prefix[-8:]
+        assert all(c in "0123456789abcdef" for c in prefix[-8:])
+
+    def test_long_name_prefix_is_deterministic_across_calls(self):
+        mgr = SchemaManager()
+        t = _FakeTenant(self.PIPN_NAME, "pipn-001")
+        assert mgr._view_prefix(t) == mgr._view_prefix(t)
+
+    def test_pipn_views_distinct_and_within_byte_limit(self):
+        """The production regression: raw_completed_works / raw_completed_modules
+        previously truncated to the same 63-byte identifier."""
+        mgr = SchemaManager()
+        t = _FakeTenant(self.PIPN_NAME, "pipn-001")
+        prefix = mgr._view_prefix(t)
+        works = f"{prefix}__raw_completed_works"
+        modules = f"{prefix}__raw_completed_modules"
+        assert works != modules
+        assert len(works.encode("utf-8")) <= 63
+        assert len(modules.encode("utf-8")) <= 63
+
+    def test_two_long_names_sharing_head_get_distinct_prefixes(self):
+        mgr = SchemaManager()
+        head = "Maternal Child Health Program "
+        t1 = _FakeTenant(head + "Northern Region Implementation", "mch-north-1")
+        t2 = _FakeTenant(head + "Southern Region Implementation", "mch-south-1")
+        p1 = mgr._view_prefix(t1)
+        p2 = mgr._view_prefix(t2)
+        assert p1[:23] == p2[:23]
+        assert p1 != p2
+        assert len(p1) <= 32
+        assert len(p2) <= 32
+
+    def test_long_name_prefix_distinct_for_distinct_external_ids(self):
+        mgr = SchemaManager()
+        # Identical long canonical names, different external_ids -> different digests
+        t1 = _FakeTenant(self.PIPN_NAME, "pipn-001")
+        t2 = _FakeTenant(self.PIPN_NAME, "pipn-002")
+        assert mgr._view_prefix(t1) != mgr._view_prefix(t2)

--- a/tests/test_view_schema_builder.py
+++ b/tests/test_view_schema_builder.py
@@ -2,15 +2,19 @@ import os
 from unittest.mock import MagicMock, patch
 
 import pytest
+from django.contrib.auth import get_user_model
 
 from apps.users.models import Tenant
 from apps.workspaces.models import (
     SchemaState,
+    TenantSchema,
     Workspace,
     WorkspaceMembership,
     WorkspaceRole,
     WorkspaceTenant,
+    WorkspaceViewSchema,
 )
+from apps.workspaces.services.schema_manager import SchemaManager
 
 pytestmark = pytest.mark.skipif(
     not os.environ.get("MANAGED_DATABASE_URL"),
@@ -417,3 +421,305 @@ def test_build_view_schema_returns_active_record(workspace, tenant):
         ts.delete()
         if vs:
             vs.delete()
+
+
+# --- Truncation-safety and idempotency coverage -----------------------------
+
+# Exact production tenant whose long canonical name + table names previously
+# truncated two distinct views to the same 63-byte identifier.
+_PIPN_NAME = "Kangaroo Mother Care- Preterm Infants Parents Network (PIPN)"
+
+
+def _make_long_named_workspace(canonical_a, external_a, canonical_b, external_b):
+    """Build a 2-tenant workspace with arbitrary canonical names / external ids."""
+
+    User = get_user_model()
+    user = User.objects.create_user(email="longnames@example.com", password="pass")
+    t1 = Tenant.objects.create(
+        provider="commcare", external_id=external_a, canonical_name=canonical_a
+    )
+    t2 = Tenant.objects.create(
+        provider="commcare", external_id=external_b, canonical_name=canonical_b
+    )
+    ws = Workspace.objects.create(name="Long WS", created_by=user)
+    WorkspaceMembership.objects.create(workspace=ws, user=user, role=WorkspaceRole.MANAGE)
+    WorkspaceTenant.objects.create(workspace=ws, tenant=t1)
+    WorkspaceTenant.objects.create(workspace=ws, tenant=t2)
+    return ws, t1, t2
+
+
+def test_build_view_schema_long_canonical_name_no_truncation_collision(db, managed_db_connection):
+    """The exact production tenant ("...PIPN") whose long name made
+    raw_completed_works and raw_completed_modules truncate to the same 63-byte
+    identifier now produces two distinct, <=63-byte views and the build succeeds."""
+    ws, t1, _t2 = _make_long_named_workspace(_PIPN_NAME, "pipn-001", "Short Partner", "short-001")
+
+    ts1 = TenantSchema.objects.create(
+        tenant=t1, schema_name="build_pipn_long", state=SchemaState.ACTIVE
+    )
+    ts2 = TenantSchema.objects.create(
+        tenant=_t2, schema_name="build_pipn_short", state=SchemaState.ACTIVE
+    )
+    conn = managed_db_connection
+    c = conn.cursor()
+    try:
+        c.execute("CREATE SCHEMA IF NOT EXISTS build_pipn_long")
+        # Two tables whose composed view names previously collided after truncation
+        c.execute(
+            "CREATE TABLE IF NOT EXISTS build_pipn_long.raw_completed_works "
+            "(opportunity_id TEXT, payment_date TEXT)"
+        )
+        c.execute(
+            "CREATE TABLE IF NOT EXISTS build_pipn_long.raw_completed_modules "
+            "(module TEXT, completed_at TEXT)"
+        )
+        c.execute("CREATE SCHEMA IF NOT EXISTS build_pipn_short")
+    finally:
+        c.close()
+
+    vs = None
+    try:
+        # Must not raise InvalidTableDefinition / column-rename error
+        vs = SchemaManager().build_view_schema(ws)
+        assert vs.state == SchemaState.ACTIVE
+
+        prefix = SchemaManager()._view_prefix(t1)
+        works_view = f"{prefix}__raw_completed_works"
+        modules_view = f"{prefix}__raw_completed_modules"
+
+        # Distinct view names, both within PG's 63-byte identifier limit
+        assert works_view != modules_view
+        assert len(works_view.encode("utf-8")) <= 63
+        assert len(modules_view.encode("utf-8")) <= 63
+
+        c2 = conn.cursor()
+        try:
+            c2.execute(
+                "SELECT table_name FROM information_schema.tables "
+                f"WHERE table_schema = '{vs.schema_name}'"
+            )
+            view_names = {row[0] for row in c2.fetchall()}
+            # Each view exposes its own source columns (no silent redefinition)
+            c2.execute(
+                "SELECT column_name FROM information_schema.columns "
+                f"WHERE table_schema = '{vs.schema_name}' AND table_name = %s",
+                (works_view,),
+            )
+            works_cols = {row[0] for row in c2.fetchall()}
+        finally:
+            c2.close()
+
+        assert works_view in view_names
+        assert modules_view in view_names
+        assert works_cols == {"opportunity_id", "payment_date"}
+    finally:
+        c3 = conn.cursor()
+        try:
+            if vs:
+                c3.execute(f"DROP SCHEMA IF EXISTS {vs.schema_name} CASCADE")
+            c3.execute("DROP SCHEMA IF EXISTS build_pipn_long CASCADE")
+            c3.execute("DROP SCHEMA IF EXISTS build_pipn_short CASCADE")
+        finally:
+            c3.close()
+        if vs:
+            vs.delete()
+        ts1.delete()
+        ts2.delete()
+
+
+def test_build_view_schema_two_long_names_shared_head_get_distinct_prefixes(
+    db, managed_db_connection
+):
+    """Two long canonical names sharing their first 23 sanitized chars must still
+    get distinct prefixes (disambiguated by the external_id digest) so their
+    views do not collide."""
+    shared_head = "Maternal Child Health Program "  # >23 chars once sanitized
+    ws, t1, t2 = _make_long_named_workspace(
+        shared_head + "Northern Region Implementation",
+        "mch-north-1",
+        shared_head + "Southern Region Implementation",
+        "mch-south-1",
+    )
+
+    mgr = SchemaManager()
+    p1 = mgr._view_prefix(t1)
+    p2 = mgr._view_prefix(t2)
+    # Both bounded and distinct despite identical 23-char heads
+    assert len(p1) <= 32
+    assert len(p2) <= 32
+    assert p1[:23] == p2[:23]
+    assert p1 != p2
+
+    ts1 = TenantSchema.objects.create(
+        tenant=t1, schema_name="build_mch_north", state=SchemaState.ACTIVE
+    )
+    ts2 = TenantSchema.objects.create(
+        tenant=t2, schema_name="build_mch_south", state=SchemaState.ACTIVE
+    )
+    conn = managed_db_connection
+    c = conn.cursor()
+    try:
+        c.execute("CREATE SCHEMA IF NOT EXISTS build_mch_north")
+        c.execute("CREATE TABLE IF NOT EXISTS build_mch_north.cases (id TEXT)")
+        c.execute("CREATE SCHEMA IF NOT EXISTS build_mch_south")
+        c.execute("CREATE TABLE IF NOT EXISTS build_mch_south.cases (id TEXT)")
+    finally:
+        c.close()
+
+    vs = None
+    try:
+        vs = SchemaManager().build_view_schema(ws)
+        c2 = conn.cursor()
+        try:
+            c2.execute(
+                "SELECT table_name FROM information_schema.tables "
+                f"WHERE table_schema = '{vs.schema_name}'"
+            )
+            view_names = {row[0] for row in c2.fetchall()}
+        finally:
+            c2.close()
+        assert f"{p1}__cases" in view_names
+        assert f"{p2}__cases" in view_names
+    finally:
+        c3 = conn.cursor()
+        try:
+            if vs:
+                c3.execute(f"DROP SCHEMA IF EXISTS {vs.schema_name} CASCADE")
+            c3.execute("DROP SCHEMA IF EXISTS build_mch_north CASCADE")
+            c3.execute("DROP SCHEMA IF EXISTS build_mch_south CASCADE")
+        finally:
+            c3.close()
+        if vs:
+            vs.delete()
+        ts1.delete()
+        ts2.delete()
+
+
+def test_build_view_schema_idempotent_rebuild_after_column_change(
+    two_tenant_workspace, managed_db_connection
+):
+    """A rebuild after an underlying table's columns were renamed must succeed.
+
+    The workspace view from the first build survives into the second build. With
+    the old ``CREATE OR REPLACE VIEW`` path this raised
+    "cannot change name of view column ..." (the exact production error). The
+    drop-schema-and-recreate rebuild makes it idempotent — the second build
+    reflects the new column set."""
+    ws, t1, _t2 = two_tenant_workspace
+
+    ts1 = TenantSchema.objects.create(
+        tenant=t1, schema_name="build_idem_a", state=SchemaState.ACTIVE
+    )
+    ts2 = TenantSchema.objects.create(
+        tenant=_t2, schema_name="build_idem_b", state=SchemaState.ACTIVE
+    )
+    conn = managed_db_connection
+    c = conn.cursor()
+    try:
+        c.execute("CREATE SCHEMA IF NOT EXISTS build_idem_a")
+        c.execute("CREATE TABLE IF NOT EXISTS build_idem_a.reports (module TEXT, score TEXT)")
+        c.execute("CREATE SCHEMA IF NOT EXISTS build_idem_b")
+    finally:
+        c.close()
+
+    vs = None
+    try:
+        # First build — view has columns (module, score)
+        vs = SchemaManager().build_view_schema(ws)
+        c2 = conn.cursor()
+        try:
+            c2.execute(
+                "SELECT column_name FROM information_schema.columns "
+                f"WHERE table_schema = '{vs.schema_name}' AND table_name = 'domain_a__reports'"
+            )
+            cols_before = {row[0] for row in c2.fetchall()}
+        finally:
+            c2.close()
+        assert cols_before == {"module", "score"}
+
+        # Rename the source columns in place. The first build's view SURVIVES
+        # (ALTER does not cascade-drop it), so the second build must redefine a
+        # view whose column names changed — the case CREATE OR REPLACE VIEW
+        # rejected. Add a brand-new column too, to assert the new definition.
+        c4 = conn.cursor()
+        try:
+            c4.execute("ALTER TABLE build_idem_a.reports RENAME COLUMN module TO opportunity_id")
+            c4.execute("ALTER TABLE build_idem_a.reports RENAME COLUMN score TO payment_amount")
+            c4.execute("ALTER TABLE build_idem_a.reports ADD COLUMN status TEXT")
+        finally:
+            c4.close()
+
+        # Second build must succeed (no column-rename error) and reflect new cols
+        vs2 = SchemaManager().build_view_schema(ws)
+        assert vs2.state == SchemaState.ACTIVE
+
+        c5 = conn.cursor()
+        try:
+            c5.execute(
+                "SELECT column_name FROM information_schema.columns "
+                f"WHERE table_schema = '{vs.schema_name}' AND table_name = 'domain_a__reports'"
+            )
+            cols_after = {row[0] for row in c5.fetchall()}
+        finally:
+            c5.close()
+        assert cols_after == {"opportunity_id", "payment_amount", "status"}
+    finally:
+        c6 = conn.cursor()
+        try:
+            if vs:
+                c6.execute(f"DROP SCHEMA IF EXISTS {vs.schema_name} CASCADE")
+            c6.execute("DROP SCHEMA IF EXISTS build_idem_a CASCADE")
+            c6.execute("DROP SCHEMA IF EXISTS build_idem_b CASCADE")
+        finally:
+            c6.close()
+        if vs:
+            vs.delete()
+        ts1.delete()
+        ts2.delete()
+
+
+def test_build_view_schema_oversized_view_name_raises(two_tenant_workspace, managed_db_connection):
+    """A composed view name exceeding 63 bytes must raise ValueError naming the
+    offending view BEFORE any DDL, rather than letting PostgreSQL silently
+    truncate it."""
+    ws, t1, _t2 = two_tenant_workspace
+
+    ts1 = TenantSchema.objects.create(
+        tenant=t1, schema_name="build_oversize_a", state=SchemaState.ACTIVE
+    )
+    ts2 = TenantSchema.objects.create(
+        tenant=_t2, schema_name="build_oversize_b", state=SchemaState.ACTIVE
+    )
+    # t1 canonical_name "domain_a" -> prefix "domain_a" (8 chars) + "__" = 10.
+    # A 60-char table name pushes the composed name to 70 bytes (>63).
+    long_table = "x" * 60
+    conn = managed_db_connection
+    c = conn.cursor()
+    try:
+        c.execute("CREATE SCHEMA IF NOT EXISTS build_oversize_a")
+        c.execute(f'CREATE TABLE IF NOT EXISTS build_oversize_a."{long_table}" (id TEXT)')
+        c.execute("CREATE SCHEMA IF NOT EXISTS build_oversize_b")
+    finally:
+        c.close()
+
+    try:
+        with pytest.raises(ValueError, match="63-byte"):
+            SchemaManager().build_view_schema(ws)
+        # Offending view name is identified in the message
+        prefix = SchemaManager()._view_prefix(t1)
+        try:
+            SchemaManager().build_view_schema(ws)
+        except ValueError as exc:
+            assert f"{prefix}__{long_table}" in str(exc)
+    finally:
+        c3 = conn.cursor()
+        try:
+            view_schema = SchemaManager()._view_schema_name(ws.id)
+            c3.execute(f"DROP SCHEMA IF EXISTS {view_schema} CASCADE")
+            c3.execute("DROP SCHEMA IF EXISTS build_oversize_a CASCADE")
+            c3.execute("DROP SCHEMA IF EXISTS build_oversize_b CASCADE")
+        finally:
+            c3.close()
+        WorkspaceViewSchema.objects.filter(workspace=ws).delete()
+        ts1.delete()
+        ts2.delete()


### PR DESCRIPTION
## Problem (prod incident 2026-06-10, workspace "KMC June 10")

Multi-tenant view schemas namespace views as `{prefix}__{table}` where the prefix is the sanitized tenant canonical name — unbounded. PostgreSQL silently truncates identifiers to 63 bytes, so tenant 524's 51-char prefix made `…__raw_completed_works` and `…__raw_completed_modules` truncate to the **identical** identifier. The second `CREATE OR REPLACE VIEW` then redefined the first view with different columns:

```
psycopg.errors.InvalidTableDefinition: cannot change name of view column "module" to "opportunity_id"
```

(or `cannot drop columns from view`, depending on `information_schema` enumeration order — both observed in prod). The in-code collision check compared **untruncated** Python strings, so it was blind to this. Every materialization of the affected workspace fails at the view-build step, forever.

## Fix

- New `SchemaManager._view_prefix(tenant)` — single source of truth, caps the prefix at 32 chars (long names become `first-23-chars + "_" + 8-char sha256(external_id)`: deterministic, stable across rebuilds, distinct per tenant).
- Prefix- and view-name-collision checks now run on the **final** (bounded) names; a defensive check raises `ValueError` before any DDL if a composed name would still exceed 63 bytes.
- The build is now idempotent: `DROP SCHEMA IF EXISTS … CASCADE` → `CREATE SCHEMA` → plain `CREATE VIEW` (no `OR REPLACE`), so a rebuild after an underlying table's columns changed succeeds, and any unexpected duplicate name is a hard error instead of a silent redefinition (which would have been silent data loss).

## Tests

- Exact production tenant names produce non-colliding, ≤63-byte view names.
- Two long names sharing their first 23 chars get distinct prefixes.
- DB-backed idempotency test: rebuild after an underlying column change succeeds (previously raised `InvalidTableDefinition`).
- Oversized composed names raise before DDL.

`uv run pytest` full suite green (1184 passed) on the integration branch combining the six incident-fix PRs.

Note for merge order: this is the root-cause fix for the incident; recommend landing first. Test-file conflicts with #<surface-failures PR> are union-trivial; I'll rebase whichever lands second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)