### PR TITLE
fix(workspaces): keep sibling view schemas consistent across tenant rematerialization/teardown

### DIFF
--- a/apps/workspaces/tasks.py
+++ b/apps/workspaces/tasks.py
@@ -9,6 +9,7 @@ from datetime import timedelta
 import sentry_sdk
 from django.conf import settings
 from django.db import close_old_connections
+from django.db.models import Count, OuterRef, Subquery
 from django.utils import timezone
 from langchain_core.messages import AIMessage, HumanMessage
 from procrastinate.contrib.django.models import ProcrastinateJob
@@ -334,6 +335,19 @@ async def materialize_workspace(
                 )
                 view_schema_outcome = {"ok": False, "error": str(exc)[:500]}
 
+        # Tenant data schemas (t_<id>) are SHARED across workspaces. Re-materializing
+        # a tenant from THIS workspace drops & recreates its raw_* tables, which
+        # cascade-drops the namespaced views inside every OTHER workspace's view
+        # schema — leaving those WorkspaceViewSchema rows ACTIVE but empty. Defer a
+        # rebuild for each sibling multi-tenant workspace that shares any tenant we
+        # just (re)materialized so their views are recreated against the new tables.
+        # Failures of individual rebuilds are handled inside rebuild_workspace_view_schema;
+        # we never block the resume on them.
+        await _rebuild_sibling_view_schemas(
+            current_workspace_id=str(workspace.id),
+            tenant_ids=[tm.tenant_id for tm in memberships],
+        )
+
         return {
             "tenants": tenant_results,
             "all_succeeded": all_succeeded,
@@ -379,6 +393,74 @@ async def _defer_resume_for_job(job_id: int) -> None:
         await resume_thread_after_materialization.defer_async(thread_job_id=str(tj.id))
     except Exception:
         logger.exception("Failed to defer resume task for job %s", job_id)
+
+
+def _multi_tenant_count_subquery():
+    """Correlated subquery yielding a workspace's total tenant count.
+
+    A plain ``annotate(Count("workspace_tenants"))`` shares the same join as a
+    ``filter(workspace_tenants__tenant_id__in=...)`` predicate, so the count
+    collapses to only the *filtered* tenants (always 1 here) — the classic
+    Django filter+aggregate-on-the-same-multivalued-relation trap. Counting via
+    an independent subquery over the junction sidesteps that and stays a single
+    SQL round-trip (no per-tenant N+1).
+    """
+    return Subquery(
+        WorkspaceTenant.objects.filter(workspace=OuterRef("pk"))
+        .order_by()
+        .values("workspace")
+        .annotate(n=Count("id"))
+        .values("n")
+    )
+
+
+def _sibling_view_schema_workspaces(tenant_ids, exclude_workspace_id):
+    """Queryset of OTHER multi-tenant workspaces with a WorkspaceViewSchema row
+    that share any of ``tenant_ids``.
+
+    A workspace qualifies when it (i) contains at least one of the given tenants,
+    (ii) is multi-tenant (>= 2 tenants), and (iii) has a WorkspaceViewSchema row
+    in any state. The current workspace is excluded.
+
+    Uses a single annotated query (a subquery tenant count) rather than walking
+    each tenant's workspaces, so cost is independent of the number of tenants
+    materialized (no N+1).
+    """
+    return (
+        Workspace.objects.filter(
+            workspace_tenants__tenant_id__in=tenant_ids,
+            view_schema__isnull=False,
+        )
+        .exclude(id=exclude_workspace_id)
+        .annotate(num_tenants=_multi_tenant_count_subquery())
+        .filter(num_tenants__gte=2)
+        .distinct()
+    )
+
+
+async def _rebuild_sibling_view_schemas(*, current_workspace_id: str, tenant_ids) -> None:
+    """Defer a view-schema rebuild for every sibling workspace whose namespaced
+    views were (or will be) cascade-dropped by this workspace's re-materialization.
+
+    See the call site in materialize_workspace for the why. The query already
+    yields distinct workspace ids, so no extra dedupe is needed. Best-effort: a
+    failure to defer one rebuild must not block the resume, so each defer is
+    individually guarded and the dispatched task owns its own failure handling.
+    """
+    async for sibling_id in (
+        _sibling_view_schema_workspaces(tenant_ids, current_workspace_id)
+        .values_list("id", flat=True)
+        .aiterator()
+    ):
+        try:
+            await rebuild_workspace_view_schema.defer_async(workspace_id=str(sibling_id))
+        except Exception:
+            logger.exception(
+                "Failed to defer sibling view-schema rebuild for workspace %s "
+                "(triggered by re-materialization of workspace %s)",
+                sibling_id,
+                current_workspace_id,
+            )
 
 
 def _run_pipeline_with_progress(
@@ -562,6 +644,14 @@ async def teardown_schema(schema_id: str) -> None:
         ],
     ).aupdate(state=MaterializationRun.RunState.STALE)
 
