### PR TITLE
fix(security): restore artifact iframe isolation (drop allow-same-origin)

### DIFF
--- a/apps/artifacts/views.py
+++ b/apps/artifacts/views.py
@@ -247,7 +247,22 @@ SANDBOX_HTML_TEMPLATE = """<!DOCTYPE html>
                     return;
                 }
 
-                // If the artifact has live queries, fetch fresh data from the server
+                // If the artifact has live queries, fetch fresh data from the server.
+                //
+                // KNOWN LIMITATION (pre-existing, out of scope for the postMessage
+                // fix below): this frame is sandboxed WITHOUT allow-same-origin, so
+                // its document has an opaque ("null") origin. A fetch() from a
+                // null-origin document is treated as cross-origin, so the browser
+                // requires CORS on the response; /query-data returns no
+                // Access-Control-Allow-Origin header, so the response is BLOCKED
+                // ("from origin 'null' has been blocked by CORS policy"), regardless
+                // of credentials. The artifact's embedded data is also {} for live
+                // queries (see ArtifactSandboxView), so a live-query artifact cannot
+                // self-hydrate inside the iframe and will show "Data Fetch Error".
+                // The parent ArtifactPanel still loads live data for its Data tab via
+                // its own same-origin api.get(); fixing the iframe VIEW tab needs a
+                // separate change (e.g. embed query results server-side, or add CORS)
+                // and is deliberately not attempted here.
                 if (artifact.has_live_queries) {
                     this.showLoading('Querying database...');
                     try {
@@ -260,13 +275,23 @@ SANDBOX_HTML_TEMPLATE = """<!DOCTYPE html>
                         }
                         const queryData = await resp.json();
                         artifact.data = this.mergeQueryResults(queryData, artifact.data || {});
