### PR TITLE
fix(chat): auto-retry transient Anthropic overloads instead of paging Sentry

### DIFF
--- a/apps/chat/stream.py
+++ b/apps/chat/stream.py
@@ -31,12 +31,40 @@ import uuid
 from collections.abc import AsyncGenerator
 from typing import Any
 
+from anthropic import APIStatusError, InternalServerError, RateLimitError
 from langchain_core.messages import ToolMessage
 
 logger = logging.getLogger(__name__)
 
 # Maximum wall-clock time for agent execution before we abort.
 AGENT_TIMEOUT_SECONDS = 300  # 5 minutes
+
+# Anthropic error.type values that indicate a transient, retryable capacity
+# problem (overload / rate limit) rather than a bug on our side.
+_TRANSIENT_ERROR_TYPES = {"overloaded_error", "rate_limit_error"}
+_TRANSIENT_STATUS_CODES = {429, 503, 529}
+
+
+def _is_transient_overload(exc: BaseException) -> bool:
+    """True for transient Anthropic capacity errors worth retrying.
+
+    On a mid-stream ``error`` SSE event the streaming response opened with HTTP
+    200, so anthropic raises a base ``APIStatusError`` whose ``status_code`` is
+    200 -- the body's ``error.type`` is then the only reliable signal. The
+    subclass / status-code checks cover the non-streaming (real HTTP status)
+    path.
+    """
+    if isinstance(exc, RateLimitError | InternalServerError):
+        return True
+    if isinstance(exc, APIStatusError):
+        body = getattr(exc, "body", None)
+        if isinstance(body, dict):
+            err = body.get("error")
+            if isinstance(err, dict) and err.get("type") in _TRANSIENT_ERROR_TYPES:
+                return True
+        if getattr(exc, "status_code", None) in _TRANSIENT_STATUS_CODES:
+            return True
+    return False
 
 
 def _sse(chunk: dict) -> str:
@@ -223,20 +251,38 @@ async def langgraph_to_ui_stream(
                 "delta": "\n\nThe request timed out. Try simplifying your question or breaking it into smaller steps.",
             }
         )
-    except Exception:
-        logger.exception("Error during agent streaming")
-        if reasoning_started:
-            yield _sse({"type": "reasoning-end", "id": reasoning_id})
-        if not text_started:
-            yield _sse({"type": "text-start", "id": text_id})
-            text_started = True
-        yield _sse(
-            {
-                "type": "text-delta",
-                "id": text_id,
-                "delta": "\n\nAn error occurred while processing your request.",
-            }
-        )
+    except Exception as exc:
+        if _is_transient_overload(exc):
+            # Anthropic was momentarily overloaded / rate-limited -- a transient
+            # upstream condition, not a bug. Log at WARNING (so it does not page
+            # via Sentry's ERROR-level capture) and emit a transient data part
+            # the frontend can use to auto-retry the turn. Any open text/
+            # reasoning part is closed by the shared block below.
+            logger.warning(
+                "Anthropic capacity error during stream (retryable): %s",
+                exc.__class__.__name__,
+            )
+            yield _sse(
+                {
+                    "type": "data-chat-status",
+                    "data": {"kind": "retryable-error", "reason": "overloaded"},
+                    "transient": True,
+                }
+            )
+        else:
+            logger.exception("Error during agent streaming")
+            if reasoning_started:
+                yield _sse({"type": "reasoning-end", "id": reasoning_id})
+            if not text_started:
+                yield _sse({"type": "text-start", "id": text_id})
+                text_started = True
+            yield _sse(
+                {
+                    "type": "text-delta",
+                    "id": text_id,
+                    "delta": "\n\nAn error occurred while processing your request.",
+                }
+            )
 
     # Close any open parts
     if reasoning_started:

--- a/frontend/src/components/ChatPanel/ChatPanel.tsx
+++ b/frontend/src/components/ChatPanel/ChatPanel.tsx
@@ -14,6 +14,7 @@ import { SlashCommandMenu } from "./SlashCommandMenu"
 import { useWorkspaceJobs } from "@/contexts/WorkspaceJobsContext"
 import { ChatEmptyState } from "@/components/ChatEmptyState"
 import { writeSavedThreadId, clearSavedThreadId } from "./threadStorage"
+import { decideOverloadAction, isRetryableErrorPart } from "./overloadRetry"
 
 /** True when an error looks like a stale/missing-thread rejection (HTTP 404 or
  * a body containing the backend's "Thread not found" marker). */
