### PR TITLE
fix(teardown): unbind agent teardown_schema tool + add drop-site state CAS (arch #237)

### DIFF
--- a/apps/agents/graph/base.py
+++ b/apps/agents/graph/base.py
@@ -70,10 +70,25 @@ MCP_TOOL_NAMES = frozenset(
         "get_metadata",
         "run_materialization",
         "get_schema_status",
-        "teardown_schema",
         "get_lineage",
     }
 )
+
+# MCP tools the server advertises but that must NEVER be exposed to the agent.
+#
+# ``teardown_schema`` (arch #237 / finding 00#2) physically DROPs every tenant
+# and view schema for a workspace but updates no Django state — TenantSchema
+# stays ACTIVE over dropped schemas, MaterializationRuns stay COMPLETED, the
+# WorkspaceViewSchema stays ACTIVE, and sibling multi-tenant workspaces sharing
+# the (external_id-keyed) tenant schema are silently destroyed without being
+# failed. Its only guards are an LLM-suppliable ``confirm`` flag and workspace
+# existence; there is no role/membership check. It duplicates the worker
+# ``teardown_schema`` task (which carries the full state-update + sibling-fail
+# machinery) with none of its safety, and has no legitimate agent use case
+# (schemas are re-provisioned automatically on the next materialization). It is
+# therefore filtered out before tools are bound to the LLM. The MCP server still
+# defines the tool so operator/HTTP callers are unaffected.
+AGENT_EXCLUDED_MCP_TOOLS = frozenset({"teardown_schema"})
 
 
 # Configuration constants
@@ -689,7 +704,9 @@ def _build_tools(workspace: Workspace, user: User | None, mcp_tools: list) -> li
     Returns:
         List of LangChain tool functions.
     """
-    tools = list(mcp_tools)
+    # Drop any MCP tool the server advertises but that must not reach the LLM
+    # (e.g. the destructive ``teardown_schema`` — see AGENT_EXCLUDED_MCP_TOOLS).
+    tools = [t for t in mcp_tools if getattr(t, "name", None) not in AGENT_EXCLUDED_MCP_TOOLS]
     tools.append(create_save_learning_tool(workspace, user))
     tools.extend(create_artifact_tools(workspace, user))
     tools.append(create_recipe_tool(workspace, user))

--- a/apps/workspaces/tasks.py
+++ b/apps/workspaces/tasks.py
@@ -613,6 +613,18 @@ async def teardown_view_schema_task(view_schema_id: str) -> None:
         logger.exception("teardown_view_schema_task: view schema %s not found", view_schema_id)
         return
 
+    # State CAS (arch #237, finding 03#0): abort the DROP if the row is no longer
+    # TEARDOWN — it may have been reactivated (rebuild → ACTIVE) after this
+    # teardown was queued, in which case the physical schema is live again.
+    if vs.state != SchemaState.TEARDOWN:
+        logger.info(
+            "teardown_view_schema_task: view schema %s is %s (not TEARDOWN) — "
+            "aborting drop; the row was likely reactivated after teardown was queued",
+            vs.id,
+            vs.state,
+        )
+        return
+
     manager = SchemaManager()
     try:
         await asyncio.to_thread(manager.teardown_view_schema, vs)
@@ -633,6 +645,21 @@ async def teardown_schema(schema_id: str) -> None:
         schema = await TenantSchema.objects.aget(id=schema_id)
     except TenantSchema.DoesNotExist:
         logger.exception("teardown_schema: schema %s not found", schema_id)
+        return
+
+    # State CAS (arch #237, finding 03#0): this task is enqueued against a row
+    # that was TEARDOWN at dispatch time, but provision() resurrects EXPIRED/
+    # TEARDOWN rows back to ACTIVE (the 2026-06-10 incident-b fix). If a
+    # resurrection raced ahead of this queued teardown, the row is ACTIVE again
+    # and its (re-provisioned) data must be preserved — abort the DROP. Only a
+    # row still in TEARDOWN is safe to drop.
+    if schema.state != SchemaState.TEARDOWN:
+        logger.info(
+            "teardown_schema: schema %s is %s (not TEARDOWN) — aborting drop; "
+            "the row was likely resurrected by provision() after teardown was queued",
+            schema.id,
+            schema.state,
+        )
         return
 
     manager = SchemaManager()

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -802,6 +802,14 @@ async def get_schema_status(workspace_id: str = "") -> dict:
 async def teardown_schema(confirm: bool = False, workspace_id: str = "") -> dict:
     """Drop all materialized data for this workspace.
 
