### PR TITLE
fix(workspaces): refresh schema TTL on provision and multi-tenant activity

### DIFF
--- a/apps/workspaces/services/schema_manager.py
+++ b/apps/workspaces/services/schema_manager.py
@@ -14,6 +14,7 @@ import uuid
 import psycopg
 import psycopg.sql
 from django.conf import settings
+from django.utils import timezone
 
 from apps.workspaces.models import SchemaState, TenantSchema, WorkspaceViewSchema
 
@@ -101,8 +102,15 @@ class SchemaManager:
             ts.delete()
             raise
 
+        # Activating here covers both the fresh-create path and the
+        # resurrect/fall-through path (an existing record that was EXPIRED or
+        # otherwise inactive). Either way the schema is now ACTIVE, so its
+        # inactivity TTL must be reset — otherwise a resurrected schema keeps a
+        # stale last_accessed_at and expire_inactive_schemas drops it on its
+        # next tick, right after data was materialized into it.
         ts.state = SchemaState.ACTIVE
-        ts.save(update_fields=["state"])
+        ts.last_accessed_at = timezone.now()
+        ts.save(update_fields=["state", "last_accessed_at"])
 
         logger.info(
             "Provisioned schema '%s' for tenant '%s'",

--- a/apps/workspaces/services/workspace_service.py
+++ b/apps/workspaces/services/workspace_service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from django.core.exceptions import ValidationError
 from django.db import transaction
+from django.utils import timezone
 
 from apps.workspaces.models import SchemaState, WorkspaceTenant, WorkspaceViewSchema
 from apps.workspaces.tasks import rebuild_workspace_view_schema, teardown_view_schema_task
@@ -74,7 +75,12 @@ async def touch_workspace_schemas(workspace) -> None:
     """Reset the inactivity TTL for active schemas associated with a workspace.
 
     For single-tenant workspaces, touches the TenantSchema of the sole tenant.
-    For multi-tenant workspaces, touches the WorkspaceViewSchema.
+    For multi-tenant workspaces, touches the WorkspaceViewSchema *and* every
+    constituent tenant's TenantSchema. The view schema is just a set of views
+    over the per-tenant tables — multi-tenant chat activity never touches the
+    underlying TenantSchemas directly, so without this bulk-touch they expire
+    after the TTL and their DROP SCHEMA CASCADE silently destroys the views
+    inside the still-ACTIVE view schema.
     """
     from apps.workspaces.models import TenantSchema
 
@@ -88,6 +94,14 @@ async def touch_workspace_schemas(workspace) -> None:
         if ts is not None:
             await ts.atouch()
     elif tenant_count > 1:
+        # Touch the constituent tenant schemas regardless of whether the view
+        # schema row exists — they underpin everything the view schema serves.
+        tenant_ids = [t.id async for t in workspace.tenants.all()]
+        await TenantSchema.objects.filter(
+            tenant_id__in=tenant_ids,
+            state__in=[SchemaState.ACTIVE, SchemaState.MATERIALIZING],
+        ).aupdate(last_accessed_at=timezone.now())
+
         vs = await WorkspaceViewSchema.objects.filter(
             workspace=workspace,
             state__in=[SchemaState.ACTIVE, SchemaState.MATERIALIZING],

--- a/apps/workspaces/tasks.py
+++ b/apps/workspaces/tasks.py
@@ -175,9 +175,12 @@ async def refresh_tenant_schema(schema_id: str, membership_id: str) -> dict:
         await _drop_schema_and_fail(new_schema)
         return {"error": "Materialization failed"}
 
-    # Step 3: Mark new schema as active
+    # Step 3: Mark new schema as active. Set last_accessed_at to now so the
+    # freshly materialized schema starts with a clean inactivity TTL —
+    # otherwise expire_inactive_schemas could drop it before it is ever used.
     new_schema.state = SchemaState.ACTIVE
-    await new_schema.asave(update_fields=["state"])
+    new_schema.last_accessed_at = timezone.now()
+    await new_schema.asave(update_fields=["state", "last_accessed_at"])
 
     # Step 4: Schedule teardown of previously active schemas with a delay to allow
     # in-flight queries against the old schema to complete before it is dropped.

--- a/tests/test_schema_manager.py
+++ b/tests/test_schema_manager.py
@@ -1,10 +1,12 @@
+from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
 import psycopg.errors
 import psycopg.sql
 import pytest
+from django.utils import timezone
 
-from apps.workspaces.models import TenantSchema, WorkspaceViewSchema
+from apps.workspaces.models import SchemaState, TenantSchema, WorkspaceViewSchema
 from apps.workspaces.services.schema_manager import SchemaManager, readonly_role_name
 
 
@@ -28,6 +30,25 @@ class TestSchemaManager:
         # Verify DDL was executed
         calls = [str(c) for c in mock_cursor.execute.call_args_list]
         assert any("CREATE SCHEMA" in c for c in calls)
+
+    def test_provision_fresh_sets_last_accessed_at(self, tenant_membership):
+        """A freshly provisioned schema must start with a populated
+        last_accessed_at so the inactivity TTL begins from now, not null."""
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.cursor.return_value = mock_cursor
+
+        before = timezone.now()
+        with patch(
+            "apps.workspaces.services.schema_manager.get_managed_db_connection",
+            return_value=mock_conn,
+        ):
+            ts = SchemaManager().provision(tenant_membership.tenant)
+
+        ts.refresh_from_db()
+        assert ts.state == SchemaState.ACTIVE
+        assert ts.last_accessed_at is not None
+        assert ts.last_accessed_at >= before
 
     def test_provision_returns_existing(self, tenant_membership):
         mgr = SchemaManager()
@@ -57,6 +78,48 @@ class TestSchemaManager:
                 psycopg.sql.Identifier(schema_name)
             )
         )