@@ -33,6 +34,13 @@ export function ChatPanel() {
   const [slashMenuIndex, setSlashMenuIndex] = useState(0)
   const [messageReloadKey, setMessageReloadKey] = useState(0)
   const prevStatusRef = useRef<string>("")
+  // Transient-overload auto-retry (see ./overloadRetry):
+  //   hitRetryableRef — a retryable-error data part arrived during this turn
+  //   retriedRef      — we've already auto-retried this turn once
+  const hitRetryableRef = useRef(false)
+  const retriedRef = useRef(false)
+  const prevRetryStatusRef = useRef<string>("")
+  const [overloadNotice, setOverloadNotice] = useState(false)
 
   const {
     jobsByThreadId,
@@ -57,9 +65,19 @@ export function ChatPanel() {
       }),
   )
 
-  const { messages, sendMessage, status, stop, error, setMessages } = useChat({
+  const { messages, sendMessage, status, stop, error, setMessages, regenerate } = useChat({
     transport,
+    onData: (part) => {
+      if (isRetryableErrorPart(part)) hitRetryableRef.current = true
+    },
   })
+
+  // Clear auto-retry bookkeeping at the start of each user-initiated turn.
+  function resetOverloadState() {
+    hitRetryableRef.current = false
+    retriedRef.current = false
+    setOverloadNotice(false)
+  }
 
   const isStreaming = status === "streaming" || status === "submitted"
 
@@ -138,6 +156,29 @@ export function ChatPanel() {
     prevStatusRef.current = status
   }, [status, activeDomainId, fetchThreads])
 
+  // Auto-retry a turn once if it hit a transient Anthropic overload; if the
+  // retry also hits it, surface a notice instead. See ./overloadRetry.
+  useEffect(() => {
+    const prev = prevRetryStatusRef.current
+    prevRetryStatusRef.current = status
+    const justFinished =
+      (prev === "streaming" || prev === "submitted") && status === "ready"
+    if (!justFinished) return
+
+    const action = decideOverloadAction({
+      hitRetryable: hitRetryableRef.current,
+      alreadyRetried: retriedRef.current,
+    })
+    hitRetryableRef.current = false
+    if (action === "retry") {
+      retriedRef.current = true
+      void regenerate()
+    } else if (action === "notify") {
+      retriedRef.current = false
+      setOverloadNotice(true)
+    }
+  }, [status, regenerate])
+
   // Auto-scroll to bottom on new messages
   useEffect(() => {
     if (scrollRef.current) {
@@ -151,7 +192,13 @@ export function ChatPanel() {
     if (!text || isStreaming) return
 
     setInput("")
+    resetOverloadState()
     sendMessage({ text: resolveSlashCommand(text) })
+  }
+
+  function handleOverloadRetry() {
+    resetOverloadState()
+    void regenerate()
   }
 
   // Recover from a stale/unavailable thread: forget the saved id for this
@@ -191,7 +238,10 @@ export function ChatPanel() {
       <ChatEmptyState
         input={input}
         setInput={setInput}
-        onSend={(text) => sendMessage({ text })}
+        onSend={(text) => {
+          resetOverloadState()
+          sendMessage({ text })
+        }}
         disabled={isStreaming}
       />
     )
@@ -215,6 +265,7 @@ export function ChatPanel() {
         ))}
         {isStreaming && <ThinkingIndicator />}
         {error && <ChatError error={error} onStartNewThread={startFreshThread} />}
+        {overloadNotice && <OverloadNotice onRetry={handleOverloadRetry} />}
       </div>
 
       {/* Materialization progress banner — always visible when a job is active for this thread */}
@@ -302,6 +353,30 @@ function ChatError({
           Start new chat
         </Button>
       )}
+    </div>
+  )
+}
+
+/**
+ * Shown when a turn hit a transient Anthropic overload and the one automatic
+ * retry also failed. Offers a manual retry rather than a dead end.
+ */
+function OverloadNotice({ onRetry }: { onRetry: () => void }) {
+  return (
+    <div
+      className="text-sm text-muted-foreground bg-muted rounded-lg px-4 py-3 space-y-2"
+      data-testid="chat-overload-notice"
+    >
+      <p>The assistant is busy right now. Please try again in a moment.</p>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={onRetry}
+        data-testid="chat-overload-retry"
+      >
+        Retry
+      </Button>
     </div>
   )
 }