+    NOT exposed to the agent (arch #237 / finding 00#2): this tool DROPs
+    physical schemas but updates no Django state and does not fail dependent
+    sibling workspaces, so it is filtered out of the agent's tool set
+    (``AGENT_EXCLUDED_MCP_TOOLS`` in ``apps/agents/graph/base.py``). It remains
+    defined for operator/HTTP callers only. Legitimate teardown for the agent's
+    workflow happens via the worker ``teardown_schema`` task (TTL expiry /
+    refresh), which performs the full state update + sibling-fail machinery.
+
     Destructive — all tenant schemas and the workspace view schema are
     permanently dropped. Schemas will be re-provisioned automatically on
     the next materialization run. Metadata extracted during materialization

--- a/tests/test_agent_graph.py
+++ b/tests/test_agent_graph.py
@@ -1,16 +1,18 @@
 """Tests for the agent graph builder."""
 
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
 import pytest
 
 
 class TestMcpToolNames:
     """Verify MCP_TOOL_NAMES contains all tools that need workspace_id injection."""
 
-    def test_new_tools_in_mcp_tool_names(self):
+    def test_get_schema_status_in_mcp_tool_names(self):
         from apps.agents.graph.base import MCP_TOOL_NAMES
 
         assert "get_schema_status" in MCP_TOOL_NAMES
-        assert "teardown_schema" in MCP_TOOL_NAMES
 
     def test_existing_tools_still_present(self):
         from apps.agents.graph.base import MCP_TOOL_NAMES
@@ -20,6 +22,48 @@ class TestMcpToolNames:
         assert "query" in MCP_TOOL_NAMES
         assert "get_metadata" in MCP_TOOL_NAMES
         assert "run_materialization" in MCP_TOOL_NAMES
+
+
+class TestTeardownSchemaUnbound:
+    """The destructive MCP ``teardown_schema`` tool must NOT be exposed to the agent.
+
+    arch #237 / finding 00#2: the agent-facing ``teardown_schema`` MCP tool DROPs
+    physical schemas but updates no Django state (TenantSchema stays ACTIVE, runs
+    stay COMPLETED, sibling multi-tenant view schemas are never failed) and has no
+    role/membership check — only an LLM-suppliable ``confirm`` flag. It duplicates
+    the worker teardown task with none of its safety machinery, so it is unbound
+    from the agent: the LLM can no longer call it.
+    """
+
+    def test_teardown_schema_not_in_mcp_tool_names(self):
+        from apps.agents.graph.base import MCP_TOOL_NAMES
+
+        assert "teardown_schema" not in MCP_TOOL_NAMES
+
+    def test_teardown_schema_filtered_from_agent_tools(self):
+        """``_build_tools`` must drop the MCP ``teardown_schema`` tool even though
+        the MCP server still advertises it (operator/HTTP callers keep it)."""
+        from apps.agents.graph.base import _build_tools
+
+        def _fake_mcp_tool(name):
+            t = MagicMock()
+            t.name = name
+            return t
+
+        mcp_tools = [
+            _fake_mcp_tool("query"),
+            _fake_mcp_tool("list_tables"),
+            _fake_mcp_tool("teardown_schema"),
+        ]
+        workspace = SimpleNamespace(id="ws-1", system_prompt="")
+
+        tools = _build_tools(workspace, None, mcp_tools)
+        tool_names = {t.name for t in tools}
+
+        assert "teardown_schema" not in tool_names
+        # The non-destructive MCP tools survive.
+        assert "query" in tool_names
+        assert "list_tables" in tool_names
 
 
 class TestSystemPrompt:

--- a/tests/test_chat_mcp_contract.py
+++ b/tests/test_chat_mcp_contract.py
@@ -44,6 +44,7 @@ from mcp.client.session import ClientSession
 from mcp.shared.memory import create_connected_server_and_client_session
 
 from apps.agents.graph.base import (
+    AGENT_EXCLUDED_MCP_TOOLS,
     MCP_TOOL_NAMES,
     _fetch_schema_context,
     _make_injecting_tool_node,
@@ -132,7 +133,13 @@ async def test_advertised_tool_set_matches_graph_expectation():
     """
     async with mcp_wire() as (_session, tools):
         advertised = set(tools)
-    expected = set(MCP_TOOL_NAMES) | CONTEXT_FREE_TOOLS
+    # ``AGENT_EXCLUDED_MCP_TOOLS`` (e.g. the destructive ``teardown_schema``) are
+    # advertised by the server for operator/HTTP callers but deliberately NOT bound
+    # to the agent (arch #237 / finding 00#2). They are a third accounted-for bucket
+    # alongside graph-injected (``MCP_TOOL_NAMES``) and ``CONTEXT_FREE_TOOLS`` tools.
+    # The drift-detection intent is preserved: a NEW server tool that is neither
+    # expected, context-free, nor explicitly excluded still trips the ``extra`` check.
+    expected = set(MCP_TOOL_NAMES) | CONTEXT_FREE_TOOLS | AGENT_EXCLUDED_MCP_TOOLS
 
     missing = expected - advertised
     extra = advertised - expected

--- a/tests/test_schema_ttl_task.py
+++ b/tests/test_schema_ttl_task.py
@@ -115,6 +115,11 @@ async def test_schema_with_null_last_accessed_is_not_expired(active_schema):
 @pytest.mark.asyncio
 @pytest.mark.django_db(transaction=True)
 async def test_teardown_schema_marks_expired_on_success(active_schema):
+    # Production flips the row to TEARDOWN before dispatching teardown_schema;
+    # the state CAS (arch #237) only drops a row still in TEARDOWN.
+    active_schema.state = SchemaState.TEARDOWN
+    await active_schema.asave(update_fields=["state"])
+
     with patch("apps.workspaces.tasks.SchemaManager") as MockManager:
         MockManager.return_value.teardown.return_value = None
         from apps.workspaces.tasks import teardown_schema
@@ -164,6 +169,11 @@ async def test_teardown_schema_marks_runs_stale_on_success(active_schema):
     must be flipped to STALE so the catalog stops returning ghost entries for
     tables that no longer exist. CANCELLED/FAILED runs are left alone.
     """
+    # Production flips the row to TEARDOWN before dispatch; the CAS (arch #237)
+    # only drops a row still in TEARDOWN.
+    active_schema.state = SchemaState.TEARDOWN
+    await active_schema.asave(update_fields=["state"])
+
     completed_run = await MaterializationRun.objects.acreate(
         tenant_schema=active_schema,
         pipeline="commcare_sync",
@@ -317,6 +327,11 @@ async def test_teardown_schema_fails_dependent_multitenant_view_schemas(
     """After the physical DROP, the ACTIVE view schema of a multi-tenant
     workspace B (sharing the torn-down tenant) is flipped to FAILED, while a
     single-tenant workspace's view schema is left untouched."""
+    # Production flips the row to TEARDOWN before dispatch; the CAS (arch #237)
+    # only drops a row still in TEARDOWN.
+    active_schema.state = SchemaState.TEARDOWN
+    await active_schema.asave(update_fields=["state"])
+
     # Multi-tenant workspace B: shares `tenant` + a second tenant, ACTIVE view schema.
     extra_tenant = await Tenant.objects.acreate(
         provider="commcare", external_id="teardown-extra", canonical_name="Teardown Extra"
@@ -424,3 +439,115 @@ async def test_teardown_schema_rebuilds_dependent_views_when_surviving_active_sc
     # Data is intact (new schema ACTIVE) → views are rebuildable, NOT failed.
     assert vs_b.state == SchemaState.ACTIVE
     mock_rebuild.assert_awaited_once_with(workspace_id=str(ws_b.id))
+
+
+# ---------------------------------------------------------------------------
+# teardown state CAS (arch #237, finding 03#0)
+# ---------------------------------------------------------------------------
+#
+# provision() resurrects TEARDOWN/EXPIRED rows back to ACTIVE (the 2026-06-10
+# incident-b fix). A teardown task that was already queued before the resurrection
+# fetches the row by id and would otherwise DROP SCHEMA CASCADE unconditionally —
+# destroying the freshly re-provisioned data. The task must re-read the row's state
+# and ABORT the drop when the row is no longer TEARDOWN.
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_teardown_schema_aborts_when_row_resurrected_to_active(active_schema):
+    """A stale queued teardown_schema must NOT drop a schema that provision()
+    resurrected to ACTIVE between enqueue and execution. The CAS holds: the
+    physical DROP is skipped and the schema stays ACTIVE."""
+    # The row is ACTIVE (active_schema fixture) — i.e. it was resurrected after the
+    # teardown was queued (which would have required it to be TEARDOWN at enqueue).
+    assert active_schema.state == SchemaState.ACTIVE
+
+    with patch("apps.workspaces.tasks.SchemaManager") as MockManager:
+        await teardown_schema(schema_id=str(active_schema.id))
+
+    # The drop never happened — the manager was never asked to teardown.
+    MockManager.return_value.teardown.assert_not_called()
+
+    await active_schema.arefresh_from_db()
+    # The resurrected schema is untouched.
+    assert active_schema.state == SchemaState.ACTIVE
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_teardown_schema_aborts_does_not_stale_runs(active_schema):
+    """When the CAS aborts the drop, data-bearing runs must remain terminal —
+    they must NOT be flipped to STALE, since the schema/tables are still present."""
+    completed_run = await MaterializationRun.objects.acreate(
+        tenant_schema=active_schema,
+        pipeline="commcare_sync",
+        state=MaterializationRun.RunState.COMPLETED,
+        result={"sources": {"cases": {"state": "completed", "rows": 1}}},
+    )
+
+    with patch("apps.workspaces.tasks.SchemaManager") as MockManager:
+        await teardown_schema(schema_id=str(active_schema.id))
+
+    MockManager.return_value.teardown.assert_not_called()
+
+    await completed_run.arefresh_from_db()
+    assert completed_run.state == MaterializationRun.RunState.COMPLETED
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_teardown_schema_still_drops_when_state_is_teardown(active_schema):
+    """Sanity: the CAS does not break the normal path — a row legitimately in
+    TEARDOWN is still dropped and marked EXPIRED."""
+    active_schema.state = SchemaState.TEARDOWN
+    await active_schema.asave(update_fields=["state"])
+
+    with patch("apps.workspaces.tasks.SchemaManager") as MockManager:
+        MockManager.return_value.teardown.return_value = None
+        await teardown_schema(schema_id=str(active_schema.id))
+
+    MockManager.return_value.teardown.assert_called_once()
+    await active_schema.arefresh_from_db()
+    assert active_schema.state == SchemaState.EXPIRED
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_teardown_view_schema_aborts_when_row_resurrected_to_active(db, user):
+    """A stale queued teardown_view_schema_task must NOT drop a view schema that
+    was reactivated (ACTIVE) between enqueue and execution."""
+    workspace = await Workspace.objects.acreate(name="CAS view ws", created_by=user)
+    vs = await WorkspaceViewSchema.objects.acreate(
+        workspace=workspace, schema_name="ws_cas_active", state=SchemaState.ACTIVE
+    )
+
+    from apps.workspaces.tasks import teardown_view_schema_task
+
+    with patch("apps.workspaces.tasks.SchemaManager") as MockManager:
+        await teardown_view_schema_task(view_schema_id=str(vs.id))
+
+    MockManager.return_value.teardown_view_schema.assert_not_called()
+
+    await vs.arefresh_from_db()
+    assert vs.state == SchemaState.ACTIVE
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_teardown_view_schema_still_drops_when_state_is_teardown(db, user):
+    """Sanity: a view schema legitimately in TEARDOWN is still dropped and
+    marked EXPIRED."""
+    workspace = await Workspace.objects.acreate(name="CAS view ws 2", created_by=user)
+    vs = await WorkspaceViewSchema.objects.acreate(
+        workspace=workspace, schema_name="ws_cas_teardown", state=SchemaState.TEARDOWN
+    )
+
+    from apps.workspaces.tasks import teardown_view_schema_task
+
+    with patch("apps.workspaces.tasks.SchemaManager") as MockManager:
+        MockManager.return_value.teardown_view_schema.return_value = None
+        await teardown_view_schema_task(view_schema_id=str(vs.id))
+
+    MockManager.return_value.teardown_view_schema.assert_called_once()
+    await vs.arefresh_from_db()
+    assert vs.state == SchemaState.EXPIRED


### PR DESCRIPTION
## arch #237 — MCP teardown_schema updates no Django state; add CAS at the drop site [DATA-LOSS]

Two data-loss findings at the schema teardown path.

### 00#2 (data-loss): agent-exposed `teardown_schema` MCP tool — UNBIND

The agent-facing MCP `teardown_schema` tool physically DROPs every tenant and
view schema for a workspace but updates **no Django state**: `TenantSchema`
stays `ACTIVE` over dropped schemas, `MaterializationRun`s stay `COMPLETED`
(never `STALE`), `WorkspaceViewSchema` stays `ACTIVE`, and sibling multi-tenant
workspaces sharing the (external_id-keyed) tenant schema are silently destroyed
without being failed — unlike the worker `teardown_schema` task, which does all
of this plus carries the PR #230 sibling-fail machinery. Its only guards are an
LLM-suppliable `confirm=True` flag and workspace existence; there is **no
role/membership check**.

**Decision: UNBIND (not keep).** It is a strictly inferior duplicate of the
worker task with none of its safety, and has no legitimate agent use case —
schemas re-provision automatically on the next materialization, and legitimate
teardown (TTL expiry / refresh / tenant-removal) already runs through the worker
task. A prompt-injected agent could otherwise silently destroy sibling
workspaces' data.

Note: `get_mcp_tools()` loads **all** server-advertised tools and `_build_tools`
binds them to the LLM, so `MCP_TOOL_NAMES` membership did **not** gate binding —
the tool was genuinely callable. The fix adds `AGENT_EXCLUDED_MCP_TOOLS` and
filters it out in `_build_tools` before binding, and drops it from
`MCP_TOOL_NAMES`. The MCP server keeps the tool defined for operator/HTTP callers.

### 03#0 (latent data-loss): state CAS at the drop site

`provision()` resurrects `TEARDOWN`/`EXPIRED` rows back to `ACTIVE` (the
2026-06-10 incident-b fix). A `teardown_schema` / `teardown_view_schema_task`
already queued before the resurrection fetched the row by id and dropped the
schema **unconditionally** — destroying the freshly re-provisioned data. Added a
state CAS: re-read the row and **abort** the drop when it is no longer `TEARDOWN`.
All three production dispatch sites (TTL expiry, refresh, tenant-removal) flip to
`TEARDOWN` before dispatching, so legitimate drops are unaffected.

## Tests

- `TestTeardownSchemaUnbound`: `teardown_schema` absent from `MCP_TOOL_NAMES` and
  filtered out of the built agent tool set (non-destructive MCP tools survive).
- `test_teardown_schema_aborts_when_row_resurrected_to_active` + runs-not-staled
  variant: a stale queued teardown does NOT drop a resurrected `ACTIVE` schema.
- `test_teardown_view_schema_aborts_when_row_resurrected_to_active`: same for the
  view-schema task.
- Sanity: rows legitimately in `TEARDOWN` still drop → `EXPIRED`.
- Updated 3 pre-existing tests that drove the task from an `ACTIVE` row (an
  unrealistic state) to set `TEARDOWN` first, matching production.

All ran green locally (`scout_test_237`); 111 related tests pass, ruff clean.

Closes #237

🤖 Generated with [Claude Code](https://claude.com/claude-code)