### PR TITLE
fix(chat): stop carrying threads across workspaces and recover from stale threads

### DIFF
--- a/apps/chat/thread_views.py
+++ b/apps/chat/thread_views.py
@@ -145,6 +145,14 @@ async def thread_messages_view(request, workspace_id, thread_id):
 
     thread = await _get_thread(thread_id, user, workspace_id=workspace_id)
     if thread is None:
+        # Distinguish a brand-new chat from a stale/foreign one. New chats use
+        # client-generated UUIDs with no Thread row until the first POST, so a
+        # missing row must keep returning [] 200. But if a row *exists* and just
+        # doesn't belong to this (user, workspace), it's a stale/cross-workspace
+        # thread — return 404 so the client can recover instead of silently
+        # showing an empty, "haunted" chat.
+        if await Thread.objects.filter(id=thread_id).aexists():
+            return JsonResponse({"error": "Thread not found"}, status=404)
         return JsonResponse([], safe=False)
 
     ui_messages = await _load_thread_messages(thread_id)

--- a/apps/chat/views.py
+++ b/apps/chat/views.py
@@ -125,6 +125,15 @@ async def chat_view(request):
     if existing_thread is not None and (
         existing_thread.user_id != user.pk or existing_thread.workspace_id != workspace.pk
     ):
+        logger.warning(
+            "Rejected chat POST to foreign thread: thread_id=%s requesting_user=%s "
+            "owner_user=%s thread_workspace=%s requested_workspace=%s",
+            thread_id,
+            user.pk,
+            existing_thread.user_id,
+            existing_thread.workspace_id,
+            workspace.pk,
+        )
         return JsonResponse({"error": "Thread not found"}, status=404)
 
     # Record thread metadata (fire-and-forget on error)

--- a/frontend/src/components/ChatPanel/ChatPanel.tsx
+++ b/frontend/src/components/ChatPanel/ChatPanel.tsx
@@ -1,7 +1,7 @@
 import { useChat } from "@ai-sdk/react"
 import { DefaultChatTransport, type UIMessage } from "ai"
 import { useEffect, useRef, useState } from "react"
-import { getCsrfToken, api } from "@/api/client"
+import { getCsrfToken, api, ApiError } from "@/api/client"
 import { BASE_PATH } from "@/config"
 import { useAppStore } from "@/store/store"
 import { ChatMessage } from "@/components/ChatMessage/ChatMessage"
@@ -13,12 +13,21 @@ import { SLASH_COMMANDS, resolveSlashCommand } from "./slashCommands"
 import { SlashCommandMenu } from "./SlashCommandMenu"
 import { useWorkspaceJobs } from "@/contexts/WorkspaceJobsContext"
 import { ChatEmptyState } from "@/components/ChatEmptyState"