+    # The tenant schema (t_<id>) is SHARED across workspaces. DROP SCHEMA ... CASCADE
+    # just cascade-dropped the namespaced views inside every dependent multi-tenant
+    # workspace's view schema (ws_<hash>). Those WorkspaceViewSchema rows still claim
+    # ACTIVE, which is now a lie — querying through them returns nothing. Flip them to
+    # FAILED so the catalog reports the truth. We do NOT defer a rebuild: the tenant's
+    # data is gone, so a rebuild would rightly fail until the tenant is re-materialized.
+    await _fail_dependent_view_schemas(schema.tenant_id)
+
     try:
         schema.state = SchemaState.EXPIRED
         await schema.asave(update_fields=["state"])
@@ -571,6 +661,30 @@ async def teardown_schema(schema_id: str) -> None:
             "teardown_schema: failed to mark schema %s EXPIRED after teardown", schema.id
         )
         raise
+
+
+async def _fail_dependent_view_schemas(tenant_id) -> int:
+    """Flip every ACTIVE WorkspaceViewSchema that depends on ``tenant_id`` to FAILED.
+
+    A view schema depends on a tenant when its workspace is multi-tenant (>= 2
+    tenants) and contains that tenant: its namespaced views were just
+    cascade-dropped by the tenant-schema DROP. We only touch ACTIVE rows — rows
+    already in TEARDOWN/FAILED/EXPIRED must not be clobbered out of their
+    lifecycle state. A single annotated subquery scopes the update to the right
+    workspaces, so cost is independent of how many workspaces share the tenant.
+
+    Returns the number of rows flipped.
+    """
+    dependent_workspace_ids = (
+        Workspace.objects.filter(workspace_tenants__tenant_id=tenant_id)
+        .annotate(num_tenants=_multi_tenant_count_subquery())
+        .filter(num_tenants__gte=2)
+        .values("id")
+    )
+    return await WorkspaceViewSchema.objects.filter(
+        workspace_id__in=dependent_workspace_ids,
+        state=SchemaState.ACTIVE,
+    ).aupdate(state=SchemaState.FAILED)
 
 
 STALE_JOB_THRESHOLD = timedelta(minutes=10)

--- a/tests/test_materialize_workspace_task.py
+++ b/tests/test_materialize_workspace_task.py
@@ -18,6 +18,7 @@ from apps.workspaces.models import (
     WorkspaceMembership,
     WorkspaceRole,
     WorkspaceTenant,
+    WorkspaceViewSchema,
 )
 from apps.workspaces.tasks import _run_pipeline_with_progress, materialize_workspace
 from mcp_server.services.materializer import MaterializationCancelled
@@ -798,3 +799,132 @@ async def test_legacy_cancel_orphan_path_skips_other_users_runs(
         1002,
         abort=True,
     )
