### PR TITLE
fix(workspaces): refresh loads data into the new schema, not the old one

### DIFF
--- a/apps/workspaces/tasks.py
+++ b/apps/workspaces/tasks.py
@@ -170,7 +170,13 @@ async def refresh_tenant_schema(schema_id: str, membership_id: str) -> dict:
             await _drop_schema_and_fail(new_schema)
             return {"error": f"No pipeline configured for provider '{membership.tenant.provider}'"}
         pipeline_config = registry.get(pipeline_name)
-        await asyncio.to_thread(run_pipeline, membership, credential, pipeline_config)
+        # Load into the new "_r" schema this task created — NOT the tenant's
+        # base schema. Without target_schema, run_pipeline re-resolves the base
+        # (old active) schema via provision() and the data lands there; we then
+        # activate this empty new schema and tear down the data-bearing old one.
+        await asyncio.to_thread(
+            run_pipeline, membership, credential, pipeline_config, target_schema=new_schema
+        )
     except Exception:
         logger.exception("Materialization failed for schema '%s'", new_schema.schema_name)
         await _drop_schema_and_fail(new_schema)

--- a/mcp_server/services/materializer.py
+++ b/mcp_server/services/materializer.py
@@ -52,7 +52,7 @@ from psycopg import sql as psql
 from apps.transformations.models import TransformationAsset
 from apps.transformations.services.commcare_staging import upsert_system_assets
 from apps.transformations.services.executor import run_transformation_pipeline
-from apps.workspaces.models import MaterializationRun, TenantMetadata
+from apps.workspaces.models import MaterializationRun, TenantMetadata, TenantSchema
 from apps.workspaces.services.schema_manager import SchemaManager, get_managed_db_connection
 from mcp_server.loaders.commcare_cases import CommCareCaseLoader
 from mcp_server.loaders.commcare_forms import CommCareFormLoader
@@ -99,6 +99,7 @@ def run_pipeline(
     pipeline: PipelineConfig,
     progress_updater: ProgressUpdater | None = None,
     procrastinate_job_id: int | None = None,
+    target_schema: TenantSchema | None = None,
 ) -> dict:
     """Run a three-phase materialization pipeline.
 
@@ -118,6 +119,10 @@ def run_pipeline(
             triggering a transaction rollback.
         procrastinate_job_id: When set, written to ``MaterializationRun`` so
             the cancel endpoint can target the underlying procrastinate job.
+        target_schema: When set, the explicit ``TenantSchema`` to load into
+            (used by the blue-green refresh path to load into its new "_r"
+            schema). When ``None``, the tenant's base schema is resolved via
+            ``SchemaManager().provision()`` (the initial-materialization path).
 
     Returns a summary dict with run_id, status, and per-source row counts.
     """
