### PR TITLE
Fix recipe runs crashing with SynchronousOnlyOperation

### DIFF
--- a/apps/recipes/services/runner.py
+++ b/apps/recipes/services/runner.py
@@ -102,9 +102,13 @@ class RecipeRunner:
             return self._provided_graph
 
         if self._graph is None:
+            # Reference the FK by its already-loaded column (workspace_id) rather
+            # than self.recipe.workspace: this coroutine runs inside async_to_sync,
+            # and a lazy FK load would issue a sync DB query, raising
+            # SynchronousOnlyOperation in the async context.
             workspace_tenant = (
                 await WorkspaceTenant.objects.select_related("tenant")
-                .filter(workspace=self.recipe.workspace)
+                .filter(workspace_id=self.recipe.workspace_id)
                 .afirst()
             )
             tenant = workspace_tenant.tenant if workspace_tenant else None
@@ -291,11 +295,12 @@ class RecipeRunner:
         }
 
         try:
-            workspace = self.recipe.workspace
-            # Fetch tenant info asynchronously to avoid sync query in async context
+            # Fetch tenant info asynchronously to avoid sync query in async context.
+            # Filter by workspace_id (already loaded) rather than self.recipe.workspace,
+            # which would trigger a sync lazy FK load and raise SynchronousOnlyOperation.
             wt = (
                 await WorkspaceTenant.objects.select_related("tenant")
-                .filter(workspace=workspace)
+                .filter(workspace_id=self.recipe.workspace_id)
                 .afirst()
             )
             _tenant = wt.tenant if wt else None

--- a/tests/test_recipe_runner.py
+++ b/tests/test_recipe_runner.py
@@ -1,6 +1,12 @@
 """Tests for recipe runner module."""
 
+from unittest.mock import AsyncMock, Mock, patch
+
 import pytest
+from asgiref.sync import async_to_sync
+
+from apps.recipes.models import Recipe
+from apps.recipes.services.runner import RecipeRunner
 
 
 class TestRecipeRunner:
@@ -25,3 +31,36 @@ class TestRecipeRunner:
     def test_recipe_error_recovery(self):
         """Test error recovery during recipe execution."""
         pass
+
+
+@pytest.mark.django_db
+def test_build_graph_does_not_trigger_sync_fk_load_in_async_context(user, workspace):
+    """Regression test for SCOUT-DJANGO-1P.
+
+    ``_build_graph`` is run via ``async_to_sync`` from the sync ``execute()``
+    path, so it executes inside an async event loop. The API view loads the
+    recipe with ``Recipe.objects.get(pk=..., workspace=...)``, which does NOT
+    cache the forward ``workspace`` FK. Accessing ``self.recipe.workspace``
+    therefore triggers a synchronous lazy DB load, which Django rejects with
+    ``SynchronousOnlyOperation`` inside an async context. The runner must
+    reference the FK by its already-loaded ``workspace_id`` column instead.
+    """
+    Recipe.objects.create(
+        workspace=workspace,
+        name="Async FK Recipe",
+        prompt="hello",
+        created_by=user,
+    )
+    # Re-fetch so the workspace FK is NOT cached (mirrors RecipeRunView.post).
+    fresh = Recipe.objects.get(name="Async FK Recipe")
+
+    runner = RecipeRunner(recipe=fresh, variable_values={}, user=user)
+
+    with patch(
+        "apps.recipes.services.runner.build_agent_graph",
+        new=AsyncMock(return_value=Mock()),
+    ):
+        # Must not raise SynchronousOnlyOperation.
+        graph = async_to_sync(runner._build_graph)()
+
+    assert graph is not None


### PR DESCRIPTION
Fixes #276 (Sentry SCOUT-DJANGO-1P).

## Problem
Running a recipe crashed with `SynchronousOnlyOperation: You cannot call this from an async context`.

`RecipeRunView.post` (a sync DRF view) loads the recipe with `Recipe.objects.get(pk=..., workspace=...)`. Filtering *by* the workspace FK does **not** cache the related object on the instance. `execute()` then runs `_build_graph` via `async_to_sync` — inside an async event loop — where `.filter(workspace=self.recipe.workspace)` evaluated the uncached forward FK (`KeyError: 'workspace'` cache miss), triggering a synchronous lazy DB load. Django forbids sync ORM in an async context, hence the crash.

## Solution
Reference the FK by its already-loaded column attribute `workspace_id` instead of the lazy-loading `workspace` object — equivalent lookup, zero DB I/O, async-safe. Applied to `_build_graph` (the reported crash) and to `execute_async`, which carried the identical latent access.

## Why we can be confident
Added a regression test that re-fetches the recipe (uncached FK, mirroring the view) and drives `_build_graph` through `async_to_sync`. It reproduces the exact `SynchronousOnlyOperation` at `runner.py:107` before the fix and passes after. Full recipe suite (49 passed) and `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)