--- a/frontend/src/components/ChatPanel/overloadRetry.test.ts
+++ b/frontend/src/components/ChatPanel/overloadRetry.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest"
+import { decideOverloadAction, isRetryableErrorPart } from "./overloadRetry"
+
+describe("decideOverloadAction", () => {
+  it("does nothing when no retryable error occurred", () => {
+    expect(decideOverloadAction({ hitRetryable: false, alreadyRetried: false })).toBe("none")
+    expect(decideOverloadAction({ hitRetryable: false, alreadyRetried: true })).toBe("none")
+  })
+
+  it("auto-retries once on the first retryable error", () => {
+    expect(decideOverloadAction({ hitRetryable: true, alreadyRetried: false })).toBe("retry")
+  })
+
+  it("notifies instead of retrying again after one retry", () => {
+    expect(decideOverloadAction({ hitRetryable: true, alreadyRetried: true })).toBe("notify")
+  })
+})
+
+describe("isRetryableErrorPart", () => {
+  it("matches the backend retryable-error data part", () => {
+    expect(
+      isRetryableErrorPart({
+        type: "data-chat-status",
+        data: { kind: "retryable-error", reason: "overloaded" },
+      }),
+    ).toBe(true)
+  })
+
+  it("ignores other kinds, types, and malformed shapes", () => {
+    expect(isRetryableErrorPart({ type: "data-chat-status", data: { kind: "other" } })).toBe(false)
+    expect(
+      isRetryableErrorPart({ type: "text-delta", data: { kind: "retryable-error" } }),
+    ).toBe(false)
+    expect(isRetryableErrorPart({ type: "data-chat-status" })).toBe(false)
+    expect(isRetryableErrorPart({ type: "data-chat-status", data: null })).toBe(false)
+    expect(isRetryableErrorPart({})).toBe(false)
+  })
+})

--- a/frontend/src/components/ChatPanel/overloadRetry.ts
+++ b/frontend/src/components/ChatPanel/overloadRetry.ts
@@ -1,0 +1,35 @@
+/**
+ * Client-side handling for the backend's transient "overloaded" signal.
+ *
+ * When Anthropic is momentarily overloaded mid-stream, the chat endpoint emits a
+ * transient `data-chat-status` part (see apps/chat/stream.py) instead of a
+ * dead-end error. We auto-retry the turn once, and only surface a message if the
+ * retry also fails.
+ */
+
+/** What to do after a turn that may have hit a transient overload. */
+export type OverloadAction = "retry" | "notify" | "none"
+
+/**
+ * Decide what to do once a turn finishes:
+ * - no retryable error seen        -> "none"
+ * - first retryable error          -> "retry"  (auto-resend once)
+ * - retryable error after a retry  -> "notify" (surface a message, stop)
+ */
+export function decideOverloadAction(args: {
+  hitRetryable: boolean
+  alreadyRetried: boolean
+}): OverloadAction {
+  if (!args.hitRetryable) return "none"
+  return args.alreadyRetried ? "notify" : "retry"
+}
+
+/** True when a useChat `onData` part is the backend's retryable-error signal. */
+export function isRetryableErrorPart(part: { type?: string; data?: unknown }): boolean {
+  return (
+    part?.type === "data-chat-status" &&
+    typeof part.data === "object" &&
+    part.data !== null &&
+    (part.data as { kind?: unknown }).kind === "retryable-error"
+  )
+}