+
+
+# ---------------------------------------------------------------------------
+# Sibling view-schema consistency on re-materialization
+# ---------------------------------------------------------------------------
+#
+# Tenant data schemas (t_<id>) are SHARED across workspaces. Re-materializing a
+# tenant from workspace A cascade-drops the namespaced views inside every OTHER
+# multi-tenant workspace that shares that tenant, so materialize_workspace must
+# defer a rebuild for each such sibling.
+
+
+async def _make_sibling_multitenant_workspace(user, shared_tenant, *, with_view_schema, suffix):
+    """Build a multi-tenant workspace that shares ``shared_tenant`` and has a
+    distinct extra tenant, optionally with a WorkspaceViewSchema row."""
+    extra_tenant = await Tenant.objects.acreate(
+        provider="commcare",
+        external_id=f"sibling-extra-{suffix}",
+        canonical_name=f"Sibling Extra {suffix}",
+    )
+    ws = await Workspace.objects.acreate(name=f"Sibling WS {suffix}", created_by=user)
+    await WorkspaceMembership.objects.acreate(workspace=ws, user=user, role=WorkspaceRole.MANAGE)
+    await WorkspaceTenant.objects.acreate(workspace=ws, tenant=shared_tenant)
+    await WorkspaceTenant.objects.acreate(workspace=ws, tenant=extra_tenant)
+    if with_view_schema:
+        await WorkspaceViewSchema.objects.acreate(
+            workspace=ws,
+            schema_name=f"ws_sibling_{suffix}",
+            state=SchemaState.ACTIVE,
+        )
+    return ws
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_materialize_workspace_defers_rebuild_for_sibling_view_schemas(
+    workspace, tenant, tenant_membership_obj, user, context_with_job_id
+):
+    """Materializing workspace A (sharing tenant T) defers a rebuild for the
+    multi-tenant sibling B that shares T and has a WorkspaceViewSchema — and
+    does NOT defer one for A itself nor for a single-tenant sibling."""
+    # Sibling B: multi-tenant, shares T, has a view schema → must be rebuilt.
+    sibling_b = await _make_sibling_multitenant_workspace(
+        user, tenant, with_view_schema=True, suffix="b"
+    )
+    # Sibling C: single-tenant (only T), no view schema → must NOT be rebuilt.
+    sibling_c = await Workspace.objects.acreate(name="Sibling C single", created_by=user)
+    await WorkspaceTenant.objects.acreate(workspace=sibling_c, tenant=tenant)
+
+    with (
+        patch("apps.workspaces.tasks.aresolve_credential", new_callable=AsyncMock) as mock_cred,
+        patch("apps.workspaces.tasks.get_registry", return_value=_mock_registry("commcare")),
+        patch("apps.workspaces.tasks._run_pipeline_with_progress", return_value={"status": "ok"}),
+        patch("apps.workspaces.tasks._defer_resume_for_job", new_callable=AsyncMock),
+        patch(
+            "apps.workspaces.tasks.rebuild_workspace_view_schema.defer_async",
+            new_callable=AsyncMock,
+        ) as mock_rebuild,
+    ):
+        mock_cred.return_value = {"type": "api_key", "value": "k"}
+        await materialize_workspace(
+            context_with_job_id,
+            workspace_id=str(workspace.id),
+            user_id="",
+        )
+
+    mock_rebuild.assert_awaited_once_with(workspace_id=str(sibling_b.id))
+    deferred_ids = {c.kwargs["workspace_id"] for c in mock_rebuild.await_args_list}
+    assert str(workspace.id) not in deferred_ids  # never the current workspace
+    assert str(sibling_c.id) not in deferred_ids  # single-tenant siblings excluded
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_materialize_workspace_dedupes_sibling_rebuild(
+    workspace, tenant, tenant_membership_obj, user, context_with_job_id
+):
+    """A sibling B that shares the materialized tenant must be deferred exactly
+    once even though the dedupe path could otherwise enqueue duplicates."""
+    sibling_b = await _make_sibling_multitenant_workspace(
+        user, tenant, with_view_schema=True, suffix="dedup"
+    )
+
+    with (
+        patch("apps.workspaces.tasks.aresolve_credential", new_callable=AsyncMock) as mock_cred,
+        patch("apps.workspaces.tasks.get_registry", return_value=_mock_registry("commcare")),
+        patch("apps.workspaces.tasks._run_pipeline_with_progress", return_value={"status": "ok"}),
+        patch("apps.workspaces.tasks._defer_resume_for_job", new_callable=AsyncMock),
+        patch(
+            "apps.workspaces.tasks.rebuild_workspace_view_schema.defer_async",
+            new_callable=AsyncMock,
+        ) as mock_rebuild,
+    ):
+        mock_cred.return_value = {"type": "api_key", "value": "k"}
+        await materialize_workspace(
+            context_with_job_id,
+            workspace_id=str(workspace.id),
+            user_id="",
+        )
+
+    assert mock_rebuild.await_count == 1
+    mock_rebuild.assert_awaited_once_with(workspace_id=str(sibling_b.id))
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_materialize_workspace_no_sibling_rebuild_when_none_qualify(
+    workspace, tenant_membership_obj, context_with_job_id
+):
+    """Regression: with no qualifying sibling (no other multi-tenant workspace
+    sharing the tenant + view schema), no rebuild is deferred."""
+    with (
+        patch("apps.workspaces.tasks.aresolve_credential", new_callable=AsyncMock) as mock_cred,
+        patch("apps.workspaces.tasks.get_registry", return_value=_mock_registry("commcare")),
+        patch("apps.workspaces.tasks._run_pipeline_with_progress", return_value={"status": "ok"}),
+        patch("apps.workspaces.tasks._defer_resume_for_job", new_callable=AsyncMock),
+        patch(
+            "apps.workspaces.tasks.rebuild_workspace_view_schema.defer_async",
+            new_callable=AsyncMock,
+        ) as mock_rebuild,
+    ):
+        mock_cred.return_value = {"type": "api_key", "value": "k"}
+        await materialize_workspace(
+            context_with_job_id,
+            workspace_id=str(workspace.id),
+            user_id="",
+        )
+
+    mock_rebuild.assert_not_awaited()