@@ -178,9 +183,20 @@ def run_pipeline(
         return _on_page
 
     # ── 1. PROVISION ──────────────────────────────────────────────────────────
-    # Create the schema and run row up-front so progress_updater always has a
-    # valid run_id to target. Progress reporting starts immediately after.
-    tenant_schema = SchemaManager().provision(tenant_membership.tenant)
+    # Resolve the target schema and create the run row up-front so
+    # progress_updater always has a valid run_id to target.
+    #
+    # A blue-green refresh passes an explicit ``target_schema``: the freshly
+    # minted, not-yet-active "_r" schema it wants this run to load into. We must
+    # honor it. Falling back to ``provision()`` here would re-resolve the
+    # tenant's OLD active *base* schema and load there; the refresh task would
+    # then activate the empty new schema and tear down the data-bearing old one,
+    # destroying the data the refresh just loaded. When no target is given
+    # (initial materialization), ``provision()`` get-or-creates the base schema.
+    if target_schema is not None:
+        tenant_schema = target_schema
+    else:
+        tenant_schema = SchemaManager().provision(tenant_membership.tenant)
     schema_name = tenant_schema.schema_name
 
     run = MaterializationRun.objects.create(
@@ -288,9 +304,7 @@ def run_pipeline(
             # The discovered visit_count counts *all* visits, so it's only a
             # valid denominator on a fresh load. On resume, rows_loaded counts
             # just this run's new rows, so leave the bar indeterminate.
-            source_total = (
-                visit_total if source.name == "visits" and start_cursor is None else None
-            )
+            source_total = visit_total if source.name == "visits" and start_cursor is None else None
             try:
                 rows = _load_and_commit_source(
                     source.name,

--- a/tests/test_refresh_task.py
+++ b/tests/test_refresh_task.py
@@ -7,6 +7,8 @@ import pytest
 from apps.users.adapters import encrypt_credential
 from apps.users.models import TenantConnection
 from apps.workspaces.models import SchemaState, TenantSchema
+from apps.workspaces.services.schema_manager import SchemaManager
+from apps.workspaces.tasks import refresh_tenant_schema
 
 
 @pytest.fixture
@@ -255,10 +257,66 @@ async def test_refresh_task_resolves_credential_in_async_context(
 @pytest.mark.asyncio
 @pytest.mark.django_db(transaction=True)
 async def test_refresh_task_returns_error_for_unknown_schema(tenant_membership_obj):
-    from apps.workspaces.tasks import refresh_tenant_schema
-
     result = await refresh_tenant_schema(
         schema_id="00000000-0000-0000-0000-000000000000",
         membership_id=str(tenant_membership_obj.id),
     )
     assert "error" in result
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_refresh_loads_into_new_schema_not_old_active(
+    provisioning_schema, old_active_schema, tenant_membership_obj
+):
+    """Regression: refresh must load the fresh data INTO the new "_r" schema.
+
+    The refresh task mints a new ``_r``-suffixed schema and then runs the
+    materialization pipeline. Before the fix, the task called ``run_pipeline``
+    without naming a target, so ``run_pipeline`` re-resolved the schema via
+    ``SchemaManager().provision()`` — which returns the tenant's OLD active
+    *base* schema. The data loaded into the old schema; the task then activated
+    the empty new schema and tore down the data-bearing old one, destroying the
+    data the refresh had just loaded (and leaving an empty, "successful" schema).
+
+    This test faithfully reproduces the bug by mirroring ``run_pipeline``'s own
+    target resolution (an explicit ``target_schema`` wins; otherwise
+    ``provision()`` picks the base schema) and asserts the pipeline loads into
+    the new ``_r`` schema, not the old active one.
+    """
+    loaded_schema_ids: list[str] = []
+
+    def fake_run_pipeline(tenant_membership, credential, pipeline, target_schema=None, **kwargs):
+        schema = target_schema or SchemaManager().provision(tenant_membership.tenant)
+        loaded_schema_ids.append(str(schema.id))
+        return {"status": "ok"}
+
+    deferrer = MagicMock()
+    deferrer.defer_async = AsyncMock(return_value=1)
+
+    with (
+        patch(
+            "apps.workspaces.services.schema_manager.get_managed_db_connection",
+            return_value=_mock_conn(),
+        ),
+        patch(
+            "apps.workspaces.tasks.aresolve_credential",
+            new=AsyncMock(return_value={"type": "api_key", "value": "tok"}),
+        ),
+        patch(
+            "apps.workspaces.tasks.get_registry",
+            return_value=_mock_registry(),
+        ),
+        patch("apps.workspaces.tasks.run_pipeline", side_effect=fake_run_pipeline),
+        patch("apps.workspaces.tasks.teardown_schema.configure", return_value=deferrer),
+    ):
+        await refresh_tenant_schema(
+            schema_id=str(provisioning_schema.id),
+            membership_id=str(tenant_membership_obj.id),
+        )
+
+    assert loaded_schema_ids == [str(provisioning_schema.id)], (
+        "Refresh loaded data into the wrong schema: expected the new schema "
+        f"{provisioning_schema.schema_name!r}, but the pipeline targeted the old "
+        "active base schema (the refresh-data-loss bug)."
+    )


### PR DESCRIPTION
## The bug (critical — data loss on every refresh)

The legacy `POST /api/workspaces/<id>/refresh/` path is a **blue-green refresh**: `refresh_tenant_schema` mints a new `_r`-suffixed `TenantSchema`, materializes into it, marks it `ACTIVE`, then tears down the previously-active schema (+30 min delayed `DROP SCHEMA CASCADE`).

But `run_pipeline` **ignored the new schema** and re-resolved its target via `SchemaManager().provision()`, which returns the tenant's **base (old active)** schema by sanitized `external_id`. Net effect of every refresh:

1. Fresh data loads into the **old** active schema (and the `MaterializationRun` is created there).
2. The task marks the **empty** `_r` schema `ACTIVE` — it becomes the only routable schema, so the tenant's data goes **invisible immediately**.
3. 30 minutes later the data-bearing old schema is **physically dropped** — destroying the data the refresh just loaded.
4. `RefreshStatusView` reports success; the catalog is empty (zero `MaterializationRun` rows on the new schema).

This is the `refresh-data-loss` finding from the 2026-06-12 architecture review — **BROKEN-NOW / data-loss, CONFIRMED, replicated by 14 reviewers** — and is reachable today from the Data Dictionary "refresh" button.

## The fix

Give `run_pipeline` an explicit `target_schema: TenantSchema | None = None` parameter. The refresh task passes its new `_r` schema, so the data lands in the schema that will be activated. The schema stays `PROVISIONING` during the load (invisible to routing), so the old schema keeps serving queries until the atomic swap — preserving the intended zero-downtime behavior.

- `materialize_workspace` (initial materialization) and the legacy `materialize_tenant` wrapper pass **no** target and keep the existing `provision()` get-or-create-base behavior. **No behavior change** on those paths.

## Tests

- New regression test `test_refresh_loads_into_new_schema_not_old_active` mirrors `run_pipeline`'s own target resolution and asserts refresh loads into the new `_r` schema. It **fails on `main`** (data targets the old base schema) and passes with the fix.
- The pre-existing refresh tests mocked `run_pipeline` entirely, so they never observed which schema received the data — that blind spot is why the bug shipped.

Verified locally:
- `tests/test_refresh_task.py` — 8 passed
- `tests/test_materializer.py` + `tests/test_materialize_workspace_task.py` — 52 passed
- `ruff check` / `ruff format --check` — clean

## Scope / known adjacent gap (not in this PR)

This PR fixes the **data-loss root cause** only. Unlike `materialize_workspace`, `refresh_tenant_schema` does **not** rebuild dependent multi-tenant `WorkspaceViewSchema` (UNION-ALL) views after the swap, so refreshing a tenant in a multi-tenant workspace can leave those views stale/FAILED until the next materialization. That is a separate finding from the same review and is intentionally left out to keep this fix small and reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)