### PR TITLE
[arch] #234 residual: arg-contract drift (02#6/07#0) + mock-audit hardening (12#0)

### DIFF
--- a/apps/agents/graph/base.py
+++ b/apps/agents/graph/base.py
@@ -215,16 +215,19 @@ async def _fetch_schema_context(tenant, user) -> str:
 
     registry = get_registry()
     pipeline_config = registry.get_by_provider(tenant.provider)
-    pipeline_name = pipeline_config.name if pipeline_config else "commcare_sync"
 
     if ts is None:
+        # NB: no `pipeline=` argument — run_materialization takes no pipeline
+        # parameter (routing moved into materialize_workspace per-provider) and
+        # all of its real params are injected server-side and hidden, so the
+        # LLM-facing schema is empty. Emitting `pipeline="..."` here told the
+        # agent to send an argument the tool can't accept (finding 02#6).
         return (
-            f"No data has been loaded yet. Call `run_materialization` with "
-            f'`pipeline="{pipeline_name}"` to start loading. This tool returns '
-            f"IMMEDIATELY with `status: started` — do NOT call other data tools "
-            f"in the same turn. Acknowledge to the user in ONE sentence and end "
-            f"your turn. The system will resume the conversation automatically "
-            f"when materialization completes."
+            "No data has been loaded yet. Call `run_materialization` to start "
+            "loading. This tool returns IMMEDIATELY with `status: started` — do "
+            "NOT call other data tools in the same turn. Acknowledge to the user "
+            "in ONE sentence and end your turn. The system will resume the "
+            "conversation automatically when materialization completes."
         )
 
     if ts.state == SchemaState.MATERIALIZING:

--- a/tests/agents/test_context_injection_contract.py
+++ b/tests/agents/test_context_injection_contract.py
@@ -1,0 +1,106 @@
+"""Guardrail for the MCP context-injection contract (arch-review finding 07#0).
+
+The agent graph's injecting tool node (`_make_injecting_tool_node` in
+`apps.agents.graph.base`) adds ``workspace_id``, ``user_id``, ``thread_id`` and
+``tool_call_id`` to the args of **every** MCP tool call — including the read
+tools (``list_tables``, ``query``, …) whose signatures declare only
+``workspace_id``. Those calls succeed today only because TWO independent library
+behaviours silently tolerate the extra arguments:
+
+1. **LangChain** — the MCP tools are ``StructuredTool``s whose ``args_schema`` is
+   the raw MCP ``inputSchema`` *dict* (not a Pydantic model). ``BaseTool.
+   _parse_input`` returns dict-schema input unvalidated, so the undeclared keys
+   pass straight through to the tool coroutine (which sinks ``**arguments``).
+2. **FastMCP** — on the server the arguments are validated against a generated
+   ``ArgModelBase`` subclass whose Pydantic config ignores unknown fields
+   (``extra='ignore'`` — Pydantic's default). The extras are dropped before the
+   Python tool function is called.
+
+If *either* library tightens (LangChain validating dict schemas, or FastMCP
+switching to ``extra='forbid'``) every MCP tool call would start failing at
+once, in production, with no local signal. These tests pin both halves so that
+regression fails loudly here instead.
+"""
+
+import pytest
+from langchain_core.tools import StructuredTool
+
+from apps.agents.graph.base import MCP_TOOL_NAMES
+from mcp_server.server import mcp
+
+# The exact arg set the injecting node writes onto every MCP tool call. Mirrors
+# the ``injections`` mapping in ``build_agent_graph`` (workspace_id/user_id/
+# thread_id) plus the per-call ``tool_call_id``. Pinned here so a change to the
+# injection set is a deliberate edit to this contract.
+INJECTED_ARGS = {
+    "workspace_id": "ws-1",
+    "user_id": "user-1",
+    "thread_id": "thread-1",
+    "tool_call_id": "tc-1",
+}
+
+# Read tools whose signature declares ONLY ``workspace_id`` — i.e. they declare
+# *none* of the other injected args. ``run_materialization`` is excluded because
+# it deliberately declares all four.
+WORKSPACE_ONLY_TOOLS = ["list_tables", "get_metadata", "get_schema_status"]
+
+
+def test_langchain_parse_input_passes_injected_extras_through_unvalidated():
+    """LangChain half: a dict-schema StructuredTool (built the way
+    langchain-mcp-adapters builds MCP tools) must accept the injected extras
+    without validation and forward them untouched."""
+
+    async def call_tool(**arguments):
+        # langchain-mcp-adapters' coroutine sinks arbitrary kwargs.
+        return ("ok", None)
+
+    # args_schema is the raw MCP inputSchema dict — declares only workspace_id.
+    dict_args_schema = {
+        "type": "object",
+        "properties": {"workspace_id": {"type": "string"}},
+        "required": [],
+    }
+    tool = StructuredTool(
+        name="list_tables",
+        description="",
+        args_schema=dict_args_schema,
+        coroutine=call_tool,
+        response_format="content_and_artifact",
+    )
+
+    parsed = tool._parse_input(dict(INJECTED_ARGS), INJECTED_ARGS["tool_call_id"])
+
+    # The undeclared keys are NOT stripped or rejected on the LangChain side —
+    # they survive to be sent to the MCP server. If LangChain ever starts
+    # validating dict schemas this assertion fails loudly.
+    assert isinstance(parsed, dict)
+    for key in INJECTED_ARGS:
+        assert key in parsed, f"LangChain dropped/rejected injected arg {key!r}"
+
+
+@pytest.mark.parametrize("tool_name", WORKSPACE_ONLY_TOOLS)
+def test_fastmcp_arg_model_accepts_and_ignores_injected_extras(tool_name):
+    """FastMCP half: the server-side arg model for a tool that declares only
+    ``workspace_id`` must accept the full injected arg set (no ValidationError)
+    and silently drop the three undeclared extras before the tool fn runs."""
+    assert tool_name in MCP_TOOL_NAMES  # sanity: this is an injected MCP tool
+
+    tool = mcp._tool_manager.get_tool(tool_name)
+    arg_model = tool.fn_metadata.arg_model
+
+    declared = set(arg_model.model_fields)
+    assert declared == {"workspace_id"}, (
+        f"{tool_name} now declares {declared}; update this guardrail if the "
+        "injected-arg surface changed"
+    )
+
+    # Must not raise — extra='forbid' would turn this into a ValidationError,
+    # which is exactly the prod-wide breakage we are guarding against.
+    validated = arg_model.model_validate(dict(INJECTED_ARGS))
+
+    # FastMCP forwards only the top-level declared fields to the tool fn; the
+    # undeclared injected args must have been dropped here.
+    forwarded = validated.model_dump_one_level()
+    assert forwarded == {"workspace_id": INJECTED_ARGS["workspace_id"]}, (
+        f"{tool_name} forwarded {forwarded}; injected extras were not ignored"
+    )