-import { writeSavedThreadId } from "./threadStorage"
+import { writeSavedThreadId, clearSavedThreadId } from "./threadStorage"
+
+/** True when an error looks like a stale/missing-thread rejection (HTTP 404 or
+ * a body containing the backend's "Thread not found" marker). */
+function isStaleThreadError(error: Error | undefined): boolean {
+  if (!error) return false
+  if (error instanceof ApiError && error.status === 404) return true
+  return error.message.includes("Thread not found")
+}
 
 export function ChatPanel() {
   const activeDomainId = useAppStore((s) => s.activeDomainId)
   const threadId = useAppStore((s) => s.threadId)
   const fetchThreads = useAppStore((s) => s.uiActions.fetchThreads)
+  const newThread = useAppStore((s) => s.uiActions.newThread)
   const scrollRef = useRef<HTMLDivElement>(null)
   const [input, setInput] = useState("")
   const [slashMenuIndex, setSlashMenuIndex] = useState(0)
@@ -67,31 +76,39 @@ export function ChatPanel() {
     setSlashMenuIndex(0)
   }
 
-  // Persist threadId to localStorage when it changes, so a bare /chat visit can
-  // restore the last-viewed thread for this workspace. The URL is the source of
-  // truth for which thread is active; this is just a "last seen" fallback.
-  useEffect(() => {
-    if (activeDomainId && threadId) {
-      writeSavedThreadId(activeDomainId, threadId)
-    }
-  }, [threadId, activeDomainId])
-
-  // Load messages from backend when threadId changes (or after a background job completes)
+  // Load messages from backend when threadId changes (or after a background job
+  // completes). On success — including an empty array for a brand-new thread —
+  // persist this (workspace, thread) pair so a later bare /chat visit can
+  // restore it. We persist ONLY here so a stale/foreign thread (which 404s
+  // below) never gets stamped into this workspace's localStorage. A 404 means
+  // the thread exists but isn't ours / isn't this workspace's: drop the saved
+  // id and start a fresh thread so the user lands in a clean chat instead of a
+  // haunted one.
   useEffect(() => {
     if (!threadId || !activeDomainId) return
     let cancelled = false
 
     async function loadMessages() {
       try {
-        const msgs = await api.get<UIMessage[]>(`/api/workspaces/${activeDomainId}/threads/${threadId}/messages/`)
-        if (!cancelled) {
-          setMessages(msgs)
+        const msgs = await api.get<UIMessage[]>(
+          `/api/workspaces/${activeDomainId}/threads/${threadId}/messages/`,
+        )
+        if (cancelled) return
+        setMessages(msgs)
+        if (activeDomainId && threadId) {
+          writeSavedThreadId(activeDomainId, threadId)
         }
-      } catch {
-        // New thread or fetch failed — start with empty
-        if (!cancelled) {
+      } catch (err) {
+        if (cancelled) return
+        if (err instanceof ApiError && err.status === 404) {
+          // Stale / cross-workspace thread: recover into a fresh chat.
+          if (activeDomainId) clearSavedThreadId(activeDomainId, threadId)
           setMessages([])
+          newThread()
+          return
         }
+        // New thread or transient fetch failure — start with empty.
+        setMessages([])
       }
     }
 
@@ -135,6 +152,15 @@ export function ChatPanel() {
 
     setInput("")
     sendMessage({ text: resolveSlashCommand(text) })
+  }
+
+  // Recover from a stale/unavailable thread: forget the saved id for this
+  // workspace and start a fresh thread. The URL sync hook then rewrites the
+  // address bar to the new thread.
+  function startFreshThread() {
+    if (activeDomainId) clearSavedThreadId(activeDomainId)
+    setMessages([])
+    newThread()
   }
 
   function handleKeyDown(e: React.KeyboardEvent) {
@@ -188,11 +214,7 @@ export function ChatPanel() {
           />
         ))}
         {isStreaming && <ThinkingIndicator />}
-        {error && (
-          <div className="text-sm text-destructive bg-destructive/10 rounded-lg px-4 py-2">
-            {error.message}
-          </div>
-        )}
+        {error && <ChatError error={error} onStartNewThread={startFreshThread} />}
       </div>
 
       {/* Materialization progress banner — always visible when a job is active for this thread */}
@@ -237,6 +259,49 @@ export function ChatPanel() {
           )}
         </form>
       </div>
+    </div>
+  )
+}
+
+/**
+ * Friendly chat error. Never renders a raw response body (e.g. the JSON
+ * `{"error":"Thread not found"}` the backend returns). The stale-thread case
+ * gets a recovery button; everything else gets a generic message, with the real
+ * error kept in the console for debugging.
+ */
+function ChatError({
+  error,
+  onStartNewThread,
+}: {
+  error: Error
+  onStartNewThread: () => void
+}) {
+  const stale = isStaleThreadError(error)
+  useEffect(() => {
+    console.error("[Scout] Chat error:", error)
+  }, [error])
+
+  return (
+    <div
+      className="text-sm text-destructive bg-destructive/10 rounded-lg px-4 py-3 space-y-2"
+      data-testid="chat-error"
+    >
+      <p>
+        {stale
+          ? "This conversation is no longer available."
+          : "Something went wrong. Please try again."}
+      </p>
+      {stale && (
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={onStartNewThread}
+          data-testid="chat-error-new-thread"
+        >
+          Start new chat
+        </Button>
+      )}
     </div>
   )
 }

--- a/frontend/src/components/ChatPanel/ChatRedirect.tsx
+++ b/frontend/src/components/ChatPanel/ChatRedirect.tsx
@@ -17,7 +17,6 @@ export function ChatRedirect() {
   const pathPrefix = location.pathname.startsWith("/embed") ? "/embed" : ""
   const activeDomainId = useAppStore((s) => s.activeDomainId)
   const domains = useAppStore((s) => s.domains)
-  const threadId = useAppStore((s) => s.threadId)
   const domainsStatus = useAppStore((s) => s.domainsStatus)
   const fetchDomains = useAppStore((s) => s.domainActions.fetchDomains)
 
@@ -27,9 +26,14 @@ export function ChatRedirect() {
   }, [domainsStatus, fetchDomains])
 
   if (activeDomainId) {
-    // Prefer the last thread the user viewed in this workspace (persisted in
-    // localStorage by ChatPanel); fall back to the store's current threadId.
-    const resolvedThreadId = readSavedThreadId(activeDomainId) || threadId
+    // Resolve the last thread the user viewed *in this workspace* (persisted in
+    // localStorage by ChatPanel, only after a successful messages load). We do
+    // NOT fall back to the store's `threadId` here: that value can belong to a
+    // different workspace (e.g. right after a workspace switch), and grafting it
+    // onto this workspace's URL is exactly the bug that produced "Thread not
+    // found". When there's no saved thread, redirect to the bare chat URL and
+    // let ChatPanel start a fresh thread.
+    const resolvedThreadId = readSavedThreadId(activeDomainId)
     const activeWorkspace = domains.find((d) => d.id === activeDomainId)
     const chatBase = `${pathPrefix}${workspacePath(activeWorkspace ?? { id: activeDomainId })}/chat`
     const target = resolvedThreadId ? `${chatBase}/${resolvedThreadId}` : chatBase

--- a/frontend/src/components/ChatPanel/threadStorage.ts
+++ b/frontend/src/components/ChatPanel/threadStorage.ts
@@ -19,3 +19,17 @@ export function writeSavedThreadId(workspaceId: string, threadId: string): void 
     // Storage may be unavailable (private mode, quota). Persistence is best-effort.
   }
 }