--- a/tests/test_schema_ttl_task.py
+++ b/tests/test_schema_ttl_task.py
@@ -7,9 +7,17 @@ import pytest
 from asgiref.sync import sync_to_async
 from django.utils import timezone
 
-from apps.workspaces.models import MaterializationRun, SchemaState, TenantSchema
+from apps.users.models import Tenant
+from apps.workspaces.models import (
+    MaterializationRun,
+    SchemaState,
+    TenantSchema,
+    Workspace,
+    WorkspaceTenant,
+    WorkspaceViewSchema,
+)
 from apps.workspaces.services.schema_manager import SchemaManager
-from apps.workspaces.tasks import expire_inactive_schemas
+from apps.workspaces.tasks import expire_inactive_schemas, teardown_schema
 
 
 @pytest.fixture
@@ -289,3 +297,78 @@ async def test_expire_then_failed_teardown_keeps_data_visible(active_schema):
     # Data is intact and still visible to the catalog.
     assert active_schema.state == SchemaState.ACTIVE
     assert completed_run.state == MaterializationRun.RunState.COMPLETED
+
+
+# ---------------------------------------------------------------------------
+# teardown_schema: dependent view-schema consistency
+# ---------------------------------------------------------------------------
+#
+# A tenant data schema (t_<id>) is SHARED across workspaces. DROP SCHEMA CASCADE
+# cascade-drops the namespaced views inside every dependent multi-tenant
+# workspace's view schema, so teardown_schema must flip those ACTIVE
+# WorkspaceViewSchema rows to FAILED (ACTIVE would be a lie).
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_teardown_schema_fails_dependent_multitenant_view_schemas(
+    active_schema, tenant, user
+):
+    """After the physical DROP, the ACTIVE view schema of a multi-tenant
+    workspace B (sharing the torn-down tenant) is flipped to FAILED, while a
+    single-tenant workspace's view schema is left untouched."""
+    # Multi-tenant workspace B: shares `tenant` + a second tenant, ACTIVE view schema.
+    extra_tenant = await Tenant.objects.acreate(
+        provider="commcare", external_id="teardown-extra", canonical_name="Teardown Extra"
+    )
+    ws_b = await Workspace.objects.acreate(name="Teardown Sibling B", created_by=user)
+    await WorkspaceTenant.objects.acreate(workspace=ws_b, tenant=tenant)
+    await WorkspaceTenant.objects.acreate(workspace=ws_b, tenant=extra_tenant)
+    vs_b = await WorkspaceViewSchema.objects.acreate(
+        workspace=ws_b, schema_name="ws_teardown_b", state=SchemaState.ACTIVE
+    )
+
+    # Single-tenant workspace C: contains only `tenant`. Even if it has a view
+    # schema row, it is not multi-tenant, so it must be left untouched.
+    ws_c = await Workspace.objects.acreate(name="Teardown Single C", created_by=user)
+    await WorkspaceTenant.objects.acreate(workspace=ws_c, tenant=tenant)
+    vs_c = await WorkspaceViewSchema.objects.acreate(
+        workspace=ws_c, schema_name="ws_teardown_c", state=SchemaState.ACTIVE
+    )
+
+    with patch("apps.workspaces.tasks.SchemaManager") as MockManager:
+        MockManager.return_value.teardown.return_value = None
+        await teardown_schema(schema_id=str(active_schema.id))
+
+    await active_schema.arefresh_from_db()
+    await vs_b.arefresh_from_db()
+    await vs_c.arefresh_from_db()
+
+    assert active_schema.state == SchemaState.EXPIRED
+    # B's namespaced views were cascade-dropped; ACTIVE was a lie → now FAILED.
+    assert vs_b.state == SchemaState.FAILED
+    # C is single-tenant — its view schema must not be clobbered.
+    assert vs_c.state == SchemaState.ACTIVE
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_teardown_schema_does_not_clobber_non_active_view_schema(active_schema, tenant, user):
+    """A dependent view schema that is already TEARDOWN must keep its lifecycle
+    state — only ACTIVE rows are flipped to FAILED."""
+    extra_tenant = await Tenant.objects.acreate(
+        provider="commcare", external_id="teardown-extra-2", canonical_name="Teardown Extra 2"
+    )
+    ws_b = await Workspace.objects.acreate(name="Teardown Sibling B2", created_by=user)
+    await WorkspaceTenant.objects.acreate(workspace=ws_b, tenant=tenant)
+    await WorkspaceTenant.objects.acreate(workspace=ws_b, tenant=extra_tenant)
+    vs_b = await WorkspaceViewSchema.objects.acreate(
+        workspace=ws_b, schema_name="ws_teardown_b2", state=SchemaState.TEARDOWN
+    )
+
+    with patch("apps.workspaces.tasks.SchemaManager") as MockManager:
+        MockManager.return_value.teardown.return_value = None
+        await teardown_schema(schema_id=str(active_schema.id))
+
+    await vs_b.arefresh_from_db()
+    assert vs_b.state == SchemaState.TEARDOWN


