### PR TITLE
fix(workspaces): rebuild dependent views after tenant-schema refresh (arch #236, 00#9)

### DIFF
--- a/apps/workspaces/tasks.py
+++ b/apps/workspaces/tasks.py
@@ -189,6 +189,16 @@ async def refresh_tenant_schema(schema_id: str, membership_id: str) -> dict:
     new_schema.last_accessed_at = timezone.now()
     await new_schema.asave(update_fields=["state", "last_accessed_at"])
 
+    # Step 3b: The tenant data schema is SHARED across workspaces, and this refresh
+    # swapped in a NEW physical schema. Every multi-tenant WorkspaceViewSchema that
+    # includes this tenant still points its namespaced views at the OLD schema
+    # (about to be torn down), so defer a rebuild for each so their views are
+    # recreated against the new ACTIVE schema — mirroring the sibling rebuild
+    # materialize_workspace performs (PR #230). Without this the views keep serving
+    # stale data until teardown drops the old schema, after which they'd be left
+    # empty (and falsely marked FAILED by teardown_schema).
+    await _rebuild_dependent_view_schemas([new_schema.tenant_id])
+
     # Step 4: Schedule teardown of previously active schemas with a delay to allow
     # in-flight queries against the old schema to complete before it is dropped.
     old_schemas = TenantSchema.objects.filter(
@@ -349,9 +359,9 @@ async def materialize_workspace(
         # just (re)materialized so their views are recreated against the new tables.
         # Failures of individual rebuilds are handled inside rebuild_workspace_view_schema;
         # we never block the resume on them.
-        await _rebuild_sibling_view_schemas(
-            current_workspace_id=str(workspace.id),
-            tenant_ids=[tm.tenant_id for tm in memberships],
+        await _rebuild_dependent_view_schemas(
+            [tm.tenant_id for tm in memberships],
+            exclude_workspace_id=str(workspace.id),
         )
 
         return {
@@ -420,52 +430,56 @@ def _multi_tenant_count_subquery():
     )
 
 
-def _sibling_view_schema_workspaces(tenant_ids, exclude_workspace_id):
-    """Queryset of OTHER multi-tenant workspaces with a WorkspaceViewSchema row
-    that share any of ``tenant_ids``.
+def _dependent_view_schema_workspaces(tenant_ids, exclude_workspace_id=None):
+    """Queryset of multi-tenant workspaces with a WorkspaceViewSchema row that
+    share any of ``tenant_ids``.
 
     A workspace qualifies when it (i) contains at least one of the given tenants,
     (ii) is multi-tenant (>= 2 tenants), and (iii) has a WorkspaceViewSchema row
-    in any state. The current workspace is excluded.
+    in any state. When ``exclude_workspace_id`` is given, that workspace is left
+    out — used by the materialize path, which rebuilds its own view schema inline
+    and only needs to fan out to the *siblings*. The refresh/teardown paths pass
+    no exclusion because they are not scoped to a workspace.
 
     Uses a single annotated query (a subquery tenant count) rather than walking
     each tenant's workspaces, so cost is independent of the number of tenants
     materialized (no N+1).
     """
+    qs = Workspace.objects.filter(
+        workspace_tenants__tenant_id__in=tenant_ids,
+        view_schema__isnull=False,
+    )
+    if exclude_workspace_id is not None:
+        qs = qs.exclude(id=exclude_workspace_id)
     return (
-        Workspace.objects.filter(
-            workspace_tenants__tenant_id__in=tenant_ids,
-            view_schema__isnull=False,
-        )
-        .exclude(id=exclude_workspace_id)
-        .annotate(num_tenants=_multi_tenant_count_subquery())
+        qs.annotate(num_tenants=_multi_tenant_count_subquery())
         .filter(num_tenants__gte=2)
         .distinct()
     )
 
 
-async def _rebuild_sibling_view_schemas(*, current_workspace_id: str, tenant_ids) -> None:
-    """Defer a view-schema rebuild for every sibling workspace whose namespaced
-    views were (or will be) cascade-dropped by this workspace's re-materialization.
+async def _rebuild_dependent_view_schemas(tenant_ids, *, exclude_workspace_id=None) -> None:
+    """Defer a view-schema rebuild for every multi-tenant workspace whose
+    namespaced views were (or will be) cascade-dropped by a (re-)materialization
+    or refresh of one of ``tenant_ids``.
 
-    See the call site in materialize_workspace for the why. The query already
-    yields distinct workspace ids, so no extra dedupe is needed. Best-effort: a
-    failure to defer one rebuild must not block the resume, so each defer is
-    individually guarded and the dispatched task owns its own failure handling.
+    Shared by materialize_workspace (which excludes the current workspace it
+    already rebuilt inline) and the refresh/teardown paths (which exclude
+    nothing). The query already yields distinct workspace ids, so no extra dedupe
+    is needed. Best-effort: a failure to defer one rebuild must not block the
+    caller, so each defer is individually guarded and the dispatched task owns its
+    own failure handling.
     """
-    async for sibling_id in (
-        _sibling_view_schema_workspaces(tenant_ids, current_workspace_id)
+    async for ws_id in (
+        _dependent_view_schema_workspaces(tenant_ids, exclude_workspace_id)
         .values_list("id", flat=True)
         .aiterator()
     ):
         try:
-            await rebuild_workspace_view_schema.defer_async(workspace_id=str(sibling_id))
+            await rebuild_workspace_view_schema.defer_async(workspace_id=str(ws_id))
         except Exception:
             logger.exception(
-                "Failed to defer sibling view-schema rebuild for workspace %s "
-                "(triggered by re-materialization of workspace %s)",
-                sibling_id,
-                current_workspace_id,
+                "Failed to defer dependent view-schema rebuild for workspace %s", ws_id
             )
 
 
@@ -652,11 +666,11 @@ async def teardown_schema(schema_id: str) -> None:
 
     # The tenant schema (t_<id>) is SHARED across workspaces. DROP SCHEMA ... CASCADE
     # just cascade-dropped the namespaced views inside every dependent multi-tenant
-    # workspace's view schema (ws_<hash>). Those WorkspaceViewSchema rows still claim
-    # ACTIVE, which is now a lie — querying through them returns nothing. Flip them to
-    # FAILED so the catalog reports the truth. We do NOT defer a rebuild: the tenant's
-    # data is gone, so a rebuild would rightly fail until the tenant is re-materialized.
-    await _fail_dependent_view_schemas(schema.tenant_id)
+    # workspace's view schema (ws_<hash>). What to do next depends on whether the
+    # tenant still has data: a refresh swaps in a NEW ACTIVE schema before tearing
+    # down the old one (data intact → rebuild), whereas pure TTL expiry leaves the
+    # tenant with nothing (data gone → fail). _reconcile handles both.
+    await _reconcile_dependent_view_schemas_after_teardown(schema)
 
     try:
         schema.state = SchemaState.EXPIRED
@@ -667,6 +681,38 @@ async def teardown_schema(schema_id: str) -> None:
             "teardown_schema: failed to mark schema %s EXPIRED after teardown", schema.id
         )
         raise
+
+
+async def _reconcile_dependent_view_schemas_after_teardown(schema) -> None:
+    """Reconcile dependent multi-tenant view schemas after ``schema`` is dropped.
+
+    DROP SCHEMA ... CASCADE just cascade-dropped the namespaced views inside every
+    dependent multi-tenant workspace's view schema. The correct follow-up depends
+    on whether the tenant still has data:
+
+    - If the tenant has ANOTHER ACTIVE schema (the refresh path: a fresh schema was
+      swapped in before this old one was torn down), the data is NOT gone and the
+      views are rebuildable — defer a rebuild so they point at the new schema.
+    - If the tenant has NO surviving ACTIVE schema (pure TTL expiry), the data is
+      gone; flip the dependent ACTIVE view schemas to FAILED so the catalog reports
+      the truth rather than serving an empty view.
+
+    The ``exclude(id=schema.id)`` matters: production callers flip ``schema`` to
+    TEARDOWN before dispatching teardown, but a direct caller may pass an ACTIVE
+    row — excluding it makes "another ACTIVE schema?" correct either way.
+    """
+    tenant_has_surviving_active_schema = (
+        await TenantSchema.objects.filter(
+            tenant_id=schema.tenant_id,
+            state=SchemaState.ACTIVE,
+        )
+        .exclude(id=schema.id)
+        .aexists()
+    )
+    if tenant_has_surviving_active_schema:
+        await _rebuild_dependent_view_schemas([schema.tenant_id])
+    else:
+        await _fail_dependent_view_schemas(schema.tenant_id)
 
 
 async def _fail_dependent_view_schemas(tenant_id) -> int:

--- a/docs/superpowers/specs/2026-06-16-refresh-view-schema-rebuild-design.md
+++ b/docs/superpowers/specs/2026-06-16-refresh-view-schema-rebuild-design.md
@@ -1,0 +1,109 @@
+# Fix 00#9 — `refresh_tenant_schema` leaves dependent multi-tenant views permanently FAILED
+
+**Issue:** arch-review #236 (Wave 1), finding 00#9 (latent/correctness).
+**Scope:** This fixes 00#9 only. The core data-loss bug 00#0 already shipped in PR #271 — this design does **not** touch the refresh→`target_schema` plumbing #271 added.
+
+## Background
+
+A tenant data schema (`t_<id>`) is **shared** across workspaces. Multi-tenant
+workspaces query through a `WorkspaceViewSchema` whose namespaced
+`{prefix}__{table}` views `SELECT * FROM <tenant_schema>.<table>`, so any change
+to a tenant's physical schema must be reflected in every dependent view schema.
+
+Two code paths mutate a tenant's physical schema:
+
+- **`materialize_workspace`** re-materializes a tenant *in place* (same schema
+  name), cascade-dropping sibling views. PR #230 handles this by deferring a
+  `rebuild_workspace_view_schema` for every sibling multi-tenant workspace
+  (`_rebuild_sibling_view_schemas`).
+- **`refresh_tenant_schema`** provisions a **new** physical schema
+  (`create_refresh_schema` → `{name}_r{uuid}`), materializes into it, swaps it to
+  ACTIVE, and schedules teardown of the old schema 30 minutes later.
+
+## Root cause
+
+The refresh path never mirrored #230:
+
+1. **No rebuild after the swap.** After refresh marks the new schema ACTIVE, every
+   dependent multi-tenant `WorkspaceViewSchema` still points its views at the
+   *old* schema — serving stale data, and (worse) referencing a schema that is
+   about to be dropped.
+2. **Teardown then falsely fails them.** 30 min later `teardown_schema` runs
+   `DROP SCHEMA <old> CASCADE`, cascade-dropping those views, then calls
+   `_fail_dependent_view_schemas(schema.tenant_id)` which flips them to FAILED.
+   Its comment asserts *"the tenant's data is gone, so a rebuild would rightly
+   fail."* **That is false after a refresh:** a new ACTIVE schema exists and a
+   rebuild would succeed. The dependent views stay FAILED until something else
+   re-materializes the workspace.
+
+## Fix
+
+Mirror the #230 pattern across both halves of the refresh lifecycle.
+
+### 1. `refresh_tenant_schema`: defer dependent rebuilds after the swap
+
+After Step 3 (mark new schema ACTIVE), defer a `rebuild_workspace_view_schema`
+for every multi-tenant workspace whose view schema includes this tenant. This is
+`_rebuild_sibling_view_schemas` without the "exclude the current workspace"
+clause — refresh is per-tenant-membership, not per-workspace, so there is no
+workspace to exclude.
+
+### 2. `teardown_schema`: reconcile instead of blindly failing
+
+Replace the unconditional `_fail_dependent_view_schemas(schema.tenant_id)` (and
+its false comment) with a reconcile that asks: *does the tenant still have
+another ACTIVE schema, excluding the one being torn down?*
+
+- **Yes** (refresh path) → data is intact, views are rebuildable → **defer a
+  rebuild** for each dependent workspace; do **not** fail them.
+- **No** (pure TTL expiry) → data genuinely gone → **fail** dependent ACTIVE
+  views (existing behavior, unchanged).
+
+Deferring a rebuild on the "yes" branch (rather than merely skipping the FAILED
+flip) is defense-in-depth: it self-heals even if refresh's earlier rebuild failed
+or had not yet run when teardown fired. The rebuild is idempotent and runs in the
+background.
+
+**Exclude-by-id is required.** In production both teardown callers
+(`expire_inactive_schemas`, `refresh`) flip the schema to TEARDOWN *before*
+dispatching `teardown_schema`, so the torn-down schema never counts as ACTIVE.
+But the existing unit tests call `teardown_schema` directly on an ACTIVE row.
+Excluding the torn-down schema by id makes the "surviving ACTIVE schema?" check
+correct in both cases and keeps the existing fail-path tests green.
+
+### 3. Helper refactor (localized)
+
+Generalize the query helper to make workspace exclusion optional and consolidate
+the rebuild dispatcher so both paths share it:
+
+- `_sibling_view_schema_workspaces(tenant_ids, exclude_workspace_id)` →
+  `_dependent_view_schema_workspaces(tenant_ids, exclude_workspace_id=None)`;
+  skip `.exclude()` when `exclude_workspace_id is None`.
+- `_rebuild_sibling_view_schemas` → `_rebuild_dependent_view_schemas(tenant_ids,
+  *, exclude_workspace_id=None)`. `materialize_workspace` passes
+  `exclude_workspace_id=str(workspace.id)`; refresh/teardown pass nothing.
+
+This stays in the helper region (~lines 400–470, 660–690), far from the parallel
+#243 effort (resume ~1075, reconciler ~690–816).
+
+## Tests (TDD — written failing first)
+
+In `tests/test_refresh_task.py`:
+- **Refresh defers a rebuild** for a dependent multi-tenant workspace sharing the
+  refreshed tenant (asserts `rebuild_workspace_view_schema.defer_async` awaited
+  with that workspace id). A single-tenant workspace is **not** rebuilt.
+
+In `tests/test_schema_ttl_task.py`:
+- **Teardown w/ surviving ACTIVE schema** (refresh path): tearing down the old
+  schema while a new ACTIVE schema exists defers a rebuild for the dependent
+  workspace and does **not** flip its view schema to FAILED.
+- **Regression guard:** the existing pure-expiry tests
+  (`test_teardown_schema_fails_dependent_multitenant_view_schemas`,
+  `..._does_not_clobber_non_active_view_schema`) still fail dependent ACTIVE
+  views when no surviving ACTIVE schema exists — preserved by exclude-by-id.
+
+## Out of scope
+
+- 00#0 / the `target_schema` plumbing from #271.
+- `apps/workspaces/tasks.py` resume-prompt and reconciler regions (owned by the
+  parallel #243 effort).

--- a/tests/test_refresh_task.py
+++ b/tests/test_refresh_task.py
@@ -5,8 +5,14 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from apps.users.adapters import encrypt_credential
-from apps.users.models import TenantConnection
-from apps.workspaces.models import SchemaState, TenantSchema
+from apps.users.models import Tenant, TenantConnection
+from apps.workspaces.models import (
+    SchemaState,
+    TenantSchema,
+    Workspace,
+    WorkspaceTenant,
+    WorkspaceViewSchema,
+)
 from apps.workspaces.services.schema_manager import SchemaManager
 from apps.workspaces.tasks import refresh_tenant_schema
 
@@ -320,3 +326,65 @@ async def test_refresh_loads_into_new_schema_not_old_active(
         f"{provisioning_schema.schema_name!r}, but the pipeline targeted the old "
         "active base schema (the refresh-data-loss bug)."
     )
+
+
+# ---------------------------------------------------------------------------
+# Dependent multi-tenant view-schema rebuild on refresh (arch #236, finding 00#9)
+# ---------------------------------------------------------------------------
+#
+# A tenant data schema is SHARED across workspaces. refresh_tenant_schema swaps in
+# a NEW physical schema, so every multi-tenant WorkspaceViewSchema that includes
+# the refreshed tenant still points its namespaced views at the OLD schema (about
+# to be torn down). Mirroring materialize_workspace (PR #230), refresh must defer
+# a rebuild for each such dependent workspace so the views are recreated against
+# the new schema instead of being left to rot (and later falsely marked FAILED by
+# teardown).
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_refresh_task_rebuilds_dependent_multitenant_view_schemas(
+    provisioning_schema, tenant_membership_obj, user, tenant
+):
+    """After the swap, refresh defers a rebuild for the multi-tenant workspace B
+    (sharing the refreshed tenant + a view schema) and NOT for a single-tenant
+    workspace C."""
+    # Dependent multi-tenant workspace B: shares `tenant` + an extra tenant, has a view schema.
+    extra_tenant = await Tenant.objects.acreate(
+        provider="commcare", external_id="refresh-extra", canonical_name="Refresh Extra"
+    )
+    ws_b = await Workspace.objects.acreate(name="Refresh Sibling B", created_by=user)
+    await WorkspaceTenant.objects.acreate(workspace=ws_b, tenant=tenant)
+    await WorkspaceTenant.objects.acreate(workspace=ws_b, tenant=extra_tenant)
+    await WorkspaceViewSchema.objects.acreate(
+        workspace=ws_b, schema_name="ws_refresh_b", state=SchemaState.ACTIVE
+    )
+
+    # Single-tenant workspace C: only `tenant` → must NOT be rebuilt.
+    ws_c = await Workspace.objects.acreate(name="Refresh Single C", created_by=user)
+    await WorkspaceTenant.objects.acreate(workspace=ws_c, tenant=tenant)
+
+    with (
+        patch(
+            "apps.workspaces.services.schema_manager.get_managed_db_connection",
+            return_value=_mock_conn(),
+        ),
+        patch(
+            "apps.workspaces.tasks.aresolve_credential",
+            new=AsyncMock(return_value={"type": "api_key", "value": "tok"}),
+        ),
+        patch("apps.workspaces.tasks.get_registry", return_value=_mock_registry()),
+        patch("apps.workspaces.tasks.run_pipeline"),
+        patch(
+            "apps.workspaces.tasks.rebuild_workspace_view_schema.defer_async",
+            new_callable=AsyncMock,
+        ) as mock_rebuild,
+    ):
+        await refresh_tenant_schema(
+            schema_id=str(provisioning_schema.id),
+            membership_id=str(tenant_membership_obj.id),
+        )
+
+    mock_rebuild.assert_awaited_once_with(workspace_id=str(ws_b.id))
+    deferred_ids = {c.kwargs["workspace_id"] for c in mock_rebuild.await_args_list}
+    assert str(ws_c.id) not in deferred_ids  # single-tenant workspaces excluded

--- a/tests/test_schema_ttl_task.py
+++ b/tests/test_schema_ttl_task.py
@@ -372,3 +372,55 @@ async def test_teardown_schema_does_not_clobber_non_active_view_schema(active_sc
 
     await vs_b.arefresh_from_db()
     assert vs_b.state == SchemaState.TEARDOWN
+
+
+# ---------------------------------------------------------------------------
+# teardown_schema on the REFRESH path (arch #236, finding 00#9)
+# ---------------------------------------------------------------------------
+#
+# When a refresh tears down the OLD schema, the tenant still has a NEW ACTIVE
+# schema — the data is NOT gone. teardown_schema must therefore NOT mark the
+# dependent multi-tenant view schemas permanently FAILED; instead it must defer a
+# rebuild so their views are recreated against the surviving schema.
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_teardown_schema_rebuilds_dependent_views_when_surviving_active_schema(tenant, user):
+    """Refresh path: the torn-down schema has a sibling ACTIVE schema for the same
+    tenant. Dependent multi-tenant view schemas must be rebuilt (a rebuild is
+    deferred), NOT flipped to FAILED — their data is intact."""
+    # Old schema being torn down (refresh already flipped it to TEARDOWN).
+    old_schema = await TenantSchema.objects.acreate(
+        tenant=tenant, schema_name="t_refresh_old", state=SchemaState.TEARDOWN
+    )
+    # New schema the refresh just swapped in and activated for the same tenant.
+    await TenantSchema.objects.acreate(
+        tenant=tenant, schema_name="t_refresh_new_r1234", state=SchemaState.ACTIVE
+    )
+
+    # Dependent multi-tenant workspace B with an ACTIVE view schema.
+    extra_tenant = await Tenant.objects.acreate(
+        provider="commcare", external_id="teardown-refresh-extra", canonical_name="Refresh Extra"
+    )
+    ws_b = await Workspace.objects.acreate(name="Teardown Refresh B", created_by=user)
+    await WorkspaceTenant.objects.acreate(workspace=ws_b, tenant=tenant)
+    await WorkspaceTenant.objects.acreate(workspace=ws_b, tenant=extra_tenant)
+    vs_b = await WorkspaceViewSchema.objects.acreate(
+        workspace=ws_b, schema_name="ws_teardown_refresh_b", state=SchemaState.ACTIVE
+    )
+
+    with (
+        patch("apps.workspaces.tasks.SchemaManager") as MockManager,
+        patch(
+            "apps.workspaces.tasks.rebuild_workspace_view_schema.defer_async",
+            new_callable=AsyncMock,
+        ) as mock_rebuild,
+    ):
+        MockManager.return_value.teardown.return_value = None
+        await teardown_schema(schema_id=str(old_schema.id))
+
+    await vs_b.arefresh_from_db()
+    # Data is intact (new schema ACTIVE) → views are rebuildable, NOT failed.
+    assert vs_b.state == SchemaState.ACTIVE
+    mock_rebuild.assert_awaited_once_with(workspace_id=str(ws_b.id))


### PR DESCRIPTION
## What & why

Fixes arch-review **#236**, finding **00#9** (latent/correctness).

A tenant data schema (`t_<id>`) is **shared** across workspaces; multi-tenant
workspaces query through a `WorkspaceViewSchema` whose namespaced views
`SELECT * FROM <tenant_schema>.<table>`. `refresh_tenant_schema` provisions a
**new** physical schema (`{name}_r{uuid}`), materializes into it, and swaps it to
ACTIVE — but, unlike `materialize_workspace` (PR #230), it **never rebuilt the
dependent multi-tenant views** afterward. Consequences:

1. Those views kept pointing at the **old** schema (stale data) until teardown.
2. 30 min later `teardown_schema` dropped the old schema (`DROP … CASCADE`,
   cascade-dropping the views) and flipped the dependent `WorkspaceViewSchema`
   rows to **FAILED**, with a comment asserting *"the tenant's data is gone."*
   That's **false after a refresh** — a new ACTIVE schema exists and a rebuild
   would succeed. Multi-tenant workspaces sharing a refreshed tenant stayed
   FAILED until something else re-materialized them.

## The fix (mirrors #230)

- **`refresh_tenant_schema`** — after the swap to ACTIVE, defer a
  `rebuild_workspace_view_schema` for every multi-tenant workspace whose view
  schema includes the refreshed tenant.
- **`teardown_schema`** — reconcile instead of blindly failing: if the tenant
  still has *another* ACTIVE schema (excluding the one being torn down), the data
  is intact and the views are rebuildable → defer a rebuild; only when **no**
  ACTIVE schema survives (pure TTL expiry) are dependent ACTIVE views flipped to
  FAILED. Deferring on the rebuildable branch is defense-in-depth — it self-heals
  even if the refresh-time rebuild failed or hadn't run yet.
- **Helper consolidation** — the sibling/dependent view-schema query and rebuild
  dispatcher are merged into one helper with optional workspace exclusion, shared
  by the materialize path (excludes the current workspace it rebuilt inline) and
  the refresh/teardown paths (exclude nothing).

`exclude(id=schema.id)` in the reconcile check is required: production callers
flip the schema to TEARDOWN before dispatching teardown, but the existing unit
tests call `teardown_schema` directly on an ACTIVE row — excluding it by id makes
the "surviving ACTIVE schema?" test correct either way and keeps the fail-path
tests green.

## Tests (TDD — written failing first)

- `test_refresh_task_rebuilds_dependent_multitenant_view_schemas` — refresh
  defers a rebuild for a dependent multi-tenant workspace, not a single-tenant one.
- `test_teardown_schema_rebuilds_dependent_views_when_surviving_active_schema` —
  teardown with a surviving ACTIVE schema rebuilds rather than marks FAILED.
- Existing pure-expiry fail-path tests preserved.

Full backend suite green (1218 passed). `ruff check` + `ruff format` clean.

## Scope

Does **not** touch the 00#0 / `target_schema` plumbing shipped in PR #271, nor
the resume-prompt/reconciler regions owned by the parallel #243 effort.

Closes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)
