### PR TITLE
fix(artifacts): multi-tenant live artifacts hit right schema; shared threads surface artifacts (#240)

### DIFF
--- a/apps/agents/graph/base.py
+++ b/apps/agents/graph/base.py
@@ -483,6 +483,7 @@ async def build_agent_graph(
     checkpointer: BaseCheckpointSaver | None = None,
     mcp_tools: list | None = None,
     oauth_tokens: dict | None = None,
+    conversation_id: str | None = None,
 ):
     """
     Build a LangGraph agent graph for a workspace.
@@ -493,11 +494,14 @@ async def build_agent_graph(
         checkpointer: Optional LangGraph checkpointer for conversation persistence.
         mcp_tools: List of MCP tools to include.
         oauth_tokens: Optional OAuth tokens for tool authentication.
+        conversation_id: Optional thread/conversation id. Threaded through to the
+            artifact tools so chat-created artifacts record their originating
+            conversation (so shared/public thread pages can find them).
     """
     logger.info("Building agent graph for workspace %s", workspace.id)
 
     # --- Build tools ---
-    tools = _build_tools(workspace, user, mcp_tools or [])
+    tools = _build_tools(workspace, user, mcp_tools or [], conversation_id=conversation_id)
     logger.debug("Created %d tools for workspace %s", len(tools), workspace.id)
 
     # --- Inject workspace_id and user_id into MCP tool calls from agent state ---
@@ -665,7 +669,12 @@ async def build_agent_graph(
     return compiled
 
 
-def _build_tools(workspace: Workspace, user: User | None, mcp_tools: list) -> list:
+def _build_tools(
+    workspace: Workspace,
+    user: User | None,
+    mcp_tools: list,
+    conversation_id: str | None = None,
+) -> list:
     """
     Build the tool list for the agent.
 
@@ -685,13 +694,15 @@ def _build_tools(workspace: Workspace, user: User | None, mcp_tools: list) -> li
         workspace: The Workspace model instance.
         user: Optional User for tracking learning discovery.
         mcp_tools: LangChain tools loaded from the MCP server.
+        conversation_id: Optional thread/conversation id, recorded on artifacts
+            the agent creates so shared/public thread pages can find them.
 
     Returns:
         List of LangChain tool functions.
     """
     tools = list(mcp_tools)
     tools.append(create_save_learning_tool(workspace, user))
-    tools.extend(create_artifact_tools(workspace, user))
+    tools.extend(create_artifact_tools(workspace, user, conversation_id=conversation_id))
     tools.append(create_recipe_tool(workspace, user))
     return tools
 

--- a/apps/agents/tools/artifact_tool.py
+++ b/apps/agents/tools/artifact_tool.py
@@ -205,8 +205,9 @@ def create_artifact_tools(
                 title,
             )
 
-            # Build render URL
-            render_url = f"/artifacts/{artifact.id}/render/"
+            # Build render URL pointing at the real sandbox route
+            # (/api/workspaces/<wsid>/artifacts/<id>/sandbox/).
+            render_url = f"/api/workspaces/{workspace.id}/artifacts/{artifact.id}/sandbox/"
 
             return {
                 "artifact_id": str(artifact.id),
@@ -318,8 +319,9 @@ def create_artifact_tools(
                 workspace.id,
             )
 
-            # Build render URL
-            render_url = f"/artifacts/{new_artifact.id}/render/"
+            # Build render URL pointing at the real sandbox route
+            # (/api/workspaces/<wsid>/artifacts/<id>/sandbox/).
+            render_url = f"/api/workspaces/{workspace.id}/artifacts/{new_artifact.id}/sandbox/"
 
             return {
                 "artifact_id": str(new_artifact.id),

--- a/apps/artifacts/tests/test_artifact_query_data.py
+++ b/apps/artifacts/tests/test_artifact_query_data.py
@@ -148,7 +148,7 @@ async def test_returns_query_results_for_live_artifact(live_artifact, member_cli
 
     with (
         patch(
-            "apps.artifacts.views.load_tenant_context",
+            "apps.artifacts.views.load_workspace_context",
             new=AsyncMock(return_value=FAKE_CTX),
         ),
         patch(
@@ -224,11 +224,11 @@ async def test_no_workspace_returns_404(member_user, member_client, membership):
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
 async def test_tenant_context_error_returns_error_query(live_artifact, member_client, membership):
-    """If load_tenant_context fails (no schema), return error response."""
+    """If load_workspace_context fails (no schema), return error response."""
     url = f"/api/workspaces/{membership.id}/artifacts/{live_artifact.id}/query-data/"
 
     with patch(
-        "apps.artifacts.views.load_tenant_context",
+        "apps.artifacts.views.load_workspace_context",
         new=AsyncMock(side_effect=ValueError("No active schema")),
     ):
         response = await member_client.get(url)
@@ -249,7 +249,7 @@ async def test_individual_query_failure_continues(live_artifact, member_client, 
 
     with (
         patch(
-            "apps.artifacts.views.load_tenant_context",
+            "apps.artifacts.views.load_workspace_context",
             new=AsyncMock(return_value=FAKE_CTX),
         ),
         patch(

--- a/apps/artifacts/views.py
+++ b/apps/artifacts/views.py
@@ -20,9 +20,8 @@ from django.views import View
 
 from apps.common.utils import creator_display_name
 from apps.users.decorators import LoginRequiredJsonMixin
-from apps.workspaces.models import TenantSchema
 from apps.workspaces.workspace_resolver import aresolve_workspace, resolve_workspace
-from mcp_server.context import load_tenant_context
+from mcp_server.context import load_workspace_context
 from mcp_server.services.query import execute_query
 
 from .models import Artifact
@@ -808,9 +807,12 @@ class ArtifactQueryDataView(View):
     """
     Executes an artifact's source_queries via the MCP query service and returns results.
 
-    For artifacts with source_queries, each SQL query is executed against the tenant's
-    database using the same query service as the MCP server. Results are returned in a
-    format the artifact sandbox can consume directly via mergeQueryResults().
+    For artifacts with source_queries, each SQL query is executed against the
+    workspace's query schema using the same query service as the MCP server.
+    Routing goes through ``load_workspace_context`` so multi-tenant workspaces hit
+    the ``ws_*`` view schema the agent authored queries against -- not the first
+    tenant's ``t_*`` schema. Results are returned in a format the artifact sandbox
+    can consume directly via mergeQueryResults().
     """
 
     async def get(self, request: HttpRequest, workspace_id, artifact_id: str) -> JsonResponse:
@@ -835,12 +837,11 @@ class ArtifactQueryDataView(View):
         if artifact.workspace is None:
             return JsonResponse({"error": "Artifact has no associated workspace"}, status=400)
 
-        tenant = await artifact.workspace.tenants.afirst()
-        if tenant is None:
-            return JsonResponse({"error": "Workspace has no associated tenant"}, status=400)
-
+        # Route through load_workspace_context so single- vs multi-tenant
+        # workspaces resolve to the correct schema (t_* vs ws_* view schema) and
+        # the inactivity TTL is touched on the right schema.
         try:
-            ctx = await load_tenant_context(tenant.external_id)
+            ctx = await load_workspace_context(str(artifact.workspace_id))
         except Exception as e:
             error_msg = str(e)
             results = [
@@ -848,11 +849,6 @@ class ArtifactQueryDataView(View):
                 for i, entry in enumerate(artifact.source_queries)
             ]
             return JsonResponse({"queries": results, "static_data": artifact.data or {}})
-
-        # Touch the schema to reset the inactivity TTL on user-initiated queries
-        ts = await TenantSchema.objects.filter(schema_name=ctx.schema_name).afirst()
-        if ts is not None:
-            await ts.atouch()
 
         results = []
         for i, entry in enumerate(artifact.source_queries):

--- a/apps/chat/thread_views.py
+++ b/apps/chat/thread_views.py
@@ -50,7 +50,18 @@ async def _update_thread_sharing(thread, is_shared=None):
 
 
 async def _get_thread_artifacts(thread_id):
-    """Load artifacts associated with a thread."""
+    """Load artifacts associated with a thread.
+
+    Returns the artifact ``code`` and ``data`` so a public (unauthenticated)
+    thread page can render each artifact in a client-side sandboxed iframe
+    (``srcdoc``) instead of dumping the source as ``<pre>``.
+
+    Note: the authenticated server sandbox route
+    (``/api/workspaces/<wsid>/artifacts/<id>/sandbox/``) and the live
+    ``query-data`` route both require session auth + workspace membership, so
+    they intentionally are NOT exposed here. Public rendering uses the embedded
+    static ``data`` only; live tenant data is never served to anonymous viewers.
+    """
     from apps.artifacts.models import Artifact
 
     return [

--- a/apps/chat/views.py
+++ b/apps/chat/views.py
@@ -181,6 +181,7 @@ async def chat_view(request):
             checkpointer=checkpointer,
             mcp_tools=mcp_tools,
             oauth_tokens=oauth_tokens,
+            conversation_id=str(thread_id),
         )
     except Exception:
         # Connection may have gone stale -- force a new checkpointer and retry
@@ -193,6 +194,7 @@ async def chat_view(request):
                 checkpointer=checkpointer,
                 mcp_tools=mcp_tools,
                 oauth_tokens=oauth_tokens,
+                conversation_id=str(thread_id),
             )
         except Exception as e:
             error_ref = hashlib.sha256(f"{time.time()}{e}".encode()).hexdigest()[:8]

--- a/apps/recipes/services/runner.py
+++ b/apps/recipes/services/runner.py
@@ -105,6 +105,7 @@ class RecipeRunner:
                 checkpointer=None,
                 mcp_tools=mcp_tools,
                 oauth_tokens=self._oauth_tokens,
+                conversation_id=self._thread_id or None,
             )
 
         return self._graph

--- a/apps/workspaces/tasks.py
+++ b/apps/workspaces/tasks.py
@@ -948,7 +948,7 @@ async def _build_failure_summary_for_job(procrastinate_job_id: int) -> str:
     return _compose_failure_summary(runs)
 
 
-async def _build_agent_for_resume(workspace, user):
+async def _build_agent_for_resume(workspace, user, conversation_id=None):
     """Build the LangGraph agent + load oauth_tokens for runtime config.
 
     Returns (agent, oauth_tokens).
@@ -962,6 +962,7 @@ async def _build_agent_for_resume(workspace, user):
         checkpointer=checkpointer,
         mcp_tools=mcp_tools,
         oauth_tokens=oauth_tokens,
+        conversation_id=conversation_id,
     )
     return agent, oauth_tokens
 
@@ -1010,6 +1011,7 @@ async def _persist_synthetic_failure_message(thread_job, text: str) -> None:
         agent, _ = await _build_agent_for_resume(
             thread_job.thread.workspace,
             thread_job.thread.user,
+            conversation_id=str(thread_job.thread.id),
         )
         config = {"configurable": {"thread_id": str(thread_job.thread.id)}}
         await agent.aupdate_state(
@@ -1265,7 +1267,9 @@ async def resume_thread_after_materialization(context, thread_job_id: str) -> di
     )
     start = time.monotonic()
     try:
-        agent, oauth_tokens = await _build_agent_for_resume(workspace, user)
+        agent, oauth_tokens = await _build_agent_for_resume(
+            workspace, user, conversation_id=str(tj.thread.id)
+        )
         input_state = {
             "messages": [HumanMessage(content=body)],
             "workspace_id": str(workspace.id),

--- a/frontend/src/pages/PublicThreadPage.test.tsx
+++ b/frontend/src/pages/PublicThreadPage.test.tsx
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { PublicThreadPage } from "@/pages/PublicThreadPage"
+
+// Issue #240, finding 00#8: the shared/public thread page must SANDBOX-RENDER
+// artifacts (self-contained html/svg in an iframe) instead of always dumping
+// the source as <pre>. React/Plotly artifacts (which need the CDN renderer +
+// authed live data) keep showing source for anonymous viewers.
+
+const TOKEN = "share-tok-123"
+const WS = "ws-1"
+
+// A message whose assistant turn created the artifact, so the page renders a
+// clickable artifact button that opens the preview.
+function messageFor(artifactId: string) {
+  return {
+    id: "m1",
+    role: "assistant",
+    parts: [
+      {
+        type: "tool-create_artifact",
+        toolName: "create_artifact",
+        state: "output-available",
+        output: { artifact_id: artifactId },
+      },
+    ],
+  }
+}
+
+function thread(artifact: Record<string, unknown>) {
+  return {
+    thread: { id: "t1", title: "Shared", created_at: "2026-01-01T00:00:00Z" },
+    messages: [messageFor(artifact.id as string)],
+    artifacts: [artifact],
+  }
+}
+
+function mockFetch(payload: unknown) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => payload,
+    })),
+  )
+}
+
+describe("PublicThreadPage artifact rendering (issue #240)", () => {
+  beforeEach(() => {
+    window.history.pushState({}, "", `/shared/threads/${TOKEN}`)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it("renders a self-contained html artifact in a sandboxed iframe", async () => {
+    const art = {
+      id: "a1",
+      title: "HTML Report",
+      artifact_type: "html",
+      code: "<h1>Hello</h1>",
+      data: {},
+      version: 1,
+      workspace_id: WS,
+    }
+    mockFetch(thread(art))
+
+    render(<PublicThreadPage />)
+
+    const button = await screen.findByText("HTML Report")
+    await userEvent.click(button)
+
+    const frame = await screen.findByTestId(`public-artifact-frame-${art.id}`)
+    expect(frame.tagName).toBe("IFRAME")
+    // SECURITY: untrusted markup must be sandboxed with NO allow-same-origin
+    // and (for static html/svg) NO allow-scripts.
+    expect(frame.getAttribute("sandbox")).toBe("")
+    expect(frame.getAttribute("srcdoc")).toContain("<h1>Hello</h1>")
+  })
+
+  it("falls back to a <pre> code view for react artifacts", async () => {
+    const art = {
+      id: "a2",
+      title: "React Chart",
+      artifact_type: "react",
+      code: "export default function C(){return <div/>}",
+      data: {},
+      version: 1,
+      workspace_id: WS,
+    }
+    mockFetch(thread(art))
+
+    render(<PublicThreadPage />)
+
+    const button = await screen.findByText("React Chart")
+    await userEvent.click(button)
+
+    const code = await screen.findByTestId(`public-artifact-code-${art.id}`)
+    expect(code.tagName).toBe("PRE")
+    expect(code.textContent).toContain("export default function C")
+    expect(
+      screen.queryByTestId(`public-artifact-frame-${art.id}`),
+    ).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/PublicThreadPage.tsx
+++ b/frontend/src/pages/PublicThreadPage.tsx
@@ -168,9 +168,25 @@ function PublicChatMessage({
   )
 }
 
+// Artifact types that are self-contained markup and can be rendered directly in
+// a sandboxed iframe on the public page. React/Plotly artifacts need the full
+// CDN-backed sandbox renderer plus live query data (which requires auth), so
+// they are not rendered live for anonymous viewers — their source is shown.
+const SANDBOXABLE_TYPES = new Set(["html", "svg"])
+
+// Wrap self-contained artifact markup in a minimal HTML document so the
+// sandboxed iframe renders it. SVG is centered; HTML is rendered as-is.
+function buildSandboxSrcDoc(artifact: Artifact): string {
+  const body =
+    artifact.artifact_type === "svg"
+      ? `<div style="display:flex;align-items:center;justify-content:center;min-height:100%">${artifact.code}</div>`
+      : artifact.code
+  return `<!DOCTYPE html><html><head><meta charset="utf-8"><style>html,body{margin:0;padding:12px;font-family:system-ui,-apple-system,sans-serif}</style></head><body>${body}</body></html>`
+}
+
 function ArtifactPreview({ artifact }: { artifact: Artifact }) {
   return (
-    <Card>
+    <Card data-testid={`public-artifact-${artifact.id}`}>
       <CardHeader>
         <CardTitle className="text-base">{artifact.title}</CardTitle>
         <span className="text-xs text-muted-foreground">{artifact.artifact_type}</span>
@@ -180,8 +196,24 @@ function ArtifactPreview({ artifact }: { artifact: Artifact }) {
           <div className="prose prose-sm dark:prose-invert max-w-none">
             <Markdown remarkPlugins={[remarkGfm]}>{artifact.code}</Markdown>
           </div>
+        ) : SANDBOXABLE_TYPES.has(artifact.artifact_type) ? (
+          <iframe
+            // SECURITY: render untrusted, agent-generated markup with NO
+            // allow-same-origin so the frame gets a unique opaque origin and
+            // cannot touch the parent or this origin's cookies. allow-scripts
+            // is intentionally omitted: static html/svg need no JS, and
+            // withholding it blocks script execution entirely.
+            sandbox=""
+            srcDoc={buildSandboxSrcDoc(artifact)}
+            title={artifact.title}
+            className="h-96 w-full rounded border bg-white"
+            data-testid={`public-artifact-frame-${artifact.id}`}
+          />
         ) : (
-          <pre className="max-h-96 overflow-auto rounded bg-muted p-3 text-xs font-mono whitespace-pre-wrap">
+          <pre
+            className="max-h-96 overflow-auto rounded bg-muted p-3 text-xs font-mono whitespace-pre-wrap"
+            data-testid={`public-artifact-code-${artifact.id}`}
+          >
             {artifact.code}
           </pre>
         )}

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -5,12 +5,24 @@ Tests artifact models, views, access control, versioning, and artifact tools.
 """
 
 import uuid
+from unittest.mock import AsyncMock, patch
 
 import pytest
+from asgiref.sync import sync_to_async
 from django.contrib.auth import get_user_model
-from django.test import Client
+from django.test import AsyncClient, Client
 
+import apps.artifacts.views as artifact_views
+from apps.agents.tools.artifact_tool import create_artifact_tools
 from apps.artifacts.models import Artifact, ArtifactType
+from apps.users.models import Tenant
+from apps.workspaces.models import (
+    Workspace,
+    WorkspaceMembership,
+    WorkspaceRole,
+    WorkspaceTenant,
+)
+from mcp_server.context import QueryContext
 
 User = get_user_model()
 
@@ -441,8 +453,11 @@ class TestArtifactTools:
         assert "artifact_id" in result
         assert result["title"] == "Revenue Chart"
         assert result["type"] == "react"
-        assert "/artifacts/" in result["render_url"]
-        assert "/render" in result["render_url"]
+        # render_url must point at the real sandbox route, not the dead
+        # /artifacts/<id>/render/ path (issue #240, finding 00#8).
+        assert result["render_url"] == (
+            f"/api/workspaces/{workspace.id}/artifacts/{result['artifact_id']}/sandbox/"
+        )
 
         # Verify artifact was created in database
         artifact = await Artifact.objects.aget(id=result["artifact_id"])
@@ -518,3 +533,121 @@ class TestArtifactTools:
 
         assert result2["status"] == "updated"
         assert result2["version"] == original_version + 2
+
+    @pytest.mark.asyncio
+    async def test_create_artifact_threads_conversation_id(self, user, workspace):
+        """create_artifact must persist the conversation_id it was built with.
+
+        Regression for issue #240, finding 00#8: chat-created artifacts stored
+        conversation_id='' because _build_tools never passed it, so shared/public
+        thread pages (which filter conversation_id=str(thread_id)) showed ZERO
+        artifacts.
+        """
+        tools = create_artifact_tools(workspace, user, conversation_id="thread-xyz")
+        create_artifact_tool = tools[0]
+
+        result = await create_artifact_tool.ainvoke(
+            {
+                "title": "Threaded Chart",
+                "artifact_type": "react",
+                "code": "export default function C() { return <div/>; }",
+            }
+        )
+
+        assert result["status"] == "created"
+        artifact = await Artifact.objects.aget(id=result["artifact_id"])
+        assert artifact.conversation_id == "thread-xyz"
+
+    @pytest.mark.asyncio
+    async def test_update_artifact_render_url_points_at_sandbox(
+        self, user, workspace, artifact, tenant_membership
+    ):
+        """update_artifact's render_url must resolve to the real sandbox route."""
+        tools = create_artifact_tools(workspace, user)
+        update_artifact_tool = tools[1]
+
+        result = await update_artifact_tool.ainvoke(
+            {
+                "artifact_id": str(artifact.id),
+                "code": "export default function C() { return <div>v2</div>; }",
+            }
+        )
+
+        assert result["status"] == "updated"
+        assert result["render_url"] == (
+            f"/api/workspaces/{workspace.id}/artifacts/{result['artifact_id']}/sandbox/"
+        )
+
+
+@pytest.mark.django_db(transaction=True)
+class TestArtifactQueryDataRouting:
+    """Tests for ArtifactQueryDataView schema routing (issue #240, finding 00#6)."""
+
+    @pytest.mark.asyncio
+    async def test_query_data_routes_through_workspace_context(self, user):
+        """Live query-data in a multi-tenant workspace must execute against the
+        VIEW schema (ws_*), not the FIRST tenant's t_* schema.
+
+        Before the fix, ArtifactQueryDataView resolved context via
+        workspace.tenants.afirst() + load_tenant_context(external_id), so it ran
+        against the wrong schema (relation-does-not-exist / silent single-tenant
+        slice). The fix routes through load_workspace_context like every other
+        consumer.
+        """
+
+        ws = await Workspace.objects.acreate(name="Multi WS", created_by=user)
+        await WorkspaceMembership.objects.acreate(
+            workspace=ws, user=user, role=WorkspaceRole.MANAGE
+        )
+        for ext in ("first-tenant", "second-tenant"):
+            t = await Tenant.objects.acreate(
+                provider="commcare", external_id=ext, canonical_name=ext
+            )
+            await WorkspaceTenant.objects.acreate(workspace=ws, tenant=t)
+        art = await Artifact.objects.acreate(
+            workspace=ws,
+            created_by=user,
+            title="Live",
+            artifact_type=ArtifactType.REACT,
+            code="export default function C(){return <div/>}",
+            source_queries=[{"name": "q", "sql": "SELECT 1"}],
+        )
+
+        view_ctx = QueryContext(
+            tenant_id=str(ws.id),
+            schema_name="ws_viewschema123",
+            connection_params={"host": "localhost"},
+        )
+
+        client = AsyncClient()
+        await sync_to_async(client.force_login)(user)
+
+        with (
+            patch(
+                "apps.artifacts.views.load_workspace_context",
+                new=AsyncMock(return_value=view_ctx),
+            ) as mock_lwc,
+            patch(
+                "apps.artifacts.views.execute_query",
+                new=AsyncMock(
+                    return_value={
+                        "success": True,
+                        "columns": ["n"],
+                        "rows": [[1]],
+                        "row_count": 1,
+                        "truncated": False,
+                    }
+                ),
+            ) as mock_exec,
+        ):
+            resp = await client.get(f"/api/workspaces/{ws.id}/artifacts/{art.id}/query-data/")
+
+        assert resp.status_code == 200
+        mock_lwc.assert_awaited_once_with(str(ws.id))
+        # The query ran against the view-schema context, not a tenant context.
+        assert mock_exec.await_args.args[0].schema_name == "ws_viewschema123"
+        body = resp.json()
+        assert body["queries"][0]["rows"] == [[1]]
+
+        # Regression guard: the view must no longer reach for per-tenant context.
+        assert not hasattr(artifact_views, "load_tenant_context")

--- a/tests/test_public_thread_artifacts.py
+++ b/tests/test_public_thread_artifacts.py
@@ -1,0 +1,125 @@
+"""Tests for shared/public thread artifact rendering (issue #240, finding 00#8).
+
+A shared thread page must surface the artifacts created during that conversation
+so the public viewer can render them in a sandbox. Two things have to hold:
+
+1. Artifacts created during a chat carry a non-empty ``conversation_id`` equal to
+   the thread id, so the public page filter (``conversation_id=str(thread_id)``)
+   actually finds them.
+2. The public-thread endpoint returns each artifact's ``code`` and ``data`` so
+   the public page can render it in a client-side sandboxed iframe (srcdoc)
+   instead of dumping ``<pre>`` source. Live tenant data (authenticated
+   query-data / sandbox routes) is intentionally NOT exposed to anonymous
+   viewers.
+"""
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import AsyncClient
+
+from apps.artifacts.models import Artifact, ArtifactType
+from apps.chat.models import Thread
+from apps.users.models import Tenant
+from apps.workspaces.models import (
+    Workspace,
+    WorkspaceMembership,
+    WorkspaceRole,
+    WorkspaceTenant,
+)
+
+User = get_user_model()
+
+
+async def _setup_shared_thread_with_artifact():
+    user = await User.objects.acreate_user(email="sharer@example.com", password="pass")
+    tenant = await Tenant.objects.acreate(
+        provider="commcare", external_id="share-domain", canonical_name="Share"
+    )
+    ws = await Workspace.objects.acreate(name="Share WS", created_by=user)
+    await WorkspaceMembership.objects.acreate(workspace=ws, user=user, role=WorkspaceRole.MANAGE)
+    await WorkspaceTenant.objects.acreate(workspace=ws, tenant=tenant)
+
+    thread = Thread(workspace=ws, user=user, title="Shared analysis", is_shared=True)
+    await thread.asave()  # save() mints the share_token
+
+    artifact = await Artifact.objects.acreate(
+        workspace=ws,
+        created_by=user,
+        title="Live Dashboard",
+        artifact_type=ArtifactType.REACT,
+        code="export default function C(){return <div/>}",
+        conversation_id=str(thread.id),
+        source_queries=[{"name": "q", "sql": "SELECT 1"}],
+    )
+    # A second artifact from a DIFFERENT conversation must NOT leak in.
+    await Artifact.objects.acreate(
+        workspace=ws,
+        created_by=user,
+        title="Other",
+        artifact_type=ArtifactType.REACT,
+        code="export default function O(){return <div/>}",
+        conversation_id="some-other-thread",
+    )
+    return ws, thread, artifact
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_public_thread_returns_only_its_artifacts():
+    """The public-thread endpoint returns artifacts filtered by conversation_id."""
+    _ws, thread, artifact = await _setup_shared_thread_with_artifact()
+
+    client = AsyncClient()
+    resp = await client.get(f"/api/chat/threads/shared/{thread.share_token}/")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    artifacts = body["artifacts"]
+    assert [a["id"] for a in artifacts] == [str(artifact.id)]
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_public_thread_artifact_returns_code_for_sandbox_render():
+    """The returned artifact carries the code + data needed to render it in a
+    client-side sandboxed iframe on the public page (not just <pre> source)."""
+    _ws, thread, artifact = await _setup_shared_thread_with_artifact()
+
+    client = AsyncClient()
+    resp = await client.get(f"/api/chat/threads/shared/{thread.share_token}/")
+
+    assert resp.status_code == 200
+    art = resp.json()["artifacts"][0]
+
+    assert art["id"] == str(artifact.id)
+    assert art["artifact_type"] == artifact.artifact_type
+    assert art["code"] == artifact.code
+    # Live/authenticated routes must NOT leak to anonymous viewers.
+    assert "render_url" not in art
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_public_thread_with_empty_conversation_id_artifacts_finds_none():
+    """If chat-created artifacts had an empty conversation_id (the original bug),
+    the public page would find zero artifacts. Guard the filter contract."""
+    ws, thread, _artifact = await _setup_shared_thread_with_artifact()
+
+    # thread.user is the cached instance set at construction (no DB hit).
+    await Artifact.objects.acreate(
+        workspace=ws,
+        created_by=thread.user,
+        title="Orphan",
+        artifact_type=ArtifactType.REACT,
+        code="export default function X(){return <div/>}",
+        conversation_id="",  # the pre-fix bug value
+    )
+
+    client = AsyncClient()
+    resp = await client.get(f"/api/chat/threads/shared/{thread.share_token}/")
+
+    assert resp.status_code == 200
+    titles = [a["title"] for a in resp.json()["artifacts"]]
+    # The orphan (conversation_id="") must not appear; only the correctly-tagged one.
+    assert "Orphan" not in titles
+    assert "Live Dashboard" in titles


### PR DESCRIPTION
Closes #240

Two findings, both broken-now.

## 00#6 — Live artifacts queried the wrong schema in multi-tenant workspaces
`ArtifactQueryDataView` resolved its query context via `workspace.tenants.afirst()` + `load_tenant_context(external_id)`, so live artifacts in a multi-tenant workspace executed against the **first tenant's** `t_*` schema instead of the `ws_*` view schema the agent authored its queries against — yielding "relation does not exist" (or a silent single-tenant slice). The TTL touch targeted the wrong schema too.

**Fix:** route query-data through `load_workspace_context(workspace_id)` like every other consumer. That helper already touches the correct schema (tenant `t_*` for single-tenant, view `ws_*` for multi-tenant), so the redundant/wrong `TenantSchema` touch in the view is removed.

`apps/artifacts/views.py`

## 00#8 — Chat-created artifacts never appeared on shared/public thread pages
`_build_tools` called `create_artifact_tools(workspace, user)` **without** `conversation_id`, so every chat-created artifact stored `conversation_id=''`. The public/shared thread page filters `conversation_id=str(thread_id)`, so it always found **zero** artifacts. The tool also returned `render_url='/artifacts/<id>/render/'`, which matches no route.

**Fix:**
- Thread `conversation_id` through `build_agent_graph` → `_build_tools` → `create_artifact_tools` at every call site (chat view, resume task, recipe runner).
- Fix the tool `render_url` to the real sandbox route `/api/workspaces/<wsid>/artifacts/<id>/sandbox/` (create + update).
- Public thread page now sandbox-renders self-contained `html`/`svg` artifacts in an iframe (`srcdoc`) instead of always dumping `<pre>`. `react`/`plotly` keep showing source: live rendering needs the authenticated CDN sandbox + tenant data, which is deliberately **never** exposed to anonymous viewers (the auth sandbox + `query-data` routes require session auth + workspace membership).

`apps/agents/graph/base.py`, `apps/agents/tools/artifact_tool.py`, `apps/chat/views.py`, `apps/workspaces/tasks.py`, `apps/recipes/services/runner.py`, `apps/chat/thread_views.py`, `frontend/src/pages/PublicThreadPage.tsx`

## Tests
- `tests/test_artifacts.py`
  - multi-tenant query-data routes through `load_workspace_context` (asserts `execute_query` ran against the `ws_*` view-schema context, not a tenant context; regression guard that the view no longer imports `load_tenant_context`)
  - create/update artifact tools persist `conversation_id` and emit a `render_url` resolving to the real sandbox route
- `tests/test_public_thread_artifacts.py` (new)
  - shared/public thread returns **only** its artifacts (filtered by `conversation_id`), with `code`/`data` for client-side sandbox render; an orphaned `conversation_id=''` artifact (the pre-fix bug value) does not leak in
- `frontend/src/pages/PublicThreadPage.test.tsx` (new)
  - `html` artifact renders in a sandboxed iframe (`sandbox=""`, srcdoc contains the markup); `react` falls back to `<pre>`

Local: full backend suite **1230 passed / 5 skipped / 1 xfailed** (incl. the async-conventions CI guard). Frontend **21 vitest tests pass**, `tsc` clean, ESLint clean on changed files. All new tests written failing-first (TDD).

🤖 Generated with [Claude Code](https://claude.com/claude-code)