### PR TITLE
Frontend test infrastructure (#234 / 10#5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,5 +35,9 @@ jobs:
         run: bun run lint
         working-directory: frontend
 
+      - name: Unit test frontend
+        run: bun run test
+        working-directory: frontend
+
   test:
     uses: ./.github/workflows/test.yml

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,34 @@
+name: Smoke Tests (manual)
+
+# Post-deploy smoke checks against a running Scout deployment. Manual only —
+# needs a live URL + (optionally) credentials, so it never runs in PR CI.
+on:
+  workflow_dispatch:
+    inputs:
+      frontend_url:
+        description: "Frontend base URL (SCOUT_FRONTEND_URL)"
+        required: true
+        default: "https://labs.connect.dimagi.com/scout"
+      api_url:
+        description: "API base URL (SCOUT_API_URL)"
+        required: true
+        default: "https://labs.connect.dimagi.com/scout"
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    env:
+      SCOUT_FRONTEND_URL: ${{ inputs.frontend_url }}
+      SCOUT_API_URL: ${{ inputs.api_url }}
+      # Optional — the authenticated-flow tests skip when these are absent.
+      SCOUT_TEST_EMAIL: ${{ secrets.SCOUT_TEST_EMAIL }}
+      SCOUT_TEST_PASSWORD: ${{ secrets.SCOUT_TEST_PASSWORD }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v6
+
+      - name: Run deployment smoke tests
+        run: >-
+          uv run pytest tests/smoke/test_deployment.py
+          -v --override-ini="addopts=" -p no:django

--- a/docs/superpowers/plans/2026-06-16-frontend-test-infra.md
+++ b/docs/superpowers/plans/2026-06-16-frontend-test-infra.md
@@ -1,0 +1,686 @@
+# Frontend Test Infrastructure Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stand up a frontend unit-test runner (Vitest + Testing Library), seed regression tests for the threadId-leak and workspace-switch incident classes, wire frontend unit tests into CI, and make the smoke/e2e suites invocable & documented. (Part of #234, finding 10#5.)
+
+**Architecture:** Vitest runs over the existing Vite/React 19 pipeline in jsdom, driven by `bun run test`. Store and hook regression tests exercise the real zustand store + the `useWorkspaceThreadSync` hook (no network). The smoke suite gets a manual `workflow_dispatch` GitHub workflow; everything invocable is documented in `docs/testing.md`.
+
+**Tech Stack:** Vitest 3, @testing-library/react 16, @testing-library/jest-dom 6, @testing-library/user-event 14, jsdom; bun; GitHub Actions.
+
+---
+
+## File Structure
+
+**Frontend runner (Task 1):**
+- Create `frontend/vitest.config.ts` — Vitest config (jsdom, react plugin, `@` alias, setup file). Separate from `vite.config.ts` so build/Sentry plugins don't load under test.
+- Create `frontend/src/test/setup.ts` — jest-dom matchers + RTL cleanup wiring.
+- Create `frontend/src/test/sanity.test.tsx` — proves the runner + jsdom + matchers work; deleted/kept as a living smoke check (kept).
+- Modify `frontend/package.json` — add devDeps + `test`/`test:watch` scripts.
+- Modify `frontend/tsconfig.app.json` — add test/runtime types.
+- Modify `frontend/tsconfig.node.json` — typecheck `vitest.config.ts`.
+- Modify `frontend/eslint.config.js` — ignore `vitest.config.ts`; test-file override.
+
+**Regression tests (Tasks 2–5):**
+- Create `frontend/src/components/ChatPanel/threadStorage.test.ts`
+- Create `frontend/src/store/domainSlice.test.ts`
+- Create `frontend/src/hooks/useWorkspaceThreadSync.test.tsx`
+- Create `frontend/src/store/workspaceSwitch.test.ts`
+
+**CI + invocable checks (Tasks 6–7):**
+- Modify `.github/workflows/ci.yml` — add a frontend unit-test step.
+- Create `.github/workflows/smoke.yml` — manual smoke run.
+- Create `docs/testing.md` — every invocable test path.
+
+---
+
+## Task 1: Scaffold the Vitest runner
+
+**Files:**
+- Modify: `frontend/package.json`
+- Create: `frontend/vitest.config.ts`
+- Create: `frontend/src/test/setup.ts`
+- Create: `frontend/src/test/sanity.test.tsx`
+- Modify: `frontend/tsconfig.app.json`
+- Modify: `frontend/tsconfig.node.json`
+- Modify: `frontend/eslint.config.js`
+
+- [ ] **Step 1: Install dev dependencies**
+
+Run (from `frontend/`):
+```bash
+bun add -d vitest @testing-library/react @testing-library/jest-dom @testing-library/user-event jsdom
+```
+Expected: `package.json` devDependencies gains the five packages; `bun.lock` updates.
+
+- [ ] **Step 2: Add test scripts to `frontend/package.json`**
+
+In the `"scripts"` block, add (keep existing scripts):
+```json
+    "test": "vitest run",
+    "test:watch": "vitest",
+```
+
+- [ ] **Step 3: Create `frontend/vitest.config.ts`**
+
+```ts
+import { defineConfig } from "vitest/config"
+import react from "@vitejs/plugin-react"
+import path from "path"
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+  test: {
+    environment: "jsdom",
+    globals: true,
+    setupFiles: ["./src/test/setup.ts"],
+    include: ["src/**/*.test.{ts,tsx}"],
+  },
+})
+```
+
+- [ ] **Step 4: Create `frontend/src/test/setup.ts`**
+
+```ts
+import { afterEach } from "vitest"
+import { cleanup } from "@testing-library/react"
+import "@testing-library/jest-dom/vitest"
+
+// Unmount React trees between tests even though globals/auto-cleanup is on —
+// explicit and resilient to config changes.
+afterEach(() => {
+  cleanup()
+})
+```
+
+- [ ] **Step 5: Write the runner sanity test (failing first)**
+
+Create `frontend/src/test/sanity.test.tsx`:
+```tsx
+import { describe, expect, it } from "vitest"
+import { render, screen } from "@testing-library/react"
+
+describe("vitest runner", () => {
+  it("renders into jsdom and exposes jest-dom matchers", () => {
+    render(<div data-testid="probe">ready</div>)
+    expect(screen.getByTestId("probe")).toBeInTheDocument()
+    expect(screen.getByTestId("probe")).toHaveTextContent("ready")
+  })
+
+  it("exposes crypto.randomUUID (used by the store)", () => {
+    expect(typeof crypto.randomUUID()).toBe("string")
+  })
+})
+```
+
+- [ ] **Step 6: Run the sanity test**
+
+Run (from `frontend/`): `bun run test`
+Expected: 2 tests PASS. If `crypto.randomUUID` is undefined, add to the top of `src/test/setup.ts`:
+```ts
+import { webcrypto } from "node:crypto"
+if (!globalThis.crypto) globalThis.crypto = webcrypto as Crypto
+```
+(Node 24 normally provides it, so this is a fallback only.)
+
+- [ ] **Step 7: Wire TypeScript so `bun run build` stays green**
+
+In `frontend/tsconfig.app.json`, change the `"types"` line to:
+```json
+    "types": ["vite/client", "vitest/globals", "@testing-library/jest-dom"],
+```
+
+In `frontend/tsconfig.node.json`, change `"include"` to:
+```json
+  "include": ["vite.config.ts", "vitest.config.ts"]
+```
+
+- [ ] **Step 8: Wire ESLint for config + test files**
+
+In `frontend/eslint.config.js`:
+- Change the `globalIgnores` line to also ignore the vitest config:
+```js
+  globalIgnores(['dist', 'vite.config.ts', 'vitest.config.ts']),
+```
+- Add a new override block at the end of the array (after the `tests/**` block):
+```js
+  {
+    files: ['src/**/*.test.{ts,tsx}', 'src/test/**/*.{ts,tsx}'],
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'off',
+      'react-refresh/only-export-components': 'off',
+    },
+  },
+```
+
+- [ ] **Step 9: Verify lint + build + test all pass**
+
+Run (from `frontend/`):
+```bash
+bun run lint && bun run build && bun run test
+```
+Expected: lint clean, `tsc -b && vite build` succeeds, 2 tests pass.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add frontend/package.json frontend/bun.lock frontend/vitest.config.ts \
+  frontend/src/test/setup.ts frontend/src/test/sanity.test.tsx \
+  frontend/tsconfig.app.json frontend/tsconfig.node.json frontend/eslint.config.js
+git commit -m "test(frontend): add Vitest + Testing Library unit-test runner
+
+Part of #234 (frontend test infra / 10#5)."
+```
+
+---
+
+## Task 2: Regression test — threadStorage helpers (threadId-leak class)
+
+**Files:**
+- Create: `frontend/src/components/ChatPanel/threadStorage.test.ts`
+- Reference (do not modify): `frontend/src/components/ChatPanel/threadStorage.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `frontend/src/components/ChatPanel/threadStorage.test.ts`:
+```ts
+import { beforeEach, describe, expect, it } from "vitest"
+import {
+  clearSavedThreadId,
+  readSavedThreadId,
+  writeSavedThreadId,
+} from "./threadStorage"
+
+describe("threadStorage (per-workspace last thread)", () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it("round-trips a saved thread id per workspace", () => {
+    writeSavedThreadId("ws-a", "thread-a")
+    writeSavedThreadId("ws-b", "thread-b")
+    expect(readSavedThreadId("ws-a")).toBe("thread-a")
+    expect(readSavedThreadId("ws-b")).toBe("thread-b")
+  })
+
+  it("returns null when nothing is saved for a workspace", () => {
+    expect(readSavedThreadId("ws-none")).toBeNull()
+  })
+
+  it("clearSavedThreadId removes the saved id when it matches", () => {
+    writeSavedThreadId("ws-a", "thread-a")
+    clearSavedThreadId("ws-a", "thread-a")
+    expect(readSavedThreadId("ws-a")).toBeNull()
+  })
+
+  it("clearSavedThreadId does NOT clobber a newer saved thread (match guard)", () => {
+    // A stale thread's failed load must not wipe a thread saved more recently.
+    writeSavedThreadId("ws-a", "thread-new")
+    clearSavedThreadId("ws-a", "thread-stale")
+    expect(readSavedThreadId("ws-a")).toBe("thread-new")
+  })
+
+  it("clearSavedThreadId with no id removes unconditionally", () => {
+    writeSavedThreadId("ws-a", "thread-a")
+    clearSavedThreadId("ws-a")
+    expect(readSavedThreadId("ws-a")).toBeNull()
+  })
+})
+```
+
+- [ ] **Step 2: Run it to confirm it passes (code already exists)**
+
+Run (from `frontend/`): `bun run test src/components/ChatPanel/threadStorage.test.ts`
+Expected: 5 tests PASS. (This guards existing behavior from commit `00c423d`; it should pass immediately. If any fail, the test encodes a wrong expectation — fix the test, not `threadStorage.ts`.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/components/ChatPanel/threadStorage.test.ts
+git commit -m "test(frontend): regression coverage for threadStorage match guard (00c423d)
+
+Part of #234 (frontend test infra / 10#5)."
+```
+
+---
+
+## Task 3: Regression test — `setActiveDomain` resets threadId (threadId-leak core)
+
+**Files:**
+- Create: `frontend/src/store/domainSlice.test.ts`
+- Reference (do not modify): `frontend/src/store/domainSlice.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `frontend/src/store/domainSlice.test.ts`:
+```ts
+import { beforeEach, describe, expect, it } from "vitest"
+import { useAppStore } from "@/store/store"
+
+describe("domainSlice.setActiveDomain — threadId leak guard (00c423d)", () => {
+  beforeEach(() => {
+    useAppStore.setState({ activeDomainId: "ws-a", threadId: "thread-a" })
+  })
+
+  it("resets threadId to a fresh id when switching to a different workspace", () => {
+    useAppStore.getState().domainActions.setActiveDomain("ws-b")
+    const s = useAppStore.getState()
+    expect(s.activeDomainId).toBe("ws-b")
+    expect(s.threadId).not.toBe("thread-a")
+    // fresh client-generated UUID
+    expect(s.threadId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i)
+  })
+
+  it("keeps threadId when re-selecting the same workspace", () => {
+    useAppStore.getState().domainActions.setActiveDomain("ws-a")
+    expect(useAppStore.getState().activeDomainId).toBe("ws-a")
+    expect(useAppStore.getState().threadId).toBe("thread-a")
+  })
+})
+```
+
+- [ ] **Step 2: Run it**
+
+Run (from `frontend/`): `bun run test src/store/domainSlice.test.ts`
+Expected: 2 tests PASS (guards the existing fix). If the UUID regex fails, confirm jsdom exposes `crypto.randomUUID` (see Task 1 Step 6 fallback).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/store/domainSlice.test.ts
+git commit -m "test(frontend): guard setActiveDomain threadId reset (00c423d)
+
+Part of #234 (frontend test infra / 10#5)."
+```
+
+---
+
+## Task 4: Regression test — `useWorkspaceThreadSync` does not carry threads across workspaces
+
+**Files:**
+- Create: `frontend/src/hooks/useWorkspaceThreadSync.test.tsx`
+- Reference (do not modify): `frontend/src/hooks/useWorkspaceThreadSync.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `frontend/src/hooks/useWorkspaceThreadSync.test.tsx`:
+```tsx
+import { beforeEach, describe, expect, it } from "vitest"
+import { act, render, screen, waitFor } from "@testing-library/react"
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom"
+import { useAppStore } from "@/store/store"
+import { useWorkspaceThreadSync } from "@/hooks/useWorkspaceThreadSync"
+import type { TenantMembership } from "@/store/domainSlice"
+
+// Workspace ids with EMPTY names so workspacePath yields the bare
+// `/workspaces/<id>` form (no slug) and URLs are fully predictable.
+const WS_A = "11111111-1111-1111-1111-111111111111"
+const WS_B = "22222222-2222-2222-2222-222222222222"
+const THREAD_A = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+
+function domain(id: string): TenantMembership {
+  return {
+    id,
+    name: "",
+    display_name: "",
+    is_auto_created: false,
+    role: "manage",
+    tenants: [],
+    member_count: 1,
+    schema_status: "available",
+    last_synced_at: null,
+    created_at: "2026-01-01T00:00:00Z",
+  }
+}
+
+function Probe() {
+  useWorkspaceThreadSync("")
+  const loc = useLocation()
+  return <div data-testid="path">{loc.pathname}</div>
+}
+
+describe("useWorkspaceThreadSync — no cross-workspace thread carry (00c423d)", () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      domains: [domain(WS_A), domain(WS_B)],
+      domainsStatus: "loaded",
+      activeDomainId: WS_A,
+      threadId: THREAD_A,
+    })
+  })
+
+  it("navigates to the new workspace with a fresh thread, never grafting the old one", async () => {
+    render(
+      <MemoryRouter initialEntries={[`/workspaces/${WS_A}/chat/${THREAD_A}`]}>
+        <Routes>
+          <Route path="/workspaces/:workspaceId/chat/:threadId" element={<Probe />} />
+          <Route path="/workspaces/:workspaceId/chat" element={<Probe />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    // URL → store reconciled; address bar stays on A/threadA.
+    await waitFor(() =>
+      expect(screen.getByTestId("path").textContent).toBe(
+        `/workspaces/${WS_A}/chat/${THREAD_A}`,
+      ),
+    )
+
+    // Switch workspace the same way the WorkspaceSwitcher does.
+    act(() => {
+      useAppStore.getState().domainActions.setActiveDomain(WS_B)
+    })
+
+    await waitFor(() => {
+      const path = screen.getByTestId("path").textContent ?? ""
+      expect(path.startsWith(`/workspaces/${WS_B}/chat/`)).toBe(true)
+      expect(path).not.toContain(THREAD_A)
+    })
+  })
+})
+```
+
+- [ ] **Step 2: Run it**
+
+Run (from `frontend/`): `bun run test src/hooks/useWorkspaceThreadSync.test.tsx`
+Expected: 1 test PASS. If a real network call surfaces (it should not — no fetching action runs on this path), add at the top of the file:
+```ts
+import { vi } from "vitest"
+vi.mock("@/api/threads", () => ({ markThreadViewed: vi.fn().mockResolvedValue(undefined) }))
+```
+and re-run.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/hooks/useWorkspaceThreadSync.test.tsx
+git commit -m "test(frontend): guard useWorkspaceThreadSync against cross-workspace thread carry (00c423d)
+
+Part of #234 (frontend test infra / 10#5)."
+```
+
+---
+
+## Task 5: Regression test — workspace-switch state reset (coordinates with #247)
+
+**Files:**
+- Create: `frontend/src/store/workspaceSwitch.test.ts`
+
+- [ ] **Step 1: Write the test (passing now + #247 placeholders)**
+
+Create `frontend/src/store/workspaceSwitch.test.ts`:
+```ts
+import { beforeEach, describe, expect, it } from "vitest"
+import { useAppStore } from "@/store/store"
+
+/**
+ * Workspace-switch state-reset contract. Coordinates with issue #247.
+ *
+ * PASSING NOW: switching workspaces starts a fresh per-workspace thread — the
+ * only per-workspace state reset that exists today (from the 00c423d
+ * threadId-leak fix).
+ *
+ * SKIPPED (#247): on a workspace switch the pages must also refetch / clear
+ * their per-workspace state. #247 supplies the runtime fix; when it lands, flip
+ * the `it.skip` calls below to `it` and assert the refetch/clear behaviour.
+ */
+describe("workspace switch resets per-workspace state", () => {
+  beforeEach(() => {
+    useAppStore.setState({ activeDomainId: "ws-a", threadId: "thread-a" })
+  })
+
+  it("starts a fresh thread for the new workspace (no cross-workspace carry)", () => {
+    const before = useAppStore.getState().threadId
+    useAppStore.getState().domainActions.setActiveDomain("ws-b")
+    expect(useAppStore.getState().threadId).not.toBe(before)
+  })
+
+  // --- #247: pages don't refetch / clear state on workspace switch ---
+  it.skip("refetches the recipes list on workspace switch (#247, 04#9)", () => {})
+  it.skip("refetches the artifacts list on workspace switch (#247, 04#9)", () => {})
+  it.skip("clears a prior workspace-detail load error on later success (#247, 05#5)", () => {})
+})
+```
+
+- [ ] **Step 2: Run it**
+
+Run (from `frontend/`): `bun run test src/store/workspaceSwitch.test.ts`
+Expected: 1 PASS, 3 SKIPPED.
+
+- [ ] **Step 3: Run the whole suite**
+
+Run (from `frontend/`): `bun run test`
+Expected: all tests pass (sanity + threadStorage + domainSlice + hook + workspaceSwitch), 3 skipped, 0 failures.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/store/workspaceSwitch.test.ts
+git commit -m "test(frontend): workspace-switch state-reset contract + #247 placeholders
+
+Part of #234 (frontend test infra / 10#5)."
+```
+
+---
+
+## Task 6: Wire frontend unit tests into CI
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+
+- [ ] **Step 1: Add the unit-test step**
+
+In `.github/workflows/ci.yml`, in the `lint-frontend` job, after the existing
+"Lint frontend" step, append:
+```yaml
+      - name: Unit test frontend
+        run: bun run test
+        working-directory: frontend
+```
+(Keep the job named `lint-frontend` so existing required-status-check config is
+undisturbed.)
+
+- [ ] **Step 2: Validate the workflow YAML**
+
+Run (from repo root):
+```bash
+uv run python -c "import yaml,sys; yaml.safe_load(open('.github/workflows/ci.yml')); print('ci.yml OK')"
+```
+Expected: `ci.yml OK`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "ci: run frontend unit tests in the frontend job
+
+Part of #234 (frontend test infra / 10#5)."
+```
+
+---
+
+## Task 7: Make smoke (and document e2e) invocable
+
+**Files:**
+- Create: `.github/workflows/smoke.yml`
+- Create: `docs/testing.md`
+
+- [ ] **Step 1: Create the manual smoke workflow**
+
+Create `.github/workflows/smoke.yml`:
+```yaml
+name: Smoke Tests (manual)
+
+# Post-deploy smoke checks against a running Scout deployment. Manual only —
+# needs a live URL + (optionally) credentials, so it never runs in PR CI.
+on:
+  workflow_dispatch:
+    inputs:
+      frontend_url:
+        description: "Frontend base URL (SCOUT_FRONTEND_URL)"
+        required: true
+        default: "https://labs.connect.dimagi.com/scout"
+      api_url:
+        description: "API base URL (SCOUT_API_URL)"
+        required: true
+        default: "https://labs.connect.dimagi.com/scout"
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    env:
+      SCOUT_FRONTEND_URL: ${{ inputs.frontend_url }}
+      SCOUT_API_URL: ${{ inputs.api_url }}
+      # Optional — the authenticated-flow tests skip when these are absent.
+      SCOUT_TEST_EMAIL: ${{ secrets.SCOUT_TEST_EMAIL }}
+      SCOUT_TEST_PASSWORD: ${{ secrets.SCOUT_TEST_PASSWORD }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v6
+
+      - name: Run deployment smoke tests
+        run: >-
+          uv run pytest tests/smoke/test_deployment.py
+          -v --override-ini="addopts=" -p no:django
+```
+
+- [ ] **Step 2: Validate the workflow YAML**
+
+Run (from repo root):
+```bash
+uv run python -c "import yaml; yaml.safe_load(open('.github/workflows/smoke.yml')); print('smoke.yml OK')"
+```
+Expected: `smoke.yml OK`.
+
+- [ ] **Step 3: Verify the smoke command collects offline**
+
+Run (from repo root):
+```bash
+uv run pytest tests/smoke/test_deployment.py --collect-only --override-ini="addopts=" -p no:django -q | tail -3
+```
+Expected: tests collected, no import/collection errors.
+
+- [ ] **Step 4: Create `docs/testing.md`**
+
+```markdown
+# Testing
+
+Every runnable test path in Scout.
+
+## Backend (Python / pytest)
+
+```bash
+uv run pytest                 # full suite (smoke tests excluded by default)
+uv run pytest tests/test_x.py # one file
+uv run pytest -k name         # by name
+```
+
+The default `addopts` (`pyproject.toml`) include `-m 'not smoke'`, so smoke tests
+are excluded from the normal run. CI runs `uv run pytest` via
+`.github/workflows/test.yml`.
+
+## Frontend unit tests (Vitest + Testing Library)
+
+```bash
+cd frontend
+bun run test        # one-shot (used by CI)
+bun run test:watch  # watch mode for local dev
+```
+
+Runs in jsdom. Config: `frontend/vitest.config.ts`; setup:
+`frontend/src/test/setup.ts`. CI runs `bun run test` in the `lint-frontend` job
+(`.github/workflows/ci.yml`).
+
+## Smoke tests (post-deploy, live deployment)
+
+HTTP checks against a running deployment. Excluded from the default backend run;
+run explicitly:
+
+```bash
+uv run pytest tests/smoke/test_deployment.py \
+    -v --override-ini="addopts=" -p no:django \
+    # configure target via env or tests/smoke/.env:
+    #   SCOUT_FRONTEND_URL=... SCOUT_API_URL=...
+    #   SCOUT_TEST_EMAIL=... SCOUT_TEST_PASSWORD=...  (authenticated-flow tests)
+```
+
+In CI: run the **Smoke Tests (manual)** workflow
+(`.github/workflows/smoke.yml`) via *Actions → Run workflow*, supplying the
+target URLs. `test_connect_sync.py` additionally needs platform-DB access — see
+`tests/smoke/conftest.py` and `tests/smoke/.env.example`.
+
+## Frontend end-to-end (Playwright)
+
+```bash
+cd frontend
+bun run test:e2e              # all projects
+bun run test:e2e:widget       # widget-sdk project only
+bun run test:e2e:integration  # embed-integration (auto-starts API + Vite)
+```
+
+Config: `frontend/playwright.config.ts`. Some projects require a live backend
+and/or credentials. Fully gated, credentialed e2e in CI is a planned follow-up
+(see #234).
+```
+
+(Note: the fenced code blocks above are part of the file content — write them verbatim.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/smoke.yml docs/testing.md
+git commit -m "ci: add manual smoke workflow + document all test paths
+
+Part of #234 (frontend test infra / 10#5)."
+```
+
+---
+
+## Task 8: Final verification & PR
+
+- [ ] **Step 1: Full local verification**
+
+Run (from `frontend/`):
+```bash
+bun run lint && bun run build && bun run test
+```
+Expected: lint clean; `tsc -b && vite build` succeeds; all unit tests pass (3 skipped), 0 failures.
+
+- [ ] **Step 2: Confirm scope — only intended files changed**
+
+Run (from repo root): `git diff --stat origin/main...HEAD`
+Expected: only the files listed in this plan (frontend runner + tests, `ci.yml`, `smoke.yml`, `docs/testing.md`, the two spec/plan docs). No backend source changes, no `#247` runtime changes.
+
+- [ ] **Step 3: Push branch and open the PR**
+
+Use the dev-utils:create-pr skill (or `gh pr create`). PR title references #234
+(frontend test infra). PR body MUST contain **"Part of #234 (frontend test infra
+/ 10#5)"** and MUST NOT use "Closes #234" (backend findings remain).
+
+- [ ] **Step 4: Iterate against the auto-review until clean, then add reviewer**
+
+Address auto-review feedback (use superpowers:receiving-code-review for judgment).
+Once the PR is clean, add `snopoke` as a reviewer.
+
+---
+
+## Self-Review (author check)
+
+- **Spec coverage:** runner (Task 1) ✓; threadId-leak regression — threadStorage
+  (Task 2), setActiveDomain (Task 3), hook (Task 4) ✓; workspace-switch reset +
+  #247 placeholders (Task 5) ✓; CI unit-test step (Task 6) ✓; smoke invocable +
+  e2e documented (Task 7) ✓; PR conventions (Task 8) ✓.
+- **Placeholder scan:** no TBD/TODO; all code shown in full.
+- **Type consistency:** `setActiveDomain`, `threadId`, `activeDomainId`,
+  `domains`, `domainsStatus`, `TenantMembership`, `readSavedThreadId`,
+  `writeSavedThreadId`, `clearSavedThreadId`, `useWorkspaceThreadSync(pathPrefix)`
+  all match the current source signatures verified during planning.
+- **Out of scope (untouched):** backend 12#0 / 07#0 / 02#6, contract test 10#4
+  (PR #274), and #247's runtime fix.
+```

--- a/docs/superpowers/specs/2026-06-16-frontend-test-infra-design.md
+++ b/docs/superpowers/specs/2026-06-16-frontend-test-infra-design.md
@@ -1,0 +1,148 @@
+# Frontend test infrastructure — design
+
+**Date:** 2026-06-16
+**Issue:** Part of #234 (arch-review Wave 0), finding **10#5** only.
+**Scope owner:** frontend test infra. The backend contract test (10#4) shipped in
+PR #274 and is **not** revisited here.
+
+## Problem
+
+Per arch-review finding 10#5:
+
+- `frontend/package.json` has **no unit-test runner** — only Playwright e2e
+  scripts that never run in CI (the frontend CI job is ESLint only).
+- The Playwright e2e suite (`frontend/playwright.config.ts`) **runs in no
+  workflow**.
+- The post-deploy smoke suite (`tests/smoke/test_deployment.py`) is **excluded by
+  default** (`pyproject.toml` `addopts = "... -m 'not smoke'"`) and **no workflow
+  invokes it**. Both June 2026 incidents were caught by humans noticing a stuck
+  UI, not by automation.
+- Two known incident classes have **zero regression coverage**:
+  - the threadId-leak fix (commit `00c423d`, `useWorkspaceThreadSync.ts` +
+    `domainSlice.setActiveDomain` + `threadStorage.ts`),
+  - workspace switching not resetting per-workspace state.
+
+## Goals
+
+1. A frontend unit-test runner (Vitest + Testing Library), runnable via `bun`.
+2. Seed regression tests for the two incident classes above.
+3. A frontend unit-test step in CI.
+4. Make the existing-but-unrun checks (smoke pytest, Playwright e2e) invocable and
+   documented.
+
+## Non-goals (explicitly out of scope — leave on #234)
+
+- Backend mock-audit findings **12#0** and **07#0**.
+- Prompt-vs-tool drift **02#6**.
+- The backend chat↔MCP contract test **10#4** (already shipped, PR #274).
+- The **runtime fix** for workspace-switch refetch — that is **#247**. This work
+  builds the test harness and a passing-now regression test; #247 supplies the
+  runtime fix and flips the skipped placeholders to live assertions.
+- Full gated/credentialed Playwright e2e in CI — explicit follow-up.
+
+## Design
+
+### 1. Unit-test runner — Vitest + Testing Library
+
+Chosen because it is the native fit for the existing Vite / React 19 / bun stack
+(shares Vite's transform pipeline; no separate Babel/Jest config) and the task
+mandates it.
+
+- **devDependencies** added to `frontend/package.json`: `vitest`,
+  `@testing-library/react`, `@testing-library/jest-dom`,
+  `@testing-library/user-event`, `jsdom`.
+- **`frontend/vitest.config.ts`** — kept separate from `vite.config.ts` so the
+  Sentry plugin / build (`sourcemap`, `base`) config does **not** load under test.
+  Uses `defineConfig` from `vitest/config` with:
+  - `@vitejs/plugin-react`
+  - `resolve.alias` `@` → `./src` (mirrors `vite.config.ts`)
+  - `test.environment = "jsdom"`
+  - `test.globals = true` (so `describe/it/expect` are global; pairs with jest-dom)
+  - `test.setupFiles = ["./src/test/setup.ts"]`
+- **`frontend/src/test/setup.ts`** — imports `@testing-library/jest-dom/vitest`;
+  RTL auto-cleanup is on by default when `globals: true`.
+- **`package.json` scripts**:
+  - `"test": "vitest run"` — one-shot, used by CI.
+  - `"test:watch": "vitest"` — local dev.
+- **TypeScript** — `bun run build` runs `tsc -b` and must keep passing. Test files
+  reference Vitest globals + jest-dom matchers. Plan: add the Vitest/jest-dom
+  types so test files typecheck, while keeping `*.test.ts(x)` and the `src/test/`
+  setup **out of the production build typecheck**. Exact tsconfig shape (a
+  dedicated `tsconfig.vitest.json` in the project-references graph vs. a `types`
+  entry + `exclude`) is settled during TDD against the current
+  `tsconfig*.json` layout; the invariant is **`bun run build` stays green**.
+
+### 2. Seed regression tests
+
+#### threadId-leak class (commit `00c423d`)
+
+- **`src/components/ChatPanel/threadStorage.test.ts`** — pure localStorage helpers
+  (`read/write/clearSavedThreadId`). Key case: `clearSavedThreadId`'s match-guard
+  only removes the saved id when it matches the passed id (so a stale thread's
+  failed load can't clobber a newer saved thread).
+- **`src/store/domainSlice.test.ts`** — `setActiveDomain`:
+  - switching to a **different** workspace resets `threadId` to a fresh UUID
+    (the core leak fix),
+  - re-selecting the **same** workspace leaves `threadId` unchanged.
+- **`src/hooks/useWorkspaceThreadSync.test.tsx`** — hook test (file named in the
+  task) via `renderHook` + `MemoryRouter`: after a workspace switch the hook
+  navigates to the **new** workspace's chat URL carrying the **new** thread, never
+  grafting the previous workspace's thread id onto the new URL.
+
+#### workspace-switch state reset (coordinating with #247)
+
+- **Passing-now** assertion: `setActiveDomain` resets the per-workspace `threadId`
+  on switch (the only per-workspace reset that exists today). Lives in the
+  `domainSlice` test above and/or a dedicated `workspaceSwitch.test.ts`.
+- **`it.skip(...)` placeholders** referencing #247 for the still-broken gaps so the
+  harness is ready and the gap is visible without breaking CI:
+  - recipes list refetches on workspace switch (#247, 04#9),
+  - artifacts list refetches on workspace switch (#247, 04#9),
+  - workspace-detail page clears a prior load error on a later success (#247, 05#5).
+
+  #247's PR converts these from `skip` to live assertions once its runtime fix
+  lands.
+
+### 3. CI
+
+- Add a **"Unit test frontend"** step (`bun run test`, `working-directory:
+  frontend`) to the existing `lint-frontend` job in `.github/workflows/ci.yml`,
+  after the lint step. Reuses the same `bun install`; keeping the job name avoids
+  disturbing any branch-protection required-status-check config.
+
+### 4. Make existing checks invocable
+
+- **`.github/workflows/smoke.yml`** — `workflow_dispatch` only. Inputs for the
+  target frontend/API URL; credentials via inputs/secrets. Runs the smoke suite:
+  `uv run pytest tests/smoke -m smoke --override-ini="addopts=" -p no:django -v`.
+  A real invocable CI path that does **not** touch `deploy.yml` / `deploy-labs.yml`.
+- **`docs/testing.md`** — documents every invocable test path: frontend unit
+  (`bun run test`), backend (`uv run pytest`), smoke (manual + the dispatch
+  workflow, with the exact `--override-ini` invocation), and Playwright e2e
+  (`bun run test:e2e` and the per-project variants). Notes that fully gated
+  credentialed e2e in CI is a follow-up.
+
+## Testing approach
+
+TDD per unit: write the failing test first, then the minimal config/code to pass.
+For the runner itself, the first "test" is a trivial smoke spec proving the runner
++ jsdom + jest-dom matchers work; then the real regression specs. Final
+verification: `bun run test`, `bun run lint`, and `bun run build` all green in the
+worktree before opening the PR.
+
+## Risks / notes
+
+- `crypto.randomUUID()` is used by `setActiveDomain`/`uiSlice`; confirm jsdom
+  exposes it under Node 24 (it does via `globalThis.crypto`) during the first
+  store test.
+- The hook test must avoid navigation ping-pong flakiness — assert on a spied
+  `navigate` (or resulting store/URL state) deterministically, not on timing.
+- Keep the skipped #247 placeholders clearly commented with the issue + finding id
+  so the handoff is unambiguous.
+
+## PR
+
+One branch, one PR titled for #234 (frontend test infra). Body: **"Part of #234
+(frontend test infra / 10#5)"** — not "Closes #234", since backend findings
+remain. Iterate against the auto-review until clean, then add `snopoke` as
+reviewer.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,58 @@
+# Testing
+
+Every runnable test path in Scout.
+
+## Backend (Python / pytest)
+
+```bash
+uv run pytest                 # full suite (smoke tests excluded by default)
+uv run pytest tests/test_x.py # one file
+uv run pytest -k name         # by name
+```
+
+The default `addopts` (`pyproject.toml`) include `-m 'not smoke'`, so smoke tests
+are excluded from the normal run. CI runs `uv run pytest` via
+`.github/workflows/test.yml`.
+
+## Frontend unit tests (Vitest + Testing Library)
+
+```bash
+cd frontend
+bun run test        # one-shot (used by CI)
+bun run test:watch  # watch mode for local dev
+```
+
+Runs in jsdom. Config: `frontend/vitest.config.ts`; setup:
+`frontend/src/test/setup.ts`. CI runs `bun run test` in the `lint-frontend` job
+(`.github/workflows/ci.yml`).
+
+## Smoke tests (post-deploy, live deployment)
+
+HTTP checks against a running deployment. Excluded from the default backend run;
+run explicitly:
+
+```bash
+uv run pytest tests/smoke/test_deployment.py \
+    -v --override-ini="addopts=" -p no:django
+# configure target via env or tests/smoke/.env:
+#   SCOUT_FRONTEND_URL=... SCOUT_API_URL=...
+#   SCOUT_TEST_EMAIL=... SCOUT_TEST_PASSWORD=...  (authenticated-flow tests)
+```
+
+In CI: run the **Smoke Tests (manual)** workflow
+(`.github/workflows/smoke.yml`) via *Actions → Run workflow*, supplying the
+target URLs. `test_connect_sync.py` additionally needs platform-DB access — see
+`tests/smoke/conftest.py` and `tests/smoke/.env.example`.
+
+## Frontend end-to-end (Playwright)
+
+```bash
+cd frontend
+bun run test:e2e              # all projects
+bun run test:e2e:widget       # widget-sdk project only
+bun run test:e2e:integration  # embed-integration (auto-starts API + Vite)
+```
+
+Config: `frontend/playwright.config.ts`. Some projects require a live backend
+and/or credentials. Fully gated, credentialed e2e in CI is a planned follow-up
+(see #234).

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -27,6 +27,9 @@
         "@eslint/js": "^9.39.1",
         "@playwright/test": "^1.58.2",
         "@sentry/vite-plugin": "^5.2.0",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/node": "^24.10.1",
         "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
@@ -35,15 +38,19 @@
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.4.24",
         "globals": "^16.5.0",
+        "jsdom": "^29.1.1",
         "shadcn": "^3.8.4",
         "tw-animate-css": "^1.4.0",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.48.0",
         "vite": "^7.3.1",
+        "vitest": "^4.1.9",
       },
     },
   },
   "packages": {
+    "@adobe/css-tools": ["@adobe/css-tools@4.5.0", "", {}, "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q=="],
+
     "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.49", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.15", "@vercel/oidc": "3.1.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-Smq0sMMqhIxZIUN7TjXitpa5M8SrJCpe/6rHxU7In6FuKb7y16qkj8vvWzmZtQFWZ/1h1Yo+h5ZdcS1KtgMP4g=="],
 
     "@ai-sdk/provider": ["@ai-sdk/provider@3.0.8", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ=="],
@@ -53,6 +60,14 @@
     "@ai-sdk/react": ["@ai-sdk/react@3.0.92", "", { "dependencies": { "@ai-sdk/provider-utils": "4.0.15", "ai": "6.0.90", "swr": "^2.2.5", "throttleit": "2.1.0" }, "peerDependencies": { "react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1" } }, "sha512-ra3Khvd8x1hIAiKC0XQ0iFDUHq/b1uCOJeOWcZfAo6PN9hSMdf3W4SG2dXzV2zEem9ylViiqISY23j9esieZrg=="],
 
     "@antfu/ni": ["@antfu/ni@25.0.0", "", { "dependencies": { "ansis": "^4.0.0", "fzf": "^0.5.2", "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" }, "bin": { "na": "bin/na.mjs", "nci": "bin/nci.mjs", "ni": "bin/ni.mjs", "nlx": "bin/nlx.mjs", "nr": "bin/nr.mjs", "nun": "bin/nun.mjs", "nup": "bin/nup.mjs" } }, "sha512-9q/yCljni37pkMr4sPrI3G4jqdIk074+iukc5aFJl7kmDCCsiJrbZ6zKxnES1Gwg+i9RcDZwvktl23puGslmvA=="],
+
+    "@asamuzakjp/css-color": ["@asamuzakjp/css-color@5.1.11", "", { "dependencies": { "@asamuzakjp/generational-cache": "^1.0.1", "@csstools/css-calc": "^3.2.0", "@csstools/css-color-parser": "^4.1.0", "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg=="],
+
+    "@asamuzakjp/dom-selector": ["@asamuzakjp/dom-selector@7.1.1", "", { "dependencies": { "@asamuzakjp/generational-cache": "^1.0.1", "@asamuzakjp/nwsapi": "^2.3.9", "bidi-js": "^1.0.3", "css-tree": "^3.2.1", "is-potential-custom-element-name": "^1.0.1" } }, "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ=="],
+
+    "@asamuzakjp/generational-cache": ["@asamuzakjp/generational-cache@1.0.1", "", {}, "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg=="],
+
+    "@asamuzakjp/nwsapi": ["@asamuzakjp/nwsapi@2.3.9", "", {}, "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
@@ -108,11 +123,27 @@
 
     "@babel/preset-typescript": ["@babel/preset-typescript@7.28.5", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1", "@babel/helper-validator-option": "^7.27.1", "@babel/plugin-syntax-jsx": "^7.27.1", "@babel/plugin-transform-modules-commonjs": "^7.27.1", "@babel/plugin-transform-typescript": "^7.28.5" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-+bQy5WOI2V6LJZpPVxY+yp66XdZ2yifu0Mc1aP5CQKgjn4QM5IN2i5fAZ4xKop47pr8rpVhiAeu+nDQa12C8+g=="],
 
+    "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
+
     "@babel/template": ["@babel/template@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ=="],
 
     "@babel/traverse": ["@babel/traverse@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/types": "^7.29.0", "debug": "^4.3.1" } }, "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA=="],
 
     "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
+    "@bramus/specificity": ["@bramus/specificity@2.4.2", "", { "dependencies": { "css-tree": "^3.0.0" }, "bin": { "specificity": "bin/cli.js" } }, "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw=="],
+
+    "@csstools/color-helpers": ["@csstools/color-helpers@6.0.2", "", {}, "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q=="],
+
+    "@csstools/css-calc": ["@csstools/css-calc@3.2.1", "", { "peerDependencies": { "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg=="],
+
+    "@csstools/css-color-parser": ["@csstools/css-color-parser@4.1.7", "", { "dependencies": { "@csstools/color-helpers": "^6.0.2", "@csstools/css-calc": "^3.2.1" }, "peerDependencies": { "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-CmjJFQTFQx/U/xNJhSjCQ0ilpesPmNQ8+eOUeM/+kDOVW33qsIjeOXc27vrQDdWVkf83ZSWwtg7kXSUvKDJ8cQ=="],
+
+    "@csstools/css-parser-algorithms": ["@csstools/css-parser-algorithms@4.0.0", "", { "peerDependencies": { "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w=="],
+
+    "@csstools/css-syntax-patches-for-csstree": ["@csstools/css-syntax-patches-for-csstree@1.1.5", "", { "peerDependencies": { "css-tree": "^3.2.1" }, "optionalPeers": ["css-tree"] }, "sha512-oNjBvzLq2GPZtJphCjLqXow/cHySHSgtxvKZb7OqSZ/xHgw6NWNhfad+6AB9cLeVm6eA9d/qMll3JdEHjy6M+A=="],
+
+    "@csstools/css-tokenizer": ["@csstools/css-tokenizer@4.0.0", "", {}, "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA=="],
 
     "@dotenvx/dotenvx": ["@dotenvx/dotenvx@1.52.0", "", { "dependencies": { "commander": "^11.1.0", "dotenv": "^17.2.1", "eciesjs": "^0.4.10", "execa": "^5.1.1", "fdir": "^6.2.0", "ignore": "^5.3.0", "object-treeify": "1.1.33", "picomatch": "^4.0.2", "which": "^4.0.0" }, "bin": { "dotenvx": "src/cli/dotenvx.js" } }, "sha512-CaQcc8JvtzQhUSm9877b6V4Tb7HCotkcyud9X2YwdqtQKwgljkMRwU96fVYKnzN3V0Hj74oP7Es+vZ0mS+Aa1w=="],
 
@@ -187,6 +218,8 @@
     "@eslint/object-schema": ["@eslint/object-schema@2.1.7", "", {}, "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA=="],
 
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.4.1", "", { "dependencies": { "@eslint/core": "^0.17.0", "levn": "^0.4.1" } }, "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA=="],
+
+    "@exodus/bytes": ["@exodus/bytes@1.15.1", "", { "peerDependencies": { "@noble/hashes": "^1.8.0 || ^2.0.0" }, "optionalPeers": ["@noble/hashes"] }, "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q=="],
 
     "@floating-ui/core": ["@floating-ui/core@1.7.4", "", { "dependencies": { "@floating-ui/utils": "^0.2.10" } }, "sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg=="],
 
@@ -502,7 +535,17 @@
 
     "@tailwindcss/vite": ["@tailwindcss/vite@4.1.18", "", { "dependencies": { "@tailwindcss/node": "4.1.18", "@tailwindcss/oxide": "4.1.18", "tailwindcss": "4.1.18" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7" } }, "sha512-jVA+/UpKL1vRLg6Hkao5jldawNmRo7mQYrZtNHMIVpLfLhDml5nMRUo/8MwoX2vNXvnaXNNMedrMfMugAVX1nA=="],
 
+    "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
+
+    "@testing-library/jest-dom": ["@testing-library/jest-dom@6.9.1", "", { "dependencies": { "@adobe/css-tools": "^4.4.0", "aria-query": "^5.0.0", "css.escape": "^1.5.1", "dom-accessibility-api": "^0.6.3", "picocolors": "^1.1.1", "redent": "^3.0.0" } }, "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA=="],
+
+    "@testing-library/react": ["@testing-library/react@16.3.2", "", { "dependencies": { "@babel/runtime": "^7.12.5" }, "peerDependencies": { "@testing-library/dom": "^10.0.0", "@types/react": "^18.0.0 || ^19.0.0", "@types/react-dom": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g=="],
+
+    "@testing-library/user-event": ["@testing-library/user-event@14.6.1", "", { "peerDependencies": { "@testing-library/dom": ">=7.21.4" } }, "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw=="],
+
     "@ts-morph/common": ["@ts-morph/common@0.27.0", "", { "dependencies": { "fast-glob": "^3.3.3", "minimatch": "^10.0.1", "path-browserify": "^1.0.1" } }, "sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ=="],
+
+    "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
 
     "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
 
@@ -512,7 +555,11 @@
 
     "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
 
+    "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
+
     "@types/debug": ["@types/debug@4.1.12", "", { "dependencies": { "@types/ms": "*" } }, "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ=="],
+
+    "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
@@ -564,6 +611,20 @@
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@5.1.4", "", { "dependencies": { "@babel/core": "^7.29.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-rc.3", "@types/babel__core": "^7.20.5", "react-refresh": "^0.18.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-VIcFLdRi/VYRU8OL/puL7QXMYafHmqOnwTZY50U1JPlCNj30PxCMx65c494b1K9be9hX83KVt0+gTEwTWLqToA=="],
 
+    "@vitest/expect": ["@vitest/expect@4.1.9", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.9", "@vitest/utils": "4.1.9", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA=="],
+
+    "@vitest/mocker": ["@vitest/mocker@4.1.9", "", { "dependencies": { "@vitest/spy": "4.1.9", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.9", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A=="],
+
+    "@vitest/runner": ["@vitest/runner@4.1.9", "", { "dependencies": { "@vitest/utils": "4.1.9", "pathe": "^2.0.3" } }, "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@4.1.9", "", { "dependencies": { "@vitest/pretty-format": "4.1.9", "@vitest/utils": "4.1.9", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA=="],
+
+    "@vitest/spy": ["@vitest/spy@4.1.9", "", {}, "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA=="],
+
+    "@vitest/utils": ["@vitest/utils@4.1.9", "", { "dependencies": { "@vitest/pretty-format": "4.1.9", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA=="],
+
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
     "acorn": ["acorn@8.15.0", "", { "bin": "bin/acorn" }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
@@ -578,7 +639,7 @@
 
     "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" }, "peerDependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 
-    "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
@@ -588,6 +649,10 @@
 
     "aria-hidden": ["aria-hidden@1.2.6", "", { "dependencies": { "tslib": "^2.0.0" } }, "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA=="],
 
+    "aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
+
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
     "ast-types": ["ast-types@0.16.1", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg=="],
 
     "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
@@ -595,6 +660,8 @@
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.9.19", "", { "bin": "dist/cli.js" }, "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg=="],
+
+    "bidi-js": ["bidi-js@1.0.3", "", { "dependencies": { "require-from-string": "^2.0.2" } }, "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw=="],
 
     "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
 
@@ -617,6 +684,8 @@
     "caniuse-lite": ["caniuse-lite@1.0.30001770", "", {}, "sha512-x/2CLQ1jHENRbHg5PSId2sXq1CIO1CISvwWAj027ltMVG2UNgW+w9oH2+HzgEIRFembL8bUlXtfbBHR1fCg2xw=="],
 
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
+
+    "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
 
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -668,13 +737,21 @@
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
+    "css-tree": ["css-tree@3.2.1", "", { "dependencies": { "mdn-data": "2.27.1", "source-map-js": "^1.2.1" } }, "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA=="],
+
+    "css.escape": ["css.escape@1.5.1", "", {}, "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg=="],
+
     "cssesc": ["cssesc@3.0.0", "", { "bin": "bin/cssesc" }, "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="],
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
     "data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
 
+    "data-urls": ["data-urls@7.0.0", "", { "dependencies": { "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.0" } }, "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA=="],
+
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
 
     "decode-named-character-reference": ["decode-named-character-reference@1.3.0", "", { "dependencies": { "character-entities": "^2.0.0" } }, "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q=="],
 
@@ -702,6 +779,8 @@
 
     "diff": ["diff@8.0.3", "", {}, "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ=="],
 
+    "dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
+
     "dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
@@ -718,6 +797,8 @@
 
     "enhanced-resolve": ["enhanced-resolve@5.19.0", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.0" } }, "sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg=="],
 
+    "entities": ["entities@8.0.0", "", {}, "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA=="],
+
     "env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
 
     "error-ex": ["error-ex@1.3.4", "", { "dependencies": { "is-arrayish": "^0.2.1" } }, "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ=="],
@@ -725,6 +806,8 @@
     "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
 
     "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-module-lexer": ["es-module-lexer@2.1.0", "", {}, "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ=="],
 
     "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
 
@@ -758,6 +841,8 @@
 
     "estree-util-is-identifier-name": ["estree-util-is-identifier-name@3.0.0", "", {}, "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg=="],
 
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
     "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
@@ -767,6 +852,8 @@
     "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
 
     "execa": ["execa@9.6.1", "", { "dependencies": { "@sindresorhus/merge-streams": "^4.0.0", "cross-spawn": "^7.0.6", "figures": "^6.1.0", "get-stream": "^9.0.0", "human-signals": "^8.0.1", "is-plain-obj": "^4.1.0", "is-stream": "^4.0.1", "npm-run-path": "^6.0.0", "pretty-ms": "^9.2.0", "signal-exit": "^4.1.0", "strip-final-newline": "^4.0.0", "yoctocolors": "^2.1.1" } }, "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA=="],
+
+    "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
 
     "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
 
@@ -866,6 +953,8 @@
 
     "hono": ["hono@4.11.10", "", {}, "sha512-kyWP5PAiMooEvGrA9jcD3IXF7ATu8+o7B3KCbPXid5se52NPqnOpM/r9qeW2heMnOekF4kqR1fXJqCYeCLKrZg=="],
 
+    "html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "", { "dependencies": { "@exodus/bytes": "^1.6.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
+
     "html-url-attributes": ["html-url-attributes@3.0.1", "", {}, "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ=="],
 
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
@@ -881,6 +970,8 @@
     "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
 
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
+
+    "indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
@@ -922,6 +1013,8 @@
 
     "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
 
+    "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
+
     "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
 
     "is-regexp": ["is-regexp@3.1.0", "", {}, "sha512-rbku49cWloU5bSMI+zaRaXdQHXnthP6DZ/vLnfdSKyL4zUzuWnomtOEiZZOd+ioQ+avFo/qau3KPTc7Fjy1uPA=="],
@@ -941,6 +1034,8 @@
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": "bin/js-yaml.js" }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
+
+    "jsdom": ["jsdom@29.1.1", "", { "dependencies": { "@asamuzakjp/css-color": "^5.1.11", "@asamuzakjp/dom-selector": "^7.1.1", "@bramus/specificity": "^2.4.2", "@csstools/css-syntax-patches-for-csstree": "^1.1.3", "@exodus/bytes": "^1.15.0", "css-tree": "^3.2.1", "data-urls": "^7.0.0", "decimal.js": "^10.6.0", "html-encoding-sniffer": "^6.0.0", "is-potential-custom-element-name": "^1.0.1", "lru-cache": "^11.3.5", "parse5": "^8.0.1", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^6.0.1", "undici": "^7.25.0", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^8.0.1", "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.1", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q=="],
 
     "jsesc": ["jsesc@3.1.0", "", { "bin": "bin/jsesc" }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
@@ -1000,9 +1095,11 @@
 
     "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
 
-    "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+    "lru-cache": ["lru-cache@11.3.5", "", {}, "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw=="],
 
     "lucide-react": ["lucide-react@0.563.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-8dXPB2GI4dI8jV4MgUDGBeLdGk8ekfqVZ0BdLcrRzocGgG75ltNEmWS+gE7uokKF/0oSUuczNDT+g9hFJ23FkA=="],
+
+    "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
@@ -1039,6 +1136,8 @@
     "mdast-util-to-markdown": ["mdast-util-to-markdown@2.1.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "longest-streak": "^3.0.0", "mdast-util-phrasing": "^4.0.0", "mdast-util-to-string": "^4.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "unist-util-visit": "^5.0.0", "zwitch": "^2.0.0" } }, "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA=="],
 
     "mdast-util-to-string": ["mdast-util-to-string@4.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0" } }, "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg=="],
+
+    "mdn-data": ["mdn-data@2.27.1", "", {}, "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ=="],
 
     "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
 
@@ -1114,6 +1213,8 @@
 
     "mimic-function": ["mimic-function@5.0.1", "", {}, "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="],
 
+    "min-indent": ["min-indent@1.0.1", "", {}, "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="],
+
     "minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
@@ -1146,6 +1247,8 @@
 
     "object-treeify": ["object-treeify@1.1.33", "", {}, "sha512-EFVjAYfzWqWsBMRHPMAXLCDIJnpMhdWAqR7xG6M6a2cs6PMFpl/+Z20w9zDW4vkxOFfddegBKq9Rehd0bxWE7A=="],
 
+    "obug": ["obug@2.1.3", "", {}, "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg=="],
+
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
@@ -1174,6 +1277,8 @@
 
     "parse-ms": ["parse-ms@4.0.0", "", {}, "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw=="],
 
+    "parse5": ["parse5@8.0.1", "", { "dependencies": { "entities": "^8.0.0" } }, "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw=="],
+
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
 
     "path-browserify": ["path-browserify@1.0.1", "", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
@@ -1185,6 +1290,8 @@
     "path-scurry": ["path-scurry@2.0.2", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg=="],
 
     "path-to-regexp": ["path-to-regexp@6.3.0", "", {}, "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="],
+
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
@@ -1203,6 +1310,8 @@
     "powershell-utils": ["powershell-utils@0.1.0", "", {}, "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A=="],
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
+
+    "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
 
     "pretty-ms": ["pretty-ms@9.3.0", "", { "dependencies": { "parse-ms": "^4.0.0" } }, "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ=="],
 
@@ -1232,6 +1341,8 @@
 
     "react-dom": ["react-dom@19.2.4", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.4" } }, "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ=="],
 
+    "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
+
     "react-markdown": ["react-markdown@10.1.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "html-url-attributes": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "unified": "^11.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" }, "peerDependencies": { "@types/react": ">=18", "react": ">=18" } }, "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ=="],
 
     "react-refresh": ["react-refresh@0.18.0", "", {}, "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw=="],
@@ -1247,6 +1358,8 @@
     "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
 
     "recast": ["recast@0.23.11", "", { "dependencies": { "ast-types": "^0.16.1", "esprima": "~4.0.0", "source-map": "~0.6.1", "tiny-invariant": "^1.3.3", "tslib": "^2.0.1" } }, "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA=="],
+
+    "redent": ["redent@3.0.0", "", { "dependencies": { "indent-string": "^4.0.0", "strip-indent": "^3.0.0" } }, "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="],
 
     "remark-gfm": ["remark-gfm@4.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-gfm": "^3.0.0", "micromark-extension-gfm": "^3.0.0", "remark-parse": "^11.0.0", "remark-stringify": "^11.0.0", "unified": "^11.0.0" } }, "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg=="],
 
@@ -1278,6 +1391,8 @@
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
+    "saxes": ["saxes@6.0.0", "", { "dependencies": { "xmlchars": "^2.2.0" } }, "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA=="],
+
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "semver": ["semver@6.3.1", "", { "bin": "bin/semver.js" }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
@@ -1304,6 +1419,8 @@
 
     "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
@@ -1314,7 +1431,11 @@
 
     "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
 
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
+    "std-env": ["std-env@4.1.0", "", {}, "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ=="],
 
     "stdin-discarder": ["stdin-discarder@0.2.2", "", {}, "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ=="],
 
@@ -1332,6 +1453,8 @@
 
     "strip-final-newline": ["strip-final-newline@4.0.0", "", {}, "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw=="],
 
+    "strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "^1.0.0" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
+
     "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
 
     "style-to-js": ["style-to-js@1.1.21", "", { "dependencies": { "style-to-object": "1.0.14" } }, "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ=="],
@@ -1341,6 +1464,8 @@
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
     "swr": ["swr@2.4.0", "", { "dependencies": { "dequal": "^2.0.3", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-sUlC20T8EOt1pHmDiqueUWMmRRX03W7w5YxovWX7VR2KHEPCTMly85x05vpkP5i6Bu4h44ePSMD9Tc+G2MItFw=="],
+
+    "symbol-tree": ["symbol-tree@3.2.4", "", {}, "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="],
 
     "tagged-tag": ["tagged-tag@1.0.0", "", {}, "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="],
 
@@ -1354,9 +1479,13 @@
 
     "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="],
 
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
     "tinyexec": ["tinyexec@1.0.2", "", {}, "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg=="],
 
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
+
+    "tinyrainbow": ["tinyrainbow@3.1.0", "", {}, "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="],
 
     "tldts": ["tldts@7.0.23", "", { "dependencies": { "tldts-core": "^7.0.23" }, "bin": "bin/cli.js" }, "sha512-ASdhgQIBSay0R/eXggAkQ53G4nTJqTXqC2kbaBbdDwM7SkjyZyO0OaaN1/FH7U/yCeqOHDwFO5j8+Os/IS1dXw=="],
 
@@ -1366,9 +1495,9 @@
 
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
 
-    "tough-cookie": ["tough-cookie@6.0.0", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w=="],
+    "tough-cookie": ["tough-cookie@6.0.1", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw=="],
 
-    "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
+    "tr46": ["tr46@6.0.0", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw=="],
 
     "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
 
@@ -1393,6 +1522,8 @@
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "typescript-eslint": ["typescript-eslint@8.56.0", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.56.0", "@typescript-eslint/parser": "8.56.0", "@typescript-eslint/typescript-estree": "8.56.0", "@typescript-eslint/utils": "8.56.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-c7toRLrotJ9oixgdW7liukZpsnq5CZ7PuKztubGYlNppuTqhIoWfhgHo/7EU0v06gS2l/x0i2NEFK1qMIf0rIg=="],
+
+    "undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
 
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
@@ -1438,13 +1569,21 @@
 
     "vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": "bin/vite.js" }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
 
+    "vitest": ["vitest@4.1.9", "", { "dependencies": { "@vitest/expect": "4.1.9", "@vitest/mocker": "4.1.9", "@vitest/pretty-format": "4.1.9", "@vitest/runner": "4.1.9", "@vitest/snapshot": "4.1.9", "@vitest/spy": "4.1.9", "@vitest/utils": "4.1.9", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.9", "@vitest/browser-preview": "4.1.9", "@vitest/browser-webdriverio": "4.1.9", "@vitest/coverage-istanbul": "4.1.9", "@vitest/coverage-v8": "4.1.9", "@vitest/ui": "4.1.9", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "./vitest.mjs" } }, "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ=="],
+
+    "w3c-xmlserializer": ["w3c-xmlserializer@5.0.0", "", { "dependencies": { "xml-name-validator": "^5.0.0" } }, "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA=="],
+
     "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
 
-    "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
+    "webidl-conversions": ["webidl-conversions@8.0.1", "", {}, "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ=="],
 
-    "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
+    "whatwg-mimetype": ["whatwg-mimetype@5.0.0", "", {}, "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw=="],
+
+    "whatwg-url": ["whatwg-url@16.0.1", "", { "dependencies": { "@exodus/bytes": "^1.11.0", "tr46": "^6.0.0", "webidl-conversions": "^8.0.1" } }, "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
@@ -1453,6 +1592,10 @@
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
     "wsl-utils": ["wsl-utils@0.3.1", "", { "dependencies": { "is-wsl": "^3.1.0", "powershell-utils": "^0.1.0" } }, "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg=="],
+
+    "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
+
+    "xmlchars": ["xmlchars@2.2.0", "", {}, "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="],
 
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 
@@ -1478,6 +1621,8 @@
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
+    "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+
     "@dotenvx/dotenvx/commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
 
     "@dotenvx/dotenvx/dotenv": ["dotenv@17.3.1", "", {}, "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA=="],
@@ -1497,6 +1642,10 @@
     "@sentry/cli/node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 
     "@tailwindcss/typography/postcss-selector-parser": ["postcss-selector-parser@6.0.10", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w=="],
+
+    "@testing-library/dom/aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
+
+    "@testing-library/dom/dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
 
     "@ts-morph/common/minimatch": ["minimatch@10.2.1", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-MClCe8IL5nRRmawL6ib/eT4oLyeKMGCghibcDWK+J0hh0Q8kqSdia6BvbRMVk6mPa6WqUa5uR2oxt6C5jd533A=="],
 
@@ -1530,15 +1679,17 @@
 
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
+    "msw/tough-cookie": ["tough-cookie@6.0.0", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w=="],
+
     "npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
 
     "ora/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
-    "path-scurry/lru-cache": ["lru-cache@11.3.5", "", {}, "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw=="],
-
     "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
+
+    "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
     "prompts/kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
 
@@ -1547,6 +1698,8 @@
     "router/path-to-regexp": ["path-to-regexp@8.3.0", "", {}, "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA=="],
 
     "shadcn/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "wrap-ansi/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
@@ -1572,6 +1725,8 @@
 
     "@sentry/cli/https-proxy-agent/agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
 
+    "@sentry/cli/node-fetch/whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
+
     "@ts-morph/common/minimatch/brace-expansion": ["brace-expansion@5.0.2", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
@@ -1580,22 +1735,20 @@
 
     "cliui/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
-    "cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
-
     "glob/minimatch/brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
 
     "wrap-ansi/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
-
-    "wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "yargs/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
+    "@sentry/cli/node-fetch/whatwg-url/tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
+
+    "@sentry/cli/node-fetch/whatwg-url/webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
+
     "@ts-morph/common/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.3", "", {}, "sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g=="],
 
     "glob/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.3", "", {}, "sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g=="],
-
-    "yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
   }
 }

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -6,7 +6,7 @@ import tseslint from 'typescript-eslint'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
 export default defineConfig([
-  globalIgnores(['dist', 'vite.config.ts']),
+  globalIgnores(['dist', 'vite.config.ts', 'vitest.config.ts']),
   {
     files: ['**/*.{ts,tsx}'],
     extends: [
@@ -30,6 +30,13 @@ export default defineConfig([
     files: ['tests/**/*.{ts,tsx}'],
     rules: {
       '@typescript-eslint/no-explicit-any': 'off',
+    },
+  },
+  {
+    files: ['src/**/*.test.{ts,tsx}', 'src/test/**/*.{ts,tsx}'],
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'off',
+      'react-refresh/only-export-components': 'off',
     },
   },
 ])

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,8 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "test:e2e": "bunx playwright test",
     "test:e2e:widget": "bunx playwright test --project=widget-sdk",
     "test:e2e:integration": "bunx playwright test --project=embed-integration"
@@ -35,6 +37,9 @@
     "@eslint/js": "^9.39.1",
     "@playwright/test": "^1.58.2",
     "@sentry/vite-plugin": "^5.2.0",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^24.10.1",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
@@ -43,10 +48,12 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^16.5.0",
+    "jsdom": "^29.1.1",
     "shadcn": "^3.8.4",
     "tw-animate-css": "^1.4.0",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.48.0",
-    "vite": "^7.3.1"
+    "vite": "^7.3.1",
+    "vitest": "^4.1.9"
   }
 }

--- a/frontend/src/components/ChatPanel/threadStorage.test.ts
+++ b/frontend/src/components/ChatPanel/threadStorage.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it } from "vitest"
+import {
+  clearSavedThreadId,
+  readSavedThreadId,
+  writeSavedThreadId,
+} from "./threadStorage"
+
+describe("threadStorage (per-workspace last thread)", () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it("round-trips a saved thread id per workspace", () => {
+    writeSavedThreadId("ws-a", "thread-a")
+    writeSavedThreadId("ws-b", "thread-b")
+    expect(readSavedThreadId("ws-a")).toBe("thread-a")
+    expect(readSavedThreadId("ws-b")).toBe("thread-b")
+  })
+
+  it("returns null when nothing is saved for a workspace", () => {
+    expect(readSavedThreadId("ws-none")).toBeNull()
+  })
+
+  it("clearSavedThreadId removes the saved id when it matches", () => {
+    writeSavedThreadId("ws-a", "thread-a")
+    clearSavedThreadId("ws-a", "thread-a")
+    expect(readSavedThreadId("ws-a")).toBeNull()
+  })
+
+  it("clearSavedThreadId does NOT clobber a newer saved thread (match guard)", () => {
+    // A stale thread's failed load must not wipe a thread saved more recently.
+    writeSavedThreadId("ws-a", "thread-new")
+    clearSavedThreadId("ws-a", "thread-stale")
+    expect(readSavedThreadId("ws-a")).toBe("thread-new")
+  })
+
+  it("clearSavedThreadId with no id removes unconditionally", () => {
+    writeSavedThreadId("ws-a", "thread-a")
+    clearSavedThreadId("ws-a")
+    expect(readSavedThreadId("ws-a")).toBeNull()
+  })
+})

--- a/frontend/src/hooks/useWorkspaceThreadSync.test.tsx
+++ b/frontend/src/hooks/useWorkspaceThreadSync.test.tsx
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it } from "vitest"
+import { act, render, screen, waitFor } from "@testing-library/react"
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom"
+import { useAppStore } from "@/store/store"
+import { useWorkspaceThreadSync } from "@/hooks/useWorkspaceThreadSync"
+import type { TenantMembership } from "@/store/domainSlice"
+
+// Workspace ids with EMPTY names so workspacePath yields the bare
+// `/workspaces/<id>` form (no slug) and URLs are fully predictable.
+const WS_A = "11111111-1111-1111-1111-111111111111"
+const WS_B = "22222222-2222-2222-2222-222222222222"
+const THREAD_A = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+
+function domain(id: string): TenantMembership {
+  return {
+    id,
+    name: "",
+    display_name: "",
+    is_auto_created: false,
+    role: "manage",
+    tenants: [],
+    member_count: 1,
+    schema_status: "available",
+    last_synced_at: null,
+    created_at: "2026-01-01T00:00:00Z",
+  }
+}
+
+function Probe() {
+  useWorkspaceThreadSync("")
+  const loc = useLocation()
+  return <div data-testid="path">{loc.pathname}</div>
+}
+
+describe("useWorkspaceThreadSync — no cross-workspace thread carry (00c423d)", () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      domains: [domain(WS_A), domain(WS_B)],
+      domainsStatus: "loaded",
+      activeDomainId: WS_A,
+      threadId: THREAD_A,
+    })
+  })
+
+  it("navigates to the new workspace with a fresh thread, never grafting the old one", async () => {
+    render(
+      <MemoryRouter initialEntries={[`/workspaces/${WS_A}/chat/${THREAD_A}`]}>
+        <Routes>
+          <Route path="/workspaces/:workspaceId/chat/:threadId" element={<Probe />} />
+          <Route path="/workspaces/:workspaceId/chat" element={<Probe />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    // URL → store reconciled; address bar stays on A/threadA.
+    await waitFor(() =>
+      expect(screen.getByTestId("path").textContent).toBe(
+        `/workspaces/${WS_A}/chat/${THREAD_A}`,
+      ),
+    )
+
+    // Switch workspace the same way the WorkspaceSwitcher does.
+    act(() => {
+      useAppStore.getState().domainActions.setActiveDomain(WS_B)
+    })
+
+    await waitFor(() => {
+      const path = screen.getByTestId("path").textContent ?? ""
+      expect(path.startsWith(`/workspaces/${WS_B}/chat/`)).toBe(true)
+      expect(path).not.toContain(THREAD_A)
+    })
+  })
+})

--- a/frontend/src/store/domainSlice.test.ts
+++ b/frontend/src/store/domainSlice.test.ts
@@ -1,0 +1,25 @@
+import { beforeEach, describe, expect, it } from "vitest"
+import { useAppStore } from "@/store/store"
+
+describe("domainSlice.setActiveDomain — threadId leak guard (00c423d)", () => {
+  beforeEach(() => {
+    useAppStore.setState({ activeDomainId: "ws-a", threadId: "thread-a" })
+  })
+
+  it("resets threadId to a fresh id when switching to a different workspace", () => {
+    useAppStore.getState().domainActions.setActiveDomain("ws-b")
+    const s = useAppStore.getState()
+    expect(s.activeDomainId).toBe("ws-b")
+    expect(s.threadId).not.toBe("thread-a")
+    // fresh client-generated UUID
+    expect(s.threadId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+    )
+  })
+
+  it("keeps threadId when re-selecting the same workspace", () => {
+    useAppStore.getState().domainActions.setActiveDomain("ws-a")
+    expect(useAppStore.getState().activeDomainId).toBe("ws-a")
+    expect(useAppStore.getState().threadId).toBe("thread-a")
+  })
+})

--- a/frontend/src/store/workspaceSwitch.test.ts
+++ b/frontend/src/store/workspaceSwitch.test.ts
@@ -1,0 +1,30 @@
+import { beforeEach, describe, expect, it } from "vitest"
+import { useAppStore } from "@/store/store"
+
+/**
+ * Workspace-switch state-reset contract. Coordinates with issue #247.
+ *
+ * PASSING NOW: switching workspaces starts a fresh per-workspace thread — the
+ * only per-workspace state reset that exists today (from the 00c423d
+ * threadId-leak fix).
+ *
+ * SKIPPED (#247): on a workspace switch the pages must also refetch / clear
+ * their per-workspace state. #247 supplies the runtime fix; when it lands, flip
+ * the `it.skip` calls below to `it` and assert the refetch/clear behaviour.
+ */
+describe("workspace switch resets per-workspace state", () => {
+  beforeEach(() => {
+    useAppStore.setState({ activeDomainId: "ws-a", threadId: "thread-a" })
+  })
+
+  it("starts a fresh thread for the new workspace (no cross-workspace carry)", () => {
+    const before = useAppStore.getState().threadId
+    useAppStore.getState().domainActions.setActiveDomain("ws-b")
+    expect(useAppStore.getState().threadId).not.toBe(before)
+  })
+
+  // --- #247: pages don't refetch / clear state on workspace switch ---
+  it.skip("refetches the recipes list on workspace switch (#247, 04#9)", () => {})
+  it.skip("refetches the artifacts list on workspace switch (#247, 04#9)", () => {})
+  it.skip("clears a prior workspace-detail load error on later success (#247, 05#5)", () => {})
+})

--- a/frontend/src/test/sanity.test.tsx
+++ b/frontend/src/test/sanity.test.tsx
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest"
+import { render, screen } from "@testing-library/react"
+
+describe("vitest runner", () => {
+  it("renders into jsdom and exposes jest-dom matchers", () => {
+    render(<div data-testid="probe">ready</div>)
+    expect(screen.getByTestId("probe")).toBeInTheDocument()
+    expect(screen.getByTestId("probe")).toHaveTextContent("ready")
+  })
+
+  it("exposes crypto.randomUUID (used by the store)", () => {
+    expect(typeof crypto.randomUUID()).toBe("string")
+  })
+})

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,0 +1,9 @@
+import { afterEach } from "vitest"
+import { cleanup } from "@testing-library/react"
+import "@testing-library/jest-dom/vitest"
+
+// Unmount React trees between tests even though globals/auto-cleanup is on —
+// explicit and resilient to config changes.
+afterEach(() => {
+  cleanup()
+})

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -5,7 +5,7 @@
     "useDefineForClassFields": true,
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
-    "types": ["vite/client"],
+    "types": ["vite/client", "vitest/globals", "@testing-library/jest-dom"],
     "skipLibCheck": true,
 
     /* Path aliases */

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -22,5 +22,5 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "vitest.config.ts"]
 }

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "vitest/config"
+import react from "@vitejs/plugin-react"
+import path from "path"
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+  test: {
+    environment: "jsdom",
+    globals: true,
+    setupFiles: ["./src/test/setup.ts"],
+    include: ["src/**/*.test.{ts,tsx}"],
+  },
+})


### PR DESCRIPTION
Part of #234 (frontend test infra / 10#5)

Addresses **only** finding 10#5 of #234: the frontend had no unit-test runner, e2e ran in no workflow, and the post-deploy smoke suite was wired to nothing. The backend chat↔MCP contract test (10#4) shipped separately in #274 and is untouched here.

## What's included

**1. Frontend unit-test runner** — Vitest + @testing-library/react over the existing Vite/React 19/bun stack.
- `frontend/vitest.config.ts` (jsdom, separate from `vite.config.ts` so build/Sentry plugins don't load under test), `frontend/src/test/setup.ts` (jest-dom matchers + RTL cleanup).
- `test` / `test:watch` scripts in `frontend/package.json`.
- TS + ESLint wired so `bun run build` (`tsc -b`) and `bun run lint` stay green.

**2. Seed regression tests for the two known zero-coverage incident classes**
- threadId-leak fix (commit `00c423d`): `threadStorage` match-guard, `domainSlice.setActiveDomain` thread reset, and a `useWorkspaceThreadSync` hook test proving a workspace switch never grafts the old workspace's thread onto the new URL.
- workspace-switch state reset: a passing-now test for the per-workspace thread reset, plus `it.skip` placeholders for the still-broken recipes/artifacts refetch + workspace-detail error-clear gaps, tagged for **#247** (its runtime fix flips these to live assertions — no overlap/conflict with this PR).

**3. CI** — a "Unit test frontend" step (`bun run test`) added to the existing `lint-frontend` job in `.github/workflows/ci.yml`.

**4. Made existing-but-unrun checks invocable**
- `.github/workflows/smoke.yml` — manual `workflow_dispatch` to run the deployment smoke suite against a target URL (does not touch the deploy pipeline).
- `docs/testing.md` — documents every runnable path: frontend unit, backend pytest, smoke, and Playwright e2e. Fully gated credentialed e2e remains a follow-up.

## Verification
- `bun run lint` clean, `bun run build` succeeds, `bun run test` → **11 passed / 3 skipped**.
- Red-green checked: reverting the `setActiveDomain` thread reset fails exactly the 3 threadId-leak regression tests; restoring makes them pass.
- `smoke.yml` command collects 21 smoke tests offline; both new workflow files validate as YAML.

## Out of scope (left on #234)
Backend mock-audit findings 12#0 and 07#0, prompt-vs-tool drift 02#6, and the already-shipped contract test 10#4. Not "Closes #234" — backend findings remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