+
+/**
+ * Remove the saved thread for a workspace, but only if it still matches
+ * `threadId`. The match guard avoids clobbering a newer saved thread when an
+ * older (stale) thread's load fails.
+ */
+export function clearSavedThreadId(workspaceId: string, threadId?: string): void {
+  try {
+    if (threadId && readSavedThreadId(workspaceId) !== threadId) return
+    localStorage.removeItem(threadStorageKey(workspaceId))
+  } catch {
+    // Storage may be unavailable; clearing is best-effort.
+  }
+}

--- a/frontend/src/store/domainSlice.ts
+++ b/frontend/src/store/domainSlice.ts
@@ -51,7 +51,22 @@ export const createDomainSlice: StateCreator<DomainSlice, [], [], DomainSlice> =
     },
 
     setActiveDomain: (id: string) => {
-      set({ activeDomainId: id })
+      // Switching workspaces must NOT carry the current thread over: the thread
+      // belongs to the previous workspace, and grafting its id onto the new
+      // workspace's URL produces a "Thread not found" chat. Reset to a fresh
+      // client-generated thread id. For deep links (URL → store), the sync hook
+      // calls selectThread(urlThreadId) immediately after, which overwrites this.
+      if (id !== get().activeDomainId) {
+        // `threadId` lives in the UI slice; cast so this cross-slice write
+        // typechecks (the slices share one store, mirroring uiSlice's read of
+        // `activeDomainId`).
+        ;(set as (partial: { activeDomainId: string; threadId: string }) => void)({
+          activeDomainId: id,
+          threadId: crypto.randomUUID(),
+        })
+      } else {
+        set({ activeDomainId: id })
+      }
     },
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/tests/test_chat_thread_ownership.py
+++ b/tests/test_chat_thread_ownership.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+import logging
 
 import pytest
 from django.contrib.auth import get_user_model