--- a/tests/agents/test_schema_context.py
+++ b/tests/agents/test_schema_context.py
@@ -34,6 +34,12 @@ async def test_fetch_schema_context_not_provisioned(mock_tenant, mock_user):
 
     assert "No data has been loaded yet" in result
     assert "run_materialization" in result
+    # Finding 02#6: the prompt must NOT instruct a `pipeline=` argument — the
+    # run_materialization MCP tool has no pipeline parameter (routing moved into
+    # materialize_workspace per-provider) and its LLM-facing schema is empty.
+    # The multi-tenant branch already omits it; the single-tenant branch must too.
+    assert "pipeline=" not in result
+    assert 'pipeline="' not in result
 
 
 @pytest.mark.asyncio

--- a/tests/test_connect_data_loaders.py
+++ b/tests/test_connect_data_loaders.py
@@ -4,6 +4,7 @@ import requests_mock as rm
 from mcp_server.loaders.connect_assessments import ConnectAssessmentLoader
 from mcp_server.loaders.connect_base import (
     EXPORT_ACCEPT_HEADER,
+    RETRY_TOTAL,
     ConnectAuthError,
     ConnectExportError,
 )
@@ -258,6 +259,39 @@ class TestConnectVisitLoader:
             m.get(
                 f"{BASE}/export/opportunity/{OPP_ID}/user_visits/",
                 json={"next": None},
+            )
+            with pytest.raises(ConnectExportError):
+                loader.load()
+
+    # --- 12#0 item 9: additional error paths (was 401 + missing-results only) ---
+
+    def test_auth_error_on_403(self, loader):
+        """403 is treated the same as 401 — a ConnectAuthError, not a generic
+        export failure."""
+        with rm.Mocker() as m:
+            m.get(f"{BASE}/export/opportunity/{OPP_ID}/user_visits/", status_code=403)
+            with pytest.raises(ConnectAuthError):
+                loader.load()
+
+    def test_export_error_on_5xx_reports_retry_exhaustion(self, loader):
+        """A retryable 5xx that never recovers surfaces as ConnectExportError
+        carrying the status and the exhausted attempt count (initial + retries),
+        so the failure is observable rather than silent."""
+        with rm.Mocker() as m:
+            m.get(f"{BASE}/export/opportunity/{OPP_ID}/user_visits/", status_code=503)
+            with pytest.raises(ConnectExportError) as exc:
+                loader.load()
+        assert exc.value.status == 503
+        assert exc.value.attempts == RETRY_TOTAL + 1
+
+    def test_export_error_on_malformed_json(self, loader):
+        """A 200 with a non-JSON body raises ConnectExportError (wrapping the
+        JSON decode error), not an unhandled ValueError deep in the writer."""
+        with rm.Mocker() as m:
+            m.get(
+                f"{BASE}/export/opportunity/{OPP_ID}/user_visits/",
+                text="<html>gateway error</html>",
+                status_code=200,
             )
             with pytest.raises(ConnectExportError):
                 loader.load()

--- a/tests/test_jobs_endpoints.py
+++ b/tests/test_jobs_endpoints.py
@@ -10,6 +10,7 @@ from procrastinate.manager import JobManager
 
 from apps.chat.models import Thread, ThreadJob
 from apps.users.models import Tenant
