### PR TITLE
Restore recipes feature (async-first): fix runner signature drift (arch #238)

### DIFF
--- a/apps/recipes/api/views.py
+++ b/apps/recipes/api/views.py
@@ -2,8 +2,12 @@
 API views for recipe management.
 """
 
+import json
 import logging
 
+from asgiref.sync import sync_to_async
+from django.http import JsonResponse
+from django.views.decorators.csrf import csrf_protect
 from rest_framework import status
 from rest_framework.permissions import AllowAny
 from rest_framework.renderers import JSONRenderer
@@ -11,6 +15,10 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from apps.recipes.models import Recipe, RecipeRun
+from apps.recipes.services.runner import RecipeRunner, VariableValidationError
+from apps.users.decorators import async_login_required
+from apps.workspaces.services.workspace_service import touch_workspace_schemas
+from apps.workspaces.workspace_resolver import aresolve_workspace
 from apps.workspaces.workspace_resolver import resolve_workspace_drf as resolve_workspace
 
 from .serializers import (
@@ -81,47 +89,54 @@ class RecipeDetailView(APIView):
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 
-class RecipeRunView(APIView):
+@csrf_protect
+@async_login_required
+async def recipe_run_view(request, workspace_id, recipe_id):
+    """POST /api/workspaces/<workspace_id>/recipes/<recipe_id>/run/
+
+    Execute a recipe with variable values. Raw async Django view (DRF APIView
+    is sync and cannot await the async-first runner).
     """
-    POST /api/recipes/<recipe_id>/run/ - Execute a recipe with variable values.
-    """
+    if request.method != "POST":
+        return JsonResponse({"error": "Method not allowed"}, status=405)
 
-    def post(self, request, workspace_id, recipe_id):
-        workspace, _membership, err = resolve_workspace(request, workspace_id)
-        if err:
-            return err
-        try:
-            recipe = Recipe.objects.get(pk=recipe_id, workspace=workspace)
-        except Recipe.DoesNotExist:
-            return Response({"error": "Recipe not found."}, status=status.HTTP_404_NOT_FOUND)
+    user = request._authenticated_user
 
-        serializer = RunRecipeSerializer(data=request.data)
-        if not serializer.is_valid():
-            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+    workspace, err = await aresolve_workspace(user, workspace_id)
+    if err:
+        return err
 
-        variable_values = serializer.validated_data.get("variable_values", {})
+    try:
+        recipe = await Recipe.objects.select_related("workspace").aget(
+            pk=recipe_id, workspace=workspace
+        )
+    except Recipe.DoesNotExist:
+        return JsonResponse({"error": "Recipe not found."}, status=404)
 
-        try:
-            from apps.recipes.services.runner import RecipeRunner
+    try:
+        body = json.loads(request.body) if request.body else {}
+    except (json.JSONDecodeError, ValueError):
+        return JsonResponse({"error": "Invalid JSON"}, status=400)
 
-            runner = RecipeRunner(recipe=recipe, variable_values=variable_values, user=request.user)
-            run = runner.execute()
-        except Exception as e:
-            logger.exception("Error running recipe %s", recipe_id)
-            return Response({"error": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+    serializer = RunRecipeSerializer(data=body)
+    if not await sync_to_async(serializer.is_valid)():
+        return JsonResponse(serializer.errors, status=400)
+    variable_values = serializer.validated_data.get("variable_values", {})
 
-        # Touch the schema to reset the inactivity TTL on user-initiated recipe runs
-        from apps.workspaces.models import SchemaState, TenantSchema
+    try:
+        runner = RecipeRunner(recipe=recipe, variable_values=variable_values, user=user)
+        run = await runner.execute_async()
+    except VariableValidationError as e:
+        return JsonResponse({"error": str(e), "errors": e.errors}, status=400)
+    except Exception as e:
+        logger.exception("Error running recipe %s", recipe_id)
+        return JsonResponse({"error": str(e)}, status=500)
 
-        tenant = workspace.tenant
-        if tenant:
-            ts = TenantSchema.objects.filter(
-                tenant=tenant, state__in=[SchemaState.ACTIVE, SchemaState.MATERIALIZING]
-            ).first()
-            if ts is not None:
-                ts.touch()
+    # Reset the inactivity TTL on user-initiated recipe runs.
+    await touch_workspace_schemas(workspace)
 
-        return Response(RecipeRunSerializer(run).data, status=status.HTTP_201_CREATED)
+    data = await sync_to_async(lambda: RecipeRunSerializer(run).data)()
+    return JsonResponse(data, status=201)
 
 
 class RecipeRunListView(APIView):

--- a/apps/recipes/api/views.py
+++ b/apps/recipes/api/views.py
@@ -2,8 +2,10 @@
 API views for recipe management.
 """
 
+import hashlib
 import json
 import logging
+import time
 
 from asgiref.sync import sync_to_async
 from django.http import JsonResponse
@@ -129,8 +131,11 @@ async def recipe_run_view(request, workspace_id, recipe_id):
     except VariableValidationError as e:
         return JsonResponse({"error": str(e), "errors": e.errors}, status=400)
     except Exception as e:
-        logger.exception("Error running recipe %s", recipe_id)
-        return JsonResponse({"error": str(e)}, status=500)
+        # Don't leak internal exception detail to the client; log it behind a
+        # short ref and return the ref (mirrors apps/chat/views.py).
+        error_ref = hashlib.sha256(f"{time.time()}{e}".encode()).hexdigest()[:8]
+        logger.exception("Error running recipe %s [ref=%s]", recipe_id, error_ref)
+        return JsonResponse({"error": f"Recipe run failed. Ref: {error_ref}"}, status=500)
 
     # Reset the inactivity TTL on user-initiated recipe runs.
     await touch_workspace_schemas(workspace)

--- a/apps/recipes/services/runner.py
+++ b/apps/recipes/services/runner.py
@@ -9,17 +9,15 @@ from __future__ import annotations
 
 import json
 import logging
-import uuid
 from typing import TYPE_CHECKING, Any
 
-from asgiref.sync import async_to_sync
 from django.utils import timezone
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 
 from apps.agents.graph.base import build_agent_graph
+from apps.agents.mcp_client import get_mcp_tools, get_user_oauth_tokens
 from apps.recipes.models import Recipe, RecipeRun, RecipeRunStatus
-from apps.users.models import TenantMembership
-from apps.workspaces.models import WorkspaceTenant
+from apps.workspaces.models import Workspace
 
 if TYPE_CHECKING:
     from langgraph.graph.state import CompiledStateGraph
@@ -76,7 +74,7 @@ class RecipeRunner:
         self._graph: CompiledStateGraph | None = None
         self._run: RecipeRun | None = None
         self._thread_id: str = ""
-        self._tenant_membership = None
+        self._oauth_tokens: dict = {}
 
     def validate_variables(self) -> None:
         """Validate that all required variables are provided."""
@@ -97,50 +95,26 @@ class RecipeRunner:
                 self.variable_values[var_name] = var_def["default"]
 
     async def _build_graph(self) -> CompiledStateGraph:
-        """Build or return the agent graph for execution."""
+        """Build or return the agent graph for execution (async-first)."""
         if self._provided_graph is not None:
             return self._provided_graph
 
         if self._graph is None:
-            workspace_tenant = (
-                await WorkspaceTenant.objects.select_related("tenant")
-                .filter(workspace=self.recipe.workspace)
-                .afirst()
-            )
-            tenant = workspace_tenant.tenant if workspace_tenant else None
-            self._tenant_membership = await TenantMembership.objects.filter(
-                user=self.user,
-                tenant=tenant,
-            ).afirst()
+            # Load the Workspace by FK id rather than traversing
+            # ``self.recipe.workspace`` lazily, which would raise
+            # SynchronousOnlyOperation under async (root of Sentry #276).
+            workspace = await Workspace.objects.aget(id=self.recipe.workspace_id)
+            mcp_tools = await get_mcp_tools()
+            self._oauth_tokens = await get_user_oauth_tokens(self.user)
             self._graph = await build_agent_graph(
-                tenant_membership=self._tenant_membership,
+                workspace=workspace,
                 user=self.user,
                 checkpointer=None,
+                mcp_tools=mcp_tools,
+                oauth_tokens=self._oauth_tokens,
             )
 
         return self._graph
-
-    def _create_run_record(self) -> RecipeRun:
-        """Create a RecipeRun record to track execution."""
-        self._thread_id = f"recipe-run-{uuid.uuid4()}"
-
-        run = RecipeRun.objects.create(
-            recipe=self.recipe,
-            status=RecipeRunStatus.RUNNING,
-            variable_values=self.variable_values,
-            step_results=[],
-            started_at=timezone.now(),
-            run_by=self.user,
-        )
-
-        logger.info(
-            "Created recipe run %s for recipe %s (thread_id: %s)",
-            run.id,
-            self.recipe.name,
-            self._thread_id,
-        )
-
-        return run
 
     def _extract_tools_used(self, messages: list) -> list[str]:
         """Extract tool names from agent response messages."""
@@ -182,78 +156,6 @@ class RecipeRunner:
 
         return artifact_ids
 
-    def execute(self) -> RecipeRun:
-        """Execute the recipe and return the RecipeRun record."""
-        self.validate_variables()
-
-        self._run = self._create_run_record()
-
-        graph = async_to_sync(self._build_graph)()
-        config = {"configurable": {"thread_id": self._thread_id}}
-
-        # Render the prompt
-        prompt = self.recipe.render_prompt(self.variable_values)
-
-        logger.info("Starting recipe execution: %s", self.recipe.name)
-
-        step_started = timezone.now()
-
-        result = {
-            "step_order": 1,
-            "prompt": prompt,
-            "response": "",
-            "tools_used": [],
-            "artifacts_created": [],
-            "success": False,
-            "error": None,
-            "started_at": step_started.isoformat(),
-            "completed_at": None,
-        }
-
-        try:
-            workspace = self.recipe.workspace
-            initial_state = {
-                "messages": [HumanMessage(content=prompt)],
-                "tenant_id": workspace.external_tenant_id if workspace else "",
-                "tenant_name": workspace.tenant_name if workspace else "",
-                "tenant_membership_id": str(self._tenant_membership.id)
-                if self._tenant_membership
-                else "",
-                "user_id": str(self.user.id),
-                "user_role": "analyst",
-            }
-
-            response = graph.invoke(initial_state, config=config)
-
-            messages = response.get("messages", [])
-            result["response"] = self._extract_response_content(messages)
-            result["tools_used"] = self._extract_tools_used(messages)
-            result["artifacts_created"] = self._extract_artifacts_created(messages)
-            result["success"] = True
-
-        except Exception as e:
-            logger.exception("Error executing recipe %s", self.recipe.name)
-            result["error"] = str(e)
-            result["success"] = False
-
-        result["completed_at"] = timezone.now().isoformat()
-
-        self._run.step_results = [result]
-        self._run.status = (
-            RecipeRunStatus.COMPLETED if result["success"] else RecipeRunStatus.FAILED
-        )
-        self._run.completed_at = timezone.now()
-        self._run.save(update_fields=["step_results", "status", "completed_at"])
-
-        logger.info(
-            "Recipe execution finished: %s (status: %s, duration: %.2fs)",
-            self.recipe.name,
-            self._run.status,
-            self._run.duration_seconds or 0,
-        )
-
-        return self._run
-
     async def execute_async(self) -> RecipeRun:
         """Execute the recipe asynchronously."""
         self.validate_variables()
@@ -270,7 +172,11 @@ class RecipeRunner:
         self._thread_id = f"recipe-run-{self._run.id}"
 
         graph = await self._build_graph()
-        config = {"configurable": {"thread_id": self._thread_id}}
+        config = {
+            "configurable": {"thread_id": self._thread_id},
+            "recursion_limit": 50,
+            "oauth_tokens": self._oauth_tokens,
+        }
 
         prompt = self.recipe.render_prompt(self.variable_values)
 
@@ -291,23 +197,12 @@ class RecipeRunner:
         }
 
         try:
-            workspace = self.recipe.workspace
-            # Fetch tenant info asynchronously to avoid sync query in async context
-            wt = (
-                await WorkspaceTenant.objects.select_related("tenant")
-                .filter(workspace=workspace)
-                .afirst()
-            )
-            _tenant = wt.tenant if wt else None
             initial_state = {
                 "messages": [HumanMessage(content=prompt)],
-                "tenant_id": _tenant.external_id if _tenant else "",
-                "tenant_name": _tenant.canonical_name if _tenant else "",
-                "tenant_membership_id": str(self._tenant_membership.id)
-                if self._tenant_membership
-                else "",
+                "workspace_id": str(self.recipe.workspace_id),
                 "user_id": str(self.user.id),
                 "user_role": "analyst",
+                "thread_id": self._thread_id,
             }
 
             response = await graph.ainvoke(initial_state, config=config)

--- a/apps/recipes/services/runner.py
+++ b/apps/recipes/services/runner.py
@@ -41,13 +41,6 @@ class VariableValidationError(RecipeRunnerError):
         super().__init__(f"Variable validation failed: {', '.join(errors)}")
 
 
-class StepExecutionError(RecipeRunnerError):
-    """Raised when execution fails."""
-
-    def __init__(self, message: str) -> None:
-        super().__init__(f"Execution failed: {message}")
-
-
 class RecipeRunner:
     """
     Executes a recipe by sending its rendered prompt to the agent.
@@ -233,6 +226,5 @@ class RecipeRunner:
 __all__ = [
     "RecipeRunner",
     "RecipeRunnerError",
-    "StepExecutionError",
     "VariableValidationError",
 ]

--- a/apps/recipes/urls.py
+++ b/apps/recipes/urls.py
@@ -11,7 +11,7 @@ from .api.views import (
     RecipeListView,
     RecipeRunDetailView,
     RecipeRunListView,
-    RecipeRunView,
+    recipe_run_view,
 )
 
 app_name = "recipes"
@@ -19,7 +19,7 @@ app_name = "recipes"
 urlpatterns = [
     path("", RecipeListView.as_view(), name="list"),
     path("<uuid:recipe_id>/", RecipeDetailView.as_view(), name="detail"),
-    path("<uuid:recipe_id>/run/", RecipeRunView.as_view(), name="run"),
+    path("<uuid:recipe_id>/run/", recipe_run_view, name="run"),
     path("<uuid:recipe_id>/runs/", RecipeRunListView.as_view(), name="runs"),
     path(
         "<uuid:recipe_id>/runs/<uuid:run_id>/",

--- a/docs/superpowers/plans/2026-06-16-recipes-async-restoration.md
+++ b/docs/superpowers/plans/2026-06-16-recipes-async-restoration.md
@@ -1,0 +1,662 @@
+# Recipe Async-First Restoration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restore the 100%-broken recipes feature (arch #238) with a minimal async-first fix to the runner and run view, plus a real unmocked test that would have caught the break.
+
+**Architecture:** Make `RecipeRunner.execute_async` the single live path: fix the `build_agent_graph(...)` call to the real signature (`workspace=`, load + pass `mcp_tools`/`oauth_tokens`), fix `initial_state` to the real `AgentState` keys, and delete the sync `execute()`/`async_to_sync` path. Convert `RecipeRunView` (DRF `APIView`) to a raw `async def` Django view mirroring `chat_view`.
+
+**Tech Stack:** Django 5 async ORM, LangGraph, `langchain_mcp_adapters`, the in-process MCP SDK transport (`mcp.shared.memory`), pytest-asyncio.
+
+---
+
+## Context the implementer needs (read once)
+
+- **The drifts** (all in `apps/recipes/services/runner.py` + the run view):
+  1. `_build_graph` calls `build_agent_graph(tenant_membership=…, user=…, checkpointer=None)`. Real signature (`apps/agents/graph/base.py:480`): `build_agent_graph(workspace, user=None, checkpointer=None, mcp_tools=None, oauth_tokens=None)`. → `TypeError`.
+  2. `execute_async`'s `initial_state` uses `tenant_id`/`tenant_name`/`tenant_membership_id`. `AgentState` (`apps/agents/graph/state.py:80`) requires `workspace_id`, `user_id`, `user_role`, `thread_id`. Wrong keys → MCP injecting node reads `workspace_id=""` → tools fail with `VALIDATION_ERROR`.
+  3. `mcp_tools` never loaded/passed.
+  4. The view calls sync `execute()` (`async_to_sync` + sync `graph.invoke()`).
+- **The correct pattern** is `apps/chat/views.py:153-197` (load `get_mcp_tools()` + `get_user_oauth_tokens()`, call `build_agent_graph(workspace=…, mcp_tools=…, oauth_tokens=…)`, config `{"configurable": {"thread_id":…}, "recursion_limit": 50, "oauth_tokens":…}`).
+- **Async-first is non-negotiable.** No `async_to_sync`. Do NOT move execution to a background task (#267). Keep `execute_async` (supersedes #266's "delete it"). Do not touch PR #277 / issues #276 / #266.
+- **Fixtures** (`tests/conftest.py`): `user` (test@example.com / testpass123), `workspace` (1 tenant "test-domain", **no** TenantSchema, `user` is MANAGE member), `other_user`. `tests/test_recipes.py` adds `recipe` (built on `workspace`, vars region/limit/start_date; only `start_date` has no default), `recipe_step_1`.
+- **`get_schema_status` contract** (`mcp_server/server.py:652`): empty `workspace_id` → `success=False, error.code="VALIDATION_ERROR"`; a workspace with 1 tenant and no ACTIVE schema → `success=True, data.state="not_provisioned"` with **no managed-DB connection**. This is the signal the contract test keys on.
+- **`RecipeRunStatus`** (`apps/recipes/models.py:281`): `PENDING/RUNNING/COMPLETED/FAILED`.
+- **Real-MCP-wire pattern** (modeled on commit `2320d52`, `tests/test_chat_mcp_contract.py`, not on main): `create_connected_server_and_client_session(scout_mcp)` + `load_mcp_tools(session)`.
+- **Fake-LLM pattern** (from `tests/test_dangling_tool_calls.py:148-154`): `mock_llm.bind_tools.return_value = mock_bound; mock_bound.ainvoke = AsyncMock(side_effect=fake)`, patched via `patch("apps.agents.graph.base.ChatAnthropic", return_value=mock_llm)`.
+
+## File structure
+
+- **Modify** `apps/recipes/services/runner.py` — fix `_build_graph` + `execute_async`; delete `execute()`, `_create_run_record()`, the `async_to_sync` import, and `tenant_membership` plumbing.
+- **Modify** `apps/recipes/api/views.py` — replace `RecipeRunView` (APIView) with `async def recipe_run_view`.
+- **Modify** `apps/recipes/urls.py` — point `run/` at `recipe_run_view`.
+- **Modify** `tests/test_recipe_runner.py` — replace the skeleton with the real unmocked contract test.
+- **Modify** `tests/test_recipes.py` — migrate the 6 mocked `TestRecipeRunner` tests to `execute_async`; add the async view test.
+
+---
+
+## Task 1: Real unmocked graph-build contract test (the guardrail)
+
+This is the test that would have caught #238. It builds the REAL graph through `execute_async` (no mock on `build_agent_graph`), with real MCP tools over the in-process wire and a mocked LLM that drives one `get_schema_status` tool call.
+
+**Files:**
+- Test: `tests/test_recipe_runner.py` (replace entire file)
+
+- [ ] **Step 1: Replace `tests/test_recipe_runner.py` with the contract test**
+
+```python
+"""Real (unmocked) recipe runner <-> graph-build contract test (arch #238).
+
+Exercises the REAL ``build_agent_graph`` through ``RecipeRunner.execute_async`` with
+real MCP tools loaded over the in-process MCP SDK transport. Only the LLM and the
+managed-data boundary are avoided: the build signature, the AgentState contract, and
+the workspace_id injection path all run for real. Every other recipe test mocks
+``build_agent_graph``, which is exactly why the March break (e26cd75) hid for months.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from langchain_core.messages import AIMessage, ToolMessage
+from langchain_mcp_adapters.tools import load_mcp_tools
+from mcp.shared.memory import create_connected_server_and_client_session
+
+from apps.recipes.models import RecipeRunStatus
+from apps.recipes.services.runner import RecipeRunner
+from mcp_server.server import mcp as scout_mcp
+
+
+def _fake_llm_driving_get_schema_status():
+    """A fake ChatAnthropic whose bound model:
+
+    1. first emits a get_schema_status tool call (workspace_id omitted, as the LLM
+       would — the param is hidden from its schema and injected from state);
+    2. then, once it sees the ToolMessage, echoes the tool envelope as its final
+       answer so the runner captures it as the response.
+    """
+
+    async def fake_ainvoke(messages, *args, **kwargs):
+        tool_msgs = [m for m in messages if isinstance(m, ToolMessage)]
+        if tool_msgs:
+            return AIMessage(content=str(tool_msgs[-1].content), id="ai-final")
+        return AIMessage(
+            content="",
+            tool_calls=[{"name": "get_schema_status", "args": {}, "id": "call_1"}],
+            id="ai-1",
+        )
+
+    mock_bound = MagicMock()
+    mock_bound.ainvoke = AsyncMock(side_effect=fake_ainvoke)
+    mock_llm = MagicMock()
+    mock_llm.bind_tools.return_value = mock_bound
+    return mock_llm
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_execute_async_builds_real_graph_and_flows_workspace_id(recipe, user):
+    """RecipeRunner.execute_async builds the REAL agent graph and runs a real MCP
+    tool call end-to-end.
+
+    Catches every #238 drift at once:
+    - build_agent_graph is called with the real signature (drift #1) — a TypeError
+      here means the runner regressed;
+    - mcp_tools are loaded and attached, so get_schema_status exists (drift #3);
+    - workspace_id flows from initial_state through the real injecting node into the
+      real MCP server (drift #2) — proven by a not_provisioned success envelope rather
+      than a VALIDATION_ERROR (which is what an empty workspace_id returns).
+    """
+    values = {"region": "North", "limit": 10, "start_date": "2024-01-01"}
+
+    async with create_connected_server_and_client_session(scout_mcp) as session:
+        tools = await load_mcp_tools(session)
+        with (
+            patch(
+                "apps.recipes.services.runner.get_mcp_tools",
+                new=AsyncMock(return_value=tools),
+            ),
+            patch(
+                "apps.agents.graph.base.ChatAnthropic",
+                return_value=_fake_llm_driving_get_schema_status(),
+            ),
+        ):
+            run = await RecipeRunner(recipe=recipe, variable_values=values, user=user).execute_async()
+
+    assert run.status == RecipeRunStatus.COMPLETED, run.step_results
+    step = run.step_results[0]
+    assert step["success"] is True
+    assert "get_schema_status" in step["tools_used"]
+    # Positive proof workspace_id reached the server: a real not_provisioned envelope,
+    # never the VALIDATION_ERROR that an empty workspace_id would have produced.
+    assert "not_provisioned" in step["response"]
+    assert "VALIDATION_ERROR" not in step["response"]
+```
+
+- [ ] **Step 2: Run it to verify it FAILS against the current (broken) runner**
+
+Run: `uv run pytest tests/test_recipe_runner.py -v`
+Expected: FAIL. The current `_build_graph` calls `build_agent_graph(tenant_membership=…)` → the run is caught inside `execute_async` and recorded as `FAILED` with a `TypeError` in `step_results[0]["error"]`, so `assert run.status == RecipeRunStatus.COMPLETED` fails (the assert message prints the TypeError).
+
+- [ ] **Step 3: Commit the failing test**
+
+```bash
+git add tests/test_recipe_runner.py
+git commit -m "test: real unmocked recipe graph-build contract (arch #238)
+
+Builds the real agent graph through execute_async with real MCP tools and
+a mocked LLM driving a get_schema_status call. Fails on the current runner
+(build_agent_graph signature drift). Will pass once the runner is fixed.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Fix the runner's async path (`execute_async` + `_build_graph`)
+
+Make the contract test pass. Do NOT delete `execute()` yet (Task 3) so the existing mocked tests stay green between commits.
+
+**Files:**
+- Modify: `apps/recipes/services/runner.py`
+
+- [ ] **Step 1: Fix the imports**
+
+Replace the import block (lines ~15-22) so it reads:
+
+```python
+from django.utils import timezone
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+
+from apps.agents.graph.base import build_agent_graph
+from apps.agents.mcp_client import get_mcp_tools, get_user_oauth_tokens
+from apps.recipes.models import Recipe, RecipeRun, RecipeRunStatus
+from apps.workspaces.models import Workspace
+```
+
+(Removes `from asgiref.sync import async_to_sync`, `from apps.users.models import TenantMembership`, and `from apps.workspaces.models import WorkspaceTenant`. Keeps `json`, `logging`, `uuid`, `TYPE_CHECKING`/`Any`, and the `TYPE_CHECKING` `User`/`CompiledStateGraph` block.)
+
+- [ ] **Step 2: Initialize `_oauth_tokens` and drop `_tenant_membership` in `__init__`**
+
+In `__init__`, replace `self._tenant_membership = None` with:
+
+```python
+        self._oauth_tokens: dict = {}
+```
+
+- [ ] **Step 3: Rewrite `_build_graph`**
+
+Replace the whole `_build_graph` method body with:
+
+```python
+    async def _build_graph(self) -> CompiledStateGraph:
+        """Build or return the agent graph for execution (async-first)."""
+        if self._provided_graph is not None:
+            return self._provided_graph
+
+        if self._graph is None:
+            # Load the Workspace by FK id rather than traversing
+            # ``self.recipe.workspace`` lazily, which would raise
+            # SynchronousOnlyOperation under async (root of Sentry #276).
+            workspace = await Workspace.objects.aget(id=self.recipe.workspace_id)
+            mcp_tools = await get_mcp_tools()
+            self._oauth_tokens = await get_user_oauth_tokens(self.user)
+            self._graph = await build_agent_graph(
+                workspace=workspace,
+                user=self.user,
+                checkpointer=None,
+                mcp_tools=mcp_tools,
+                oauth_tokens=self._oauth_tokens,
+            )
+
+        return self._graph
+```
+
+- [ ] **Step 4: Fix `execute_async`'s state, config, and remove the tenant fetch**
+
+In `execute_async`, replace the `config` line and the whole `try:` block's tenant-fetch + `initial_state` so the section reads:
+
+```python
+        graph = await self._build_graph()
+        config = {
+            "configurable": {"thread_id": self._thread_id},
+            "recursion_limit": 50,
+            "oauth_tokens": self._oauth_tokens,
+        }
+
+        prompt = self.recipe.render_prompt(self.variable_values)
+
+        logger.info("Starting async recipe execution: %s", self.recipe.name)
+
+        step_started = timezone.now()
+
+        result = {
+            "step_order": 1,
+            "prompt": prompt,
+            "response": "",
+            "tools_used": [],
+            "artifacts_created": [],
+            "success": False,
+            "error": None,
+            "started_at": step_started.isoformat(),
+            "completed_at": None,
+        }
+
+        try:
+            initial_state = {
+                "messages": [HumanMessage(content=prompt)],
+                "workspace_id": str(self.recipe.workspace_id),
+                "user_id": str(self.user.id),
+                "user_role": "analyst",
+                "thread_id": self._thread_id,
+            }
+
+            response = await graph.ainvoke(initial_state, config=config)
+
+            messages = response.get("messages", [])
+            result["response"] = self._extract_response_content(messages)
+            result["tools_used"] = self._extract_tools_used(messages)
+            result["artifacts_created"] = self._extract_artifacts_created(messages)
+            result["success"] = True
+
+        except Exception as e:
+            logger.exception("Error executing recipe %s (async)", self.recipe.name)
+            result["error"] = str(e)
+            result["success"] = False
+```
+
+(The previous `wt = await WorkspaceTenant…` fetch and the `tenant_id`/`tenant_name`/`tenant_membership_id` keys are removed.)
+
+- [ ] **Step 5: Run the contract test — expect PASS**
+
+Run: `uv run pytest tests/test_recipe_runner.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: Confirm the old mocked tests still pass (execute() untouched)**
+
+Run: `uv run pytest tests/test_recipes.py -q`
+Expected: PASS (the sync `execute()` path is unchanged this commit).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/recipes/services/runner.py
+git commit -m "fix: restore recipe execute_async graph-build contract (arch #238)
+
+Fix _build_graph to call build_agent_graph(workspace=, mcp_tools=,
+oauth_tokens=) with the real signature, load MCP tools + oauth tokens, and
+fix execute_async's initial_state to the real AgentState keys
+(workspace_id/user_id/user_role/thread_id). Load workspace by FK id to
+avoid the SynchronousOnlyOperation (Sentry #276).
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Delete the sync path; migrate the mocked unit tests to `execute_async`
+
+**Files:**
+- Modify: `apps/recipes/services/runner.py` (delete `execute()` + `_create_run_record()`)
+- Modify: `tests/test_recipes.py` (6 tests in `TestRecipeRunner`)
+
+- [ ] **Step 1: Delete `_create_run_record()` and `execute()`**
+
+In `apps/recipes/services/runner.py`, delete the entire `_create_run_record` method and the entire sync `execute` method (everything from `def _create_run_record(self)` through the end of `def execute`, i.e. up to but not including `async def execute_async`). `execute_async` calls `RecipeRun.objects.acreate(...)` directly, so `_create_run_record` is now dead.
+
+- [ ] **Step 2: Migrate the `TestRecipeRunner` class in `tests/test_recipes.py`**
+
+Replace the entire `TestRecipeRunner` class (the block starting at `class TestRecipeRunner:` near line 581, through `test_recipe_runner_updates_run_status`) with the async versions below. Each test now provides a mock graph via the `graph=` constructor arg (which `_build_graph` returns immediately, bypassing the real build) and uses `AsyncMock` for `ainvoke`:
+
+```python
+@pytest.mark.django_db(transaction=True)
+class TestRecipeRunner:
+    """Tests for the RecipeRunner async path with a provided (mocked) agent graph."""
+
+    @pytest.mark.asyncio
+    async def test_recipe_runner_validates_variables(self, recipe, user, recipe_step_1):
+        """RecipeRunner.execute_async raises VariableValidationError on missing vars."""
+        from apps.recipes.services.runner import RecipeRunner, VariableValidationError
+
+        invalid_values = {"region": "North", "limit": 10}  # start_date missing
+
+        runner = RecipeRunner(recipe, invalid_values, user, graph=Mock())
+        with pytest.raises(VariableValidationError):
+            await runner.execute_async()
+
+    @pytest.mark.asyncio
+    async def test_recipe_runner_creates_run_record(self, recipe, user, recipe_step_1):
+        """RecipeRunner creates a RecipeRun record."""
+        from apps.recipes.services.runner import RecipeRunner
+
+        values = {"region": "North", "limit": 10, "start_date": "2024-01-01"}
+        mock_graph = Mock()
+        mock_graph.ainvoke = AsyncMock(
+            return_value={"messages": [Mock(content="Result", tool_calls=[])]}
+        )
+
+        run = await RecipeRunner(recipe, values, user, graph=mock_graph).execute_async()
+
+        assert run is not None
+        assert isinstance(run, RecipeRun)
+        assert run.recipe == recipe
+        assert run.variable_values == values
+        assert run.run_by == user
+
+    @pytest.mark.asyncio
+    async def test_recipe_runner_executes_prompt(self, recipe, user, recipe_step_1):
+        """RecipeRunner records a single executed step on success."""
+        from apps.recipes.services.runner import RecipeRunner
+
+        values = {"region": "West", "limit": 15, "start_date": "2024-06-01"}
+        mock_graph = Mock()
+        mock_graph.ainvoke = AsyncMock(
+            return_value={"messages": [Mock(content="Mocked response", tool_calls=[])]}
+        )
+
+        run = await RecipeRunner(recipe, values, user, graph=mock_graph).execute_async()
+
+        assert len(run.step_results) == 1
+        assert run.step_results[0]["step_order"] == 1
+        assert run.step_results[0]["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_recipe_runner_substitutes_variables_in_prompts(
+        self, recipe, user, recipe_step_1
+    ):
+        """RecipeRunner renders variable values into the prompt."""
+        from apps.recipes.services.runner import RecipeRunner
+
+        values = {"region": "East", "limit": 25, "start_date": "2024-03-01"}
+        mock_graph = Mock()
+        mock_graph.ainvoke = AsyncMock(
+            return_value={"messages": [Mock(content="Mocked response", tool_calls=[])]}
+        )
+
+        run = await RecipeRunner(recipe, values, user, graph=mock_graph).execute_async()
+
+        step_result = run.step_results[0]
+        assert "East" in step_result["prompt"]
+        assert "25" in step_result["prompt"]
+
+    @pytest.mark.asyncio
+    async def test_recipe_runner_handles_execution_failure(self, recipe, user, recipe_step_1):
+        """RecipeRunner records a failed run when the graph raises."""
+        from apps.recipes.services.runner import RecipeRunner
+
+        values = {"region": "North", "limit": 10, "start_date": "2024-01-01"}
+        mock_graph = Mock()
+        mock_graph.ainvoke = AsyncMock(side_effect=Exception("Agent execution failed"))
+
+        run = await RecipeRunner(recipe, values, user, graph=mock_graph).execute_async()
+
+        assert run.status == RecipeRunStatus.FAILED
+        assert len(run.step_results) > 0
+        assert run.step_results[0]["success"] is False
+        assert "error" in run.step_results[0]
+
+    @pytest.mark.asyncio
+    async def test_recipe_runner_updates_run_status(self, recipe, user, recipe_step_1):
+        """RecipeRunner marks the run completed with a completion timestamp."""
+        from apps.recipes.services.runner import RecipeRunner
+
+        values = {"region": "South", "limit": 5, "start_date": "2024-02-01"}
+        mock_graph = Mock()
+        mock_graph.ainvoke = AsyncMock(
+            return_value={"messages": [Mock(content="Success", tool_calls=[])]}
+        )
+
+        run = await RecipeRunner(recipe, values, user, graph=mock_graph).execute_async()
+
+        assert run.status == RecipeRunStatus.COMPLETED
+        assert run.completed_at is not None
+```
+
+- [ ] **Step 3: Ensure `AsyncMock` is imported in `tests/test_recipes.py`**
+
+The file's top import is `from unittest.mock import Mock, patch`. Change it to:
+
+```python
+from unittest.mock import AsyncMock, Mock, patch
+```
+
+- [ ] **Step 4: Run the runner tests**
+
+Run: `uv run pytest tests/test_recipes.py::TestRecipeRunner tests/test_recipe_runner.py -v`
+Expected: PASS (6 migrated unit tests + 1 contract test).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/recipes/services/runner.py tests/test_recipes.py
+git commit -m "refactor: drop sync recipe execute() path, migrate tests to async (arch #238)
+
+Delete the sync execute() and _create_run_record() (async_to_sync is
+forbidden by the async-first convention); execute_async is now the single
+live path. Migrate the mocked TestRecipeRunner unit tests to await
+execute_async with a provided mock graph.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Convert `RecipeRunView` to a raw async Django view
+
+**Files:**
+- Modify: `apps/recipes/api/views.py`
+- Modify: `apps/recipes/urls.py`
+- Test: `tests/test_recipes.py` (new async view tests)
+
+- [ ] **Step 1: Write the failing async view tests**
+
+Append to `tests/test_recipes.py`:
+
+```python
+@pytest.mark.django_db(transaction=True)
+class TestRecipeRunView:
+    """Tests for the async recipe run endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_run_endpoint_returns_201_with_real_graph(self, recipe, user, recipe_step_1):
+        """POST run/ builds the real graph (LLM mocked, no MCP tools) and returns 201."""
+        from langchain_core.messages import AIMessage
+
+        async def fake_ainvoke(messages, *args, **kwargs):
+            return AIMessage(content="done", id="ai-1")
+
+        mock_bound = MagicMock()
+        mock_bound.ainvoke = AsyncMock(side_effect=fake_ainvoke)
+        mock_llm = MagicMock()
+        mock_llm.bind_tools.return_value = mock_bound
+
+        client = AsyncClient()
+        await sync_to_async(client.login)(email="test@example.com", password="testpass123")
+
+        url = f"/api/workspaces/{recipe.workspace_id}/recipes/{recipe.id}/run/"
+        body = {"variable_values": {"region": "North", "limit": 10, "start_date": "2024-01-01"}}
+
+        with (
+            patch(
+                "apps.recipes.services.runner.get_mcp_tools",
+                new=AsyncMock(return_value=[]),
+            ),
+            patch("apps.agents.graph.base.ChatAnthropic", return_value=mock_llm),
+        ):
+            resp = await client.post(url, data=body, content_type="application/json")
+
+        assert resp.status_code == 201, resp.content
+        data = resp.json()
+        assert data["status"] == RecipeRunStatus.COMPLETED
+
+    @pytest.mark.asyncio
+    async def test_run_endpoint_forbids_non_member(self, recipe, other_user, recipe_step_1):
+        """A user with no workspace membership gets 403."""
+        client = AsyncClient()
+        await sync_to_async(client.login)(email="other@example.com", password="otherpass123")
+        url = f"/api/workspaces/{recipe.workspace_id}/recipes/{recipe.id}/run/"
+        resp = await client.post(url, data={"variable_values": {}}, content_type="application/json")
+        assert resp.status_code == 403
+```
+
+Add these imports at the top of `tests/test_recipes.py` (the `from unittest.mock import …` line already exists; add the rest):
+
+```python
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+from asgiref.sync import sync_to_async
+from django.test import AsyncClient
+```
+
+- [ ] **Step 2: Run to verify the 201 test FAILS (sync view can't run the async path correctly)**
+
+Run: `uv run pytest "tests/test_recipes.py::TestRecipeRunView" -v`
+Expected: FAIL — the current sync `RecipeRunView.post` calls `runner.execute()`, which no longer exists after Task 3 (`AttributeError`), so the endpoint returns 500.
+
+- [ ] **Step 3: Replace `RecipeRunView` with `recipe_run_view` in `apps/recipes/api/views.py`**
+
+Update the imports at the top of the file to add (keep the existing DRF imports used by the other views):
+
+```python
+import json
+
+from asgiref.sync import sync_to_async
+from django.http import JsonResponse
+from django.views.decorators.csrf import csrf_protect
+
+from apps.recipes.services.runner import RecipeRunner
+from apps.users.decorators import async_login_required
+from apps.workspaces.services.workspace_service import touch_workspace_schemas
+from apps.workspaces.workspace_resolver import aresolve_workspace
+```
+
+Delete the entire `class RecipeRunView(APIView):` block and replace it with:
+
+```python
+@csrf_protect
+@async_login_required
+async def recipe_run_view(request, workspace_id, recipe_id):
+    """POST /api/workspaces/<workspace_id>/recipes/<recipe_id>/run/
+
+    Execute a recipe with variable values. Raw async Django view (DRF APIView
+    is sync and cannot await the async-first runner).
+    """
+    if request.method != "POST":
+        return JsonResponse({"error": "Method not allowed"}, status=405)
+
+    user = request._authenticated_user
+
+    workspace, err = await aresolve_workspace(user, workspace_id)
+    if err:
+        return err
+
+    try:
+        recipe = await Recipe.objects.select_related("workspace").aget(
+            pk=recipe_id, workspace=workspace
+        )
+    except Recipe.DoesNotExist:
+        return JsonResponse({"error": "Recipe not found."}, status=404)
+
+    try:
+        body = json.loads(request.body) if request.body else {}
+    except (json.JSONDecodeError, ValueError):
+        return JsonResponse({"error": "Invalid JSON"}, status=400)
+
+    serializer = RunRecipeSerializer(data=body)
+    if not await sync_to_async(serializer.is_valid)():
+        return JsonResponse(serializer.errors, status=400)
+    variable_values = serializer.validated_data.get("variable_values", {})
+
+    try:
+        runner = RecipeRunner(recipe=recipe, variable_values=variable_values, user=user)
+        run = await runner.execute_async()
+    except VariableValidationError as e:
+        return JsonResponse({"error": str(e), "errors": e.errors}, status=400)
+    except Exception as e:
+        logger.exception("Error running recipe %s", recipe_id)
+        return JsonResponse({"error": str(e)}, status=500)
+
+    # Reset the inactivity TTL on user-initiated recipe runs.
+    await touch_workspace_schemas(workspace)
+
+    data = await sync_to_async(lambda: RecipeRunSerializer(run).data)()
+    return JsonResponse(data, status=201)
+```
+
+Add `VariableValidationError` to the runner import so the `except` works:
+
+```python
+from apps.recipes.services.runner import RecipeRunner, VariableValidationError
+```
+
+- [ ] **Step 4: Point the URL at the function in `apps/recipes/urls.py`**
+
+Change the import `RecipeRunView` → `recipe_run_view` in the `from .api.views import (...)` block, and change the run path from:
+
+```python
+    path("<uuid:recipe_id>/run/", RecipeRunView.as_view(), name="run"),
+```
+
+to:
+
+```python
+    path("<uuid:recipe_id>/run/", recipe_run_view, name="run"),
+```
+
+- [ ] **Step 5: Run the view tests — expect PASS**
+
+Run: `uv run pytest "tests/test_recipes.py::TestRecipeRunView" -v`
+Expected: PASS (201 + 403).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/recipes/api/views.py apps/recipes/urls.py tests/test_recipes.py
+git commit -m "feat: make recipe run endpoint a raw async Django view (arch #238)
+
+Convert RecipeRunView (DRF APIView, which can't await the async-first
+runner) to an async def view mirroring chat_view: @async_login_required +
+@csrf_protect, aresolve_workspace, async ORM recipe lookup, await
+execute_async, async TTL touch, serializer wrapped in sync_to_async.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Full verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Full recipe test suite**
+
+Run: `uv run pytest tests/test_recipes.py tests/test_recipe_runner.py -v`
+Expected: all pass, 0 skipped in `test_recipe_runner.py` (skeleton replaced).
+
+- [ ] **Step 2: Lint + format**
+
+Run: `uv run ruff check apps/recipes tests/test_recipes.py tests/test_recipe_runner.py && uv run ruff format --check apps/recipes`
+Expected: clean. Fix any unused-import (e.g. confirm `status`, `APIView`, `Response` are still used by the remaining DRF views — they are — and that nothing references the removed `WorkspaceTenant`/`TenantMembership`/`async_to_sync`).
+
+- [ ] **Step 3: No unintended migrations**
+
+Run: `uv run python manage.py makemigrations --check --dry-run`
+Expected: "No changes detected" (no model changes were made).
+
+- [ ] **Step 4: Broader regression sweep (touched seams)**
+
+Run: `uv run pytest tests/test_recipes.py tests/test_recipe_runner.py tests/test_dangling_tool_calls.py -q`
+Expected: all pass (confirms the shared `build_agent_graph` contract still holds).
+
+- [ ] **Step 5: Manual end-to-end (required before "done")**
+
+Start deps + servers (`docker compose up platform-db mcp-server`, then `uv run honcho -f Procfile.dev start`), ensure a real `ANTHROPIC_API_KEY` is set, and run a real recipe via the UI or a `curl` POST to `/api/workspaces/<ws>/recipes/<id>/run/`. Confirm the response is a real, non-empty answer and `status == "completed"` with sensible `tools_used`. Capture the output for the PR description.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** drift #1 (Task 2 step 3), #2 (Task 2 step 4), #3 (Task 2 step 3), #4 (Tasks 3+4); unmocked test (Task 1); migrated tests (Task 3); async view (Task 4); oauth_tokens kept + no Langfuse (Task 2 steps 3-4); manual e2e (Task 5 step 5). All covered.
+- **Type/name consistency:** `recipe_run_view`, `RecipeRunner.execute_async`, `_oauth_tokens`, `RunRecipeSerializer`/`RecipeRunSerializer`, `aresolve_workspace`, `touch_workspace_schemas`, `get_mcp_tools`/`get_user_oauth_tokens` all used consistently across tasks.
+- **No background-task / no PR-#277 changes** — scope boundary honored.

--- a/docs/superpowers/plans/2026-06-16-recipes-async-restoration.md
+++ b/docs/superpowers/plans/2026-06-16-recipes-async-restoration.md
@@ -19,7 +19,7 @@
   4. The view calls sync `execute()` (`async_to_sync` + sync `graph.invoke()`).
 - **The correct pattern** is `apps/chat/views.py:153-197` (load `get_mcp_tools()` + `get_user_oauth_tokens()`, call `build_agent_graph(workspace=…, mcp_tools=…, oauth_tokens=…)`, config `{"configurable": {"thread_id":…}, "recursion_limit": 50, "oauth_tokens":…}`).
 - **Async-first is non-negotiable.** No `async_to_sync`. Do NOT move execution to a background task (#267). Keep `execute_async` (supersedes #266's "delete it"). Do not touch PR #277 / issues #276 / #266.
-- **Fixtures** (`tests/conftest.py`): `user` (test@example.com / testpass123), `workspace` (1 tenant "test-domain", **no** TenantSchema, `user` is MANAGE member), `other_user`. `tests/test_recipes.py` adds `recipe` (built on `workspace`, vars region/limit/start_date; only `start_date` has no default), `recipe_step_1`.
+- **Fixtures** (`tests/conftest.py`): `user` (test@example.com / testpass123), `workspace` (1 tenant "test-domain", **no** TenantSchema, `user` is MANAGE member), `other_user`. The `recipe`/`recipe_step_1` fixtures are **module-local to `tests/test_recipes.py`** (the codebase pattern: each recipe test module defines its own `recipe` — see also `test_recipe_soft_delete.py`). `tests/test_recipe_runner.py` therefore defines its own local `recipe` fixture (depending on the conftest `user`/`workspace`).
 - **`get_schema_status` contract** (`mcp_server/server.py:652`): empty `workspace_id` → `success=False, error.code="VALIDATION_ERROR"`; a workspace with 1 tenant and no ACTIVE schema → `success=True, data.state="not_provisioned"` with **no managed-DB connection**. This is the signal the contract test keys on.
 - **`RecipeRunStatus`** (`apps/recipes/models.py:281`): `PENDING/RUNNING/COMPLETED/FAILED`.
 - **Real-MCP-wire pattern** (modeled on commit `2320d52`, `tests/test_chat_mcp_contract.py`, not on main): `create_connected_server_and_client_session(scout_mcp)` + `load_mcp_tools(session)`.
@@ -137,7 +137,7 @@ async def test_execute_async_builds_real_graph_and_flows_workspace_id(recipe, us
 - [ ] **Step 2: Run it to verify it FAILS against the current (broken) runner**
 
 Run: `uv run pytest tests/test_recipe_runner.py -v`
-Expected: FAIL. The current `_build_graph` calls `build_agent_graph(tenant_membership=…)` → the run is caught inside `execute_async` and recorded as `FAILED` with a `TypeError` in `step_results[0]["error"]`, so `assert run.status == RecipeRunStatus.COMPLETED` fails (the assert message prints the TypeError).
+Expected: RED (the feature isn't implemented yet). The current runner does **not** import `get_mcp_tools` (drift #3 — mcp_tools are never loaded), so `patch("apps.recipes.services.runner.get_mcp_tools", …)` raises `AttributeError` on context entry. That is a legitimate TDD red: it directly reflects the missing-mcp_tools drift. (Once Task 2 adds `from apps.agents.mcp_client import get_mcp_tools` to the runner and fixes the `build_agent_graph` signature, the patch target exists and the assertions run for real.) Acceptable RED signatures: the `AttributeError` on the missing `get_mcp_tools`, OR — if the import were present but the signature still wrong — a FAILED run with a `TypeError` printed by the `assert run.status == RecipeRunStatus.COMPLETED` message. The test must COLLECT and RUN cleanly (no import error, no "fixture not found"); it must simply not PASS.
 
 - [ ] **Step 3: Commit the failing test**
 
@@ -154,9 +154,9 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
 
 ---
 
-## Task 2: Fix the runner's async path (`execute_async` + `_build_graph`)
+## Task 2: Fix the runner's async path + delete sync path + migrate unit tests (MERGED with Task 3)
 
-Make the contract test pass. Do NOT delete `execute()` yet (Task 3) so the existing mocked tests stay green between commits.
+> **Execution note (revised during implementation):** Tasks 2 and 3 are executed as ONE task. Reason: `_build_graph` is shared by both `execute()` and `execute_async`. Rewriting it to call `get_mcp_tools()` (unmocked in the old `execute()`-based tests) plus removing `self._tenant_membership` would break the old tests in the gap between commits. So the runner fix, the deletion of `execute()`/`_create_run_record()`, and the migration of the 6 mocked unit tests all land together. The contract test goes GREEN and the migrated unit tests (which pass `graph=mock_graph`, bypassing `_build_graph`) stay GREEN. Step 6 below ("old mocked tests still pass, execute() untouched") is superseded by Task 3's migration steps.
 
 **Files:**
 - Modify: `apps/recipes/services/runner.py`
@@ -295,7 +295,7 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
 
 ---
 
-## Task 3: Delete the sync path; migrate the mocked unit tests to `execute_async`
+## Task 3: Delete the sync path; migrate the mocked unit tests to `execute_async` (MERGED INTO TASK 2 — executed together)
 
 **Files:**
 - Modify: `apps/recipes/services/runner.py` (delete `execute()` + `_create_run_record()`)

--- a/docs/superpowers/plans/2026-06-16-recipes-async-restoration.md
+++ b/docs/superpowers/plans/2026-06-16-recipes-async-restoration.md
@@ -500,19 +500,23 @@ class TestRecipeRunView:
         assert resp.status_code == 403
 ```
 
-Add these imports at the top of `tests/test_recipes.py` (the `from unittest.mock import …` line already exists; add the rest):
+Add these imports at the top of `tests/test_recipes.py` (the `from unittest.mock import …` line already exists; add `MagicMock`, and the rest):
 
 ```python
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 from asgiref.sync import sync_to_async
 from django.test import AsyncClient
+
+from apps.recipes.services.runner import RecipeRunner, VariableValidationError
 ```
+
+Also, while here, **fix the code-review Minor #4 from Task 2**: hoist the per-test inline `from apps.recipes.services.runner import RecipeRunner` (and `VariableValidationError`) statements out of the migrated `TestRecipeRunner` methods, relying on the new module-level import above (CLAUDE.md: imports at module level, never inside function bodies). Remove the now-redundant inline `from apps.recipes.services.runner import ...` lines inside those test methods. (`tests/test_recipe_runner.py` already imports `RecipeRunner` at module level with no circular-import issue, confirming the hoist is safe.)
 
 - [ ] **Step 2: Run to verify the 201 test FAILS (sync view can't run the async path correctly)**
 
 Run: `uv run pytest "tests/test_recipes.py::TestRecipeRunView" -v`
-Expected: FAIL — the current sync `RecipeRunView.post` calls `runner.execute()`, which no longer exists after Task 3 (`AttributeError`), so the endpoint returns 500.
+Expected: FAIL — the current sync `RecipeRunView.post` calls `runner.execute()`, which was deleted in Task 2 (`AttributeError`), so the endpoint returns 500. (This is the Critical the Task-2 code review flagged; Task 4 fixes it.)
 
 - [ ] **Step 3: Replace `RecipeRunView` with `recipe_run_view` in `apps/recipes/api/views.py`**
 

--- a/docs/superpowers/specs/2026-06-16-recipes-async-restoration-design.md
+++ b/docs/superpowers/specs/2026-06-16-recipes-async-restoration-design.md
@@ -71,6 +71,24 @@ and the enforcement guardrail. **No `async_to_sync`.**
   Remove the now-dead `WorkspaceTenant` tenant fetch and the `tenant_*` keys.
 - **Config** mirrors chat:
   `{"configurable": {"thread_id": self._thread_id}, "recursion_limit": 50, "oauth_tokens": self._oauth_tokens}`.
+
+#### Design note: `oauth_tokens` (kept) and Langfuse (excluded)
+
+Two independent things ride in chat's `config`. We copy only one:
+
+- **`config["oauth_tokens"]` — KEPT.** Fetched per-run from the running user via
+  `get_user_oauth_tokens(self.user)`; ride the LangGraph runtime config →
+  `langchain_mcp_adapters` forwards them into each MCP tool call's `_meta` (transport
+  layer) → the MCP server reads them via `extract_oauth_tokens` (`mcp_server/auth.py:25`).
+  They are **never visible to the LLM** and are **scrubbed from audit logs**
+  (`mcp_server/envelope.py:82` `_SCRUB_KEYS`). The only consumer is `run_materialization`
+  (data refresh). Tokens are **never stored** on the `Recipe` or `RecipeRun`: a shared
+  recipe carries only its prompt + variables, so whoever runs it authenticates as
+  *themselves* (their tokens, their membership). Sharing is therefore secure by
+  construction; a user without CommCare-linked tokens simply can't trigger an in-recipe
+  refresh — identical to chat.
+- **`config["callbacks"]` (Langfuse tracing) — EXCLUDED.** That is chat-specific; the
+  recipe runner attaches no Langfuse callback.
 - **Imports:** add `get_mcp_tools`, `get_user_oauth_tokens` from `apps.agents.mcp_client`
   and `Workspace` from `apps.workspaces.models`. Remove `WorkspaceTenant` /
   `TenantMembership` if they become unused.

--- a/docs/superpowers/specs/2026-06-16-recipes-async-restoration-design.md
+++ b/docs/superpowers/specs/2026-06-16-recipes-async-restoration-design.md
@@ -1,0 +1,152 @@
+# Recipe runner async-first restoration (arch #238)
+
+**Date:** 2026-06-16
+**Issue:** arch-review #238 — "Recipe runner signature drift — feature 100% dead since March"
+**Wave/tier:** Wave 1, tier:now, status:broken-now
+**PR closes:** #238, #276 (Sentry SCOUT-DJANGO-1P `SynchronousOnlyOperation`)
+
+## Problem
+
+Recipe execution has been 100% broken since a March refactor (commit `e26cd75`). The
+runner and run view drifted away from the agent-graph contract and were never caught
+because every recipe test mocks `build_agent_graph`, masking the break. Sentry #276
+(`SynchronousOnlyOperation`) is the first crash users hit — a symptom of #238, not a
+separate bug.
+
+### Verified drifts (against current `main`)
+
+1. **`_build_graph` signature drift** — `apps/recipes/services/runner.py` calls
+   `build_agent_graph(tenant_membership=…, user=…, checkpointer=None)`. The real
+   signature (`apps/agents/graph/base.py:480`) is
+   `build_agent_graph(workspace, user=None, checkpointer=None, mcp_tools=None, oauth_tokens=None)`
+   — no `tenant_membership`, `workspace` required. → `TypeError`.
+2. **`initial_state` key drift** — uses `tenant_id` / `tenant_name` /
+   `tenant_membership_id`. `AgentState` (`apps/agents/graph/state.py:80`) requires
+   `workspace_id`, `user_id`, `user_role`, `thread_id`. Wrong keys → the injecting tool
+   node reads `workspace_id=""` → every MCP data tool fails server-side validation.
+3. **`mcp_tools` never loaded or passed** — the graph is built without tools, so the
+   agent has no data access even if the signature were correct.
+4. **Sync execution path** — `RecipeRunView` (DRF `APIView`) calls the sync `execute()`,
+   which does `async_to_sync(self._build_graph)()` then sync `graph.invoke()`. This
+   violates the codebase's async-first convention and is the proximate source of the
+   `SynchronousOnlyOperation` (lazy FK / sync-ORM-in-async).
+
+## Required approach (non-negotiable)
+
+Async-first, per `CLAUDE.md` async conventions, the sync→native-async migration history,
+and the enforcement guardrail. **No `async_to_sync`.**
+
+- Delete the sync `execute()` path and the `async_to_sync` import.
+- `execute_async` becomes the single live path (it has drifts 1–3 too — fix there).
+- `RecipeRunView` becomes a raw `async def` Django view that `await`s `execute_async`,
+  mirroring the chat/tenant async endpoints. DRF `APIView` is sync; it cannot stay.
+
+### Scope boundary
+
+- Request-scoped async restoration. **Do NOT** move recipe execution to a background
+  Procrastinate task — that redesign is owned by #267.
+- #266 lists `RecipeRunner.execute_async` as dead code to delete. That is **superseded**
+  here — we promote it to the live path. Keep it.
+- Do NOT touch / comment on PR #277, #276, or #266. This PR supersedes #277.
+
+## Design
+
+### 1. `apps/recipes/services/runner.py`
+
+- **Remove** `from asgiref.sync import async_to_sync` and the entire `execute()` method.
+- **`_build_graph`** rewritten to mirror chat (`apps/chat/views.py:153-185`):
+  - Load the `Workspace` by FK id via async ORM:
+    `ws = await Workspace.objects.aget(id=self.recipe.workspace_id)`. Using the stored
+    FK id (no lazy `recipe.workspace` traversal) is what prevents the
+    `SynchronousOnlyOperation` regardless of how the recipe was loaded (the insight
+    behind jjackson's PR #277, generalised).
+  - `mcp_tools = await get_mcp_tools()` and
+    `oauth_tokens = await get_user_oauth_tokens(self.user)`.
+  - `self._graph = await build_agent_graph(workspace=ws, user=self.user, checkpointer=None, mcp_tools=mcp_tools, oauth_tokens=oauth_tokens)`.
+  - Drop all `tenant_membership` loading and the `self._tenant_membership` attribute —
+    not needed by the new signature or state. `user_role` stays `"analyst"` (same as
+    chat and the pre-break code). Store `oauth_tokens` on the instance for config use.
+- **`execute_async`** `initial_state` fixed to real `AgentState` keys:
+  `{"messages": [HumanMessage(...)], "workspace_id": str(ws.id), "user_id": str(user.id), "user_role": "analyst", "thread_id": self._thread_id}`.
+  Remove the now-dead `WorkspaceTenant` tenant fetch and the `tenant_*` keys.
+- **Config** mirrors chat:
+  `{"configurable": {"thread_id": self._thread_id}, "recursion_limit": 50, "oauth_tokens": self._oauth_tokens}`.
+- **Imports:** add `get_mcp_tools`, `get_user_oauth_tokens` from `apps.agents.mcp_client`
+  and `Workspace` from `apps.workspaces.models`. Remove `WorkspaceTenant` /
+  `TenantMembership` if they become unused.
+
+### 2. `apps/recipes/api/views.py` + `apps/recipes/urls.py`
+
+- Replace the `RecipeRunView` DRF `APIView` with a raw async function view:
+  `@csrf_protect @async_login_required async def recipe_run_view(request, workspace_id, recipe_id)`.
+  - `user = request._authenticated_user`.
+  - `workspace, err = await aresolve_workspace(user, workspace_id)` → 403 `JsonResponse` on err.
+  - `recipe = await Recipe.objects.select_related("workspace").aget(pk=recipe_id, workspace=workspace)`
+    → 404 `JsonResponse` on `Recipe.DoesNotExist`.
+  - Parse JSON body; validate `variable_values` (reuse `RunRecipeSerializer` via
+    `sync_to_async`, or inline) → 400 on invalid.
+  - `run = await RecipeRunner(recipe=recipe, variable_values=…, user=user).execute_async()`.
+    Wrap in try/except → 500 `JsonResponse` with `{"error": str(e)}` (same envelope).
+  - `await touch_workspace_schemas(workspace)` (replaces the inline sync TTL-touch).
+  - Return `JsonResponse(await sync_to_async(lambda: RecipeRunSerializer(run).data)(), status=201)`.
+    `RecipeRunSerializer` only serializes scalar `RecipeRun` columns (no FK traversal),
+    but DRF `.data` is sync, so it is wrapped in `sync_to_async`.
+- The other five recipe views stay DRF `APIView` — only `run/` becomes async.
+- `apps/recipes/urls.py`: point the `run/` path at `recipe_run_view` instead of `.as_view()`.
+
+### 3. Tests
+
+- **Migrate** the six mocked `TestRecipeRunner` tests (`tests/test_recipes.py:584+`) from
+  sync `execute()` → async `execute_async()` (`@pytest.mark.asyncio` +
+  `@pytest.mark.django_db(transaction=True)`), since `execute()` is removed. They keep
+  mocking `build_agent_graph` — they are unit tests of validation / record creation /
+  result extraction. `mock_graph.ainvoke` (AsyncMock) replaces `mock_graph.invoke`.
+- **Add the real unmocked contract test** (the guardrail that would have caught #238):
+  stand up the real in-memory MCP wire
+  (`mcp.shared.memory.create_connected_server_and_client_session` over
+  `mcp_server.server.mcp`, tools via `langchain_mcp_adapters.load_mcp_tools`), patch
+  `apps.recipes.services.runner.get_mcp_tools` to return those real tools, and patch
+  `apps.agents.graph.base.ChatAnthropic` with a fake LLM (pattern from
+  `tests/test_dangling_tool_calls.py:153`) that emits a `get_schema_status` tool call,
+  then a final `AIMessage` echoing the tool envelope. `build_agent_graph` is **not**
+  mocked. Run `execute_async()` and assert:
+  - `run.status == COMPLETED` (proves drift #1: the real build signature is satisfied);
+  - the captured response contains `not_provisioned` and **not** `VALIDATION_ERROR`
+    (proves drifts #2/#3: `workspace_id` flowed from state through the real injecting
+    node into the real MCP server, with real tools attached).
+  This mirrors the arch #234 / PR #277 unmocked pattern (`tests/test_chat_mcp_contract.py`,
+  commit `2320d52`, not yet on `main`).
+- **Replace** the `tests/test_recipe_runner.py` skeleton skips with the real contract
+  test above (or co-locate it there; final placement decided in the plan).
+- **Add an async view test**: `POST …/recipes/<id>/run/` end-to-end with the LLM mocked,
+  asserting `201` + a serialized run body, and that a non-member gets `403`.
+
+## Error handling
+
+| Condition | Response |
+|---|---|
+| Unauthenticated | 401 (`@async_login_required`) |
+| Not a workspace member | 403 (`aresolve_workspace`) |
+| Recipe not found in workspace | 404 |
+| Invalid/missing variable values | 400 |
+| Runner raises (graph build / invoke) | 500, `{"error": str(e)}`, logged via `logger.exception` |
+| Success | 201, `RecipeRunSerializer(run).data` |
+
+A graph-level failure inside `execute_async` is still captured into
+`step_results[0]["error"]` with `run.status = FAILED` and returned as a 201 (the run
+record exists and records the failure) — matching existing behaviour. Only failures
+*outside* the run record (resolution, validation, build) surface as 4xx/5xx.
+
+## Verification before "done"
+
+1. `uv run pytest tests/test_recipes.py tests/test_recipe_runner.py` green, including the
+   new unmocked contract test.
+2. Full async-ORM-in-async-view sanity: no `SynchronousOnlyOperation` under the async view.
+3. **End-to-end**: run a real recipe locally (real MCP server + real `ANTHROPIC_API_KEY`)
+   and confirm it returns a real answer — not just green unit tests.
+
+## Out of scope
+
+- Background-task execution (#267).
+- Deleting `execute_async` (#266 — superseded).
+- Any change to PR #277 / issues #276 / #266 coordination.

--- a/tests/test_recipe_runner.py
+++ b/tests/test_recipe_runner.py
@@ -1,27 +1,120 @@
-"""Tests for recipe runner module."""
+"""Real (unmocked) recipe runner <-> graph-build contract test (arch #238).
+
+Exercises the REAL ``build_agent_graph`` through ``RecipeRunner.execute_async`` with
+real MCP tools loaded over the in-process MCP SDK transport. Only the LLM and the
+managed-data boundary are avoided: the build signature, the AgentState contract, and
+the workspace_id injection path all run for real. Every other recipe test mocks
+``build_agent_graph``, which is exactly why the March break (e26cd75) hid for months.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from langchain_core.messages import AIMessage, ToolMessage
+from langchain_mcp_adapters.tools import load_mcp_tools
+from mcp.shared.memory import create_connected_server_and_client_session
+
+from apps.recipes.models import Recipe, RecipeRunStatus
+from apps.recipes.services.runner import RecipeRunner
+from mcp_server.server import mcp as scout_mcp
 
 
-class TestRecipeRunner:
-    """Placeholder tests for recipe runner - implement actual tests."""
+@pytest.fixture
+def recipe(db, user, workspace):
+    """Create a test recipe with variables (module-local, mirroring test_recipes.py)."""
+    return Recipe.objects.create(
+        workspace=workspace,
+        name="Sales Analysis",
+        description="Analyze sales data for a specific region and time period",
+        prompt="Show me the top {{limit}} customers in {{region}} region starting from {{start_date}}",
+        variables=[
+            {
+                "name": "region",
+                "type": "select",
+                "label": "Region",
+                "default": "North",
+                "options": ["North", "South", "East", "West"],
+            },
+            {
+                "name": "limit",
+                "type": "number",
+                "label": "Number of results",
+                "default": 10,
+            },
+            {
+                "name": "start_date",
+                "type": "date",
+                "label": "Start Date",
+            },
+        ],
+        is_shared=False,
+        created_by=user,
+    )
 
-    @pytest.mark.skip(reason="TODO: implement")
-    def test_recipe_execution(self):
-        """Test basic recipe execution."""
-        pass
 
-    @pytest.mark.skip(reason="TODO: implement")
-    def test_recipe_step_sequencing(self):
-        """Test that recipe steps execute in correct order."""
-        pass
+def _fake_llm_driving_get_schema_status():
+    """A fake ChatAnthropic whose bound model:
 
-    @pytest.mark.skip(reason="TODO: implement")
-    def test_recipe_variable_substitution(self):
-        """Test variable substitution in recipe steps."""
-        pass
+    1. first emits a get_schema_status tool call (workspace_id omitted, as the LLM
+       would — the param is hidden from its schema and injected from state);
+    2. then, once it sees the ToolMessage, echoes the tool envelope as its final
+       answer so the runner captures it as the response.
+    """
 
-    @pytest.mark.skip(reason="TODO: implement")
-    def test_recipe_error_recovery(self):
-        """Test error recovery during recipe execution."""
-        pass
+    async def fake_ainvoke(messages, *args, **kwargs):
+        tool_msgs = [m for m in messages if isinstance(m, ToolMessage)]
+        if tool_msgs:
+            return AIMessage(content=str(tool_msgs[-1].content), id="ai-final")
+        return AIMessage(
+            content="",
+            tool_calls=[{"name": "get_schema_status", "args": {}, "id": "call_1"}],
+            id="ai-1",
+        )
+
+    mock_bound = MagicMock()
+    mock_bound.ainvoke = AsyncMock(side_effect=fake_ainvoke)
+    mock_llm = MagicMock()
+    mock_llm.bind_tools.return_value = mock_bound
+    return mock_llm
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_execute_async_builds_real_graph_and_flows_workspace_id(recipe, user):
+    """RecipeRunner.execute_async builds the REAL agent graph and runs a real MCP
+    tool call end-to-end.
+
+    Catches every #238 drift at once:
+    - build_agent_graph is called with the real signature (drift #1) — a TypeError
+      here means the runner regressed;
+    - mcp_tools are loaded and attached, so get_schema_status exists (drift #3);
+    - workspace_id flows from initial_state through the real injecting node into the
+      real MCP server (drift #2) — proven by a not_provisioned success envelope rather
+      than a VALIDATION_ERROR (which is what an empty workspace_id returns).
+    """
+    values = {"region": "North", "limit": 10, "start_date": "2024-01-01"}
+
+    async with create_connected_server_and_client_session(scout_mcp) as session:
+        tools = await load_mcp_tools(session)
+        with (
+            patch(
+                "apps.recipes.services.runner.get_mcp_tools",
+                new=AsyncMock(return_value=tools),
+            ),
+            patch(
+                "apps.agents.graph.base.ChatAnthropic",
+                return_value=_fake_llm_driving_get_schema_status(),
+            ),
+        ):
+            run = await RecipeRunner(recipe=recipe, variable_values=values, user=user).execute_async()
+
+    assert run.status == RecipeRunStatus.COMPLETED, run.step_results
+    step = run.step_results[0]
+    assert step["success"] is True
+    assert "get_schema_status" in step["tools_used"]
+    # Positive proof workspace_id reached the server: a real not_provisioned envelope,
+    # never the VALIDATION_ERROR that an empty workspace_id would have produced.
+    assert "not_provisioned" in step["response"]
+    assert "VALIDATION_ERROR" not in step["response"]

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -12,6 +12,7 @@ from django.contrib.auth import get_user_model
 from django.db import IntegrityError
 from django.test import AsyncClient
 from django.utils import timezone
+from langchain_core.messages import AIMessage
 
 from apps.recipes.models import Recipe, RecipeRun, RecipeRunStatus, RecipeStep
 from apps.recipes.services.runner import RecipeRunner, VariableValidationError
@@ -811,7 +812,6 @@ class TestRecipeRunView:
     @pytest.mark.asyncio
     async def test_run_endpoint_returns_201_with_real_graph(self, recipe, user, recipe_step_1):
         """POST run/ builds the real graph (LLM mocked, no MCP tools) and returns 201."""
-        from langchain_core.messages import AIMessage
 
         async def fake_ainvoke(messages, *args, **kwargs):
             return AIMessage(content="done", id="ai-1")

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -4,7 +4,7 @@ Comprehensive tests for Phase 4 (Recipes) of the Scout data agent platform.
 Tests recipe CRUD, variable substitution, recipe runner, and save_as_recipe tool.
 """
 
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from django.contrib.auth import get_user_model
@@ -577,43 +577,33 @@ class TestRecipeRunModel:
 # ============================================================================
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(transaction=True)
 class TestRecipeRunner:
-    """Tests for the RecipeRunner with mocked agent graph."""
+    """Tests for the RecipeRunner async path with a provided (mocked) agent graph."""
 
-    @patch("apps.recipes.services.runner.build_agent_graph")
-    def test_recipe_runner_validates_variables(self, mock_build_graph, recipe, user, recipe_step_1):
-        """Test that RecipeRunner validates variables before execution."""
-        # Import here to avoid circular imports
+    @pytest.mark.asyncio
+    async def test_recipe_runner_validates_variables(self, recipe, user, recipe_step_1):
+        """RecipeRunner.execute_async raises VariableValidationError on missing vars."""
+        from apps.recipes.services.runner import RecipeRunner, VariableValidationError
+
+        invalid_values = {"region": "North", "limit": 10}  # start_date missing
+
+        runner = RecipeRunner(recipe, invalid_values, user, graph=Mock())
+        with pytest.raises(VariableValidationError):
+            await runner.execute_async()
+
+    @pytest.mark.asyncio
+    async def test_recipe_runner_creates_run_record(self, recipe, user, recipe_step_1):
+        """RecipeRunner creates a RecipeRun record."""
         from apps.recipes.services.runner import RecipeRunner
 
-        # Invalid values (missing required variable)
-        invalid_values = {"region": "North", "limit": 10}
-
-        RecipeRunner(recipe, invalid_values, user)
-
-        # start_date is missing - should raise validation error
-        errors = recipe.validate_variable_values(invalid_values)
-        assert len(errors) > 0
-
-    @patch("apps.recipes.services.runner.build_agent_graph")
-    def test_recipe_runner_creates_run_record(self, mock_build_graph, recipe, user, recipe_step_1):
-        """Test that RecipeRunner creates a RecipeRun record."""
-        from apps.recipes.services.runner import RecipeRunner
-
-        values = {
-            "region": "North",
-            "limit": 10,
-            "start_date": "2024-01-01",
-        }
-
-        # Mock the agent graph
+        values = {"region": "North", "limit": 10, "start_date": "2024-01-01"}
         mock_graph = Mock()
-        mock_graph.invoke.return_value = {"messages": [Mock(content="Result", tool_calls=[])]}
-        mock_build_graph.return_value = mock_graph
+        mock_graph.ainvoke = AsyncMock(
+            return_value={"messages": [Mock(content="Result", tool_calls=[])]}
+        )
 
-        runner = RecipeRunner(recipe, values, user)
-        run = runner.execute()
+        run = await RecipeRunner(recipe, values, user, graph=mock_graph).execute_async()
 
         assert run is not None
         assert isinstance(run, RecipeRun)
@@ -621,108 +611,71 @@ class TestRecipeRunner:
         assert run.variable_values == values
         assert run.run_by == user
 
-    @patch("apps.recipes.services.runner.build_agent_graph")
-    def test_recipe_runner_executes_prompt(self, mock_build_graph, recipe, user, recipe_step_1):
-        """Test that RecipeRunner executes the rendered prompt."""
+    @pytest.mark.asyncio
+    async def test_recipe_runner_executes_prompt(self, recipe, user, recipe_step_1):
+        """RecipeRunner records a single executed step on success."""
         from apps.recipes.services.runner import RecipeRunner
 
-        # Mock the agent graph
+        values = {"region": "West", "limit": 15, "start_date": "2024-06-01"}
         mock_graph = Mock()
-        mock_graph.invoke.return_value = {
-            "messages": [Mock(content="Mocked response", tool_calls=[])]
-        }
-        mock_build_graph.return_value = mock_graph
+        mock_graph.ainvoke = AsyncMock(
+            return_value={"messages": [Mock(content="Mocked response", tool_calls=[])]}
+        )
 
-        values = {
-            "region": "West",
-            "limit": 15,
-            "start_date": "2024-06-01",
-        }
+        run = await RecipeRunner(recipe, values, user, graph=mock_graph).execute_async()
 
-        runner = RecipeRunner(recipe, values, user)
-        run = runner.execute()
-
-        # Runner executes a single prompt (not multi-step)
         assert len(run.step_results) == 1
         assert run.step_results[0]["step_order"] == 1
         assert run.step_results[0]["success"] is True
 
-    @patch("apps.recipes.services.runner.build_agent_graph")
-    def test_recipe_runner_substitutes_variables_in_prompts(
-        self, mock_build_graph, recipe, user, recipe_step_1
+    @pytest.mark.asyncio
+    async def test_recipe_runner_substitutes_variables_in_prompts(
+        self, recipe, user, recipe_step_1
     ):
-        """Test that RecipeRunner substitutes variables in prompt templates."""
+        """RecipeRunner renders variable values into the prompt."""
         from apps.recipes.services.runner import RecipeRunner
 
-        # Mock the agent graph
+        values = {"region": "East", "limit": 25, "start_date": "2024-03-01"}
         mock_graph = Mock()
-        mock_graph.invoke.return_value = {
-            "messages": [Mock(content="Mocked response", tool_calls=[])]
-        }
-        mock_build_graph.return_value = mock_graph
+        mock_graph.ainvoke = AsyncMock(
+            return_value={"messages": [Mock(content="Mocked response", tool_calls=[])]}
+        )
 
-        values = {
-            "region": "East",
-            "limit": 25,
-            "start_date": "2024-03-01",
-        }
+        run = await RecipeRunner(recipe, values, user, graph=mock_graph).execute_async()
 
-        runner = RecipeRunner(recipe, values, user)
-        run = runner.execute()
-
-        # Check that the prompt was rendered with values
         step_result = run.step_results[0]
         assert "East" in step_result["prompt"]
         assert "25" in step_result["prompt"]
 
-    @patch("apps.recipes.services.runner.build_agent_graph")
-    def test_recipe_runner_handles_execution_failure(
-        self, mock_build_graph, recipe, user, recipe_step_1
-    ):
-        """Test that RecipeRunner handles step execution failures."""
+    @pytest.mark.asyncio
+    async def test_recipe_runner_handles_execution_failure(self, recipe, user, recipe_step_1):
+        """RecipeRunner records a failed run when the graph raises."""
         from apps.recipes.services.runner import RecipeRunner
 
-        # Mock the agent graph to raise an error during invoke
+        values = {"region": "North", "limit": 10, "start_date": "2024-01-01"}
         mock_graph = Mock()
-        mock_graph.invoke = Mock(side_effect=Exception("Agent execution failed"))
-        mock_build_graph.return_value = mock_graph
+        mock_graph.ainvoke = AsyncMock(side_effect=Exception("Agent execution failed"))
 
-        values = {
-            "region": "North",
-            "limit": 10,
-            "start_date": "2024-01-01",
-        }
+        run = await RecipeRunner(recipe, values, user, graph=mock_graph).execute_async()
 
-        runner = RecipeRunner(recipe, values, user, graph=mock_graph)
-        run = runner.execute()
-
-        # Run should be marked as failed
         assert run.status == RecipeRunStatus.FAILED
-        # Should have error in step results
         assert len(run.step_results) > 0
         assert run.step_results[0]["success"] is False
         assert "error" in run.step_results[0]
 
-    @patch("apps.recipes.services.runner.build_agent_graph")
-    def test_recipe_runner_updates_run_status(self, mock_build_graph, recipe, user, recipe_step_1):
-        """Test that RecipeRunner updates run status throughout execution."""
+    @pytest.mark.asyncio
+    async def test_recipe_runner_updates_run_status(self, recipe, user, recipe_step_1):
+        """RecipeRunner marks the run completed with a completion timestamp."""
         from apps.recipes.services.runner import RecipeRunner
 
-        # Mock the agent graph
+        values = {"region": "South", "limit": 5, "start_date": "2024-02-01"}
         mock_graph = Mock()
-        mock_graph.invoke.return_value = {"messages": [Mock(content="Success", tool_calls=[])]}
-        mock_build_graph.return_value = mock_graph
+        mock_graph.ainvoke = AsyncMock(
+            return_value={"messages": [Mock(content="Success", tool_calls=[])]}
+        )
 
-        values = {
-            "region": "South",
-            "limit": 5,
-            "start_date": "2024-02-01",
-        }
+        run = await RecipeRunner(recipe, values, user, graph=mock_graph).execute_async()
 
-        runner = RecipeRunner(recipe, values, user)
-        run = runner.execute()
-
-        # Run should be completed
         assert run.status == RecipeRunStatus.COMPLETED
         assert run.completed_at is not None
 

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -4,14 +4,17 @@ Comprehensive tests for Phase 4 (Recipes) of the Scout data agent platform.
 Tests recipe CRUD, variable substitution, recipe runner, and save_as_recipe tool.
 """
 
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
+from asgiref.sync import sync_to_async
 from django.contrib.auth import get_user_model
 from django.db import IntegrityError
+from django.test import AsyncClient
 from django.utils import timezone
 
 from apps.recipes.models import Recipe, RecipeRun, RecipeRunStatus, RecipeStep
+from apps.recipes.services.runner import RecipeRunner, VariableValidationError
 
 User = get_user_model()
 
@@ -584,8 +587,6 @@ class TestRecipeRunner:
     @pytest.mark.asyncio
     async def test_recipe_runner_validates_variables(self, recipe, user, recipe_step_1):
         """RecipeRunner.execute_async raises VariableValidationError on missing vars."""
-        from apps.recipes.services.runner import RecipeRunner, VariableValidationError
-
         invalid_values = {"region": "North", "limit": 10}  # start_date missing
 
         runner = RecipeRunner(recipe, invalid_values, user, graph=Mock())
@@ -595,8 +596,6 @@ class TestRecipeRunner:
     @pytest.mark.asyncio
     async def test_recipe_runner_creates_run_record(self, recipe, user, recipe_step_1):
         """RecipeRunner creates a RecipeRun record."""
-        from apps.recipes.services.runner import RecipeRunner
-
         values = {"region": "North", "limit": 10, "start_date": "2024-01-01"}
         mock_graph = Mock()
         mock_graph.ainvoke = AsyncMock(
@@ -614,8 +613,6 @@ class TestRecipeRunner:
     @pytest.mark.asyncio
     async def test_recipe_runner_executes_prompt(self, recipe, user, recipe_step_1):
         """RecipeRunner records a single executed step on success."""
-        from apps.recipes.services.runner import RecipeRunner
-
         values = {"region": "West", "limit": 15, "start_date": "2024-06-01"}
         mock_graph = Mock()
         mock_graph.ainvoke = AsyncMock(
@@ -633,8 +630,6 @@ class TestRecipeRunner:
         self, recipe, user, recipe_step_1
     ):
         """RecipeRunner renders variable values into the prompt."""
-        from apps.recipes.services.runner import RecipeRunner
-
         values = {"region": "East", "limit": 25, "start_date": "2024-03-01"}
         mock_graph = Mock()
         mock_graph.ainvoke = AsyncMock(
@@ -650,8 +645,6 @@ class TestRecipeRunner:
     @pytest.mark.asyncio
     async def test_recipe_runner_handles_execution_failure(self, recipe, user, recipe_step_1):
         """RecipeRunner records a failed run when the graph raises."""
-        from apps.recipes.services.runner import RecipeRunner
-
         values = {"region": "North", "limit": 10, "start_date": "2024-01-01"}
         mock_graph = Mock()
         mock_graph.ainvoke = AsyncMock(side_effect=Exception("Agent execution failed"))
@@ -666,8 +659,6 @@ class TestRecipeRunner:
     @pytest.mark.asyncio
     async def test_recipe_runner_updates_run_status(self, recipe, user, recipe_step_1):
         """RecipeRunner marks the run completed with a completion timestamp."""
-        from apps.recipes.services.runner import RecipeRunner
-
         values = {"region": "South", "limit": 5, "start_date": "2024-02-01"}
         mock_graph = Mock()
         mock_graph.ainvoke = AsyncMock(
@@ -806,3 +797,54 @@ class TestSaveAsRecipeTool:
 
         recipe = await Recipe.objects.aget(id=result["recipe_id"])
         assert recipe.is_shared is True
+
+
+# ============================================================================
+# 8. TestRecipeRunView
+# ============================================================================
+
+
+@pytest.mark.django_db(transaction=True)
+class TestRecipeRunView:
+    """Tests for the async recipe run endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_run_endpoint_returns_201_with_real_graph(self, recipe, user, recipe_step_1):
+        """POST run/ builds the real graph (LLM mocked, no MCP tools) and returns 201."""
+        from langchain_core.messages import AIMessage
+
+        async def fake_ainvoke(messages, *args, **kwargs):
+            return AIMessage(content="done", id="ai-1")
+
+        mock_bound = MagicMock()
+        mock_bound.ainvoke = AsyncMock(side_effect=fake_ainvoke)
+        mock_llm = MagicMock()
+        mock_llm.bind_tools.return_value = mock_bound
+
+        client = AsyncClient()
+        await sync_to_async(client.login)(email="test@example.com", password="testpass123")
+
+        url = f"/api/workspaces/{recipe.workspace_id}/recipes/{recipe.id}/run/"
+        body = {"variable_values": {"region": "North", "limit": 10, "start_date": "2024-01-01"}}
+
+        with (
+            patch(
+                "apps.recipes.services.runner.get_mcp_tools",
+                new=AsyncMock(return_value=[]),
+            ),
+            patch("apps.agents.graph.base.ChatAnthropic", return_value=mock_llm),
+        ):
+            resp = await client.post(url, data=body, content_type="application/json")
+
+        assert resp.status_code == 201, resp.content
+        data = resp.json()
+        assert data["status"] == RecipeRunStatus.COMPLETED
+
+    @pytest.mark.asyncio
+    async def test_run_endpoint_forbids_non_member(self, recipe, other_user, recipe_step_1):
+        """A user with no workspace membership gets 403."""
+        client = AsyncClient()
+        await sync_to_async(client.login)(email="other@example.com", password="otherpass123")
+        url = f"/api/workspaces/{recipe.workspace_id}/recipes/{recipe.id}/run/"
+        resp = await client.post(url, data={"variable_values": {}}, content_type="application/json")
+        assert resp.status_code == 403


### PR DESCRIPTION
## Summary

Recipes have been **100% broken since the March refactor (`e26cd75`)** — every recipe run crashed before reaching the LLM. The runner had drifted away from the agent-graph contract, and the break stayed hidden for ~3 months because every recipe test mocked `build_agent_graph`. This PR restores the feature **async-first** with a minimal, request-scoped fix, and adds a real unmocked test that would have caught the break.

Sentry #276 (`SynchronousOnlyOperation`) was the first crash users hit — a symptom of this issue, not a separate bug — so it's resolved here too.

## The drifts fixed (`apps/recipes/services/runner.py`)

1. **`build_agent_graph` signature** — was called with `tenant_membership=…` (removed param); now `build_agent_graph(workspace=…, user=…, checkpointer=None, mcp_tools=…, oauth_tokens=…)`, the real signature.
2. **`AgentState` keys** — `initial_state` used `tenant_id`/`tenant_name`/`tenant_membership_id`; now uses the real keys `workspace_id`/`user_id`/`user_role`/`thread_id`, so MCP tools receive a valid `workspace_id` instead of `""`.
3. **MCP tools never loaded** — now loads `get_mcp_tools()` + `get_user_oauth_tokens()` and passes them, mirroring `apps/chat`.
4. **Sync execution path** — deleted the sync `execute()` (`async_to_sync` + sync `graph.invoke()`). `execute_async` is now the single live path.

The `Workspace` is loaded by FK id (`recipe.workspace_id`) rather than via lazy `recipe.workspace` traversal — that lazy load was the proximate source of the `SynchronousOnlyOperation` (Sentry #276).

## Run endpoint → raw async view

`RecipeRunView` (DRF `APIView`, which cannot `await` the async-first runner) is replaced by `async def recipe_run_view`, mirroring `chat_view`: `@csrf_protect` + `@async_login_required`, `aresolve_workspace`, async ORM recipe lookup, `await execute_async`, async TTL touch, DRF serializers wrapped in `sync_to_async`, and a hashed error-ref on 500 (no raw exception leak). The other five recipe views stay DRF.

## Tests (this is why the break hid)

- **New real unmocked contract test** (`tests/test_recipe_runner.py`): stands up the real in-process MCP server and loads real tools, builds the **real** agent graph through `execute_async` (only the LLM and MCP transport are stubbed), and drives a `get_schema_status` tool call. It fails loudly on any of the three drifts — wrong kwargs (`TypeError`), missing `mcp_tools` (tool absent), or wrong state keys (`VALIDATION_ERROR` instead of `not_provisioned`).
- Migrated the previously-mocked `TestRecipeRunner` unit tests to `await execute_async`.
- Added async endpoint tests (201 real-graph path + 403 non-member).

## Scope

- Request-scoped restoration only. Does **not** move execution to a background Procrastinate task — that redesign is #267.
- Keeps `RecipeRunner.execute_async` (supersedes #266's "delete as dead code" — it's now the live path).
- **Supersedes PR #277** (which patched only the FK lazy-load — necessary but insufficient).

## Test plan

- [x] `uv run pytest tests/test_recipes.py tests/test_recipe_runner.py` — 47 passed
- [x] Full backend suite — 1216 passed, 5 skipped, 1 xfailed, 0 failures
- [x] `ruff check` / `ruff format --check` clean; `makemigrations --check` → no changes
- [x] **Real end-to-end**: ran a recipe against the real MCP server + real Anthropic API → run `COMPLETED`, `get_schema_status` invoked with the correct `workspace_id` (coherent "no data loaded yet" answer, not `VALIDATION_ERROR`)

Closes #238
Closes #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)