### PR TITLE
fix(workspaces): janitor job-status lookup via ORM instead of unresolved FutureApp

### DIFF
--- a/apps/workspaces/tasks.py
+++ b/apps/workspaces/tasks.py
@@ -11,7 +11,7 @@ from django.conf import settings
 from django.db import close_old_connections
 from django.utils import timezone
 from langchain_core.messages import AIMessage, HumanMessage
-from procrastinate.contrib.django.procrastinate_app import current_app
+from procrastinate.contrib.django.models import ProcrastinateJob
 
 from apps.agents.graph.base import build_agent_graph
 from apps.agents.mcp_client import get_mcp_tools, get_user_oauth_tokens
@@ -571,13 +571,29 @@ STALE_JOB_THRESHOLD = timedelta(minutes=10)
 async def _procrastinate_job_status(job_id: int) -> str | None:
     """Return the raw procrastinate job status string, or None when unknown.
 
+    Reads the status directly from the ``procrastinate_jobs`` table via the
+    Django contrib ORM model rather than ``current_app.job_manager``. The
+    module-level ``current_app`` reference resolves to procrastinate's
+    ``FutureApp`` blueprint proxy at import time; ``AppConfig.ready()`` rebinds
+    the name in procrastinate's own module to the real ``App``, but our
+    already-imported reference keeps pointing at the unresolved ``FutureApp``,
+    which has no ``job_manager`` (it is a ``Blueprint``). In the worker that
+    raised ``AttributeError`` on every call, so the janitor treated every
+    lookup as "couldn't tell" and never reconciled. The ORM model sidesteps the
+    app lifecycle entirely and is async-native.
+
     Returning a sentinel on exception would conflate "not active" with
     "couldn't tell" — the janitor would then misclassify actively-running jobs
     as candidates for cleanup during a transient DB blip. Callers must treat
-    ``None`` as "don't touch this row this tick".
+    ``None`` as "don't touch this row this tick" (also returned for an unknown
+    job id, where there is nothing to reconcile against).
     """
     try:
-        status = await current_app.job_manager.get_job_status_async(job_id)
+        return (
+            await ProcrastinateJob.objects.filter(id=job_id)
+            .values_list("status", flat=True)
+            .afirst()
+        )
     except Exception:
         logger.warning(
             "Could not fetch procrastinate status for job %s; skipping reconcile this tick",
@@ -585,7 +601,6 @@ async def _procrastinate_job_status(job_id: int) -> str | None:
             exc_info=True,
         )
         return None
-    return status.value
 
 
 async def reconcile_stale_thread_job(tj: ThreadJob) -> str | None:

--- a/tests/test_threadjob_janitor.py
+++ b/tests/test_threadjob_janitor.py
@@ -2,7 +2,9 @@ from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from asgiref.sync import sync_to_async
 from django.contrib.auth import get_user_model
+from django.db import connection
 from django.utils import timezone
 from langchain_core.messages import AIMessage
 
@@ -11,10 +13,48 @@ from apps.workspaces.models import Workspace
 from apps.workspaces.tasks import (
     RESUME_STUCK_RUNNING_MESSAGE,
     STALE_JOB_THRESHOLD,
+    _procrastinate_job_status,
     expire_stale_thread_jobs,
 )
 
 User = get_user_model()
+
+
+@pytest.fixture
+def procrastinate_job():
+    """Factory that inserts real rows into the unmanaged procrastinate_jobs
+    table and cleans them up on teardown.
+
+    The Django contrib ProcrastinateJob model is read-only (managed=False), so
+    rows are inserted via raw SQL (status/queue_name/task_name are the only
+    NOT NULL columns without a default; status is what the janitor reads).
+
+    Explicit cleanup is required: with django_db(transaction=True), Django's
+    teardown TRUNCATEs tables with data, and the procrastinate_jobs FK graph
+    breaks the non-CASCADE truncate ordering — leaving stray rows there
+    poisons the connection for subsequent tests. We delete what we inserted.
+    """
+    created: list[int] = []
+
+    def _make(status: str) -> int:
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "INSERT INTO procrastinate_jobs (queue_name, task_name, status) "
+                "VALUES (%s, %s, %s::procrastinate_job_status) RETURNING id",
+                ["default", "test_task", status],
+            )
+            job_id = cursor.fetchone()[0]
+        created.append(job_id)
+        return job_id
+
+    yield _make
+
+    if created:
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "DELETE FROM procrastinate_jobs WHERE id = ANY(%s)",
+                [created],
+            )
 
 
 @pytest.mark.asyncio
@@ -302,6 +342,71 @@ async def test_janitor_flips_pending_failed_job_directly_without_resume():
 
     resume.defer_async.assert_not_called()
     persist.assert_awaited_once()