-                        // Expose raw query info for parent frame (Data tab)
+                        // Expose raw query info for parent frame (Data tab).
+                        // targetOrigin is '*' rather than the document origin:
+                        // this frame is sandboxed WITHOUT allow-same-origin, so
+                        // its document has an opaque origin whose
+                        // window.location.origin is the string 'null'. Passing
+                        // 'null' as targetOrigin is rejected by the browser
+                        // ("Invalid target origin 'null'"), and any concrete
+                        // origin would not match the parent's, so the message
+                        // would never be delivered. '*' is safe because the
+                        // parent (ArtifactPanel) authenticates inbound messages by
+                        // event.source === this iframe's contentWindow, not origin.
                         artifact._queryResults = queryData;
                         window.parent.postMessage({
                             type: 'artifact-query-data',
                             artifactId: artifact.id,
                             queryData: queryData,
-                        }, window.location.origin);
+                        }, '*');
                     } catch (error) {
                         this.showError('Data Fetch Error', error.message);
                         return;
@@ -633,12 +658,18 @@ SANDBOX_HTML_TEMPLATE = """<!DOCTYPE html>
                     </div>
                 `;
 
-                // Notify parent of error (if embedded in iframe)
+                // Notify parent of error (if embedded in iframe).
+                // targetOrigin is '*' rather than the document origin, for the
+                // same reason as artifact-query-data above: this opaque-origin
+                // sandbox frame has window.location.origin equal to the string
+                // 'null', which the browser rejects as a postMessage target, so
+                // the message would never reach the parent. The parent
+                // authenticates by event.source, so '*' leaks nothing.
                 try {
                     window.parent.postMessage({
                         type: 'artifact-error',
                         error: { title, message, details }
-                    }, window.location.origin);
+                    }, '*');
                 } catch (e) { /* ignore if not in iframe */ }
             },
 

--- a/apps/artifacts/views.py
+++ b/apps/artifacts/views.py
@@ -659,8 +659,20 @@ SANDBOX_HTML_TEMPLATE = """<!DOCTYPE html>
         // Print-to-PDF: the parent frame posts {type: 'scout-print'} to print
         // only the artifact (not the surrounding app). Triggering print inside
         // the sandboxed iframe scopes the print job to the artifact content.
+        //
+        // SECURITY: this iframe is sandboxed WITHOUT allow-same-origin, so its
+        // document has a unique opaque ("null") security origin. An origin
+        // allowlist is therefore broken here on BOTH ends: legitimate messages
+        // from the real parent arrive with event.origin === the app's concrete
+        // origin (never "null"), so an `event.origin === window.location.origin`
+        // check would silently REJECT them and break Export PDF; and any other
+        // sandboxed frame on the page also reports event.origin "null", so a
+        // "null"-origin allowance would TRUST forgeries from sibling frames.
+        // The robust gate is on the message source: only accept messages posted
+        // by our actual parent window, mirroring the source-based check the
+        // parent (ArtifactPanel) uses on inbound artifact messages.
         window.addEventListener('message', (event) => {
-            if (event.origin !== window.location.origin) return;
+            if (event.source !== window.parent) return;
             if (event.data && event.data.type === 'scout-print') {
                 window.print();
             }

--- a/frontend/src/components/ArtifactPanel/ArtifactPanel.tsx
+++ b/frontend/src/components/ArtifactPanel/ArtifactPanel.tsx
@@ -43,10 +43,15 @@ export function ArtifactPanel() {
     // Trigger print inside the sandboxed iframe so the print job is scoped to
     // the artifact content, not the surrounding app. The sandbox HTML listens
     // for this message and calls window.print() (browser "Save as PDF").
-    iframeRef.current?.contentWindow?.postMessage(
-      { type: "scout-print" },
-      window.location.origin,
-    )
+    //
+    // targetOrigin is "*" because the iframe is sandboxed WITHOUT
+    // allow-same-origin and therefore has an opaque ("null") security origin.
+    // The browser drops a postMessage whose targetOrigin is a concrete origin
+    // string (e.g. window.location.origin) when the target frame's security
+    // origin is opaque, which would silently break Export PDF. "*" is safe
+    // here: the message is a trivial non-secret "scout-print" signal sent only
+    // to our own artifact iframe via iframeRef, so there is nothing to leak.
+    iframeRef.current?.contentWindow?.postMessage({ type: "scout-print" }, "*")
   }, [])
 
   const fetchQueryData = useCallback(async (id: string) => {
@@ -71,6 +76,16 @@ export function ArtifactPanel() {
 
   useEffect(() => {
     function handleMessage(event: MessageEvent) {
+      // Only trust messages that came from our own artifact iframe. The iframe
+      // runs agent-generated (prompt-injectable) code, and it is sandboxed
+      // WITHOUT allow-same-origin, so it is a unique opaque origin whose
+      // event.origin is the literal string "null" — an origin allowlist would
+      // either reject legitimate messages or have to trust "null" (which any
+      // sandboxed frame on the page could also claim). The robust check is on
+      // the message source: reject anything not posted by this iframe's window
+      // (e.g. other frames, popups, or window.opener attempting to forge
+      // artifact-query-data).
+      if (event.source !== iframeRef.current?.contentWindow) return
       if (event.data?.type === "artifact-query-data" && event.data.artifactId === artifactId) {
         setQueryData(event.data.queryData)
       }
@@ -191,7 +206,16 @@ export function ArtifactPanel() {
               key={artifactId}
               src={activeDomainId ? `/api/workspaces/${activeDomainId}/artifacts/${artifactId}/sandbox/` : ""}
               className="flex-1 w-full"
-              sandbox="allow-scripts allow-same-origin allow-modals"
+              // SECURITY: deliberately NO allow-same-origin. The sandbox doc is
+              // served same-origin and session-authenticated, and it executes
+              // agent-generated (prompt-injectable) code. With allow-same-origin
+              // that code could read the viewer's cookies/CSRF token, issue
+              // credentialed /api/ requests, and reach window.parent — a full
+              // session takeover. Omitting it gives the frame a unique opaque
+              // origin: scripts still run and render UI, but the frame cannot
+              // touch the parent origin or send credentialed same-origin
+              // requests. Do NOT re-add allow-same-origin.
+              sandbox="allow-scripts allow-modals"
               title="Artifact"
             />
           )}

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -225,9 +225,40 @@ class TestArtifactSandboxView:
 
         # Print-optimized styling is present.
         assert "@media print" in content
-        # Parent frame triggers print via a postMessage handler scoped to origin.
+        # Parent frame triggers print via a postMessage handler.
         assert "scout-print" in content
         assert "window.print()" in content
+
+    def test_scout_print_receiver_validates_source_not_origin(
+        self, authenticated_client, artifact, workspace
+    ):
+        """The scout-print receiver must gate on event.source, not event.origin.
+
+        The iframe is sandboxed WITHOUT allow-same-origin, so its document has an
+        opaque ("null") security origin. The parent posts scout-print from the
+        app's concrete origin, so an `event.origin === window.location.origin`
+        guard would reject the legitimate message (event.origin != "null") AND
+        would trust forgeries from other "null"-origin sandboxed frames. The
+        receiver must instead accept only messages whose source is the parent
+        window (mirroring ArtifactPanel's source-based check).
+        """
+        response = authenticated_client.get(
+            f"/api/workspaces/{workspace.id}/artifacts/{artifact.id}/sandbox/"
+        )
+
+        assert response.status_code == 200
+        content = response.content.decode()
+
+        # Isolate the scout-print message listener block.
+        anchor = content.index("Print-to-PDF")
+        listener_start = content.index("window.addEventListener('message'", anchor)
+        listener_end = content.index("});", listener_start)
+        listener = content[listener_start:listener_end]
+
+        # The scout-print receiver gates on the message source (trusted parent),
+        assert "event.source !== window.parent" in listener
+        # and does NOT gate it on origin equality (which breaks opaque-origin frames).
+        assert "event.origin !== window.location.origin" not in listener
 
     def test_sandbox_csp_headers(self, authenticated_client, artifact, workspace):
         """Test that CSP headers are set correctly for security."""

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -260,6 +260,50 @@ class TestArtifactSandboxView:
         # and does NOT gate it on origin equality (which breaks opaque-origin frames).
         assert "event.origin !== window.location.origin" not in listener
 
+    def test_iframe_to_parent_messages_use_wildcard_target_origin(
+        self, authenticated_client, artifact, workspace
+    ):
+        """iframe->parent postMessage must target "*", never window.location.origin.
+
+        The iframe is sandboxed WITHOUT allow-same-origin, so its document has an
+        opaque ("null") security origin: inside the frame
+        window.location.origin === "null". A postMessage whose targetOrigin is a
+        concrete origin string (or "null") will NOT match the parent's real
+        concrete origin, so the browser SILENTLY DROPS the message. Both
+        iframe->parent sends (artifact-query-data and artifact-error) must use
+        targetOrigin "*". This is safe because the parent (ArtifactPanel)
+        authenticates inbound messages by event.source === the iframe's
+        contentWindow, not by origin.
+        """
+        response = authenticated_client.get(
+            f"/api/workspaces/{workspace.id}/artifacts/{artifact.id}/sandbox/"
+        )
+
+        assert response.status_code == 200
+        content = response.content.decode()
+
+        # No iframe->parent postMessage call may target the document origin
+        # (window.location.origin == "null"). Match the concrete call form
+        # `}, window.location.origin)` so explanatory comments don't trip it.
+        assert "}, window.location.origin)" not in content, (
+            "iframe->parent postMessage still targets window.location.origin, "
+            "which is 'null' for an opaque-origin sandbox frame and will be "
+            "silently dropped by the browser."
+        )
+
+        # Both message types must be posted to the parent with the "*" target.
+        # The targetOrigin is the final argument on the `}, <target>);` line that
+        # closes each postMessage call; locate it from the message type marker.
+        for msg_type in ("artifact-query-data", "artifact-error"):
+            idx = content.index(f"type: '{msg_type}'")
+            close = content.index("}, ", idx)
+            # Slice the closing line up to the call terminator `);`.
+            target_arg = content[close + len("}, ") : content.index(");", close)]
+            assert target_arg == "'*'", (
+                f"iframe->parent '{msg_type}' postMessage must use targetOrigin "
+                f"'*'; found: {target_arg!r}"
+            )
+
     def test_sandbox_csp_headers(self, authenticated_client, artifact, workspace):
         """Test that CSP headers are set correctly for security."""
         response = authenticated_client.get(


### PR DESCRIPTION
Closes #239

## The vulnerability

The artifact preview iframe was embedded with
`sandbox="allow-scripts allow-same-origin allow-modals"` on a document
served **same-origin and session-authenticated** (`/api/workspaces/.../artifacts/.../sandbox/`).
That document executes **agent-generated** React/HTML via `Babel.transform` + `new Function`
(and re-executes arbitrary `<script>` tags for HTML artifacts), and artifact code is
**prompt-injectable** from materialized third-party data or any read_write member.

`allow-scripts` + `allow-same-origin` on a same-origin document makes the sandbox a **no-op**:
the iframe keeps the parent's real origin, so injected code could

- read the viewer's cookies and the JS-readable CSRF token (`CSRF_COOKIE_HTTPONLY=False`),
- issue credentialed state-changing `/api/` requests as the viewing user, and
- reach `window.parent` / the parent DOM.

That is stored-XSS-with-full-API-authority across workspace members. The
`ArtifactPanel` `postMessage` listener also accepted messages from **any** window with no
source/origin check.

## The fix

**Frontend (`frontend/src/components/ArtifactPanel/ArtifactPanel.tsx`):**

1. **Drop `allow-same-origin`** from the iframe `sandbox` attribute
   (`allow-scripts allow-same-origin allow-modals` → `allow-scripts allow-modals`).
   The frame becomes a **unique opaque origin**: scripts still run and render UI, but the
   frame can no longer touch the parent origin or send credentialed same-origin requests.
2. **Harden the parent `postMessage` listener.** Reject any message whose
   `event.source !== iframeRef.current?.contentWindow`. This is **origin-independent** and
   correct for the opaque frame, whose `event.origin` is the literal string `"null"` — an
   origin allowlist would either reject legitimate messages or have to trust `"null"`
   (which any sandboxed frame could claim). A source check is the robust choice.
3. **Keep Export PDF working from the sender side.** `handleExportPdf` posts the
   `scout-print` signal with `targetOrigin: "*"` instead of `window.location.origin`. The
   browser **drops** a concrete-origin `postMessage` aimed at an opaque-origin frame, which
   would have silently broken delivery after change (1). `"*"` is safe here: the message is
   a trivial, non-secret signal sent only to our own artifact iframe via `iframeRef`.

**Backend (`apps/artifacts/views.py`, sandbox HTML — regression fix):**

4. **Fix the sandbox HTML's `scout-print` RECEIVER.** Delivering the message (3) is not
   enough: the in-iframe listener still gated on `event.origin === window.location.origin`.
   In an opaque-origin frame `window.location.origin === "null"` but the parent's
   `scout-print` arrives with `event.origin === <app's concrete origin>`, so the legitimate
   message was **rejected** and Export PDF was silently broken. That origin guard was also
   unsafe — any *other* `"null"`-origin sandboxed frame on the page reports `event.origin`
   `"null"` and could forge a `scout-print`. The receiver now gates on the source:
   `event.source !== window.parent` → return, mirroring the parent-side source check. This
   restores Export PDF and **tightens** isolation.

A regression test (`tests/test_artifacts.py::test_scout_print_receiver_validates_source_not_origin`)
asserts the served listener gates on `event.source` and not origin equality; it fails
against the old guard and passes with the fix.

Out-of-scope items from the finding (server-side PNG/PDF export SSRF; the in-iframe
`credentials:'include'` live-query fetch) were **not** touched.

## How I verified (runtime — corrected, genuinely opaque-origin)

The frontend has no JS unit runner, so I drove a minimal HTTP repro with `playwright-cli`.
**Crucially, the test iframe is `sandbox="allow-scripts allow-modals"` (NO
`allow-same-origin`)**, so inside it `window.location.origin === "null"` — a genuinely
opaque origin (an earlier repro mistakenly showed both sides as `http://localhost`, which
only happens with a real same-origin doc and hid this regression). The iframe embeds the
**exact** `scout-print` receiver string served by `views.py`.

Observed results against the fixed receiver:

| property | value | meaning |
| --- | --- | --- |
| `iframeOrigin` | `"null"` | iframe is **genuinely opaque-origin** |
| `parentOrigin` | `http://localhost:8779` | distinct concrete parent origin |
| `printAcceptedFromParent` | `true` | **(1) Export PDF works** — parent `scout-print` (targetOrigin `"*"`) accepted by the source check, `window.print()` fires |
| `iframeReadParentOrigin` | `BLOCKED:SecurityError` | **(2)** iframe cannot read the parent origin |
| `iframeReadParentCookie` | `BLOCKED:SecurityError` | **(2)** iframe cannot read the parent `document.cookie` |
| `printAcceptedFromForged` | `false` | **(2)** forged `scout-print` from a sibling non-parent frame **rejected** by the source check |
| `panelAcceptedFromIframe` | `true` | **(2c)** ArtifactPanel-style guard accepts a real message from the iframe |
| `panelAcceptedFromForged` | `false` | **(2c)** ArtifactPanel-style guard rejects a forged message from a non-iframe window |
| `iframeRendered` | `true` | **(3)** a normal artifact still renders |

Against the **old** origin-equality receiver the same harness showed
`printAcceptedFromParent: false` (Export PDF broken) and `printAcceptedFromForged: true`
(sibling forgery accepted) — confirming both the regression and the isolation flaw the fix
closes.

Also: `uv run ruff check .` clean; `uv run pytest tests/test_artifacts.py` → 15 passed;
`cd frontend && bun install && bun run build` (tsc + vite, clean) and `bun run lint`
(ESLint, clean).

## Notes / risks for the integrator

- **Live-query artifacts:** the sandbox doc's in-iframe `credentials:'include'` fetch to
  `/api/.../query-data/` (apps/artifacts/views.py) is now a cross-origin request from a
  null origin, so it will no longer carry session cookies (and CSP `connect-src 'self'`
  blocks it). The parent-driven **Data** tab path (parent fetches `query-data` itself) is
  unaffected. The iframe's outbound `artifact-query-data`/`artifact-error` messages still
  post with `targetOrigin: window.location.origin` (`"null"`) and so are not delivered to
  the concrete-origin parent — but for live-query artifacts they were already unreachable
  because the prerequisite credential-less fetch fails. Wiring query results server-side
  for the *View* tab is a sensible follow-up, but is out of scope here.
- No behavioral change for the common case (static artifacts render unchanged).
- No new interactive elements, so no new `data-testid` needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Follow-up (commit `10fee30`): symmetric iframe→parent fix

The original PR fixed the **parent→iframe** `scout-print` direction but left the
**iframe→parent** sends in `SANDBOX_HTML_TEMPLATE` (`artifact-query-data` ~L265 and
`artifact-error` ~L638) posting with `window.parent.postMessage(..., window.location.origin)`.
In the opaque-origin frame `window.location.origin === "null"`, and a `"null"` targetOrigin
is **rejected by the browser** (`Invalid target origin 'null'`), so those messages never
reached the parent. Both sends now use `targetOrigin: "*"`, mirroring the parent→iframe fix.
This is safe: `ArtifactPanel` authenticates inbound messages by
`event.source === iframeRef.current?.contentWindow`, never by origin.

A regression test
(`tests/test_artifacts.py::test_iframe_to_parent_messages_use_wildcard_target_origin`) asserts
the served template no longer posts to `window.location.origin` and that both message types
target `"*"`. It fails against the old template and passes with the fix.

### What the data-flow trace found (corrected)

Tracing the Data-tab path end-to-end and runtime-verifying against a **genuinely
opaque-origin** frame (`srcdoc` so `window.location.origin === "null"`) corrected an earlier
assumption in the Notes below:

- The iframe's own `fetch('/api/.../query-data/', {credentials:'include'})` fails **because of
  CORS**, not (only) cookie behavior: a fetch from a `null`-origin document is treated as
  cross-origin and the response carries no `Access-Control-Allow-Origin`, so the browser
  blocks it (`from origin 'null' has been blocked by CORS policy`). For live-query artifacts
  the embedded `data` is `{}`, so the **View tab of a live-query artifact cannot self-hydrate
  inside the iframe and shows "Data Fetch Error."** This is a **pre-existing** consequence of
  dropping `allow-same-origin` (introduced in the first commit of this PR), independent of the
  postMessage change, and is documented in a code comment at the fetch site.
- The **Data tab is unaffected**: `ArtifactPanel` fetches `query-data` itself via a
  same-origin `api.get()`, which succeeds.
- The `"*"` targetOrigin fix **fully restores** the iframe→parent message channel: the
  `artifact-query-data` message now reaches the parent (so the Data tab is also fed by the
  iframe when its fetch succeeds), and `artifact-error` now surfaces to the parent.

### Runtime verification (playwright-cli, genuinely opaque frame, `location.origin === "null"`)

| check | result |
| --- | --- |
| frame `window.location.origin` | `"null"` (genuinely opaque) |
| old send `postMessage(.., window.location.origin)` | **threw** `Invalid target origin 'null'` → not delivered |
| new send `postMessage(.., "*")` (`artifact-query-data`) | **delivered** to parent |
| parent→iframe `scout-print` (targetOrigin `"*"`) | **delivered** (iframe acked) — prior fix still works |
| forged message from non-iframe source | **rejected** by parent's `event.source` check |
| iframe credentialed `/query-data` fetch | **blocked by CORS** (`from origin 'null'`) — residual, out of scope |

`uv run ruff check .` clean; `tests/test_artifacts.py` → 16 passed;
`frontend` `bun run build` + `bun run lint` clean.

### Residual risk (out of scope, stated honestly)

The iframe's in-iframe live-query fetch is still CORS-blocked, so live-query artifacts cannot
render fresh data in the **View** tab from inside the sandbox. Fixing it needs a separate
design decision (e.g. embed query results server-side into the template, or add a narrow CORS
allowance on `query-data`) and was intentionally not attempted under this PR's scope (two
postMessage sites + tests). The Data tab and static artifacts are unaffected.