@@ -9,7 +10,7 @@ from django.test import AsyncClient
 
 from apps.chat.models import Thread
 from apps.chat.views import _upsert_thread
-from apps.users.models import Tenant
+from apps.users.models import Tenant, TenantMembership
 from apps.workspaces.models import (
     Workspace,
     WorkspaceMembership,
@@ -147,3 +148,114 @@ async def test_upsert_thread_bumps_updated_at_on_subsequent_turn():
         f"updated_at should bump on second turn; "
         f"initial={initial_updated_at!r} refreshed={refreshed.updated_at!r}"
     )
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_chat_rejection_logs_warning(caplog):
+    """The ownership-rejection path must emit a warning (ids only) so the stale
+    cross-workspace thread can be traced from logs."""
+    owner = await User.objects.acreate_user(email="owner-log@b.c", password="x")
+    attacker = await User.objects.acreate_user(email="attacker-log@b.c", password="x")
+    ws = await Workspace.objects.acreate(name="W-log", created_by=owner)
+    tenant = await Tenant.objects.acreate(
+        external_id="t-log", provider="commcare", canonical_name="Log Tenant"
+    )
+    await WorkspaceTenant.objects.acreate(workspace=ws, tenant=tenant)
+    await WorkspaceMembership.objects.acreate(
+        workspace=ws, user=owner, role=WorkspaceRole.READ_WRITE
+    )
+    await WorkspaceMembership.objects.acreate(
+        workspace=ws, user=attacker, role=WorkspaceRole.READ_WRITE
+    )
+    # The attacker needs a TenantMembership to pass the single-tenant access gate
+    # and actually reach the thread-ownership check (the bug under test).
+    await TenantMembership.objects.acreate(user=attacker, tenant=tenant)
+    owners_thread = await Thread.objects.acreate(workspace=ws, user=owner)
+
+    client = AsyncClient(enforce_csrf_checks=True)
+    await client.alogin(email="attacker-log@b.c", password="x")
+    csrf_resp = await client.get("/api/auth/csrf/")
+    csrf_token = csrf_resp.json()["csrfToken"]
+    with caplog.at_level(logging.WARNING, logger="apps.chat.views"):
+        resp = await client.post(
+            "/api/chat/",
+            data=json.dumps(
+                {
+                    "messages": [{"role": "user", "content": "inject"}],
+                    "workspaceId": str(ws.id),
+                    "threadId": str(owners_thread.id),
+                }
+            ),
+            content_type="application/json",
+            headers={"X-CSRFToken": csrf_token},
+        )
+
+    assert resp.status_code == 404
+    rejection_logs = [
+        r for r in caplog.records if "Rejected chat POST to foreign thread" in r.getMessage()
+    ]
+    assert rejection_logs, "expected a warning on the ownership-rejection path"
+    msg = rejection_logs[0].getMessage()
+    # Ids of every relevant entity must appear; no PII / object reprs.
+    assert str(owners_thread.id) in msg
+    assert f"requesting_user={attacker.pk}" in msg
+    assert f"owner_user={owner.pk}" in msg
+    assert f"thread_workspace={ws.pk}" in msg
+    assert f"requested_workspace={ws.pk}" in msg
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_messages_view_404_for_foreign_owned_thread():
+    """A thread row that exists but belongs to another user must 404 from the
+    messages endpoint — not silently return [] and look like a healthy chat."""
+    owner = await User.objects.acreate_user(email="owner-msg@b.c", password="x")
+    other = await User.objects.acreate_user(email="other-msg@b.c", password="x")
+    ws = await Workspace.objects.acreate(name="W-msg", created_by=owner)
+    tenant = await Tenant.objects.acreate(
+        external_id="t-msg", provider="commcare", canonical_name="Msg Tenant"
+    )
+    await WorkspaceTenant.objects.acreate(workspace=ws, tenant=tenant)
+    await WorkspaceMembership.objects.acreate(
+        workspace=ws, user=owner, role=WorkspaceRole.READ_WRITE
+    )
+    # `other` is a member of the workspace but does NOT own the thread.
+    await WorkspaceMembership.objects.acreate(
+        workspace=ws, user=other, role=WorkspaceRole.READ_WRITE
+    )
+    owners_thread = await Thread.objects.acreate(workspace=ws, user=owner)
+
+    client = AsyncClient()
+    await client.alogin(email="other-msg@b.c", password="x")
+    resp = await client.get(f"/api/workspaces/{ws.id}/threads/{owners_thread.id}/messages/")
+
+    assert resp.status_code == 404
+    assert resp.json() == {"error": "Thread not found"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_messages_view_empty_for_nonexistent_thread():
+    """A thread_id with no Thread row (a fresh client-generated UUID) must keep
+    returning [] 200 so brand-new chats aren't broken."""
+    user = await User.objects.acreate_user(email="new-msg@b.c", password="x")
+    ws = await Workspace.objects.acreate(name="W-new", created_by=user)
+    tenant = await Tenant.objects.acreate(
+        external_id="t-new", provider="commcare", canonical_name="New Tenant"
+    )
+    await WorkspaceTenant.objects.acreate(workspace=ws, tenant=tenant)
+    await WorkspaceMembership.objects.acreate(
+        workspace=ws, user=user, role=WorkspaceRole.READ_WRITE
+    )
+
+    # A random UUID that has no Thread row yet.
+    fresh_thread_id = "22222222-2222-2222-2222-222222222222"
+    assert not await Thread.objects.filter(id=fresh_thread_id).aexists()
+
+    client = AsyncClient()
+    await client.alogin(email="new-msg@b.c", password="x")
+    resp = await client.get(f"/api/workspaces/{ws.id}/threads/{fresh_thread_id}/messages/")
+
+    assert resp.status_code == 200
+    assert resp.json() == []


### PR DESCRIPTION
## Problem (prod incident 2026-06-10, user mtheis)

A user's chat POSTs failed three times with raw `{"error": "Thread not found"}` rendered in the chat. Verified chain:

1. The store keeps `threadId` across workspace switches, so the URL sync grafts the old workspace's thread onto the new workspace's URL.
2. `ChatPanel` persisted `(workspace, thread)` to localStorage on every change — stamping the foreign thread into the **new** workspace's key; `ChatRedirect` resurrects it on every bare `/chat` visit, including after fresh logins. One stale thread followed the user through three workspaces.
3. `thread_messages_view` returned `[]` 200 for an existing-but-foreign thread, so the broken state looked like a healthy empty chat until the user typed.
4. The chat POST 404 logged nothing server-side and the frontend rendered the raw JSON body with no recovery path.

## Fix

Backend:
- Chat POST ownership rejection now logs a warning with the relevant ids.
- `thread_messages_view` distinguishes a nonexistent thread (still `[]` 200 — new chats use client-generated UUIDs with no row until first POST) from an existing-but-foreign thread (now 404), so the client can detect staleness before the user types.

Frontend:
- `setActiveDomain` resets `threadId` to a fresh UUID when the workspace actually changes (deep links unaffected: direction-1 calls `selectThread` immediately after).
- `ChatRedirect` no longer falls back to the store's cross-workspace `threadId`.
- The localStorage write happens only after a successful messages GET for that (workspace, thread); a 404 clears the saved id (match-guarded) and recovers into a fresh chat.
- Raw error bodies are never rendered: stale-thread errors show "This conversation is no longer available." with a Start-new-chat button (`data-testid="chat-error-new-thread"`); other errors get a generic message with the detail in the console.

## Tests / verification

Async backend tests (foreign-thread 404, nonexistent-thread `[]`, rejection log via caplog); `bun run lint` and `bun run build` (tsc) clean.

`uv run pytest` full suite green (1184 passed) on the integration branch combining the six incident-fix PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)