+    assert result["flipped"] == 1
+    await tj.arefresh_from_db()
+    assert tj.state == ThreadJob.State.FAILED
+    assert tj.completed_at is not None
+    assert tj.error_summary
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_procrastinate_job_status_reads_status_from_orm_row(procrastinate_job):
+    """_procrastinate_job_status reads the raw status string from the
+    procrastinate_jobs table via the Django contrib ORM model — not via the
+    unresolved FutureApp proxy, which raised AttributeError on every call in
+    the worker and silently disabled the janitor."""
+    failed_id = await sync_to_async(procrastinate_job)("failed")
+    assert await _procrastinate_job_status(failed_id) == "failed"
+
+    doing_id = await sync_to_async(procrastinate_job)("doing")
+    assert await _procrastinate_job_status(doing_id) == "doing"
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_procrastinate_job_status_returns_none_for_missing_job():
+    """A job id with no matching procrastinate_jobs row returns None (the
+    "unknown — don't touch this row" sentinel), not an exception."""
+    assert await _procrastinate_job_status(999_999_999) is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_janitor_reconciles_stale_job_against_real_failed_procrastinate_row(
+    procrastinate_job,
+):
+    """End-to-end: a stale PENDING ThreadJob backed by a real procrastinate
+    job in 'failed' state is flipped to FAILED by the janitor using the
+    ORM-based status lookup (no mock of _procrastinate_job_status). This is the
+    exact scenario the FutureApp bug was suppressing for the zombie ThreadJobs."""
+    job_id = await sync_to_async(procrastinate_job)("failed")
+    user = await User.objects.acreate_user(email="zombie@b.c", password="x")
+    ws = await Workspace.objects.acreate(name="W-zombie", created_by=user)
+    thread = await Thread.objects.acreate(workspace=ws, user=user)
+    tj = await ThreadJob.objects.acreate(
+        thread=thread,
+        job_type="materialization",
+        procrastinate_job_id=job_id,
+        tool_call_id="tc-zombie",
+        state=ThreadJob.State.PENDING,
+    )
+    await ThreadJob.objects.filter(id=tj.id).aupdate(
+        created_at=timezone.now() - timedelta(hours=2),
+    )
+
+    with (
+        patch("apps.workspaces.tasks.resume_thread_after_materialization") as resume,
+        patch(
+            "apps.workspaces.tasks._persist_synthetic_failure_message",
+            new=AsyncMock(return_value=None),
+        ),
+    ):
+        resume.defer_async = AsyncMock(return_value=None)
+        result = await expire_stale_thread_jobs()
+
+    # Failed procrastinate job -> ThreadJob flipped straight to FAILED, no resume.
+    resume.defer_async.assert_not_called()
     assert result["flipped"] == 1
     await tj.arefresh_from_db()
     assert tj.state == ThreadJob.State.FAILED


### PR DESCRIPTION
## Problem (ongoing in prod)

`_procrastinate_job_status` used a module-level `from procrastinate.contrib.django.procrastinate_app import current_app` and called `current_app.job_manager…`. That import captures procrastinate's `FutureApp` blueprint proxy; `AppConfig.ready()` later rebinds the name **in procrastinate's module**, but our already-imported reference keeps pointing at the unresolved `FutureApp` (a `Blueprint`, no `job_manager`). In the prod worker this raises `AttributeError` on **every** call, so `reconcile_stale_thread_job` treats every lookup as "couldn't tell" and skips — the janitor and the API-side staleness backstop have been dead. Five zombie ThreadJobs (pending since 06-09, procrastinate jobs long `failed`) spam this warning every 15 minutes; their users' threads are stuck.

## Fix

Read the status via the Django contrib ORM model (`procrastinate.contrib.django.models.ProcrastinateJob`, procrastinate 3.8.1) — async-native and immune to app lifecycle:

```python
await ProcrastinateJob.objects.filter(id=job_id).values_list("status", flat=True).afirst()
```

Contract unchanged (raw status string or `None`; never raises). `reconcile_stale_thread_job` already handles `failed`/`aborted` → flips the ThreadJob to FAILED with a user-facing summary and a synthetic chat message, so the existing zombies self-heal on the first janitor tick after deploy.

Note: `jobs_cancel.py` / `materialization_views.py` use the same `current_app` pattern in the API process — flagged as a possible follow-up, intentionally out of scope here.

## Tests

ORM status lookup against real `procrastinate_jobs` rows (incl. missing id → None); end-to-end janitor reconcile of a stale ThreadJob backed by a real `failed` row (no mocking of the lookup).

`uv run pytest` full suite green (1184 passed) on the integration branch combining the six incident-fix PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)