+
+
+@pytest.mark.django_db(transaction=True)
+def test_provision_resurrects_expired_schema_and_refreshes_ttl(tenant_membership):
+    """Provisioning over an EXPIRED record (the resurrect/fall-through path)
+    re-activates it AND refreshes last_accessed_at — otherwise the janitor
+    would drop the freshly resurrected schema using its stale timestamp.
+
+    Uses transaction=True so the IntegrityError raised by objects.create (the
+    schema_name already exists) does not poison an enclosing atomic block —
+    mirroring production, where provision() runs outside a transaction.
+    """
+    mgr = SchemaManager()
+    schema_name = mgr._sanitize_schema_name(tenant_membership.tenant.external_id)
+    stale = timezone.now() - timedelta(days=20)
+    TenantSchema.objects.create(
+        tenant=tenant_membership.tenant,
+        schema_name=schema_name,
+        state=SchemaState.EXPIRED,
+        last_accessed_at=stale,
+    )
+
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_conn.cursor.return_value = mock_cursor
+    mock_cursor.fetchone.return_value = None  # role doesn't exist yet
+
+    before = timezone.now()
+    with patch(
+        "apps.workspaces.services.schema_manager.get_managed_db_connection",
+        return_value=mock_conn,
+    ):
+        ts = mgr.provision(tenant_membership.tenant)
+
+    # No duplicate row; the existing one was resurrected in place.
+    assert TenantSchema.objects.count() == 1
+    ts.refresh_from_db()
+    assert ts.state == SchemaState.ACTIVE
+    assert ts.last_accessed_at is not None
+    assert ts.last_accessed_at >= before
+    # The stale timestamp must be gone.
+    assert ts.last_accessed_at > stale
 
 
 @pytest.mark.django_db

