### PR TITLE
fix(onboarding): POST API key to live /api/auth/connections/ endpoint (#242)

### DIFF
--- a/frontend/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/frontend/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -9,6 +9,12 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 
 type Step = "choose" | "api-key"
 
+interface MembershipResult {
+  membership_id: string
+  tenant_id: string
+  tenant_name: string
+}
+
 export function OnboardingWizard() {
   const [step, setStep] = useState<Step>("choose")
   const [domain, setDomain] = useState("")
@@ -24,11 +30,13 @@ export function OnboardingWizard() {
     setLoading(true)
     setError(null)
     try {
-      await api.post("/api/auth/tenant-credentials/", {
+      await api.post<{ memberships: MembershipResult[] }>("/api/auth/connections/", {
         provider: "commcare",
-        tenant_id: domain,
-        tenant_name: domain,
-        credential: `${username}:${apiKey}`,
+        fields: {
+          domain,
+          username,
+          api_key: apiKey,
+        },
       })
       // Refresh auth state so onboarding_complete becomes true
       await fetchMe()


### PR DESCRIPTION
## Problem

The first-run "Use an API Key" path in `OnboardingWizard` POSTed to `/api/auth/tenant-credentials/` with the pre-#220 payload `{provider, tenant_id, tenant_name, credential}`. That route was **removed** in the #220 TenantConnection rebuild (replaced by `POST /api/auth/connections/` with `{provider, fields}`). Every non-OAuth user is forced into the wizard until a connection-backed `TenantMembership` exists, so the wizard guaranteed a **404 → "Failed to save credentials" dead end** on the critical first-run path.

## Fix

Re-point the wizard's API-key submit to the live endpoint, matching `ApiConnectionDialog`'s add path byte-for-byte:

- **Old:** `POST /api/auth/tenant-credentials/` `{ provider: "commcare", tenant_id, tenant_name, credential: "${username}:${apiKey}" }`
- **New:** `POST /api/auth/connections/` `{ provider: "commcare", fields: { domain, username, api_key } }`

The field keys (`domain`, `username`, `api_key`) match the CommCare strategy's `form_fields` (`apps/users/services/api_key_providers/commcare.py`). The server's `pack_credential` builds `username:api_key` itself, so the client no longer pre-concatenates the credential. The response is typed as `{ memberships: MembershipResult[] }`, mirroring `ApiConnectionDialog`.

## Design notes (autonomous decisions)

- **Minimal re-point, not a rewrite.** This is `effort:S` / `status:broken-now`. The wizard stays a deliberately simple CommCare-only first-run UI (OAuth + API key). Rewriting it to use the full dynamic provider registry like `ApiConnectionDialog` is out of scope for this bug.
- **Error handling already correct.** The shared `api` client throws `ApiError` carrying the server's `error` message, so the existing `catch` now surfaces real validation errors (e.g. "User X is not a member of domain Y") instead of a generic failure; the catch fallback string is preserved.
- **No data-model or unrelated changes.** Only `OnboardingWizard.tsx` is touched. Existing `data-testid`s (`onboarding-domain`, `onboarding-username`, `onboarding-api-key`) are preserved; no new interactive elements added, so no new test ids needed.

## Verification

- `cd frontend && bun run build` → `tsc -b && vite build` passed (the >500 kB chunk warning is pre-existing and project-wide, unrelated to this change).
- `cd frontend && bun run lint` → ESLint clean, no errors.
- Grep contract: `tenant-credentials` no longer appears anywhere in `frontend/src`; onboarding now POSTs `{provider, fields}` to `/api/auth/connections/`.
- No JS unit-test runner exists (Playwright e2e only); a full-stack e2e would require standing up Django + DB + a fresh non-OAuth user, which was out of scope. The request shape is verified identical to the working `ApiConnectionDialog` add path.

## Notes / risks for integrator

- Low risk: single-file, request-shape-only change with no data-model impact.
- Worth a quick manual smoke once integrated: create a fresh non-OAuth user, choose "Use an API Key", submit valid CommCare domain/username/api_key, confirm onboarding completes (201 + `fetchMe`/`fetchDomains` flip `onboarding_complete`).

Closes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)