### PR TITLE
fix(security): block cross-tenant metadata disclosure via pg_catalog (#244)

### DIFF
--- a/apps/agents/prompts/base_system.py
+++ b/apps/agents/prompts/base_system.py
@@ -164,7 +164,7 @@ Your access is strictly limited for safety:
 
 2. **Schema-Scoped**: You can ONLY access tables within the current project's schema. Attempts to access other schemas will fail.
 
-3. **No `information_schema`**: You cannot query `information_schema` directly. Use the `describe_table` and `list_tables` tools to inspect schema. Unqualified `pg_catalog` views (`pg_namespace`, `pg_class`, `pg_views`, `pg_tables`) are reachable if you really need raw system-state introspection, but prefer the dedicated tools.
+3. **No System Catalogs**: You cannot query `information_schema` or PostgreSQL system catalogs (`pg_namespace`, `pg_class`, `pg_views`, `pg_tables`, and the rest of `pg_catalog`), whether qualified or unqualified. These are shared across all customers and are blocked to prevent cross-tenant metadata disclosure. Use the `describe_table` and `list_tables` tools to inspect schema instead.
 
 4. **Query Limits**: Large queries have row limits and timeouts to prevent runaway operations.
 

--- a/apps/workspaces/services/schema_manager.py
+++ b/apps/workspaces/services/schema_manager.py
@@ -378,9 +378,18 @@ class SchemaManager:
             # Create read-only role for the view schema
             self._create_readonly_role(cursor, view_schema_name)
 
+            view_role = readonly_role_name(view_schema_name)
+
+            # Revoke grants the role still holds on tenant schemas that are no
+            # longer part of this workspace. The role is reused across rebuilds,
+            # so without this a removed tenant's schema keeps SELECT/USAGE for
+            # the _ro role — leaving the prior tenant's data reachable through a
+            # role that should only see the current members (issue #244).
+            current_schemas = {view_schema_name} | {s for s, _ in tenant_schemas}
+            self._revoke_stale_view_role_grants(cursor, view_role, current_schemas)
+
             # Grant SELECT on the views themselves (ALTER DEFAULT PRIVILEGES
             # only covers future tables, not the views just created above)
-            view_role = readonly_role_name(view_schema_name)
             cursor.execute(
                 psycopg.sql.SQL("GRANT SELECT ON ALL TABLES IN SCHEMA {} TO {}").format(
                     psycopg.sql.Identifier(view_schema_name),
@@ -621,6 +630,37 @@ class SchemaManager:
                 psycopg.sql.Identifier(role_name),
             )
         )
+
+    def _revoke_stale_view_role_grants(
+        self, cursor, role_name: str, current_schemas: set[str]
+    ) -> None:
+        """Revoke the view-schema _ro role's grants on schemas it should no longer reach.
+
+        On a view-schema rebuild the role is reused, so any tenant schema that
+        was dropped from the workspace since the last build still carries
+        SELECT/USAGE for this role. Find every schema where the role holds an
+        ACL entry and revoke from those not in ``current_schemas`` (the view
+        schema plus the constituent tenant schemas of the new membership).
+        Best-effort per schema: a removed schema that has since been dropped
+        from the database leaves no ACL to revoke.
+        """
+        cursor.execute(self._SCHEMAS_WITH_ROLE_GRANTS_SQL, (role_name,))
+        granted_schemas = [row[0] for row in cursor.fetchall()]
+        for schema in granted_schemas:
+            if schema in current_schemas:
+                continue
+            cursor.execute(
+                psycopg.sql.SQL("REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA {} FROM {}").format(
+                    psycopg.sql.Identifier(schema),
+                    psycopg.sql.Identifier(role_name),
+                )
+            )
+            cursor.execute(
+                psycopg.sql.SQL("REVOKE ALL PRIVILEGES ON SCHEMA {} FROM {}").format(
+                    psycopg.sql.Identifier(schema),
+                    psycopg.sql.Identifier(role_name),
+                )
+            )
 
     def _sanitize_schema_name(self, tenant_id: str) -> str:
         """Convert a tenant_id to a valid PostgreSQL schema name."""

--- a/mcp_server/services/sql_validator.py
+++ b/mcp_server/services/sql_validator.py
@@ -73,6 +73,11 @@ DANGEROUS_FUNCTIONS: frozenset[str] = frozenset(
         "pg_rotate_logfile",
         "pg_terminate_backend",
         "pg_cancel_backend",
+        # Denial of service / session tampering
+        "pg_sleep",
+        "pg_sleep_for",
+        "pg_sleep_until",
+        "set_config",
         # Command execution
         "query_to_xml",
         "query_to_xml_and_xmlschema",
@@ -105,6 +110,40 @@ FORBIDDEN_STATEMENT_TYPES: frozenset[type] = frozenset(
         exp.Merge,
         exp.Set,
         exp.Command,
+    }
+)
+
+# System catalog relations that resolve via the implicit ``pg_catalog`` schema
+# even when written UNqualified. These are world-readable in PG16+ regardless of
+# SET ROLE, so an unqualified reference (where the AST carries no schema) leaks
+# cross-tenant metadata: tenant schema names derive from customer identifiers and
+# ``pg_class.reltuples`` exposes row counts. Schema-qualified ``pg_catalog.*`` is
+# already rejected by ``_validate_table_access``; this set closes the unqualified
+# gap. Names are matched case-insensitively against the bare relation name.
+SYSTEM_CATALOG_RELATIONS: frozenset[str] = frozenset(
+    {
+        "pg_namespace",
+        "pg_class",
+        "pg_views",
+        "pg_tables",
+        "pg_matviews",
+        "pg_attribute",
+        "pg_proc",
+        "pg_roles",
+        "pg_user",
+        "pg_shadow",
+        "pg_authid",
+        "pg_database",
+        "pg_stat_activity",
+        "pg_stat_user_tables",
+        "pg_stat_all_tables",
+        "pg_statio_user_tables",
+        "pg_index",
+        "pg_indexes",
+        "pg_constraint",
+        "pg_type",
+        "pg_description",
+        "pg_settings",
     }
 )
 
@@ -213,29 +252,51 @@ class SQLValidator:
         # Check for dangerous functions
         self._validate_no_dangerous_functions(statement, sql)
 
+        # Reject unqualified system-catalog reads (cross-tenant disclosure)
+        self._validate_no_system_catalogs(statement, sql)
+
         # Check table access permissions
         self._validate_table_access(statement, sql)
 
         return statement
 
     def _validate_statement_type(self, statement: exp.Expression, sql: str) -> None:
-        """Ensure only SELECT statements are allowed."""
+        """Ensure only SELECT statements are allowed.
+
+        Beyond the top-level expression type, this also rejects:
+
+        - ``SELECT ... INTO`` (a table-creating SELECT — the ``into`` arg on a
+          ``Select`` node), and
+        - data-modifying CTEs (``WITH x AS (INSERT/UPDATE/DELETE ...) SELECT ...``)
+          which parse as a top-level ``Select`` but embed DML in a subtree.
+
+        Both pass a naive top-level ``isinstance`` check, so we scan the AST.
+        """
+        # SELECT ... INTO creates a new relation; reject regardless of nesting.
+        if statement.args.get("into") is not None or statement.find(exp.Into) is not None:
+            raise SQLValidationError(
+                "SELECT ... INTO is not allowed. Only read-only SELECT queries are permitted.",
+                sql=sql,
+                error_type="forbidden_statement",
+            )
+
+        # Data-modifying CTEs / subqueries: any embedded INSERT/UPDATE/DELETE/
+        # MERGE/etc. is forbidden even if the outer statement is a SELECT.
+        forbidden_tuple = tuple(FORBIDDEN_STATEMENT_TYPES)
+        for node in statement.find_all(*forbidden_tuple):
+            raise SQLValidationError(
+                f"{type(node).__name__.upper()} statements are not allowed "
+                "(including inside CTEs and subqueries). Only SELECT queries are permitted.",
+                sql=sql,
+                error_type="forbidden_statement",
+            )
+
         # Check if it's a SELECT statement
         if not isinstance(statement, exp.Select):
             # Also allow UNION, INTERSECT, EXCEPT which wrap SELECT statements
             if isinstance(statement, exp.Union | exp.Intersect | exp.Except):
                 # These are valid compound SELECT operations
                 return
-
-            # Check for forbidden statement types
-            for forbidden_type in FORBIDDEN_STATEMENT_TYPES:
-                if isinstance(statement, forbidden_type):
-                    raise SQLValidationError(
-                        f"{forbidden_type.__name__.upper()} statements are not allowed. "
-                        "Only SELECT queries are permitted.",
-                        sql=sql,
-                        error_type="forbidden_statement",
-                    )
 
             # If not a SELECT and not explicitly forbidden, still reject
             raise SQLValidationError(
@@ -244,6 +305,24 @@ class SQLValidator:
                 sql=sql,
                 error_type="forbidden_statement",
             )
+
+    def _validate_no_system_catalogs(self, statement: exp.Expression, sql: str) -> None:
+        """Reject references to PostgreSQL system catalogs.
+
+        Unqualified catalog relations (``pg_class``, ``pg_namespace``, ...)
+        resolve via the implicit ``pg_catalog`` schema and are world-readable
+        regardless of ``SET ROLE``, leaking cross-tenant metadata. Schema-
+        qualified ``pg_catalog.*`` is already blocked by ``_validate_table_access``;
+        this catches the unqualified form the AST records with no schema.
+        """
+        for table in statement.find_all(exp.Table):
+            if table.name.lower() in SYSTEM_CATALOG_RELATIONS:
+                raise SQLValidationError(
+                    f"Access to system catalog '{table.name}' is not permitted. "
+                    "Use the describe_table and list_tables tools to inspect schema.",
+                    sql=sql,
+                    error_type="system_catalog_not_allowed",
+                )
 
     def _validate_no_dangerous_functions(self, statement: exp.Expression, sql: str) -> None:
         """Check for dangerous function calls in the query."""
@@ -396,6 +475,7 @@ class SQLValidator:
 __all__ = [
     "DANGEROUS_FUNCTIONS",
     "FORBIDDEN_STATEMENT_TYPES",
+    "SYSTEM_CATALOG_RELATIONS",
     "SQLValidationError",
     "SQLValidator",
 ]

--- a/tests/test_sql_validator.py
+++ b/tests/test_sql_validator.py
@@ -503,6 +503,96 @@ class TestEdgeCases:
         assert "users" in tables
 
 
+class TestSystemCatalogDisclosure:
+    """Issue #244: block cross-tenant metadata disclosure via system catalogs."""
+
+    def test_reject_unqualified_pg_namespace(self):
+        validator = SQLValidator(schema="ws_demo")
+        with pytest.raises(SQLValidationError, match="(?i)system catalog|pg_catalog"):
+            validator.validate("SELECT nspname FROM pg_namespace")
+
+    def test_reject_unqualified_pg_class(self):
+        validator = SQLValidator(schema="ws_demo")
+        with pytest.raises(SQLValidationError, match="(?i)system catalog|pg_catalog"):
+            validator.validate("SELECT relname, reltuples FROM pg_class")
+
+    def test_reject_unqualified_pg_tables(self):
+        validator = SQLValidator(schema="ws_demo")
+        with pytest.raises(SQLValidationError, match="(?i)system catalog|pg_catalog"):
+            validator.validate("SELECT schemaname FROM pg_tables")
+
+    def test_reject_unqualified_pg_views(self):
+        validator = SQLValidator(schema="ws_demo")
+        with pytest.raises(SQLValidationError, match="(?i)system catalog|pg_catalog"):
+            validator.validate("SELECT viewname FROM pg_views")
+
+    def test_reject_unqualified_pg_catalog_in_join(self):
+        """A system catalog hidden inside a JOIN must still be caught."""
+        validator = SQLValidator(schema="ws_demo")
+        with pytest.raises(SQLValidationError, match="(?i)system catalog|pg_catalog"):
+            validator.validate("SELECT n.nspname FROM users u JOIN pg_namespace n ON true")
+
+    def test_reject_schema_qualified_pg_catalog(self):
+        """Explicit pg_catalog.* is rejected by schema enforcement too."""
+        validator = SQLValidator(schema="ws_demo")
+        with pytest.raises(SQLValidationError, match="(?i)pg_catalog|schema|system catalog"):
+            validator.validate("SELECT * FROM pg_catalog.pg_class")
+
+    def test_allow_legitimate_unqualified_table(self):
+        """A normal user table that is not a system catalog must still pass."""
+        validator = SQLValidator(schema="ws_demo")
+        statement = validator.validate("SELECT id FROM users")
+        assert statement is not None
+
+
+class TestDataModifyingStatements:
+    """Issue #244: harden statement-type checks against hidden DML."""
+
+    def test_reject_select_into(self):
+        """SELECT ... INTO creates a table — must be rejected."""
+        validator = SQLValidator(schema="public")
+        with pytest.raises(SQLValidationError, match="(?i)only SELECT|INTO"):
+            validator.validate("SELECT * INTO new_table FROM users")
+
+    def test_reject_cte_insert(self):
+        """A data-modifying CTE (WITH x AS (INSERT ...)) must be rejected."""
+        validator = SQLValidator(schema="public")
+        with pytest.raises(SQLValidationError, match="(?i)only SELECT|INSERT|modif"):
+            validator.validate(
+                "WITH x AS (INSERT INTO users VALUES (1) RETURNING id) SELECT * FROM x"
+            )
+
+    def test_reject_cte_update(self):
+        validator = SQLValidator(schema="public")
+        with pytest.raises(SQLValidationError, match="(?i)only SELECT|UPDATE|modif"):
+            validator.validate("WITH x AS (UPDATE users SET a = 1 RETURNING id) SELECT * FROM x")
+
+    def test_reject_cte_delete(self):
+        validator = SQLValidator(schema="public")
+        with pytest.raises(SQLValidationError, match="(?i)only SELECT|DELETE|modif"):
+            validator.validate("WITH x AS (DELETE FROM users RETURNING id) SELECT * FROM x")
+
+    def test_allow_read_only_cte(self):
+        """A read-only CTE must still pass."""
+        validator = SQLValidator(schema="public")
+        statement = validator.validate("WITH x AS (SELECT id FROM users) SELECT * FROM x")
+        assert statement is not None
+
+
+class TestDangerousTimingFunctions:
+    """Issue #244: pg_sleep (DoS) and set_config (session tampering)."""
+
+    def test_reject_pg_sleep(self):
+        validator = SQLValidator(schema="public")
+        with pytest.raises(SQLValidationError, match="(?i)not allowed"):
+            validator.validate("SELECT pg_sleep(10)")
+
+    def test_reject_set_config(self):
+        validator = SQLValidator(schema="public")
+        with pytest.raises(SQLValidationError, match="(?i)not allowed"):
+            validator.validate("SELECT set_config('search_path', 'pg_catalog', false)")
+
+
 class TestPromptValidatorAlignment:
     """Meta-tests ensuring the system prompt matches the validator's real behavior."""
 
@@ -511,15 +601,20 @@ class TestPromptValidatorAlignment:
         with pytest.raises(SQLValidationError, match="information_schema"):
             validator.validate("SELECT * FROM information_schema.columns")
 
-    def test_unqualified_pg_catalog_views_are_allowed(self):
+    def test_unqualified_pg_catalog_views_are_rejected(self):
+        """Unqualified system-catalog reads resolve via implicit pg_catalog and
+        leak cross-tenant metadata (schema names from external_id, row counts
+        from pg_class.reltuples). The validator MUST reject them — secure
+        contract (was previously pinned ALLOWED, see issue #244)."""
         validator = SQLValidator(schema="ws_demo")
         for sql in (
             "SELECT schemaname, tablename FROM pg_tables",
             "SELECT schemaname, viewname FROM pg_views",
             "SELECT nspname FROM pg_namespace",
-            "SELECT relname FROM pg_class",
+            "SELECT relname, reltuples FROM pg_class",
         ):
-            validator.validate(sql)
+            with pytest.raises(SQLValidationError, match="(?i)system catalog|pg_catalog"):
+                validator.validate(sql)
 
     def test_prompt_mentions_information_schema_restriction(self):
         prompt = BASE_SYSTEM_PROMPT.lower()
@@ -527,14 +622,18 @@ class TestPromptValidatorAlignment:
         assert "describe_table" in prompt
         assert "list_tables" in prompt
 
-    def test_prompt_does_not_claim_pg_catalog_is_blocked(self):
-        prompt = BASE_SYSTEM_PROMPT
-        forbidden_phrases = [
-            "cannot query pg_catalog",
-            "cannot access pg_catalog",
+    def test_prompt_does_not_advertise_pg_catalog_reachability(self):
+        """The prompt must NOT advertise unqualified pg_catalog views as
+        reachable — doing so invites chat users / prompt-injected content to
+        enumerate the shared DB's customer list (issue #244)."""
+        prompt = BASE_SYSTEM_PROMPT.lower()
+        advertised_phrases = [
+            "are reachable",
+            "is reachable",
+            "if you really need raw system-state introspection",
         ]
-        for phrase in forbidden_phrases:
-            assert phrase.lower() not in prompt.lower(), (
-                f"Prompt still claims pg_catalog is blocked ({phrase!r}), but the "
-                "validator allows unqualified pg_* views."
+        for phrase in advertised_phrases:
+            assert phrase not in prompt, (
+                f"Prompt still advertises pg_catalog reachability ({phrase!r}), but the "
+                "validator now rejects unqualified pg_* views (issue #244)."
             )

--- a/tests/test_view_schema_builder.py
+++ b/tests/test_view_schema_builder.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from django.contrib.auth import get_user_model
+from psycopg import sql as psycopg_sql
 
 from apps.users.models import Tenant
 from apps.workspaces.models import (
@@ -14,7 +15,7 @@ from apps.workspaces.models import (
     WorkspaceTenant,
     WorkspaceViewSchema,
 )
-from apps.workspaces.services.schema_manager import SchemaManager
+from apps.workspaces.services.schema_manager import SchemaManager, readonly_role_name
 
 pytestmark = pytest.mark.skipif(
     not os.environ.get("MANAGED_DATABASE_URL"),
@@ -721,6 +722,7 @@ def test_build_view_schema_oversized_view_name_raises(two_tenant_workspace, mana
         ts1.delete()
         ts2.delete()
 
+
 @pytest.mark.django_db
 def test_build_view_schema_clears_last_error_on_success(workspace, tenant):
     """A successful build must clear any stale last_error from a prior failure."""
@@ -786,3 +788,111 @@ def test_build_view_schema_records_last_error_on_failure(workspace, tenant):
     finally:
         ts.delete()
         WorkspaceViewSchema.objects.filter(workspace=workspace).delete()
+
+
+def _role_grant_schemas(cursor, role_name: str) -> set[str]:
+    """Return the set of schemas on which ``role_name`` holds a direct ACL entry."""
+    cursor.execute(
+        """
+        SELECT DISTINCT n.nspname
+        FROM pg_namespace n, aclexplode(n.nspacl) AS acl
+        JOIN pg_roles r ON r.oid = acl.grantee
+        WHERE r.rolname = %s
+        """,
+        (role_name,),
+    )
+    return {row[0] for row in cursor.fetchall()}
+
+
+def test_rebuild_revokes_ro_grants_on_removed_tenant_schema(db, managed_db_connection):
+    """Issue #244: after a tenant is removed and the view schema is rebuilt, the
+    _ro role must no longer hold SELECT/USAGE on the removed tenant's schema."""
+    User = get_user_model()
+    user = User.objects.create_user(email="revoke@example.com", password="pass")
+    # Unique schema names so sibling agents sharing the managed DB don't collide.
+    ta = Tenant.objects.create(
+        provider="commcare", external_id="revoke-dom-a-244", canonical_name="revoke_a_244"
+    )
+    tb = Tenant.objects.create(
+        provider="commcare", external_id="revoke-dom-b-244", canonical_name="revoke_b_244"
+    )
+    tc = Tenant.objects.create(
+        provider="commcare", external_id="revoke-dom-c-244", canonical_name="revoke_c_244"
+    )
+    ws = Workspace.objects.create(name="Revoke WS 244", created_by=user)
+    WorkspaceMembership.objects.create(workspace=ws, user=user, role=WorkspaceRole.MANAGE)
+    WorkspaceTenant.objects.create(workspace=ws, tenant=ta)
+    WorkspaceTenant.objects.create(workspace=ws, tenant=tb)
+    wt_c = WorkspaceTenant.objects.create(workspace=ws, tenant=tc)
+
+    sa, sb, sc = "revoke_a_244_sch", "revoke_b_244_sch", "revoke_c_244_sch"
+    tsa = TenantSchema.objects.create(tenant=ta, schema_name=sa, state=SchemaState.ACTIVE)
+    tsb = TenantSchema.objects.create(tenant=tb, schema_name=sb, state=SchemaState.ACTIVE)
+    tsc = TenantSchema.objects.create(tenant=tc, schema_name=sc, state=SchemaState.ACTIVE)
+
+    conn = managed_db_connection
+    c = conn.cursor()
+    try:
+        for s in (sa, sb, sc):
+            c.execute(f"CREATE SCHEMA IF NOT EXISTS {s}")
+            c.execute(f"CREATE TABLE IF NOT EXISTS {s}.cases (id TEXT)")
+    finally:
+        c.close()
+
+    vs = None
+    try:
+        vs = SchemaManager().build_view_schema(ws)
+        view_role = readonly_role_name(vs.schema_name)
+
+        c2 = conn.cursor()
+        try:
+            granted = _role_grant_schemas(c2, view_role)
+            # Initially the role can read all three constituent tenant schemas.
+            assert {sa, sb, sc} <= granted
+        finally:
+            c2.close()
+
+        # Remove tenant C from the workspace, then rebuild.
+        wt_c.delete()
+        tsc_schema = sc
+        vs = SchemaManager().build_view_schema(ws)
+
+        c3 = conn.cursor()
+        try:
+            granted_after = _role_grant_schemas(c3, view_role)
+            # The _ro role must NO LONGER reach the removed tenant's schema.
+            assert tsc_schema not in granted_after, (
+                f"_ro role {view_role} still holds grants on removed schema {tsc_schema}: "
+                f"{sorted(granted_after)}"
+            )
+            # ...but still reaches the remaining members.
+            assert {sa, sb} <= granted_after
+        finally:
+            c3.close()
+    finally:
+        c4 = conn.cursor()
+        try:
+            # Drop all schemas first (CASCADE removes the grants that would
+            # otherwise block DROP ROLE), then drop the roles.
+            schemas_to_drop = list((sa, sb, sc))
+            roles_to_drop = [readonly_role_name(s) for s in (sa, sb, sc)]
+            if vs:
+                schemas_to_drop.append(vs.schema_name)
+                roles_to_drop.append(readonly_role_name(vs.schema_name))
+            for s in schemas_to_drop:
+                c4.execute(
+                    psycopg_sql.SQL("DROP SCHEMA IF EXISTS {} CASCADE").format(
+                        psycopg_sql.Identifier(s)
+                    )
+                )
+            for role in roles_to_drop:
+                c4.execute(
+                    psycopg_sql.SQL("DROP ROLE IF EXISTS {}").format(psycopg_sql.Identifier(role))
+                )
+        finally:
+            c4.close()
+        if vs:
+            vs.delete()
+        tsa.delete()
+        tsb.delete()
+        tsc.delete()


### PR DESCRIPTION
## Summary

Closes #244 (finding 09#0, SECURITY, broken-now).

The `SQLValidator` only checked **schema-qualified** system-catalog references, so unqualified `pg_namespace` / `pg_class` / `pg_views` / `pg_tables` resolved via the implicit `pg_catalog` schema — world-readable in PG16 regardless of `SET ROLE`. Tenant schema names derive from `tenant.external_id` (customer identifiers) and `pg_class.reltuples` leaks row counts, so any chat user or prompt-injected content could enumerate the shared DB's customer list. The system prompt also **explicitly advertised** these catalog views as reachable.

## Fixes (all five sub-issues)

1. **Unqualified system-catalog enumeration blocked.** New `SYSTEM_CATALOG_RELATIONS` set in `sql_validator.py`; `_validate_no_system_catalogs` rejects `pg_namespace`/`pg_class`/`pg_views`/`pg_tables` (and ~20 more) by bare relation name, including inside JOINs. Schema-qualified `pg_catalog.*` was already rejected by `_validate_table_access`.
2. **Prompt no longer advertises catalog reachability.** `base_system.py` now states system catalogs are blocked (qualified or not) and points to `describe_table`/`list_tables`.
3. **`_validate_statement_type` hardened** against `SELECT … INTO` (table-creating) and data-modifying CTEs (`WITH x AS (INSERT/UPDATE/DELETE …) SELECT …`) — both previously passed the naive top-level `isinstance` check. Now scans the AST for an `Into` node and any embedded forbidden statement type.
4. **`pg_sleep` / `pg_sleep_for` / `pg_sleep_until` (DoS) and `set_config` (session tampering)** added to `DANGEROUS_FUNCTIONS`.
5. **Stale `_ro` grant revoke on rebuild.** `build_view_schema` now revokes the reused `_ro` role's `SELECT`/`USAGE` on tenant schemas that are no longer part of the workspace, so a removed tenant's data is no longer reachable after a view-schema rebuild.

`workspace_service.remove_workspace_tenant` already dispatches `rebuild_workspace_view_schema` → `build_view_schema`, so the revoke fires on tenant removal; no change needed there.

## Cross-window test seam

Flipped `tests/test_sql_validator.py::TestPromptValidatorAlignment` to the new **secure** contract: unqualified `pg_catalog` is now asserted **DISALLOWED** (was pinned ALLOWED) and the prompt is asserted to no longer advertise reachability.

## Tests

- `TestSystemCatalogDisclosure` — unqualified `pg_namespace`/`pg_class`/`pg_tables`/`pg_views`, catalog-in-JOIN, qualified `pg_catalog.*`, plus a positive case for legit user tables.
- `TestDataModifyingStatements` — `SELECT … INTO`, CTE-INSERT/UPDATE/DELETE rejected; read-only CTE still allowed.
- `TestDangerousTimingFunctions` — `pg_sleep` / `set_config` rejected.
- `test_rebuild_revokes_ro_grants_on_removed_tenant_schema` — `MANAGED_DATABASE_URL`-gated regression; **verified load-bearing locally** against native PG (fails without the revoke, passes with it).

**Local result:** validator/prompt tests + the revoke test + MCP/async-conventions suites all green (119 passed). `ruff check .` clean, files formatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)