--- a/tests/test_schema_ttl_task.py
+++ b/tests/test_schema_ttl_task.py
@@ -1,12 +1,15 @@
 """Tests for schema TTL tasks."""
 
 from datetime import timedelta
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from asgiref.sync import sync_to_async
 from django.utils import timezone
 
 from apps.workspaces.models import MaterializationRun, SchemaState, TenantSchema
+from apps.workspaces.services.schema_manager import SchemaManager
+from apps.workspaces.tasks import expire_inactive_schemas
 
 
 @pytest.fixture
@@ -35,6 +38,41 @@ async def test_expire_inactive_schemas_marks_stale_schema_for_teardown(active_sc
     await active_schema.arefresh_from_db()
     assert active_schema.state == SchemaState.TEARDOWN
     mock_defer.assert_called_once_with(schema_id=str(active_schema.id))
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_resurrected_schema_survives_immediate_expire_sweep(tenant):
+    """Regression for the production drop loop: an EXPIRED schema resurrected via
+    provision() must NOT be re-expired by the very next expire_inactive_schemas
+    tick. provision() now refreshes last_accessed_at, so the schema is fresh."""
+    mgr = SchemaManager()
+    schema_name = mgr._sanitize_schema_name(tenant.external_id)
+    stale = timezone.now() - timedelta(days=20)
+    await TenantSchema.objects.acreate(
+        tenant=tenant,
+        schema_name=schema_name,
+        state=SchemaState.EXPIRED,
+        last_accessed_at=stale,
+    )
+
+    mock_conn = MagicMock()
+    mock_conn.cursor.return_value = MagicMock()
+    mock_conn.cursor.return_value.fetchone.return_value = None
+
+    with patch(
+        "apps.workspaces.services.schema_manager.get_managed_db_connection",
+        return_value=mock_conn,
+    ):
+        ts = await sync_to_async(mgr.provision)(tenant)
+
+    # Now run the janitor immediately, as production did 60s after materialization.
+    with patch("apps.workspaces.tasks.teardown_schema.defer_async", new_callable=AsyncMock):
+        await expire_inactive_schemas()
+
+    await ts.arefresh_from_db()
+    # The schema survives — it is still ACTIVE, not flipped to TEARDOWN.
+    assert ts.state == SchemaState.ACTIVE
 
 
 @pytest.mark.asyncio

--- a/tests/test_workspace_service.py
+++ b/tests/test_workspace_service.py
@@ -1,12 +1,20 @@
+from datetime import timedelta
 from unittest.mock import patch
 
 import pytest
+from django.utils import timezone
 
 from apps.users.models import Tenant, TenantMembership
-from apps.workspaces.models import SchemaState, WorkspaceTenant, WorkspaceViewSchema
+from apps.workspaces.models import (
+    SchemaState,
+    TenantSchema,
+    WorkspaceTenant,
+    WorkspaceViewSchema,
+)
 from apps.workspaces.services.workspace_service import (
     add_workspace_tenant,
     remove_workspace_tenant,
+    touch_workspace_schemas,
 )
 
 
@@ -100,3 +108,78 @@ def test_remove_tenant_no_op_on_tenant_count_above_one(
     assert vs.state == SchemaState.PROVISIONING
     mock_rebuild.assert_called_once_with(workspace_id=str(workspace.id))
     mock_teardown.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_touch_multitenant_workspace_touches_constituent_tenant_schemas(
+    workspace, tenant, tenant2, tenant_membership2
+):
+    """Multi-tenant chat activity must refresh the TTL on each constituent
+    TenantSchema, not just the view schema — otherwise the tenant schemas
+    expire and their DROP CASCADE destroys the views in the view schema."""
+    await WorkspaceTenant.objects.acreate(workspace=workspace, tenant=tenant2)
+
+    stale = timezone.now() - timedelta(days=20)
+    ts1 = await TenantSchema.objects.acreate(
+        tenant=tenant,
+        schema_name="touch_tenant_1",
+        state=SchemaState.ACTIVE,
+        last_accessed_at=stale,
+    )
+    ts2 = await TenantSchema.objects.acreate(
+        tenant=tenant2,
+        schema_name="touch_tenant_2",
+        state=SchemaState.MATERIALIZING,
+        last_accessed_at=stale,
+    )
+    vs = await WorkspaceViewSchema.objects.acreate(
+        workspace=workspace,
+        schema_name="ws_touchtest12345",
+        state=SchemaState.ACTIVE,
+        last_accessed_at=stale,
+    )
+
+    before = timezone.now()
+    await touch_workspace_schemas(workspace)
+
+    await ts1.arefresh_from_db()
+    await ts2.arefresh_from_db()
+    await vs.arefresh_from_db()
+    # Both ACTIVE and MATERIALIZING tenant schemas refreshed.
+    assert ts1.last_accessed_at >= before
+    assert ts2.last_accessed_at >= before
+    # The view schema is still touched as well.
+    assert vs.last_accessed_at >= before
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_touch_multitenant_touches_tenant_schemas_without_view_schema(
+    workspace, tenant, tenant2, tenant_membership2
+):
+    """The tenant schemas underpin everything, so they must be touched even when
+    no WorkspaceViewSchema row exists yet (e.g. mid-provision)."""
+    await WorkspaceTenant.objects.acreate(workspace=workspace, tenant=tenant2)
+
+    stale = timezone.now() - timedelta(days=20)
+    ts1 = await TenantSchema.objects.acreate(
+        tenant=tenant,
+        schema_name="touch_noview_1",
+        state=SchemaState.ACTIVE,
+        last_accessed_at=stale,
+    )
+    ts2 = await TenantSchema.objects.acreate(
+        tenant=tenant2,
+        schema_name="touch_noview_2",
+        state=SchemaState.ACTIVE,
+        last_accessed_at=stale,
+    )
+
+    before = timezone.now()
+    await touch_workspace_schemas(workspace)
+
+    await ts1.arefresh_from_db()
+    await ts2.arefresh_from_db()
+    assert ts1.last_accessed_at >= before
+    assert ts2.last_accessed_at >= before


### PR DESCRIPTION
## Problem (prod incident 2026-06-10)

Two TTL bugs that combined to destroy freshly-materialized data:

1. `SchemaManager.provision()` resurrects an EXPIRED `TenantSchema` row (IntegrityError fall-through) and flips it ACTIVE **without** updating `last_accessed_at`. In prod, three tenant schemas were resurrected with `last_accessed_at` from May 21; the 24h-TTL janitor's next 15-minute tick saw "ACTIVE, last accessed 20 days ago" and **dropped them 60 seconds after ~24,500 rows were loaded**. Every re-materialization loops the same way.
2. `touch_workspace_schemas` for multi-tenant workspaces touched only the `WorkspaceViewSchema` — the constituent `TenantSchema`s were never touched by multi-tenant chat, so after 24h idle they expire and their `DROP SCHEMA CASCADE` silently destroys the views inside the still-ACTIVE view schema (verified in prod: an ACTIVE view schema containing zero views).

## Fix

- `provision()` activation point (covers both fresh-create and resurrect paths) now sets `last_accessed_at = now` alongside `state`.
- Same defect fixed in the `refresh_tenant_schema` task's activation step.
- `touch_workspace_schemas` multi-tenant branch bulk-touches all constituent ACTIVE/MATERIALIZING tenant schemas (single `aupdate`), independent of whether a view-schema row exists.

## Tests

- Resurrect-via-provision refreshes the TTL, and an immediate `expire_inactive_schemas` sweep no longer kills the schema (end-to-end regression of the prod sequence).
- Fresh provision sets `last_accessed_at`.
- Multi-tenant `touch_workspace_schemas` touches tenant schemas (with and without a view-schema row).

`uv run pytest` full suite green (1184 passed) on the integration branch combining the six incident-fix PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)