+from apps.workspaces.api import jobs_cancel
 from apps.workspaces.api.jobs_cancel import cancel_thread_job
 from apps.workspaces.models import (
     MaterializationRun,
@@ -911,8 +912,6 @@ async def test_reconcile_leaves_fresh_running_resume_alone_even_when_job_termina
 def test_jobs_cancel_current_app_binding_is_live_not_a_blueprint():
     """The surviving-sibling binding must resolve to a real App exposing a
     usable job_manager — not procrastinate's not-ready FutureApp blueprint."""
-    from apps.workspaces.api import jobs_cancel
-
     job_manager = jobs_cancel.current_app.job_manager
     assert hasattr(job_manager, "cancel_job_by_id_async")
 

--- a/tests/test_jobs_endpoints.py
+++ b/tests/test_jobs_endpoints.py
@@ -6,6 +6,7 @@ import pytest
 from django.contrib.auth import get_user_model
 from django.test import AsyncClient
 from django.utils import timezone
+from procrastinate.manager import JobManager
 
 from apps.chat.models import Thread, ThreadJob
 from apps.users.models import Tenant
@@ -18,6 +19,7 @@ from apps.workspaces.models import (
     WorkspaceRole,
     WorkspaceTenant,
 )
+from apps.workspaces.tasks import reconcile_stale_thread_job
 
 User = get_user_model()
 
@@ -786,3 +788,183 @@ async def test_active_jobs_does_not_reconcile_fresh_jobs():
     assert len(body["jobs"]) == 1
     assert body["jobs"][0]["thread_job_id"] == str(tj.id)
     assert body["jobs"][0]["state"] == "pending"
+
+
+# ---------------------------------------------------------------------------
+# 12#0 item 1: the RUNNING false-failure reconcile branch
+#
+# Every other stale-reconcile test builds a PENDING ThreadJob, so
+# reconcile_stale_thread_job's RUNNING branch (worker started a resume then
+# crashed) was never exercised. Build it explicitly.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_reconcile_flips_stale_running_job_straight_to_failed():
+    """A stale RUNNING ThreadJob whose procrastinate job is no longer running
+    (a worker claimed the resume then crashed mid-ainvoke) must be flipped
+    straight to FAILED with the interrupted-resume summary — NOT handed a
+    duplicate resume that could race a still-running first invocation."""
+    user = await User.objects.acreate_user(email="stalerun@b.c", password="x")
+    ws = await Workspace.objects.acreate(name="W-run", created_by=user)
+    await WorkspaceMembership.objects.acreate(
+        workspace=ws,
+        user=user,
+        role=WorkspaceRole.READ_WRITE,
+    )
+    thread = await Thread.objects.acreate(workspace=ws, user=user)
+    tj = await ThreadJob.objects.acreate(
+        thread=thread,
+        job_type="materialization",
+        procrastinate_job_id=60001,
+        tool_call_id="tc-run",
+        state=ThreadJob.State.RUNNING,
+    )
+    # A RUNNING job's staleness is measured from the RESUME phase (started_at),
+    # not created_at (finding 02#9). Backdate started_at so the resume reads as
+    # genuinely stuck rather than freshly started.
+    await ThreadJob.objects.filter(id=tj.id).aupdate(
+        started_at=timezone.now() - timedelta(hours=2),
+    )
+    await tj.arefresh_from_db()
+
+    with (
+        # Terminal procrastinate status (succeeded) — NOT todo/doing — so the
+        # reconcile proceeds; tj.state==RUNNING selects the worker-crash branch.
+        patch(
+            "apps.workspaces.tasks._procrastinate_job_status",
+            new=AsyncMock(return_value="succeeded"),
+        ),
+        patch(
+            "apps.workspaces.tasks._persist_synthetic_failure_message",
+            new=AsyncMock(return_value=None),
+        ) as persist,
+    ):
+        action = await reconcile_stale_thread_job(tj)
+
+    assert action == "failed"
+    await tj.arefresh_from_db()
+    assert tj.state == ThreadJob.State.FAILED
+    assert tj.completed_at is not None
+    # The summary tells the user the follow-up was interrupted and to retry —
+    # it must NOT claim the materialization itself failed.
+    assert "interrupted" in tj.error_summary.lower()
+    assert "retry" in tj.error_summary.lower()
+    # The crash is surfaced to the user via a synthetic message.
+    persist.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_reconcile_leaves_fresh_running_resume_alone_even_when_job_terminal():
+    """The 02#9 anti-false-positive guard: a RUNNING ThreadJob whose resume only
+    just started (fresh started_at) must be left alone even though its
+    materialization job long since succeeded — a healthy resume after a long
+    materialization must NOT be mistaken for a crash and falsely failed."""
+    user = await User.objects.acreate_user(email="runfresh@b.c", password="x")
+    ws = await Workspace.objects.acreate(name="W-fresh-run", created_by=user)
+    await WorkspaceMembership.objects.acreate(
+        workspace=ws,
+        user=user,
+        role=WorkspaceRole.READ_WRITE,
+    )
+    thread = await Thread.objects.acreate(workspace=ws, user=user)
+    tj = await ThreadJob.objects.acreate(
+        thread=thread,
+        job_type="materialization",
+        procrastinate_job_id=60002,
+        tool_call_id="tc-fresh-run",
+        state=ThreadJob.State.RUNNING,
+    )
+    # Resume just started — well within the staleness threshold.
+    await ThreadJob.objects.filter(id=tj.id).aupdate(started_at=timezone.now())
+    await tj.arefresh_from_db()
+
+    with patch(
+        "apps.workspaces.tasks._procrastinate_job_status",
+        new=AsyncMock(return_value="succeeded"),
+    ):
+        action = await reconcile_stale_thread_job(tj)
+
+    assert action is None
+    await tj.arefresh_from_db()
+    assert tj.state == ThreadJob.State.RUNNING
+
+
+# ---------------------------------------------------------------------------
+# 12#0 item 2: exercise the REAL current_app binding in cancel_thread_job
+#
+# The other cancel tests patch apps.workspaces.api.jobs_cancel.current_app,
+# replacing the module-level import-time binding. That masks the risk the
+# finding names: jobs_cancel does `from ...procrastinate_app import current_app`
+# (a surviving sibling of the binding that broke the worker-side janitor before
+# it moved to the ORM). If that binding ever resolved to procrastinate's
+# FutureApp blueprint, `current_app.job_manager` would raise AttributeError and
+# the abort would be silently swallowed by cancel_thread_job's try/except.
+#
+# These tests leave the binding intact and patch the abort at the JobManager
+# CLASS level, so the real binding must resolve for the abort to fire.
+# ---------------------------------------------------------------------------
+
+
+def test_jobs_cancel_current_app_binding_is_live_not_a_blueprint():
+    """The surviving-sibling binding must resolve to a real App exposing a
+    usable job_manager — not procrastinate's not-ready FutureApp blueprint."""
+    from apps.workspaces.api import jobs_cancel
+
+    job_manager = jobs_cancel.current_app.job_manager
+    assert hasattr(job_manager, "cancel_job_by_id_async")
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_cancel_thread_job_aborts_through_live_current_app_binding():
+    """cancel_thread_job must actually send the procrastinate abort through its
+    real current_app binding. Patching JobManager.cancel_job_by_id_async at the
+    class level (instead of the module binding) means a regression to a stale
+    binding makes job_manager access raise, the mock is never called, and this
+    fails loudly."""
+    user = await User.objects.acreate_user(email="livebind@b.c", password="x")
+    ws = await Workspace.objects.acreate(name="W-bind", created_by=user)
+    await WorkspaceMembership.objects.acreate(
+        workspace=ws,
+        user=user,
+        role=WorkspaceRole.READ_WRITE,
+    )
+    tenant = await Tenant.objects.acreate(
+        external_id="t-bind",
+        provider="commcare",
+        canonical_name="Bind Tenant",
+    )
+    await WorkspaceTenant.objects.acreate(workspace=ws, tenant=tenant)
+    schema = await TenantSchema.objects.acreate(tenant=tenant, schema_name="s_bind")
+    thread = await Thread.objects.acreate(workspace=ws, user=user)
+    tj = await ThreadJob.objects.acreate(
+        thread=thread,
+        job_type="materialization",
+        procrastinate_job_id=61001,
+        tool_call_id="tc-bind",
+        state=ThreadJob.State.RUNNING,
+    )
+    await MaterializationRun.objects.acreate(
+        tenant_schema=schema,
+        pipeline="commcare_sync",
+        state=MaterializationRun.RunState.LOADING,
+        procrastinate_job_id=61001,
+    )
+
+    with patch.object(
+        JobManager,
+        "cancel_job_by_id_async",
+        new=AsyncMock(return_value=None),
+    ) as mock_abort:
+        runs_cancelled = await cancel_thread_job(tj)
+
+    # The abort fired through the live binding with the right job id + abort flag.
+    mock_abort.assert_awaited_once_with(tj.procrastinate_job_id, abort=True)
+    assert runs_cancelled == 1
+    await tj.arefresh_from_db()
+    assert tj.state == ThreadJob.State.CANCELLED
+    run = await MaterializationRun.objects.aget(procrastinate_job_id=61001)
+    assert run.state == MaterializationRun.RunState.CANCELLED

--- a/tests/test_materializer.py
+++ b/tests/test_materializer.py
@@ -1,8 +1,15 @@
+from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
 import pytest
+from django.utils import timezone
 
-from mcp_server.services.materializer import _connect_visit_total
+from apps.users.models import Tenant
+from apps.workspaces.models import MaterializationRun, TenantSchema
+from mcp_server.services.materializer import (
+    _connect_visit_total,
+    _load_prior_resume_cursors,
+)
 
 
 class TestRunPipeline:
@@ -1452,3 +1459,112 @@ class TestConnectVisitTotal:
     def test_returns_none_for_no_metadata(self):
         assert _connect_visit_total(None, 765) is None
         assert _connect_visit_total({}, 765) is None
+
+
+@pytest.mark.django_db
+class TestLoadPriorResumeCursors:
+    """Real-DB exercise of the prior-run / stale-cursor selection query
+    (12#0 item 7). The stale-cursor regression test elsewhere injects prior_run
+    via a mocked filter/exclude/order_by chain, so the real ORM query
+    (filter(tenant_schema=...).exclude(id=...).order_by('-started_at').first())
+    and the PARTIAL/FAILED eligibility logic were never run against a database.
+    These build actual MaterializationRun rows.
+    """
+
+    def _schema(self, ext_id, schema_name):
+        tenant = Tenant.objects.create(
+            provider="commcare_connect",
+            external_id=ext_id,
+            canonical_name=ext_id,
+        )
+        return TenantSchema.objects.create(tenant=tenant, schema_name=schema_name)
+
+    @staticmethod
+    def _set_started_at(run, when):
+        # started_at is auto_now_add, so it can only be overridden via update().
+        MaterializationRun.objects.filter(id=run.id).update(started_at=when)
+
+    def test_completed_run_after_partial_invalidates_stale_cursor(self):
+        """Run A PARTIAL (cursor last_id=1500) -> Run B COMPLETED full reload ->
+        Run C must start clean: the MOST RECENT prior run (B, COMPLETED) is not a
+        resume target, so no cursor is surfaced from the older PARTIAL."""
+        schema = self._schema("cur-skip", "s_cur_skip")
+        run_a = MaterializationRun.objects.create(
+            tenant_schema=schema,
+            pipeline="commcare_connect",
+            state=MaterializationRun.RunState.PARTIAL,
+            result={
+                "sources": {
+                    "completed_works": {
+                        "state": "failed",
+                        "cursor_state": {"last_id": 1500},
+                    }
+                }
+            },
+        )
+        run_b = MaterializationRun.objects.create(
+            tenant_schema=schema,
+            pipeline="commcare_connect",
+            state=MaterializationRun.RunState.COMPLETED,
+            result={"sources": {"completed_works": {"state": "completed", "rows": 5000}}},
+        )
+        run_c = MaterializationRun.objects.create(
+            tenant_schema=schema,
+            pipeline="commcare_connect",
+            state=MaterializationRun.RunState.STARTED,
+        )
+        base = timezone.now()
+        self._set_started_at(run_a, base - timedelta(hours=2))
+        self._set_started_at(run_b, base - timedelta(hours=1))
+        self._set_started_at(run_c, base)
+
+        cursors = _load_prior_resume_cursors(schema, exclude_run_id=run_c.id)
+
+        assert cursors == {}
+
+    def test_recent_partial_surfaces_only_resumable_source_cursors(self):
+        """When the most-recent prior run is PARTIAL, return cursors only for
+        sources whose state was in_progress/failed AND have an int last_id —
+        completed sources are whole-history checkpoints, not resume targets."""
+        schema = self._schema("cur-keep", "s_cur_keep")
+        prior = MaterializationRun.objects.create(
+            tenant_schema=schema,
+            pipeline="commcare_connect",
+            state=MaterializationRun.RunState.PARTIAL,
+            result={
+                "sources": {
+                    "completed_works": {
+                        "state": "failed",
+                        "cursor_state": {"last_id": 1500},
+                    },
+                    "users": {"state": "completed", "rows": 100},
+                    "visits": {"state": "in_progress", "cursor_state": {"last_id": None}},
+                }
+            },
+        )
+        current = MaterializationRun.objects.create(
+            tenant_schema=schema,
+            pipeline="commcare_connect",
+            state=MaterializationRun.RunState.STARTED,
+        )
+        base = timezone.now()
+        self._set_started_at(prior, base - timedelta(hours=1))
+        self._set_started_at(current, base)
+
+        cursors = _load_prior_resume_cursors(schema, exclude_run_id=current.id)
+
+        # completed_works (failed + int last_id) only; 'users' is completed and
+        # 'visits' has a None last_id — neither is resumable.
+        assert cursors == {"completed_works": 1500}
+
+    def test_no_prior_run_returns_empty(self):
+        """A schema whose only run is the current one (excluded) has no prior to
+        resume from."""
+        schema = self._schema("cur-none", "s_cur_none")
+        current = MaterializationRun.objects.create(
+            tenant_schema=schema,
+            pipeline="commcare_connect",
+            state=MaterializationRun.RunState.STARTED,
+        )
+
+        assert _load_prior_resume_cursors(schema, exclude_run_id=current.id) == {}

--- a/tests/test_mcp_tenant_tools.py
+++ b/tests/test_mcp_tenant_tools.py
@@ -756,8 +756,14 @@ class TestGetMaterializationStatus:
         mock_run.started_at.isoformat.return_value = "2026-02-24T10:00:00+00:00"
         mock_run.completed_at.isoformat.return_value = "2026-02-24T10:05:00+00:00"
         mock_run.result = {"sources": {"cases": {"rows": 100}}}
-        mock_run.tenant_schema.tenant_membership.tenant.external_id = "dimagi"
+        # Real model path: TenantSchema.tenant -> Tenant.external_id (12#0 item 3).
+        # Prod reads run.tenant_schema.tenant.external_id; there is NO
+        # tenant_membership on TenantSchema. Delete the fabricated wrong path so
+        # a regression reading it raises AttributeError instead of silently
+        # returning a MagicMock.
+        mock_run.tenant_schema.tenant.external_id = "dimagi"
         mock_run.tenant_schema.schema_name = "dimagi"
+        del mock_run.tenant_schema.tenant_membership
 
         with patch("mcp_server.server.MaterializationRun") as mock_cls:
             mock_cls.objects.select_related.return_value.aget = AsyncMock(return_value=mock_run)
@@ -768,6 +774,8 @@ class TestGetMaterializationStatus:
         assert result["success"] is True
         assert result["data"]["run_id"] == run_id
         assert result["data"]["state"] == "completed"
+        # Pin that tenant_id was read from the real attribute path.
+        assert result["data"]["tenant_id"] == "dimagi"
 
     def test_unknown_run_returns_not_found(self):
         import asyncio
@@ -800,8 +808,10 @@ class TestCancelMaterialization:
         mock_run.id = uuid.UUID(run_id)
         mock_run.state = "loading"
         mock_run.result = {}
-        mock_run.tenant_schema.tenant_membership.tenant.external_id = "dimagi"
+        # Real model path: TenantSchema.tenant -> Tenant.external_id (12#0 item 3).
+        mock_run.tenant_schema.tenant.external_id = "dimagi"
         mock_run.tenant_schema.schema_name = "dimagi"
+        del mock_run.tenant_schema.tenant_membership
         mock_run.asave = AsyncMock()
 
         with patch("mcp_server.server.MaterializationRun") as mock_cls:
@@ -818,6 +828,17 @@ class TestCancelMaterialization:
         assert result["success"] is True
         assert result["data"]["cancelled"] is True
         assert result["data"]["run_id"] == run_id
+        assert result["data"]["previous_state"] == "loading"
+        # 12#0 item 6: assert the PERSISTED state, not just the response flag.
+        # cancel_materialization currently writes RunState.FAILED (NOT CANCELLED)
+        # and stamps result["cancelled"]=True. Pinning the written state makes the
+        # FAILED-vs-CANCELLED inconsistency vs cancel_thread_job visible; the
+        # reconciliation is tracked in #290.
+        assert mock_run.state == "failed"
+        assert mock_run.result == {"cancelled": True}
+        mock_run.asave.assert_awaited_once_with(
+            update_fields=["state", "completed_at", "result"]
+        )
 
     def test_cancel_completed_run_returns_error(self):
         import asyncio
@@ -827,8 +848,10 @@ class TestCancelMaterialization:
         run_id = str(uuid.uuid4())
         mock_run = MagicMock()
         mock_run.state = "completed"
-        mock_run.tenant_schema.tenant_membership.tenant.external_id = "dimagi"
+        # Real model path: TenantSchema.tenant -> Tenant.external_id (12#0 item 3).
+        mock_run.tenant_schema.tenant.external_id = "dimagi"
         mock_run.tenant_schema.schema_name = "dimagi"
+        del mock_run.tenant_schema.tenant_membership
 
         with patch("mcp_server.server.MaterializationRun") as mock_cls:
             mock_cls.objects.select_related.return_value.aget = AsyncMock(return_value=mock_run)

--- a/tests/test_mcp_tenant_tools.py
+++ b/tests/test_mcp_tenant_tools.py
@@ -836,9 +836,7 @@ class TestCancelMaterialization:
         # reconciliation is tracked in #290.
         assert mock_run.state == "failed"
         assert mock_run.result == {"cancelled": True}
-        mock_run.asave.assert_awaited_once_with(
-            update_fields=["state", "completed_at", "result"]
-        )
+        mock_run.asave.assert_awaited_once_with(update_fields=["state", "completed_at", "result"])
 
     def test_cancel_completed_run_returns_error(self):
         import asyncio

--- a/tests/test_merge_users_service.py
+++ b/tests/test_merge_users_service.py
@@ -11,7 +11,12 @@ from django.contrib.auth.models import Group
 from apps.chat.models import Thread
 from apps.users.models import Tenant, TenantConnection, TenantMembership
 from apps.users.services.merge import merge_users, select_canonical
-from apps.workspaces.models import Workspace, WorkspaceMembership, WorkspaceRole
+from apps.workspaces.models import (
+    TenantMetadata,
+    Workspace,
+    WorkspaceMembership,
+    WorkspaceRole,
+)
 
 User = get_user_model()
 
@@ -450,3 +455,75 @@ def test_merge_skips_auth_group_through_tables_when_shared():
     # Canonical still has the group; through-table state is consistent.
     canonical.refresh_from_db()
     assert g in canonical.groups.all()
+
+
+# ---------------------------------------------------------------------------
+# 12#0 item 8: TenantMetadata fate across a merge
+#
+# TenantMetadata is a OneToOne on TenantMembership (on_delete=CASCADE), and
+# TenantMembership.user is on_delete=CASCADE. The merge suite had ZERO
+# TenantMetadata assertions, so the data-preservation behaviour of the
+# membership repoint vs conflict-delete was invisible. Pin it: discovered
+# provider metadata must ride along when a membership is repointed, and the
+# canonical's own metadata must survive a conflict-delete of the duplicate's row.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_merge_preserves_tenant_metadata_when_membership_is_repointed():
+    """A duplicate-only tenant: the membership is repointed (user=canonical), so
+    its OneToOne TenantMetadata must survive and now be reachable via the
+    canonical's membership — no discovered metadata is lost."""
+    canonical = User.objects.create(email="canon@y.com", username="canon")
+    duplicate = User.objects.create(email="dup@y.com", username="dup")
+    only_dup = Tenant.objects.create(provider="ocs", external_id="exp1", canonical_name="Exp1")
+    dup_tm = TenantMembership.objects.create(user=duplicate, tenant=only_dup)
+    TenantMetadata.objects.create(
+        tenant_membership=dup_tm,
+        metadata={"team_slug": "alpha", "discovered": True},
+    )
+
+    merge_users(canonical=canonical, duplicate=duplicate)
+
+    # The membership row is the same row, now owned by canonical — so its
+    # metadata is preserved (not cascade-deleted with the duplicate user).
+    canon_tm = TenantMembership.objects.get(user=canonical, tenant=only_dup)
+    md = TenantMetadata.objects.get(tenant_membership=canon_tm)
+    assert md.metadata == {"team_slug": "alpha", "discovered": True}
+    # And nothing was orphaned/dropped: exactly one metadata row still exists.
+    assert TenantMetadata.objects.count() == 1
+
+
+@pytest.mark.django_db
+def test_merge_conflict_delete_keeps_canonical_tenant_metadata():
+    """When both users belong to the same tenant, the duplicate's membership is
+    conflict-deleted (its metadata cascades away with it), but the canonical
+    keeps its OWN membership and metadata for that tenant — no canonical data is
+    lost. Whichever side survives, the tenant stays covered."""
+    canonical = User.objects.create(email="canon@y.com", username="canon")
+    duplicate = User.objects.create(email="dup@y.com", username="dup")
+    shared = Tenant.objects.create(provider="ocs", external_id="shared1", canonical_name="Shared")
+
+    canon_tm = TenantMembership.objects.create(user=canonical, tenant=shared)
+    TenantMetadata.objects.create(
+        tenant_membership=canon_tm,
+        metadata={"owner": "canonical"},
+    )
+    dup_tm = TenantMembership.objects.create(user=duplicate, tenant=shared)  # conflict
+    TenantMetadata.objects.create(
+        tenant_membership=dup_tm,
+        metadata={"owner": "duplicate"},
+    )
+
+    merge_users(canonical=canonical, duplicate=duplicate)
+
+    # The duplicate's membership for the shared tenant is conflict-deleted, and
+    # its OneToOne metadata cascades away with it. The canonical keeps its OWN
+    # membership + metadata, so the tenant stays covered (no canonical data lost).
+    surviving = TenantMembership.objects.get(user=canonical, tenant=shared)
+    md = TenantMetadata.objects.get(tenant_membership=surviving)
+    assert md.metadata == {"owner": "canonical"}
+    # The duplicate's redundant metadata cascaded away with its membership — no
+    # dangling rows pointing at the deleted membership remain.
+    assert TenantMetadata.objects.count() == 1
+    assert TenantMetadata.objects.filter(tenant_membership=dup_tm.id).count() == 0

--- a/tests/test_ocs_data_loaders.py
+++ b/tests/test_ocs_data_loaders.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+import requests
+
+from mcp_server.loaders.ocs_base import OCSAuthError
 from mcp_server.loaders.ocs_experiments import OCSExperimentLoader
 from mcp_server.loaders.ocs_messages import OCSMessageLoader
 from mcp_server.loaders.ocs_participants import OCSParticipantLoader
@@ -267,3 +271,54 @@ def test_participant_loader_queries_chatbot_scoped_endpoint():
     args, kwargs = mock_get.call_args
     assert args[0] == f"{BASE_URL}/api/participants"
     assert kwargs["params"] == {"chatbot": "exp-1"}
+
+
+# ---------------------------------------------------------------------------
+# 12#0 item 9: error paths (the data-loader tests above are happy-path only).
+# The OCS loaders have no retry policy, so a non-2xx/malformed response must
+# surface as an exception rather than be silently swallowed.
+# ---------------------------------------------------------------------------
+
+
+def test_experiment_loader_raises_auth_error_on_403():
+    """A 403 from the experiment detail endpoint surfaces as OCSAuthError
+    (single-request `_get` path)."""
+    loader = OCSExperimentLoader(experiment_id="exp-1", credential=CREDENTIAL, base_url=BASE_URL)
+    resp = MagicMock(status_code=403)
+    with patch.object(loader._session, "get", return_value=resp):
+        with pytest.raises(OCSAuthError):
+            list(loader.load_pages())
+    # On an auth failure we never attempt to parse a body.
+    resp.json.assert_not_called()
+
+
+def test_experiment_loader_raises_on_server_error():
+    """A 5xx (no retry policy in OCS) propagates via raise_for_status rather
+    than being swallowed into an empty page."""
+    loader = OCSExperimentLoader(experiment_id="exp-1", credential=CREDENTIAL, base_url=BASE_URL)
+    resp = MagicMock(status_code=500)
+    resp.raise_for_status.side_effect = requests.HTTPError("500 Server Error")
+    with patch.object(loader._session, "get", return_value=resp):
+        with pytest.raises(requests.HTTPError):
+            list(loader.load_pages())
+
+
+def test_experiment_loader_raises_on_malformed_json():
+    """A 200 with a non-JSON body must raise (ValueError from .json()), not
+    yield a partial/empty row set."""
+    loader = OCSExperimentLoader(experiment_id="exp-1", credential=CREDENTIAL, base_url=BASE_URL)
+    resp = MagicMock(status_code=200)
+    resp.json.side_effect = ValueError("No JSON object could be decoded")
+    with patch.object(loader._session, "get", return_value=resp):
+        with pytest.raises(ValueError):
+            list(loader.load_pages())
+
+
+def test_session_loader_raises_auth_error_on_401():
+    """A 401 on the paginated sessions endpoint surfaces as OCSAuthError
+    (`_paginate` path)."""
+    loader = OCSSessionLoader(experiment_id="exp-1", credential=CREDENTIAL, base_url=BASE_URL)
+    resp = MagicMock(status_code=401)
+    with patch.object(loader._session, "get", return_value=resp):
+        with pytest.raises(OCSAuthError):
+            list(loader.load_pages())

--- a/tests/test_resume_thread_task.py
+++ b/tests/test_resume_thread_task.py
@@ -116,9 +116,14 @@ async def test_resume_appends_system_message_and_invokes_agent():
     assert len(messages) == 1
     assert messages[0].content.startswith("[__system_resume__]")
     assert "completed" in messages[0].content
-    # Confirm oauth_tokens is forwarded into the runtime config.
+    # Pin the runtime config's REAL, consumed contract: the checkpointer routes
+    # the resume to the right conversation via configurable.thread_id. (We do not
+    # assert on `oauth_tokens` — it is currently dead plumbing: build_agent_graph
+    # accepts the kwarg and the resume forwards it into config, but nothing in the
+    # graph reads it. Pinning it would codify dead plumbing as contract — 12#0
+    # item 4.)
     config = call_args.args[1]
-    assert "oauth_tokens" in config
+    assert config["configurable"]["thread_id"] == str(thread.id)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #289. Resolves the 3 unaddressed findings from arch-review issue #234 (auto-closed when its infra PRs merged — **not reopened**). Meta tracker: #270.

## What this does
One production fix (a dead prompt arg) plus a focused test-hardening pass that makes the suite able to catch the incident classes the existing mocks were hiding. Each seam asserts behavior that passes against current production code; no production redesign.

### 02#6 — drop dead `pipeline=` arg (production prompt fix)
`apps/agents/graph/base.py` single-tenant no-data branch told the agent to call `run_materialization` with `pipeline="<name>"`, but the MCP tool has **no** `pipeline` parameter (routing moved into `materialize_workspace` per-provider) and all real params are injected/hidden — the LLM-facing schema is empty. The multi-tenant branch already omitted it. Aligned the single-tenant branch and pinned it with a test asserting `pipeline=` never appears. (No `xfail` existed in the repo to remove.)

### 07#0 — pin the context-injection contract (guardrail)
The injecting node adds `workspace_id/user_id/thread_id/tool_call_id` to every MCP call, including the read tools that declare only `workspace_id`. This works solely because LangChain's `BaseTool._parse_input` passes dict-schema input unvalidated **and** FastMCP's generated `ArgModelBase` ignores unknown fields (`extra='ignore'`). New `tests/agents/test_context_injection_contract.py` pins both halves so a future tightening fails loudly here instead of prod-wide.

### 12#0 — mock-audit hardening
| # | Seam | Now |
|---|------|-----|
| 1 | `reconcile_stale_thread_job` RUNNING branch never built | stale-RUNNING → FAILED (interrupted summary) + fresh-RUNNING left alone (02#9 guard) |
| 2 | cancel tests patched the `current_app` binding, masking the surviving-sibling import | patch `JobManager.cancel_job_by_id_async` at the class level; the real binding must resolve for the abort to fire (+ a binding-is-live guard) |
| 3 | mock used non-existent `tenant_schema.tenant_membership.tenant.external_id` | set the real `tenant_schema.tenant.external_id`, delete the bogus path, assert `tenant_id` flows through |
| 4 | resume test pinned dead `oauth_tokens` plumbing | assert the real consumed contract (`configurable.thread_id`) |
| 6 | cancel test asserted only `cancelled==True` | assert persisted state (`FAILED`) + `asave` update_fields + `result.cancelled` |
| 7 | stale-cursor test mocked the `filter/exclude/order_by` chain | real-DB rows exercise `_load_prior_resume_cursors` end to end |
| 8 | merge-users had zero `TenantMetadata` assertions | repoint carries metadata across; conflict-delete keeps the canonical's |
| 9 | OCS/Connect loaders happy-path only | 403 / 5xx / malformed-JSON error paths |

**Out of scope (owned elsewhere, untouched):** 12#0 item 5 (sql_validator → #244), item 10 (transformation trigger → #241).

## Notes
- Item 6 pins the **current** behavior: `cancel_materialization` writes `RunState.FAILED` (not `CANCELLED`) while the cancel endpoint writes `CANCELLED`. That FAILED-vs-CANCELLED inconsistency is tracked separately in **#290** — this PR only makes it visible, it does not change it.
- Item 8 surfaced a minor reporting quirk: `report.tenant_membership_conflict_deleted` counts cascade-deleted rows too (so it's inflated when metadata exists). The tests assert the data outcome rather than that count.

## Verification
- `ruff check .` clean; `ruff format --check` clean.
- All touched modules + the async-conventions CI guard: **240 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)