### PR DESCRIPTION
## Problem (verified in prod 2026-06-10)

Tenant data schemas (`t_<id>`) are shared across workspaces, but their lifecycle ignores dependent view schemas:

- Re-materializing tenant T from one workspace `DROP TABLE … CASCADE`s its raw tables — silently dropping the namespaced views inside **every other** multi-tenant workspace's `ws_` schema while those `WorkspaceViewSchema` rows stay ACTIVE. Verified in prod: an ACTIVE view schema with zero views (the "Data is loaded but no tables are visible yet" dead end, fossilized).
- TTL teardown of a tenant schema (`DROP SCHEMA … CASCADE`) does the same.

## Fix

- `materialize_workspace`: after the per-tenant loads, defer `rebuild_workspace_view_schema` for every **other** multi-tenant workspace (≥2 tenants, has a view-schema row) sharing any just-materialized tenant. Single annotated query (correlated `Subquery` tenant count — a plain `annotate(Count)` collapses under the shared-join filter trap), deduped, never blocks the resume.
- `teardown_schema`: after the physical drop, flip dependent ACTIVE `WorkspaceViewSchema` rows to FAILED (ACTIVE is now a lie; non-ACTIVE lifecycle states are left alone). No rebuild is deferred — the tenant's data is gone, so a rebuild would rightly fail until re-materialization.

## Tests

Sibling rebuild deferred for qualifying workspaces only (not the current one, not single-tenant ones); teardown flips ACTIVE→FAILED and leaves TEARDOWN rows alone; no-sibling regression case.

`uv run pytest` full suite green (1184 passed) on the integration branch combining the six incident-fix PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)