--- a/tests/test_chat_stream_overload.py
+++ b/tests/test_chat_stream_overload.py
@@ -1,0 +1,115 @@
+"""Tests for transient-overload handling in the chat SSE stream.
+
+When Anthropic returns a transient capacity error (overloaded_error / rate
+limit), the stream should signal a retryable error to the frontend and log at
+WARNING (so it does not page via Sentry's ERROR-level capture) -- not surface a
+generic "an error occurred" message or log an exception.
+"""
+
+import logging
+
+import httpx
+import pytest
+from anthropic import APIStatusError, RateLimitError
+
+from apps.chat import stream
+
+STREAM_LOGGER = "apps.chat.stream"
+GENERIC_ERROR_TEXT = "An error occurred while processing your request."
+
+
+def _response(status_code: int) -> httpx.Response:
+    request = httpx.Request("POST", "https://api.anthropic.com/v1/messages")
+    return httpx.Response(status_code, request=request)
+
+
+def _overloaded_streaming_error() -> APIStatusError:
+    """Mirror what anthropic raises on a mid-stream 'error' SSE event: the
+    streaming response opened with status 200, so only the body carries the
+    real error type."""
+    body = {
+        "type": "error",
+        "error": {"details": None, "type": "overloaded_error", "message": "Overloaded"},
+        "request_id": "req_011Cc7SPAEPXbj37vzLkjCoM",
+    }
+    return APIStatusError(f"{body}", response=_response(200), body=body)
+
+
+class _RaisingAgent:
+    """Stands in for the LangGraph agent; its event stream raises immediately."""
+
+    def __init__(self, exc: BaseException):
+        self._exc = exc
+
+    def astream_events(self, input_state, *, config, version):
+        exc = self._exc
+
+        async def _gen():
+            if False:  # make this an async generator without yielding
+                yield
+            raise exc
+
+        return _gen()
+
+
+async def _collect(exc: BaseException) -> list[str]:
+    agent = _RaisingAgent(exc)
+    return [chunk async for chunk in stream.langgraph_to_ui_stream(agent, {}, {"configurable": {}})]
+
+
+# --- classifier ------------------------------------------------------------
+
+
+def test_classifier_true_for_streaming_overloaded():
+    assert stream._is_transient_overload(_overloaded_streaming_error()) is True
+
+
+def test_classifier_true_for_rate_limit():
+    assert (
+        stream._is_transient_overload(RateLimitError("rate", response=_response(429), body=None))
+        is True
+    )
+
+
+def test_classifier_false_for_bad_request():
+    body = {"type": "error", "error": {"type": "invalid_request_error", "message": "bad"}}
+    exc = APIStatusError(f"{body}", response=_response(400), body=body)
+    assert stream._is_transient_overload(exc) is False
+
+
+def test_classifier_false_for_generic_exception():
+    assert stream._is_transient_overload(ValueError("boom")) is False
+
+
+# --- stream behavior -------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_overloaded_emits_retryable_signal_and_warns(caplog):
+    with caplog.at_level(logging.WARNING, logger=STREAM_LOGGER):
+        chunks = await _collect(_overloaded_streaming_error())
+    joined = "".join(chunks)
+
+    # Signals a retryable error the frontend can auto-retry on...
+    assert "data-chat-status" in joined
+    assert "retryable-error" in joined
+    # ...instead of the generic dead-end error text.
+    assert GENERIC_ERROR_TEXT not in joined
+    # Stream still closes cleanly.
+    assert any('"type": "finish"' in c for c in chunks)
+
+    levels = {r.levelno for r in caplog.records if r.name == STREAM_LOGGER}
+    assert logging.WARNING in levels  # logged...
+    assert logging.ERROR not in levels  # ...but not at ERROR (no Sentry page)
+
+
+@pytest.mark.asyncio
+async def test_generic_error_still_reported_to_sentry(caplog):
+    with caplog.at_level(logging.WARNING, logger=STREAM_LOGGER):
+        chunks = await _collect(ValueError("boom"))
+    joined = "".join(chunks)
+
+    assert GENERIC_ERROR_TEXT in joined
+    assert "retryable-error" not in joined
+    # logger.exception -> ERROR record (Sentry captures this).
+    assert any(r.levelno == logging.ERROR for r in caplog.records if r.name == STREAM_LOGGER)


### PR DESCRIPTION
## What

A mid-stream Anthropic **`overloaded_error` (HTTP 529)** / rate-limit on `/api/chat/` was caught by the blanket `except Exception` in `langgraph_to_ui_stream`, which:
1. logged at **ERROR** → captured by Sentry's logging integration → **paged via Slack** (`SCOUT-DJANGO-1Q`, captured from `anthropic/_streaming.py::__stream__`), and
2. showed the user a dead-end *"an error occurred"* message.

This is a transient upstream capacity condition, not a bug on our side.

## Changes

**Backend — `apps/chat/stream.py`**
- Classify transient Anthropic capacity errors (`overloaded_error` / `rate_limit_error`, plus 429/503/529 and `RateLimitError`/`InternalServerError`).
- On match: log at **WARNING** (below Sentry's ERROR-level capture, so no page) and emit a **transient `data-chat-status`** SSE part instead of the dead-end text.
- Genuine errors are unchanged: `logger.exception` → Sentry.
- ⚠️ Subtlety: a *mid-stream* error event arrives as a base `APIStatusError` with `status_code == 200` (the stream opened fine, then errored), so the only reliable signal is `body.error.type`. The status-code / subclass checks cover the non-streaming path.

**Frontend — `ChatPanel.tsx` + `overloadRetry.ts`**
- `useChat` `onData` detects the retryable signal and **auto-`regenerate()`s the turn once**.
- If the retry also fails, a manual-retry notice is shown (`chat-overload-notice` / `chat-overload-retry` testids) — no dead end.
- Retry decision logic extracted to a pure, unit-tested helper.

## Tests
- `tests/test_chat_stream_overload.py` — classifier + stream behavior (retryable → WARNING + retryable part, no generic text; generic error → still `logger.exception`). 6 passing.
- `frontend/.../overloadRetry.test.ts` — decision + part-matching helper. 5 passing.
- Full suites green: backend chat suite (35), frontend Vitest (19), `tsc`, eslint, ruff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)