### PR TITLE
fix(recipes): materialize headlessly instead of crashing on the synthetic thread_id

### DIFF
--- a/apps/agents/graph/base.py
+++ b/apps/agents/graph/base.py
@@ -36,6 +36,7 @@ from apps.agents.prompts.artifact_prompt import ARTIFACT_PROMPT_ADDITION
 from apps.agents.prompts.base_system import BASE_SYSTEM_PROMPT
 from apps.agents.tools.artifact_tool import create_artifact_tools
 from apps.agents.tools.learning_tool import create_save_learning_tool
+from apps.agents.tools.materialization_tool import create_materialization_tool
 from apps.agents.tools.recipe_tool import create_recipe_tool
 from apps.knowledge.services.retriever import KnowledgeRetriever
 from apps.workspaces.models import (
@@ -143,18 +144,21 @@ _system_prompt_cache: dict[str, tuple[str, float]] = {}
 _SYSTEM_PROMPT_TTL = 60  # 60 seconds — short to limit staleness from knowledge/schema changes
 
 
-def _system_prompt_cache_key(workspace, user) -> str:
+def _system_prompt_cache_key(workspace, user, interactive: bool = True) -> str:
     """Build a cache key from workspace + user properties that affect the prompt.
 
     Includes user.id because _fetch_schema_context scopes TenantMetadata
     lookup to the specific user. Includes workspace.system_prompt hash
-    so edits invalidate immediately.
+    so edits invalidate immediately. Includes ``interactive`` because the
+    materialization guidance differs between interactive (fire-and-resume) and
+    headless (blocking) runs — caching one for the other would mislead the agent.
     """
     prompt_hash = hashlib.md5(
         (workspace.system_prompt or "").encode(), usedforsecurity=False
     ).hexdigest()[:8]
     user_id = getattr(user, "id", "anon")
-    return f"{workspace.id}:{user_id}:{prompt_hash}"
+    mode = "i" if interactive else "h"
+    return f"{workspace.id}:{user_id}:{prompt_hash}:{mode}"
 
 
 def _render_compact_schema(tables: list[dict], last_materialized_at: str | None) -> str:
@@ -217,11 +221,27 @@ def _render_full_schema(
     return "\n".join(lines)
 
 
-async def _fetch_schema_context(tenant, user) -> str:
+# Guidance injected for HEADLESS (non-interactive) runs — e.g. recipe execution.
+# Such runs have no chat Thread/checkpointer and no async-resume path, so the
+# agent must NOT "end its turn and wait": the headless run_materialization tool
+# BLOCKS and returns when loading finishes, and the agent continues in the same
+# run. (Deliberately avoids the substring "end your turn".)
+_HEADLESS_MATERIALIZE_GUIDANCE = (
+    "No data has been loaded yet. Call `run_materialization` to load it. This "
+    "tool BLOCKS and returns a status summary once loading finishes — keep "
+    "working in the same run rather than stopping. After it returns "
+    "`status: completed`, continue with the requested analysis; the data is ready."
+)
+
+
+async def _fetch_schema_context(tenant, user, interactive: bool = True) -> str:
     """Fetch database schema state and build a ## Data Availability prompt section.
 
     Tries to build a full schema block (tables + columns). Falls back to a compact
     block (tables + row counts only) if the full text exceeds SCHEMA_CONTEXT_CHAR_BUDGET.
+
+    ``interactive`` selects the materialization guidance: fire-and-resume (chat)
+    vs blocking (headless recipe runs).
     """
     ts = await TenantSchema.objects.filter(
         tenant=tenant,
@@ -232,6 +252,8 @@ async def _fetch_schema_context(tenant, user) -> str:
     pipeline_config = registry.get_by_provider(tenant.provider)
 
     if ts is None:
+        if not interactive:
+            return _HEADLESS_MATERIALIZE_GUIDANCE
         # NB: no `pipeline=` argument — run_materialization takes no pipeline
         # parameter (routing moved into materialize_workspace per-provider) and
         # all of its real params are injected server-side and hidden, so the
@@ -246,6 +268,8 @@ async def _fetch_schema_context(tenant, user) -> str:
         )
 
     if ts.state == SchemaState.MATERIALIZING:
+        if not interactive:
+            return _HEADLESS_MATERIALIZE_GUIDANCE
         return (
             "A materialization is already in progress in the background. Do NOT "
             "trigger another one and do NOT call other data tools (the data is "
@@ -321,7 +345,7 @@ _MULTI_TENANT_NAMESPACE_HINT = (
 )
 
 
-async def _fetch_multi_tenant_schema_context(workspace, user) -> str:
+async def _fetch_multi_tenant_schema_context(workspace, user, interactive: bool = True) -> str:
     """Build the ## Data Availability block for a multi-tenant workspace.
 
     Mirrors `_fetch_schema_context` but consults `WorkspaceViewSchema` plus the
@@ -341,6 +365,8 @@ async def _fetch_multi_tenant_schema_context(workspace, user) -> str:
         ).afirst()
 
     if active_run is not None or (vs is not None and vs.state == SchemaState.MATERIALIZING):
+        if not interactive:
+            return _HEADLESS_MATERIALIZE_GUIDANCE
         return (
             "A materialization is already in progress in the background. Do NOT "
             "trigger another one and do NOT call other data tools (the data is "
@@ -350,6 +376,8 @@ async def _fetch_multi_tenant_schema_context(workspace, user) -> str:
         )
 
     if vs is None or vs.state != SchemaState.ACTIVE:
+        if not interactive:
+            return f"{_MULTI_TENANT_NAMESPACE_HINT}\n\n{_HEADLESS_MATERIALIZE_GUIDANCE}"
         return (
             f"{_MULTI_TENANT_NAMESPACE_HINT}\n\n"
             "No data has been loaded yet. Call `run_materialization` to start "
@@ -502,6 +530,9 @@ async def build_agent_graph(
     mcp_tools: list | None = None,
     oauth_tokens: dict | None = None,
     conversation_id: str | None = None,
+    *,
+    interactive: bool = True,
+    job_id: int | None = None,
 ):
     """
     Build a LangGraph agent graph for a workspace.
@@ -515,11 +546,27 @@ async def build_agent_graph(
         conversation_id: Optional thread/conversation id. Threaded through to the
             artifact tools so chat-created artifacts record their originating
             conversation (so shared/public thread pages can find them).
+        interactive: Whether this graph serves an interactive chat turn (the
+            default). Interactive runs own a real Thread + persistent checkpointer
+            and use the fire-and-ack MCP ``run_materialization`` + async resume.
+            Headless runs (``interactive=False``, e.g. recipe execution) have no
+            Thread/checkpointer/resume path, so they get a *blocking*
+            ``run_materialization`` tool instead and matching prompt guidance.
+        job_id: Enclosing Procrastinate job id, passed to the headless
+            materialization tool for MaterializationRun traceability. Ignored in
+            interactive mode.
     """
-    logger.info("Building agent graph for workspace %s", workspace.id)
+    logger.info("Building agent graph for workspace %s (interactive=%s)", workspace.id, interactive)
 
     # --- Build tools ---
-    tools = _build_tools(workspace, user, mcp_tools or [], conversation_id=conversation_id)
+    tools = _build_tools(
+        workspace,
+        user,
+        mcp_tools or [],
+        conversation_id=conversation_id,
+        interactive=interactive,
+        job_id=job_id,
+    )
     logger.debug("Created %d tools for workspace %s", len(tools), workspace.id)
 
     # --- Inject workspace_id and user_id into MCP tool calls from agent state ---
@@ -544,7 +591,7 @@ async def build_agent_graph(
     llm_with_tools = llm.bind_tools(llm_tool_schemas)
 
     # --- Build system prompt ---
-    system_prompt = await _build_system_prompt(workspace, user)
+    system_prompt = await _build_system_prompt(workspace, user, interactive=interactive)
     logger.debug(
         "System prompt assembled: %d characters for workspace %s",
         len(system_prompt),
@@ -692,6 +739,8 @@ def _build_tools(
     user: User | None,
     mcp_tools: list,
     conversation_id: str | None = None,
+    interactive: bool = True,
+    job_id: int | None = None,
 ) -> list:
     """
     Build the tool list for the agent.
@@ -720,14 +769,24 @@ def _build_tools(
     """
     # Drop any MCP tool the server advertises but that must not reach the LLM
     # (e.g. the destructive ``teardown_schema`` — see AGENT_EXCLUDED_MCP_TOOLS).
-    tools = [t for t in mcp_tools if getattr(t, "name", None) not in AGENT_EXCLUDED_MCP_TOOLS]
+    # In headless mode also drop the interactive fire-and-ack
+    # ``run_materialization``: it requires a real chat Thread + checkpointer +
+    # async resume that a headless run does not have. It is replaced below by the
+    # blocking materialize tool, which runs the pipeline inline and returns when
+    # data is ready.
+    excluded = set(AGENT_EXCLUDED_MCP_TOOLS)
+    if not interactive:
+        excluded.add("run_materialization")
+    tools = [t for t in mcp_tools if getattr(t, "name", None) not in excluded]
     tools.append(create_save_learning_tool(workspace, user))
     tools.extend(create_artifact_tools(workspace, user, conversation_id=conversation_id))
     tools.append(create_recipe_tool(workspace, user))
+    if not interactive:
+        tools.append(create_materialization_tool(workspace, user, job_id))
     return tools
 
 
-async def _build_system_prompt(workspace: Workspace, user) -> str:
+async def _build_system_prompt(workspace: Workspace, user, interactive: bool = True) -> str:
     """
     Assemble the complete system prompt for a workspace.
 
@@ -745,7 +804,7 @@ async def _build_system_prompt(workspace: Workspace, user) -> str:
     Returns:
         Complete system prompt string.
     """
-    cache_key = _system_prompt_cache_key(workspace, user)
+    cache_key = _system_prompt_cache_key(workspace, user, interactive)
     cached = _system_prompt_cache.get(cache_key)
     if cached is not None:
         value, timestamp = cached
@@ -786,7 +845,7 @@ When results are truncated, suggest adding filters or using aggregations to redu
 """)
 
         # Pre-fetch schema state and table metadata — no need to call get_schema_status at runtime.
-        schema_context = await _fetch_schema_context(tenant, user)
+        schema_context = await _fetch_schema_context(tenant, user, interactive)
         sections.append(f"\n## Data Availability\n\n{schema_context}\n")
     elif tenant_count > 1:
         sections.append("""
@@ -797,7 +856,7 @@ When results are truncated, suggest adding filters or using aggregations to redu
 
 When results are truncated, suggest adding filters or using aggregations to reduce the result size.
 """)
-        schema_context = await _fetch_multi_tenant_schema_context(workspace, user)
+        schema_context = await _fetch_multi_tenant_schema_context(workspace, user, interactive)
         sections.append(f"\n## Data Availability\n\n{schema_context}\n")
 
     result = "\n".join(sections)

--- a/apps/agents/graph/base.py
+++ b/apps/agents/graph/base.py
@@ -233,6 +233,18 @@ _HEADLESS_MATERIALIZE_GUIDANCE = (
     "`status: completed`, continue with the requested analysis; the data is ready."
 )
 
+# Headless guidance when a materialization is ALREADY in progress. The headless
+# `run_materialization` tool waits for the in-flight load rather than starting a
+# parallel one, so we still route the agent to it — but we must NOT say "no data
+# loaded" (that would read as "start one"), matching the interactive path's
+# "don't trigger another" intent.
+_HEADLESS_MATERIALIZE_IN_PROGRESS_GUIDANCE = (
+    "A data load is already in progress for this workspace. Call "
+    "`run_materialization` to ensure fresh data — it WAITS for the in-progress "
+    "load to finish (it does not start a parallel one) and returns when the data "
+    "is ready. Then continue with the requested analysis in the same run."
+)
+
 
 async def _fetch_schema_context(tenant, user, interactive: bool = True) -> str:
     """Fetch database schema state and build a ## Data Availability prompt section.
@@ -269,7 +281,7 @@ async def _fetch_schema_context(tenant, user, interactive: bool = True) -> str:
 
     if ts.state == SchemaState.MATERIALIZING:
         if not interactive:
-            return _HEADLESS_MATERIALIZE_GUIDANCE
+            return _HEADLESS_MATERIALIZE_IN_PROGRESS_GUIDANCE
         return (
             "A materialization is already in progress in the background. Do NOT "
             "trigger another one and do NOT call other data tools (the data is "
@@ -366,7 +378,7 @@ async def _fetch_multi_tenant_schema_context(workspace, user, interactive: bool 
 
     if active_run is not None or (vs is not None and vs.state == SchemaState.MATERIALIZING):
         if not interactive:
-            return _HEADLESS_MATERIALIZE_GUIDANCE
+            return _HEADLESS_MATERIALIZE_IN_PROGRESS_GUIDANCE
         return (
             "A materialization is already in progress in the background. Do NOT "
             "trigger another one and do NOT call other data tools (the data is "

--- a/apps/agents/tools/materialization_tool.py
+++ b/apps/agents/tools/materialization_tool.py
@@ -51,9 +51,13 @@ def create_materialization_tool(workspace: Workspace, user: User | None, job_id:
         ``status: completed``, continue with the requested analysis in the same
         run — the data is ready.
         """
-        # Imported lazily: apps.workspaces.tasks imports apps.agents.graph.base
-        # (build_agent_graph) at module level, so a module-level import here
-        # would create an agents<->workspaces.tasks import cycle.
+        # Imported inside the function to break a real import cycle (verified:
+        # module-level fails with ImportError "partially initialized module
+        # apps.workspaces.tasks" in every import order). The chain is
+        # graph.base -> this module -> workspaces.tasks -> graph.base
+        # (tasks imports build_agent_graph for the resume path). This mirrors the
+        # established pattern in apps/agents/tools/recipe_tool.py, which imports
+        # apps.recipes.models inside the tool body for the same reason.
         from apps.workspaces.tasks import materialize_workspace_core
 
         summary = await materialize_workspace_core(workspace_id, user_id, job_id)

--- a/apps/agents/tools/materialization_tool.py
+++ b/apps/agents/tools/materialization_tool.py
@@ -58,9 +58,12 @@ def create_materialization_tool(workspace: Workspace, user: User | None, job_id:
         # (tasks imports build_agent_graph for the resume path). This mirrors the
         # established pattern in apps/agents/tools/recipe_tool.py, which imports
         # apps.recipes.models inside the tool body for the same reason.
-        from apps.workspaces.tasks import materialize_workspace_core
+        from apps.workspaces.tasks import materialize_workspace_blocking
 
-        summary = await materialize_workspace_core(workspace_id, user_id, job_id)
+        # Blocking + dedupe-aware: waits for any in-progress materialization on
+        # this workspace's tenants before starting its own, so a recipe never
+        # triggers a parallel run against the same tenant schema.
+        summary = await materialize_workspace_blocking(workspace_id, user_id, job_id)
         tenants = summary.get("tenants", [])
         loaded = sum(1 for t in tenants if t.get("success"))
         view_schema = summary.get("view_schema")

--- a/apps/agents/tools/materialization_tool.py
+++ b/apps/agents/tools/materialization_tool.py
@@ -1,0 +1,90 @@
+"""Headless blocking materialization tool for non-interactive agent runs.
+
+The interactive chat agent uses the MCP ``run_materialization`` tool, which
+fires a background job and acknowledges immediately, relying on a chat
+``Thread`` + checkpointer + ``resume_thread_after_materialization`` to deliver
+the result back into the conversation later.
+
+A recipe run has none of that — it is a one-shot, thread-less, checkpointer-less
+invocation. So it gets this tool instead: it runs the same materialization core
+*inline* and BLOCKS until loading finishes, returning a completion summary the
+agent can act on within the same run.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from langchain_core.tools import tool
+
+if TYPE_CHECKING:
+    from apps.users.models import User
+    from apps.workspaces.models import Workspace
+
+logger = logging.getLogger(__name__)
+
+
+def create_materialization_tool(workspace: Workspace, user: User | None, job_id: int | None = None):
+    """Factory for a headless, blocking ``run_materialization`` tool.
+
+    The tool is named ``run_materialization`` (same as the interactive MCP tool)
+    so the agent's behavior and prompts are mode-agnostic. It takes no
+    LLM-facing arguments — ``workspace``/``user``/``job_id`` are bound here by
+    closure, so the synthetic recipe ``thread_id`` is never involved.
+
+    Args:
+        workspace: The Workspace to materialize.
+        user: The user on whose behalf the run executes (scopes memberships).
+        job_id: The enclosing Procrastinate job id, recorded on the
+            MaterializationRun for traceability. May be None outside a task.
+    """
+    workspace_id = str(workspace.id)
+    user_id = str(user.id) if user else ""
+
+    @tool
+    async def run_materialization() -> dict:
+        """Load or refresh this workspace's data from its source(s).
+
+        Blocks until loading completes, then returns a status summary. Call this
+        before querying when no data has been loaded yet. After it returns
+        ``status: completed``, continue with the requested analysis in the same
+        run — the data is ready.
+        """
+        # Imported lazily: apps.workspaces.tasks imports apps.agents.graph.base
+        # (build_agent_graph) at module level, so a module-level import here
+        # would create an agents<->workspaces.tasks import cycle.
+        from apps.workspaces.tasks import materialize_workspace_core
+
+        summary = await materialize_workspace_core(workspace_id, user_id, job_id)
+        tenants = summary.get("tenants", [])
+        loaded = sum(1 for t in tenants if t.get("success"))
+        view_schema = summary.get("view_schema")
+        view_ok = view_schema is None or view_schema.get("ok")
+
+        if summary.get("all_succeeded") and view_ok:
+            status = "completed"
+            message = "Data loaded successfully. Continue with the analysis."
+        elif loaded:
+            status = "partial"
+            message = (
+                "Some tenants loaded; others failed. Proceed with the available data "
+                "and note the gap to the user."
+            )
+        else:
+            status = "failed"
+            message = "Materialization failed; no data was loaded."
+
+        logger.info(
+            "Headless materialization for workspace %s: status=%s, tenants_loaded=%d",
+            workspace_id,
+            status,
+            loaded,
+        )
+        return {"status": status, "tenants_loaded": loaded, "message": message}
+
+    run_materialization.name = "run_materialization"
+    return run_materialization
+
+
+__all__ = ["create_materialization_tool"]

--- a/apps/recipes/api/views.py
+++ b/apps/recipes/api/views.py
@@ -128,9 +128,8 @@ async def recipe_run_view(request, workspace_id, recipe_id):
 
     # Validate variables (and apply defaults) synchronously so the client gets a
     # 400 in-band; only a valid request creates a run and dispatches work.
-    runner = RecipeRunner(recipe=recipe, variable_values=variable_values, user=user)
     try:
-        runner.validate_variables()
+        values = RecipeRunner.validate_and_default(recipe, variable_values)
     except VariableValidationError as e:
         return JsonResponse({"error": str(e), "errors": e.errors}, status=400)
 
@@ -143,7 +142,7 @@ async def recipe_run_view(request, workspace_id, recipe_id):
             recipe=recipe,
             run_by=user,
             status=RecipeRunStatus.PENDING,
-            variable_values=runner.variable_values,
+            variable_values=values,
             step_results=[],
         )
         await run_recipe.defer_async(recipe_run_id=str(run.id))

--- a/apps/recipes/api/views.py
+++ b/apps/recipes/api/views.py
@@ -16,8 +16,9 @@ from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from apps.recipes.models import Recipe, RecipeRun
+from apps.recipes.models import Recipe, RecipeRun, RecipeRunStatus
 from apps.recipes.services.runner import RecipeRunner, VariableValidationError
+from apps.recipes.tasks import run_recipe
 from apps.users.decorators import async_login_required
 from apps.workspaces.services.workspace_service import touch_workspace_schemas
 from apps.workspaces.workspace_resolver import aresolve_workspace
@@ -125,23 +126,39 @@ async def recipe_run_view(request, workspace_id, recipe_id):
         return JsonResponse(serializer.errors, status=400)
     variable_values = serializer.validated_data.get("variable_values", {})
 
+    # Validate variables (and apply defaults) synchronously so the client gets a
+    # 400 in-band; only a valid request creates a run and dispatches work.
+    runner = RecipeRunner(recipe=recipe, variable_values=variable_values, user=user)
     try:
-        runner = RecipeRunner(recipe=recipe, variable_values=variable_values, user=user)
-        run = await runner.execute_async()
+        runner.validate_variables()
     except VariableValidationError as e:
         return JsonResponse({"error": str(e), "errors": e.errors}, status=400)
+
+    # Execution is async: a recipe may block on a materialization (loading fresh
+    # data before building its dashboard), which must not hold the HTTP request
+    # open. Create the run PENDING, defer the background task, and return 202;
+    # the client polls GET .../runs/<id>/ for progress and the final result.
+    try:
+        run = await RecipeRun.objects.acreate(
+            recipe=recipe,
+            run_by=user,
+            status=RecipeRunStatus.PENDING,
+            variable_values=runner.variable_values,
+            step_results=[],
+        )
+        await run_recipe.defer_async(recipe_run_id=str(run.id))
     except Exception as e:
         # Don't leak internal exception detail to the client; log it behind a
         # short ref and return the ref (mirrors apps/chat/views.py).
         error_ref = hashlib.sha256(f"{time.time()}{e}".encode()).hexdigest()[:8]
-        logger.exception("Error running recipe %s [ref=%s]", recipe_id, error_ref)
+        logger.exception("Error dispatching recipe %s [ref=%s]", recipe_id, error_ref)
         return JsonResponse({"error": f"Recipe run failed. Ref: {error_ref}"}, status=500)
 
     # Reset the inactivity TTL on user-initiated recipe runs.
     await touch_workspace_schemas(workspace)
 
     data = await sync_to_async(lambda: RecipeRunSerializer(run).data)()
-    return JsonResponse(data, status=201)
+    return JsonResponse(data, status=202)
 
 
 class RecipeRunListView(APIView):

--- a/apps/recipes/services/runner.py
+++ b/apps/recipes/services/runner.py
@@ -58,8 +58,9 @@ class RecipeRunner:
         recipe: Recipe,
         variable_values: dict[str, Any],
         user: User,
+        *,
+        run: RecipeRun,
         graph: CompiledStateGraph | None = None,
-        run: RecipeRun | None = None,
         job_id: int | None = None,
     ) -> None:
         self.recipe = recipe
@@ -67,33 +68,42 @@ class RecipeRunner:
         self.user = user
         self._provided_graph = graph
         self._graph: CompiledStateGraph | None = None
-        # When the caller (the run_recipe background task) has already created
-        # the RecipeRun, reuse it so the row the API returned to the client is
-        # the same one we update. Otherwise we create one ourselves.
-        self._run: RecipeRun | None = run
+        # The caller (recipe_run_view -> run_recipe task) creates the RecipeRun
+        # so the endpoint can return its id immediately (202) and the worker
+        # updates that same row in place. The runner always operates on it.
+        self._run: RecipeRun = run
         # The enclosing Procrastinate job id, forwarded to the headless
         # materialization tool for MaterializationRun traceability.
         self._job_id: int | None = job_id
         self._thread_id: str = ""
         self._oauth_tokens: dict = {}
 
-    def validate_variables(self) -> None:
-        """Validate that all required variables are provided."""
-        errors = self.recipe.validate_variable_values(self.variable_values)
-
+    @staticmethod
+    def validate_and_default(recipe: Recipe, variable_values: dict[str, Any]) -> dict[str, Any]:
+        """Validate ``variable_values`` against ``recipe`` and return a copy with
+        recipe defaults applied. Raises ``VariableValidationError`` on missing
+        required variables. The run endpoint uses this to validate (and return a
+        400) before creating the RecipeRun, without constructing a runner.
+        """
+        errors = recipe.validate_variable_values(variable_values)
         if errors:
             logger.warning(
                 "Variable validation failed for recipe %s: %s",
-                self.recipe.name,
+                recipe.name,
                 errors,
             )
             raise VariableValidationError(errors)
 
-        # Apply defaults for optional variables not provided
-        for var_def in self.recipe.variables:
+        values = dict(variable_values)
+        for var_def in recipe.variables:
             var_name = var_def.get("name")
-            if var_name and var_name not in self.variable_values and "default" in var_def:
-                self.variable_values[var_name] = var_def["default"]
+            if var_name and var_name not in values and "default" in var_def:
+                values[var_name] = var_def["default"]
+        return values
+
+    def validate_variables(self) -> None:
+        """Validate this run's variable values, applying defaults in place."""
+        self.variable_values = self.validate_and_default(self.recipe, self.variable_values)
 
     async def _build_graph(self) -> CompiledStateGraph:
         """Build or return the agent graph for execution (async-first)."""
@@ -169,21 +179,11 @@ class RecipeRunner:
         """Execute the recipe asynchronously."""
         self.validate_variables()
 
-        if self._run is None:
-            self._run = await RecipeRun.objects.acreate(
-                recipe=self.recipe,
-                status=RecipeRunStatus.RUNNING,
-                variable_values=self.variable_values,
-                step_results=[],
-                started_at=timezone.now(),
-                run_by=self.user,
-            )
-        else:
-            # A pre-created run (dispatched by the run_recipe background task):
-            # mark it RUNNING as execution begins.
-            self._run.status = RecipeRunStatus.RUNNING
-            self._run.started_at = timezone.now()
-            await self._run.asave(update_fields=["status", "started_at"])
+        # The run is always created by the caller (the run_recipe task); mark it
+        # RUNNING as execution begins.
+        self._run.status = RecipeRunStatus.RUNNING
+        self._run.started_at = timezone.now()
+        await self._run.asave(update_fields=["status", "started_at"])
 
         self._thread_id = f"recipe-run-{self._run.id}"
 

--- a/apps/recipes/services/runner.py
+++ b/apps/recipes/services/runner.py
@@ -59,13 +59,21 @@ class RecipeRunner:
         variable_values: dict[str, Any],
         user: User,
         graph: CompiledStateGraph | None = None,
+        run: RecipeRun | None = None,
+        job_id: int | None = None,
     ) -> None:
         self.recipe = recipe
         self.variable_values = variable_values.copy()
         self.user = user
         self._provided_graph = graph
         self._graph: CompiledStateGraph | None = None
-        self._run: RecipeRun | None = None
+        # When the caller (the run_recipe background task) has already created
+        # the RecipeRun, reuse it so the row the API returned to the client is
+        # the same one we update. Otherwise we create one ourselves.
+        self._run: RecipeRun | None = run
+        # The enclosing Procrastinate job id, forwarded to the headless
+        # materialization tool for MaterializationRun traceability.
+        self._job_id: int | None = job_id
         self._thread_id: str = ""
         self._oauth_tokens: dict = {}
 
@@ -106,6 +114,13 @@ class RecipeRunner:
                 mcp_tools=mcp_tools,
                 oauth_tokens=self._oauth_tokens,
                 conversation_id=self._thread_id or None,
+                # A recipe is a HEADLESS run: no chat Thread, no checkpointer, no
+                # async-resume path. interactive=False gives the agent the
+                # blocking materialize tool (not the fire-and-ack MCP one, which
+                # would crash on the synthetic thread_id) and blocking prompt
+                # guidance. job_id is forwarded for MaterializationRun traceability.
+                interactive=False,
+                job_id=self._job_id,
             )
 
         return self._graph
@@ -154,14 +169,21 @@ class RecipeRunner:
         """Execute the recipe asynchronously."""
         self.validate_variables()
 
-        self._run = await RecipeRun.objects.acreate(
-            recipe=self.recipe,
-            status=RecipeRunStatus.RUNNING,
-            variable_values=self.variable_values,
-            step_results=[],
-            started_at=timezone.now(),
-            run_by=self.user,
-        )
+        if self._run is None:
+            self._run = await RecipeRun.objects.acreate(
+                recipe=self.recipe,
+                status=RecipeRunStatus.RUNNING,
+                variable_values=self.variable_values,
+                step_results=[],
+                started_at=timezone.now(),
+                run_by=self.user,
+            )
+        else:
+            # A pre-created run (dispatched by the run_recipe background task):
+            # mark it RUNNING as execution begins.
+            self._run.status = RecipeRunStatus.RUNNING
+            self._run.started_at = timezone.now()
+            await self._run.asave(update_fields=["status", "started_at"])
 
         self._thread_id = f"recipe-run-{self._run.id}"
 

--- a/apps/recipes/tasks.py
+++ b/apps/recipes/tasks.py
@@ -1,0 +1,57 @@
+"""Background execution of recipe runs.
+
+A recipe run drives the LangGraph agent headlessly and may block on a
+materialization (loading fresh data before building a dashboard). That cannot
+run inline in the HTTP request — it would hold the connection open for minutes
+— so the API endpoint creates a PENDING ``RecipeRun`` and defers this task. The
+frontend polls ``GET .../runs/<id>/`` until the run reaches a terminal status.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from apps.recipes.models import RecipeRun, RecipeRunStatus
+from apps.recipes.services.runner import RecipeRunner
+from config.procrastinate import task
+
+logger = logging.getLogger(__name__)
+
+
+@task(pass_context=True, queue="recipes")
+async def run_recipe(context, recipe_run_id: str) -> dict:
+    """Execute a recipe run the API has already created (status PENDING).
+
+    Runs ``RecipeRunner.execute_async`` (headless: ``interactive=False`` graph +
+    blocking materialize), updating the existing ``RecipeRun`` in place so the
+    client's poll reflects progress and the final result.
+
+    Runs on the ``recipes`` queue so a long recipe run does not starve chat
+    materializations — deploy a dedicated worker (``--queues recipes``) or raise
+    worker concurrency if recipe and chat materialization load contend.
+    """
+    try:
+        run = await RecipeRun.objects.select_related("recipe", "run_by").aget(id=recipe_run_id)
+    except RecipeRun.DoesNotExist:
+        logger.warning("run_recipe: RecipeRun %s not found", recipe_run_id)
+        return {"status": "missing"}
+
+    runner = RecipeRunner(
+        recipe=run.recipe,
+        variable_values=run.variable_values,
+        user=run.run_by,
+        run=run,
+        job_id=context.job.id,
+    )
+    try:
+        await runner.execute_async()
+    except Exception:
+        # execute_async records FAILED itself for agent errors, but guard
+        # against anything it doesn't catch (e.g. re-validation) so the row is
+        # never left stuck in PENDING/RUNNING with the client polling forever.
+        logger.exception("run_recipe: unhandled error executing RecipeRun %s", recipe_run_id)
+        run.status = RecipeRunStatus.FAILED
+        await run.asave(update_fields=["status"])
+        return {"status": RecipeRunStatus.FAILED}
+
+    return {"status": run.status}

--- a/apps/workspaces/tasks.py
+++ b/apps/workspaces/tasks.py
@@ -217,163 +217,178 @@ async def refresh_tenant_schema(schema_id: str, membership_id: str) -> dict:
     return {"status": "active", "schema_id": schema_id}
 
 
+async def materialize_workspace_core(
+    workspace_id: str,
+    user_id: str = "",
+    job_id: int | None = None,
+) -> dict:
+    """Run materialization for all tenants in a workspace and rebuild view schemas.
+
+    Returns a per-tenant summary. Does NOT defer any chat-resume task — the
+    interactive chat path uses the ``materialize_workspace`` Procrastinate task
+    (which wraps this and defers ``resume_thread_after_materialization``);
+    headless callers (e.g. the recipe runner's blocking materialize tool) call
+    this directly and block on the return value.
+
+    Writes progress to ``MaterializationRun.progress`` (keyed by ``job_id``)
+    after each page so the MCP polling loop can surface real-time status. The
+    ``progress_updater`` closure also acts as the cancellation checkpoint: it
+    re-reads ``MaterializationRun.state`` and raises ``MaterializationCancelled``
+    when the run has been marked CANCELLED, triggering a transaction rollback.
+    """
+    tenant_results: list[dict] = []
+
+    try:
+        workspace = await Workspace.objects.aget(id=workspace_id)
+    except Workspace.DoesNotExist:
+        logger.exception("materialize_workspace: workspace %s not found", workspace_id)
+        return {"error": "Workspace not found"}
+
+    qs = TenantMembership.objects.select_related("user", "tenant", "connection").filter(
+        archived_at__isnull=True,
+        tenant_id__in=[
+            wt.tenant_id
+            async for wt in WorkspaceTenant.objects.filter(workspace=workspace).select_related(
+                "tenant"
+            )
+        ],
+    )
+    if user_id:
+        qs = qs.filter(user_id=user_id)
+
+    memberships = [tm async for tm in qs]
+    if not memberships:
+        logger.warning("materialize_workspace: no memberships for workspace %s", workspace_id)
+        return {"error": "No tenant memberships found", "tenants": []}
+
+    registry = get_registry()
+    provider_pipeline_map = {p.provider: p.name for p in registry.list()}
+
+    for tm in memberships:
+        tenant_id = tm.tenant.external_id
+        pipeline_name = provider_pipeline_map.get(tm.tenant.provider)
+        if pipeline_name is None:
+            tenant_results.append(
+                {
+                    "tenant": tenant_id,
+                    "success": False,
+                    "error": f"No pipeline for provider '{tm.tenant.provider}'",
+                }
+            )
+            continue
+
+        credential = await aresolve_credential(tm)
+        if credential is None:
+            tenant_results.append(
+                {
+                    "tenant": tenant_id,
+                    "success": False,
+                    "error": "No credential configured",
+                }
+            )
+            continue
+
+        pipeline_config = registry.get(pipeline_name)
+        try:
+            result = await asyncio.to_thread(
+                _run_pipeline_with_progress,
+                tm,
+                credential,
+                pipeline_config,
+                job_id,
+            )
+            tenant_results.append({"tenant": tenant_id, "success": True, "result": result})
+        except MaterializationCancelled:
+            tenant_results.append({"tenant": tenant_id, "success": False, "cancelled": True})
+            # Stop processing remaining tenants — the user has cancelled.
+            break
+        except ConnectExportError as e:
+            # Upstream Connect failure after retry exhaustion. Capture
+            # the response's sentry-trace header so support can correlate
+            # with Connect's Sentry in a single hop. sentry_sdk.set_tag
+            # is a no-op when the SDK was never initialised (no DSN).
+            logger.exception(
+                "Materialization failed for tenant %s on pipeline %s: "
+                "connect status=%s after %d attempts (last_id=%s, sentry-trace=%s)",
+                tenant_id,
+                pipeline_name,
+                e.status,
+                e.attempts,
+                e.last_id,
+                e.sentry_trace,
+            )
+            sentry_sdk.set_tag("connect.upstream_sentry_trace", e.sentry_trace or "")
+            sentry_sdk.set_tag("connect.pipeline", pipeline_name or "")
+            tenant_results.append({"tenant": tenant_id, "success": False, "error": str(e)})
+        except Exception as e:
+            logger.exception("Materialization failed for tenant %s", tenant_id)
+            tenant_results.append({"tenant": tenant_id, "success": False, "error": str(e)})
+
+    all_succeeded = all(r.get("success") for r in tenant_results)
+
+    # Multi-tenant workspaces query through a WorkspaceViewSchema that
+    # UNION ALLs the per-tenant tables. build_view_schema requires every
+    # tenant to have an ACTIVE TenantSchema, so we can only attempt this
+    # after the per-tenant loop completes successfully. This must run
+    # *before* the resume task fires (deferred by the task wrapper) so
+    # the agent's first list_tables call after materialization returns
+    # the namespaced view instead of "No active view schema for workspace".
+    view_schema_outcome: dict | None = None
+    workspace_tenant_count = await workspace.workspace_tenants.acount()
+    if workspace_tenant_count > 1 and all_succeeded:
+        try:
+            await asyncio.to_thread(SchemaManager().build_view_schema, workspace)
+            view_schema_outcome = {"ok": True, "error": None}
+        except Exception as exc:
+            # Don't re-raise — the resume task should still fire so the
+            # user gets *some* agent response. The failure is recorded on
+            # the WorkspaceViewSchema row (state=FAILED, last_error) and is
+            # surfaced to the agent by the resume task, which inspects the
+            # row directly rather than relying on this return value.
+            logger.exception(
+                "Post-materialization view schema rebuild failed for workspace %s",
+                workspace_id,
+            )
+            view_schema_outcome = {"ok": False, "error": str(exc)[:500]}
+
+    # Tenant data schemas (t_<id>) are SHARED across workspaces. Re-materializing
+    # a tenant from THIS workspace drops & recreates its raw_* tables, which
+    # cascade-drops the namespaced views inside every OTHER workspace's view
+    # schema — leaving those WorkspaceViewSchema rows ACTIVE but empty. Defer a
+    # rebuild for each sibling multi-tenant workspace that shares any tenant we
+    # just (re)materialized so their views are recreated against the new tables.
+    # Failures of individual rebuilds are handled inside rebuild_workspace_view_schema;
+    # we never block the resume on them.
+    await _rebuild_dependent_view_schemas(
+        [tm.tenant_id for tm in memberships],
+        exclude_workspace_id=str(workspace.id),
+    )
+
+    return {
+        "tenants": tenant_results,
+        "all_succeeded": all_succeeded,
+        "view_schema": view_schema_outcome,
+    }
+
+
 @task(pass_context=True)
 async def materialize_workspace(
     context,
     workspace_id: str,
     user_id: str = "",
 ) -> dict:
-    """Run materialization for all tenants in a workspace.
+    """Procrastinate task: run materialization for a workspace, then ALWAYS
+    defer the chat-resume task so an interactive user is never left with a
+    phantom spinner — even on early-return paths (workspace missing, no
+    memberships) where the per-tenant loop never executed.
 
-    Writes progress to ``MaterializationRun.progress`` after each page so
-    the MCP polling loop can surface real-time status to the user. The
-    ``progress_updater`` closure also acts as the cancellation checkpoint:
-    it re-reads ``MaterializationRun.state`` and raises
-    ``MaterializationCancelled`` when the run has been marked CANCELLED
-    by the cancel endpoint, triggering a transaction rollback.
-
-    Returns a per-tenant summary so the polling loop can build a final
-    aggregated result for the agent.
+    The actual work lives in ``materialize_workspace_core`` so headless callers
+    (recipes) can reuse it without the fire-and-resume machinery.
     """
     job_id = context.job.id
-    tenant_results: list[dict] = []
-
     try:
-        try:
-            workspace = await Workspace.objects.aget(id=workspace_id)
-        except Workspace.DoesNotExist:
-            logger.exception("materialize_workspace: workspace %s not found", workspace_id)
-            return {"error": "Workspace not found"}
-
-        qs = TenantMembership.objects.select_related("user", "tenant", "connection").filter(
-            archived_at__isnull=True,
-            tenant_id__in=[
-                wt.tenant_id
-                async for wt in WorkspaceTenant.objects.filter(workspace=workspace).select_related(
-                    "tenant"
-                )
-            ],
-        )
-        if user_id:
-            qs = qs.filter(user_id=user_id)
-
-        memberships = [tm async for tm in qs]
-        if not memberships:
-            logger.warning("materialize_workspace: no memberships for workspace %s", workspace_id)
-            return {"error": "No tenant memberships found", "tenants": []}
-
-        registry = get_registry()
-        provider_pipeline_map = {p.provider: p.name for p in registry.list()}
-
-        for tm in memberships:
-            tenant_id = tm.tenant.external_id
-            pipeline_name = provider_pipeline_map.get(tm.tenant.provider)
-            if pipeline_name is None:
-                tenant_results.append(
-                    {
-                        "tenant": tenant_id,
-                        "success": False,
-                        "error": f"No pipeline for provider '{tm.tenant.provider}'",
-                    }
-                )
-                continue
-
-            credential = await aresolve_credential(tm)
-            if credential is None:
-                tenant_results.append(
-                    {
-                        "tenant": tenant_id,
-                        "success": False,
-                        "error": "No credential configured",
-                    }
-                )
-                continue
-
-            pipeline_config = registry.get(pipeline_name)
-            try:
-                result = await asyncio.to_thread(
-                    _run_pipeline_with_progress,
-                    tm,
-                    credential,
-                    pipeline_config,
-                    job_id,
-                )
-                tenant_results.append({"tenant": tenant_id, "success": True, "result": result})
-            except MaterializationCancelled:
-                tenant_results.append({"tenant": tenant_id, "success": False, "cancelled": True})
-                # Stop processing remaining tenants — the user has cancelled.
-                break
-            except ConnectExportError as e:
-                # Upstream Connect failure after retry exhaustion. Capture
-                # the response's sentry-trace header so support can correlate
-                # with Connect's Sentry in a single hop. sentry_sdk.set_tag
-                # is a no-op when the SDK was never initialised (no DSN).
-                logger.exception(
-                    "Materialization failed for tenant %s on pipeline %s: "
-                    "connect status=%s after %d attempts (last_id=%s, sentry-trace=%s)",
-                    tenant_id,
-                    pipeline_name,
-                    e.status,
-                    e.attempts,
-                    e.last_id,
-                    e.sentry_trace,
-                )
-                sentry_sdk.set_tag("connect.upstream_sentry_trace", e.sentry_trace or "")
-                sentry_sdk.set_tag("connect.pipeline", pipeline_name or "")
-                tenant_results.append({"tenant": tenant_id, "success": False, "error": str(e)})
-            except Exception as e:
-                logger.exception("Materialization failed for tenant %s", tenant_id)
-                tenant_results.append({"tenant": tenant_id, "success": False, "error": str(e)})
-
-        all_succeeded = all(r.get("success") for r in tenant_results)
-
-        # Multi-tenant workspaces query through a WorkspaceViewSchema that
-        # UNION ALLs the per-tenant tables. build_view_schema requires every
-        # tenant to have an ACTIVE TenantSchema, so we can only attempt this
-        # after the per-tenant loop completes successfully. This must run
-        # *before* the resume task fires (deferred in the finally block) so
-        # the agent's first list_tables call after materialization returns
-        # the namespaced view instead of "No active view schema for workspace".
-        view_schema_outcome: dict | None = None
-        workspace_tenant_count = await workspace.workspace_tenants.acount()
-        if workspace_tenant_count > 1 and all_succeeded:
-            try:
-                await asyncio.to_thread(SchemaManager().build_view_schema, workspace)
-                view_schema_outcome = {"ok": True, "error": None}
-            except Exception as exc:
-                # Don't re-raise — the resume task should still fire so the
-                # user gets *some* agent response. The failure is recorded on
-                # the WorkspaceViewSchema row (state=FAILED, last_error) and is
-                # surfaced to the agent by the resume task, which inspects the
-                # row directly rather than relying on this return value.
-                logger.exception(
-                    "Post-materialization view schema rebuild failed for workspace %s",
-                    workspace_id,
-                )
-                view_schema_outcome = {"ok": False, "error": str(exc)[:500]}
-
-        # Tenant data schemas (t_<id>) are SHARED across workspaces. Re-materializing
-        # a tenant from THIS workspace drops & recreates its raw_* tables, which
-        # cascade-drops the namespaced views inside every OTHER workspace's view
-        # schema — leaving those WorkspaceViewSchema rows ACTIVE but empty. Defer a
-        # rebuild for each sibling multi-tenant workspace that shares any tenant we
-        # just (re)materialized so their views are recreated against the new tables.
-        # Failures of individual rebuilds are handled inside rebuild_workspace_view_schema;
-        # we never block the resume on them.
-        await _rebuild_dependent_view_schemas(
-            [tm.tenant_id for tm in memberships],
-            exclude_workspace_id=str(workspace.id),
-        )
-
-        return {
-            "tenants": tenant_results,
-            "all_succeeded": all_succeeded,
-            "view_schema": view_schema_outcome,
-        }
+        return await materialize_workspace_core(workspace_id, user_id, job_id)
     finally:
-        # ALWAYS defer the resume task so the user is not left with a phantom
-        # spinner — even on early-return paths (workspace missing, no
-        # memberships) where the loop above never executed.
         await _defer_resume_for_job(job_id)
 
 

--- a/apps/workspaces/tasks.py
+++ b/apps/workspaces/tasks.py
@@ -371,6 +371,56 @@ async def materialize_workspace_core(
     }
 
 
+async def _await_in_progress_materializations(
+    workspace_id: str, *, poll_interval: float = 2.0, max_wait_seconds: float = 1800.0
+) -> None:
+    """Block until no materialization is ACTIVE for this workspace's tenants.
+
+    Headless callers (recipes) call this before starting their own run so they
+    do not execute a parallel materialization against the same tenant schemas —
+    the pipeline drops & recreates ``raw_*`` tables, so concurrent runs corrupt
+    each other. Best-effort: on timeout, log and return so the caller proceeds.
+    """
+    tenant_ids = [
+        wt.tenant_id async for wt in WorkspaceTenant.objects.filter(workspace_id=workspace_id)
+    ]
+    if not tenant_ids:
+        return
+    # Poll the cross-process MaterializationRun state (another worker owns the
+    # in-flight run, so there is no in-process Event to await). Bounded for-loop
+    # rather than `while True` to keep a hard ceiling on the wait.
+    max_polls = max(1, int(max_wait_seconds / poll_interval))
+    for _ in range(max_polls):
+        in_progress = await MaterializationRun.objects.filter(
+            tenant_schema__tenant_id__in=tenant_ids,
+            state__in=list(MaterializationRun.ACTIVE_STATES),
+        ).aexists()
+        if not in_progress:
+            return
+        await asyncio.sleep(poll_interval)
+    logger.warning(
+        "materialize_workspace_blocking: still waiting on an in-progress materialization "
+        "of workspace %s after ~%.0fs; proceeding",
+        workspace_id,
+        max_wait_seconds,
+    )
+
+
+async def materialize_workspace_blocking(
+    workspace_id: str, user_id: str = "", job_id: int | None = None
+) -> dict:
+    """Ensure the workspace is materialized, blocking until done.
+
+    Unlike the bare ``materialize_workspace_core``, this first WAITS for any
+    materialization already in progress for the workspace's tenants to finish,
+    then runs a fresh one — so a headless recipe never starts a second, parallel
+    materialization against the same tenant schema (which the interactive path
+    avoids by telling the agent not to). Returns the core summary shape.
+    """
+    await _await_in_progress_materializations(workspace_id)
+    return await materialize_workspace_core(workspace_id, user_id, job_id)
+
+
 @task(pass_context=True)
 async def materialize_workspace(
     context,

--- a/docs/superpowers/plans/2026-06-17-recipe-headless-materialization.md
+++ b/docs/superpowers/plans/2026-06-17-recipe-headless-materialization.md
@@ -1,0 +1,609 @@
+# Recipe Headless Materialization — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make recipe runs that need fresh data work end-to-end by giving the *headless* recipe execution path its own *blocking* materialization, instead of crashing on the *interactive* chat-only `run_materialization` (fire-and-resume) tool.
+
+**Architecture:** The LangGraph agent is invoked from two front-ends — interactive **chat** (real `Thread` + Postgres checkpointer + fire-and-ack + async resume) and the **recipe runner** (one-shot, thread-less, `checkpointer=None`). The MCP `run_materialization` tool assumes the chat contract: it casts the injected `thread_id` to a `Thread` UUID, binds a `ThreadJob`, and relies on `resume_thread_after_materialization` to deliver results into the persisted thread later. A recipe's synthetic `thread_id="recipe-run-<uuid>"` is neither a UUID nor a real `Thread`, so the cast crashes — and even patched, fire-and-ack can't deliver into a one-shot recipe run. The fix makes **execution mode explicit** at the graph boundary (`interactive` vs headless): headless runs get a *blocking* materialize that reuses the existing pipeline core and returns when data is loaded, and headless recipe execution moves to a background Procrastinate task so it can block without holding an HTTP connection open.
+
+**Tech Stack:** Django 5 (async ORM), LangGraph + langchain-anthropic, FastMCP, Procrastinate (Postgres task queue), pytest / pytest-asyncio, React 19 + Vite frontend.
+
+## Global Constraints
+
+- **Imports at module level**, never inside function bodies (exceptions: optional deps guarded by `try/except ImportError`; code that must run before `django.setup()`). When moving an inline import to module level, update any `mock.patch()` target to the *consuming* module.
+- **Async-first ORM:** use `.aget()/.afirst()/.acreate()/.aupdate()/async for` in async code; never sync ORM from an async view/task. Sync pipeline code (`run_pipeline`) is called via `asyncio.to_thread`.
+- **ruff** (line-length 100, py311 target, rules E/F/I/UP/B/ASYNC/DJ/S/SIM/TRY/RUF/PTH). Run `uv run ruff check . && uv run ruff format --check .` before each commit.
+- **Tests:** async DB tests use `@pytest.mark.asyncio` + `@pytest.mark.django_db(transaction=True)`.
+- **`data-testid`** on any new interactive frontend element (kebab `{component}-{element}`).
+- Work in the worktree `/Users/bderenzi/Code/dimagi/scout-recipe-fix` on branch `bdr/recipe-materialization-fix` (branched from `origin/main`). Branch the PR against `main`.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `mcp_server/server.py` | MCP `run_materialization` tool | **Modify** — guard non-UUID `thread_id` (defensive crash-stop, all callers) |
+| `apps/workspaces/tasks.py` | Materialization task + reusable core | **Modify** — extract `materialize_workspace_core(...)`; task delegates + keeps resume `finally` |
+| `apps/agents/tools/materialization_tool.py` | Headless blocking materialize agent-side tool | **Create** |
+| `apps/agents/graph/base.py` | Graph build, prompt injection, tool gating | **Modify** — `interactive` mode param; gate prompt + tool selection |
+| `apps/recipes/services/runner.py` | Recipe runner | **Modify** — headless graph; operate on a pre-created `RecipeRun`; accept `job_id` |
+| `apps/recipes/tasks.py` | Background recipe execution task | **Create** |
+| `apps/recipes/api/views.py` | Recipe run endpoint | **Modify** — create `RecipeRun(PENDING)`, defer task, return 202 |
+| `frontend/src/pages/RecipesPage/RecipeDetail.tsx` (+ hook) | Recipe run UI | **Modify** — poll a running recipe to terminal state |
+
+Tasks 0–4 are an independently mergeable, testable slice (crash fixed + materializing recipes work, still inline). Tasks 5–6 layer the background-task migration on top. If 5–6 prove too large for one PR, ship 0–4 first.
+
+---
+
+### Task 0: Defensive guard — `run_materialization` rejects a non-Thread `thread_id`
+
+Stops the production 500-crash class for *any* caller (not just recipes): a malformed/non-UUID `thread_id` must yield a clean tool error, never a `ValueError` out of a UUIDField cast.
+
+**Files:**
+- Modify: `mcp_server/server.py` (the `run_materialization` tool, around the `Thread.objects.filter(id=thread_id,...)` check, ~`:560-570`)
+- Test: `tests/test_run_materialization_fire_and_ack.py`
+
+**Interfaces:**
+- Produces: no signature change. Behavior: when `thread_id` is not a well-formed UUID, return `error_response(VALIDATION_ERROR, "thread_id must be a valid thread identifier")` instead of raising.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_run_materialization_fire_and_ack.py
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_run_materialization_rejects_non_uuid_thread_id():
+    from mcp_server.server import run_materialization
+
+    workspace, user = await _make_workspace_with_membership()  # existing helper in this file
+    result = await run_materialization(
+        workspace_id=str(workspace.id),
+        user_id=str(user.id),
+        thread_id="recipe-run-f3be369b-d867-4ef8-aa0d-a74f21101c18",
+        tool_call_id="call_1",
+    )
+    assert result["status"] == "error"
+    assert "thread" in result["error"]["message"].lower()
+    # Must NOT have raised / created a ThreadJob
+    from apps.chat.models import ThreadJob
+    assert not await ThreadJob.objects.aexists()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_run_materialization_fire_and_ack.py::test_run_materialization_rejects_non_uuid_thread_id -v`
+Expected: FAIL — currently raises `ValueError: badly formed hexadecimal UUID string` (or `ValidationError`).
+
+- [ ] **Step 3: Add the guard before the Thread existence check**
+
+In `run_materialization`, immediately after the `if not thread_id:` validation and before `_resolve_workspace_memberships`, add:
+
+```python
+import uuid as _uuid  # module-level import at top of file
+...
+        # thread_id is injected server-side and is expected to be a real chat
+        # Thread UUID. A non-UUID value (e.g. a recipe runner's synthetic
+        # "recipe-run-<id>") must fail cleanly here rather than crash the
+        # UUIDField cast in the Thread lookup below. Headless callers that need
+        # materialization use the blocking agent-side tool, not this one.
+        try:
+            _uuid.UUID(str(thread_id))
+        except (ValueError, AttributeError, TypeError):
+            tc["result"] = error_response(
+                VALIDATION_ERROR, "thread_id must be a valid thread identifier"
+            )
+            return tc["result"]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_run_materialization_fire_and_ack.py -v`
+Expected: PASS (new test + all existing run_materialization tests stay green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp_server/server.py tests/test_run_materialization_fire_and_ack.py
+git commit -m "fix(mcp): run_materialization rejects non-UUID thread_id cleanly (stops recipe crash)"
+```
+
+---
+
+### Task 1: Extract `materialize_workspace_core` (pure refactor)
+
+Make the workspace materialization loop callable directly (and synchronously awaitable) by a headless caller, separate from the Procrastinate task wrapper that defers the chat resume.
+
+**Files:**
+- Modify: `apps/workspaces/tasks.py` (`materialize_workspace` task, `:220-377`; `_run_pipeline_with_progress` `:487`)
+- Test: `tests/test_materialize_workspace.py` (existing) — must stay green; add one direct-core test.
+
+**Interfaces:**
+- Produces: `async def materialize_workspace_core(workspace_id: str, user_id: str = "", job_id: int | None = None) -> dict` — returns `{"tenants": [...], "all_succeeded": bool, "view_schema": dict | None}`. Runs the tenant loop + view-schema rebuild + dependent-view rebuild. Does **not** defer any resume task.
+- `materialize_workspace(context, workspace_id, user_id="")` task: `try: return await materialize_workspace_core(workspace_id, user_id, context.job.id) finally: await _defer_resume_for_job(context.job.id)`.
+- `_run_pipeline_with_progress(..., job_id: int | None)` — widen `job_id` type to accept `None`.
+
+- [ ] **Step 1: Write the failing test (direct core call, no resume)**
+
+```python
+# tests/test_materialize_workspace.py
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_materialize_workspace_core_runs_without_deferring_resume(monkeypatch):
+    from apps.workspaces import tasks as wtasks
+
+    called = {"resume": False}
+    async def _no_resume(job_id):
+        called["resume"] = True
+    monkeypatch.setattr(wtasks, "_defer_resume_for_job", _no_resume)
+    # Stub the per-tenant pipeline so no real export runs.
+    def _fake_pipeline(tm, cred, cfg, job_id):
+        return {"sources": {}}
+    monkeypatch.setattr(wtasks, "_run_pipeline_with_progress", _fake_pipeline)
+
+    workspace, _user = await _make_single_tenant_workspace_with_credential()  # existing helper
+    result = await wtasks.materialize_workspace_core(str(workspace.id), "", job_id=None)
+
+    assert result["all_succeeded"] is True
+    assert called["resume"] is False  # core must NOT defer resume
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_materialize_workspace.py::test_materialize_workspace_core_runs_without_deferring_resume -v`
+Expected: FAIL — `AttributeError: module 'apps.workspaces.tasks' has no attribute 'materialize_workspace_core'`.
+
+- [ ] **Step 3: Extract the core**
+
+Move the entire body of `materialize_workspace` between `job_id = context.job.id` and the `finally:` (i.e. the `try:` block contents, `:239-372`) into a new module-level async function. Replace the task body with a thin wrapper:
+
+```python
+async def materialize_workspace_core(
+    workspace_id: str, user_id: str = "", job_id: int | None = None
+) -> dict:
+    """Run materialization for all tenants in a workspace and rebuild view
+    schemas. Returns a per-tenant summary. Does NOT defer any chat-resume task
+    — callers that need the interactive resume use the materialize_workspace
+    Procrastinate task; headless callers (recipes) call this directly and block.
+    """
+    tenant_results: list[dict] = []
+    # ... (verbatim moved body: load workspace, memberships, per-tenant loop
+    #      calling _run_pipeline_with_progress(tm, credential, pipeline_config, job_id),
+    #      view-schema rebuild, _rebuild_dependent_view_schemas, return {...}) ...
+
+
+@task(pass_context=True)
+async def materialize_workspace(context, workspace_id: str, user_id: str = "") -> dict:
+    job_id = context.job.id
+    try:
+        return await materialize_workspace_core(workspace_id, user_id, job_id)
+    finally:
+        await _defer_resume_for_job(job_id)
+```
+
+Widen `_run_pipeline_with_progress(..., job_id: int | None)`. (The `updater` closure keys off `progress["run_id"]`, not `job_id`, so `None` is safe; `run_pipeline` already declares `procrastinate_job_id: int | None = None`.)
+
+- [ ] **Step 4: Run tests to verify all green**
+
+Run: `uv run pytest tests/test_materialize_workspace.py -v`
+Expected: PASS (existing task tests + new core test).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/workspaces/tasks.py tests/test_materialize_workspace.py
+git commit -m "refactor(tasks): extract materialize_workspace_core for reuse by headless callers"
+```
+
+---
+
+### Task 2: Headless blocking-materialize agent-side tool
+
+A LangChain tool the headless agent calls instead of the MCP fire-and-ack tool. It runs in the same process as the recipe task, blocks on `materialize_workspace_core`, and returns a completion summary. It gets `workspace`/`user`/`job_id` by closure (no `thread_id` injection, so no UUID landmine).
+
+**Files:**
+- Create: `apps/agents/tools/materialization_tool.py`
+- Test: `tests/test_materialization_tool.py` (create)
+
+**Interfaces:**
+- Consumes: `apps.workspaces.tasks.materialize_workspace_core`.
+- Produces: `def create_materialization_tool(workspace: Workspace, user: User | None, job_id: int | None = None) -> BaseTool` — returns a tool **named `run_materialization`** (so the agent's behavior/prompt are mode-agnostic), zero LLM-facing params, async. On call: `summary = await materialize_workspace_core(str(workspace.id), str(user.id) if user else "", job_id)`; returns a dict `{"status": "completed"|"partial"|"failed", "tenants_loaded": N, "message": "..."}`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_materialization_tool.py
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_headless_materialization_tool_blocks_and_reports_completion(monkeypatch):
+    from apps.agents.tools import materialization_tool as mt
+
+    async def _fake_core(workspace_id, user_id="", job_id=None):
+        return {"all_succeeded": True, "tenants": [{"tenant": "t1", "success": True}],
+                "view_schema": None}
+    monkeypatch.setattr(mt, "materialize_workspace_core", _fake_core)
+
+    workspace, user = await _make_single_tenant_workspace_with_credential()
+    tool = mt.create_materialization_tool(workspace, user, job_id=99)
+    assert tool.name == "run_materialization"
+    result = await tool.ainvoke({})
+    assert result["status"] == "completed"
+    assert result["tenants_loaded"] == 1
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_materialization_tool.py -v`
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 3: Implement the tool**
+
+```python
+# apps/agents/tools/materialization_tool.py
+"""Headless blocking materialization tool for non-interactive agent runs (recipes)."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from langchain_core.tools import StructuredTool
+
+from apps.workspaces.tasks import materialize_workspace_core
+
+if TYPE_CHECKING:
+    from apps.users.models import User
+    from apps.workspaces.models import Workspace
+
+
+def create_materialization_tool(workspace: "Workspace", user: "User | None", job_id: int | None = None):
+    """Build a `run_materialization` tool that loads data and BLOCKS until done.
+
+    Unlike the interactive MCP tool (fire-and-ack + async resume), this runs the
+    pipeline inline and returns a completion summary, suitable for one-shot
+    headless runs that have no chat thread/checkpointer to resume into.
+    """
+    workspace_id = str(workspace.id)
+    user_id = str(user.id) if user else ""
+
+    async def _run() -> dict:
+        summary = await materialize_workspace_core(workspace_id, user_id, job_id)
+        tenants = summary.get("tenants", [])
+        loaded = sum(1 for t in tenants if t.get("success"))
+        vs = summary.get("view_schema")
+        if summary.get("all_succeeded") and (vs is None or vs.get("ok")):
+            status, message = "completed", "Data loaded successfully. Continue with the analysis."
+        elif loaded:
+            status, message = "partial", "Some tenants loaded; others failed. Proceed with available data."
+        else:
+            status, message = "failed", "Materialization failed; no data was loaded."
+        return {"status": status, "tenants_loaded": loaded, "message": message}
+
+    return StructuredTool.from_function(
+        coroutine=_run,
+        name="run_materialization",
+        description=(
+            "Load/refresh this workspace's data from source. Blocks until loading "
+            "completes, then returns a status summary. Call this before querying "
+            "when data is not yet loaded."
+        ),
+    )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_materialization_tool.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/agents/tools/materialization_tool.py tests/test_materialization_tool.py
+git commit -m "feat(agents): headless blocking run_materialization tool"
+```
+
+---
+
+### Task 3: Explicit `interactive` mode in `build_agent_graph` (the systemic guard)
+
+Make the Thread/checkpointer contract visible at the call boundary. `interactive=True` (default) keeps today's chat behavior. `interactive=False` swaps the materialization tool (MCP fire-and-ack → headless blocking) and the "no data" system-prompt nudge (resume → blocking).
+
+**Files:**
+- Modify: `apps/agents/graph/base.py` — `build_agent_graph` signature `:498`; `_build_tools` `:690`; `AGENT_EXCLUDED_MCP_TOOLS` usage; the schema-status prompt fn `:225-255`.
+- Test: `tests/test_agent_graph.py` (existing).
+
+**Interfaces:**
+- Consumes: `apps.agents.tools.materialization_tool.create_materialization_tool`.
+- Produces: `build_agent_graph(workspace, user=None, checkpointer=None, mcp_tools=None, oauth_tokens=None, conversation_id=None, *, interactive: bool = True, job_id: int | None = None)`. When `interactive=False`: the MCP `run_materialization` tool is excluded and the headless `create_materialization_tool(workspace, user, job_id)` is appended; the "no data loaded" prompt tells the agent the tool **blocks and returns when done** (no "end your turn / will be resumed").
+- The schema-status prompt builder takes an `interactive: bool` arg and returns the blocking variant when `False`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/test_agent_graph.py
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_headless_graph_swaps_in_blocking_materialization_tool():
+    workspace, user = await _make_single_tenant_workspace_with_credential()
+    mcp_tools = _fake_mcp_tools()  # includes an MCP "run_materialization"
+    graph_tools = await _tools_for(build_agent_graph, workspace, user, mcp_tools, interactive=False)
+    names = [t.name for t in graph_tools]
+    assert names.count("run_materialization") == 1  # exactly one, not duplicated
+    rm = next(t for t in graph_tools if t.name == "run_materialization")
+    assert rm.coroutine is not None  # the headless StructuredTool, not the MCP tool
+
+def test_no_data_prompt_blocking_variant_for_headless():
+    from apps.agents.graph.base import _schema_status_message  # name per existing code
+    msg = _schema_status_message(loaded=False, materializing=False, interactive=False)
+    assert "end your turn" not in msg.lower()
+    assert "block" in msg.lower() or "returns when" in msg.lower()
+```
+
+(Adjust helper/function names to the file's actual internals; the prompt text currently lives in the schema-status function near `:225-255` — give it an `interactive` parameter.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_agent_graph.py -k "headless or blocking" -v`
+Expected: FAIL — `interactive` kwarg unsupported / prompt has no variant.
+
+- [ ] **Step 3: Implement mode gating**
+
+1. Add `*, interactive: bool = True, job_id: int | None = None` to `build_agent_graph`.
+2. Pass `interactive`/`job_id` into `_build_tools(workspace, user, mcp_tools, conversation_id=..., interactive=interactive, job_id=job_id)`.
+3. In `_build_tools`: when `not interactive`, filter the MCP tool list to drop `run_materialization` (extend the existing `AGENT_EXCLUDED_MCP_TOOLS` filtering with a per-call exclusion set), then append `create_materialization_tool(workspace, user, job_id)`.
+4. Give the schema-status prompt function an `interactive` parameter; when `False`, return:
+   `"No data has been loaded yet. Call `run_materialization` to load it — this tool BLOCKS and returns a status summary when loading finishes. After it returns `completed`, continue with the requested analysis in the same run."` (and a matching variant for the `MATERIALIZING` branch). Thread `interactive` from `build_agent_graph` to wherever this message is assembled (system-prompt assembly).
+
+- [ ] **Step 4: Run tests to verify green**
+
+Run: `uv run pytest tests/test_agent_graph.py -v`
+Expected: PASS (new + existing; interactive default path unchanged).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/agents/graph/base.py tests/test_agent_graph.py
+git commit -m "feat(agents): explicit interactive/headless graph mode gating materialization tool + prompt"
+```
+
+---
+
+### Task 4: Recipe runner uses headless mode
+
+Point the runner at `interactive=False`, pass its `job_id`, and stop relying on the synthetic `thread_id` for anything thread-coupled. `RecipeRunner` operates on a pre-created `RecipeRun` (prep for Task 5) and takes an optional `job_id`.
+
+**Files:**
+- Modify: `apps/recipes/services/runner.py` (`__init__`, `_build_graph` `:90-121`, `execute_async` `:153-224`)
+- Test: `tests/test_recipes.py` (existing runner tests)
+
+**Interfaces:**
+- Produces: `RecipeRunner(recipe, variable_values, user, graph=None, run=None, job_id=None)`. `_build_graph` calls `build_agent_graph(workspace=..., user=..., checkpointer=None, mcp_tools=..., oauth_tokens=..., conversation_id=self._thread_id, interactive=False, job_id=self._job_id)`. If `run` is provided, `execute_async` uses it instead of `acreate`-ing a new one.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_recipes.py
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_runner_builds_headless_graph(monkeypatch):
+    captured = {}
+    async def _fake_build(**kwargs):
+        captured.update(kwargs)
+        return _stub_graph_that_returns_artifact()  # existing/added stub
+    monkeypatch.setattr("apps.recipes.services.runner.build_agent_graph", _fake_build)
+
+    recipe, user = await _make_recipe_with_workspace()
+    runner = RecipeRunner(recipe=recipe, variable_values={}, user=user, job_id=123)
+    await runner.execute_async()
+    assert captured["interactive"] is False
+    assert captured["job_id"] == 123
+    assert captured["checkpointer"] is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_recipes.py::test_runner_builds_headless_graph -v`
+Expected: FAIL — `__init__` has no `job_id`; build called without `interactive`.
+
+- [ ] **Step 3: Implement**
+
+- Add `run=None, job_id=None` to `__init__`; store `self._job_id = job_id`, `self._run = run`.
+- In `execute_async`: if `self._run is None`, `acreate` as today (back-compat for direct callers/tests); else use the provided run and set it `RUNNING`.
+- In `_build_graph`: add `interactive=False, job_id=self._job_id` to the `build_agent_graph(...)` call.
+- Keep `self._thread_id = f"recipe-run-{self._run.id}"` and `conversation_id=self._thread_id` (artifact provenance). It is no longer injected into any UUID-casting tool (headless `run_materialization` ignores it; other MCP tools never read it).
+
+- [ ] **Step 4: Run tests to verify green**
+
+Run: `uv run pytest tests/test_recipes.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/recipes/services/runner.py tests/test_recipes.py
+git commit -m "feat(recipes): runner builds headless agent graph (blocking materialize, no thread contract)"
+```
+
+---
+
+### Task 5: Move recipe execution to a background Procrastinate task
+
+Recipe runs can now legitimately block on materialization, so they must not run inline in the HTTP request. The view creates a `RecipeRun(PENDING)`, defers `run_recipe`, and returns 202; the task runs the agent and finalizes the run; the frontend polls.
+
+**Files:**
+- Create: `apps/recipes/tasks.py`
+- Modify: `apps/recipes/api/views.py` (`recipe_run_view` `:95-145`)
+- Test: `tests/test_recipes.py`, `tests/test_recipe_run_view.py` (create if absent)
+
+**Interfaces:**
+- Consumes: `RecipeRunner(recipe, variable_values, user, run=..., job_id=...)`.
+- Produces: Procrastinate task `run_recipe(context, recipe_run_id: str)` (queue `"recipes"`). It loads the `RecipeRun` + recipe + user, sets `RUNNING`, runs `RecipeRunner(..., run=run, job_id=context.job.id).execute_async()`. The view returns HTTP 202 with the `RecipeRun` (status `pending`).
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/test_recipe_run_view.py
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_run_recipe_view_defers_task_and_returns_202(monkeypatch):
+    deferred = {}
+    async def _fake_defer(recipe_run_id):
+        deferred["id"] = recipe_run_id
+    monkeypatch.setattr("apps.recipes.api.views.run_recipe.defer_async", _fake_defer)
+
+    recipe, user = await _make_recipe_with_workspace()
+    client = AsyncClient(); await sync_to_async(client.login)(email=user.email, password="pass")
+    resp = await client.post(f"/api/workspaces/{recipe.workspace_id}/recipes/{recipe.id}/run/",
+                             data={}, content_type="application/json")
+    assert resp.status_code == 202
+    body = resp.json()
+    assert body["status"] == "pending"
+    assert deferred["id"] == body["id"]
+    from apps.recipes.models import RecipeRun
+    assert await RecipeRun.objects.filter(id=body["id"], status="pending").aexists()
+```
+
+```python
+# tests/test_recipes.py
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_run_recipe_task_executes_and_finalizes(monkeypatch):
+    from apps.recipes import tasks as rtasks
+    recipe, user = await _make_recipe_with_workspace()
+    run = await RecipeRun.objects.acreate(recipe=recipe, run_by=user, status="pending",
+                                          variable_values={}, step_results=[])
+    async def _fake_exec(self):
+        self._run.status = "completed"; await self._run.asave(update_fields=["status"]); return self._run
+    monkeypatch.setattr("apps.recipes.services.runner.RecipeRunner.execute_async", _fake_exec)
+
+    ctx = types.SimpleNamespace(job=types.SimpleNamespace(id=7))
+    await rtasks.run_recipe(ctx, str(run.id))
+    await run.arefresh_from_db()
+    assert run.status == "completed"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_recipe_run_view.py tests/test_recipes.py::test_run_recipe_task_executes_and_finalizes -v`
+Expected: FAIL — `run_recipe` undefined; view returns 201 sync.
+
+- [ ] **Step 3: Implement the task**
+
+```python
+# apps/recipes/tasks.py
+"""Background execution of recipe runs."""
+import logging
+
+from apps.procrastinate import app  # use the project's procrastinate App (confirm import path)
+from apps.recipes.models import Recipe, RecipeRun, RecipeRunStatus
+from apps.recipes.services.runner import RecipeRunner
+from apps.users.models import User
+
+logger = logging.getLogger(__name__)
+
+
+@app.task(pass_context=True, queue="recipes")
+async def run_recipe(context, recipe_run_id: str) -> dict:
+    try:
+        run = await RecipeRun.objects.select_related("recipe", "run_by").aget(id=recipe_run_id)
+    except RecipeRun.DoesNotExist:
+        logger.warning("run_recipe: RecipeRun %s not found", recipe_run_id)
+        return {"status": "missing"}
+    runner = RecipeRunner(
+        recipe=run.recipe, variable_values=run.variable_values, user=run.run_by,
+        run=run, job_id=context.job.id,
+    )
+    await runner.execute_async()
+    return {"status": run.status}
+```
+
+(Confirm the canonical Procrastinate `App` import — grep `procrastinate` in `config/` / `apps/`; reuse the same `app`/`@task` that `materialize_workspace` uses. Register the `recipes` queue with the worker config in `config/deploy-worker.yml`; note a dedicated worker/queue avoids long recipe runs starving chat materializations.)
+
+- [ ] **Step 4: Implement the view change**
+
+In `recipe_run_view`, after validation: create the run, defer, return 202.
+
+```python
+    run = await RecipeRun.objects.acreate(
+        recipe=recipe, run_by=user, status=RecipeRunStatus.PENDING,
+        variable_values=variable_values, step_results=[],
+    )
+    await run_recipe.defer_async(recipe_run_id=str(run.id))
+    return JsonResponse(RecipeRunSerializer(run).data, status=202)
+```
+
+Keep the variable-validation step before creating the run (move `RecipeRunner.validate_variables` out so it can run pre-dispatch, OR validate in the serializer; raise 400 on `VariableValidationError`). Drop the inline `runner.execute()` path entirely.
+
+- [ ] **Step 5: Run tests to verify green**
+
+Run: `uv run pytest tests/test_recipe_run_view.py tests/test_recipes.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/recipes/tasks.py apps/recipes/api/views.py config/deploy-worker.yml tests/
+git commit -m "feat(recipes): execute recipe runs in a background task (async, can block on materialize)"
+```
+
+---
+
+### Task 6: Frontend — poll a running recipe to terminal state
+
+The run endpoint now returns a `pending` run instead of a finished one. The recipe detail UI must poll until `completed`/`failed`, then render results/artifacts.
+
+**Files:**
+- Modify: `frontend/src/pages/RecipesPage/RecipeDetail.tsx` and its data hook (e.g. `frontend/src/hooks/useRecipes.ts` — confirm exact hook).
+- Test: frontend lint (`cd frontend && bun run lint`); existing Vitest if recipe hook tests exist.
+
+**Interfaces:**
+- Consumes: `POST .../run/` → 202 `{id, status:"pending"}`; `GET .../runs/<id>/` → `{status, step_results, ...}`.
+
+- [ ] **Step 1: Implement polling**
+
+On run start, store the returned run id and poll `GET /api/workspaces/${workspaceId}/recipes/${recipeId}/runs/${runId}/` every ~2s while `status in ("pending","running")`; stop on terminal status and surface `step_results`/artifacts. Reuse the existing job-polling pattern (`useWorkspaceJobs.ts`) for cadence/backoff. Add `data-testid="recipe-run-status"` to the status indicator and keep the existing `recipe-run-${run.id}` / `recipe-run-view-${run.id}` testids.
+
+- [ ] **Step 2: Verify build + lint**
+
+Run: `cd frontend && bun run lint && bun run build`
+Expected: clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/pages/RecipesPage/RecipeDetail.tsx frontend/src/hooks/
+git commit -m "feat(frontend): poll async recipe runs to completion"
+```
+
+---
+
+### Task 7: End-to-end integration test (recipe materializes → builds artifact, headless, no crash)
+
+**Files:**
+- Test: `tests/test_recipe_materialization_integration.py` (create)
+
+- [ ] **Step 1: Write the test**
+
+Drive `RecipeRunner.execute_async` with a real headless graph but a stubbed pipeline (`monkeypatch` `materialize_workspace_core` to return `all_succeeded=True`) and a stubbed LLM that emits a `run_materialization` tool call then a `create_artifact` tool call. Assert: no exception; `RecipeRun.status == completed`; `step_results[0]["artifacts_created"]` non-empty; an `Artifact` row exists for the workspace; and `run_materialization` was the blocking tool (no `Thread`/`ThreadJob` created).
+
+- [ ] **Step 2: Run + verify green**
+
+Run: `uv run pytest tests/test_recipe_materialization_integration.py -v`
+Expected: PASS.
+
+- [ ] **Step 3: Full suite + lint, then commit**
+
+```bash
+uv run pytest -q && uv run ruff check . && uv run ruff format --check .
+git add tests/test_recipe_materialization_integration.py
+git commit -m "test(recipes): e2e headless materialize+artifact recipe run"
+```
+
+---
+
+## Self-Review notes
+
+- **Crash fixed:** Task 0 (defensive) + Task 4 (recipes no longer use the MCP tool) — both, defense-in-depth.
+- **Materializing recipes work:** Tasks 1–4 (blocking core + headless tool + mode + runner) + Task 7 (e2e).
+- **Systemic root closed:** Task 3 makes the Thread/checkpointer contract explicit at the boundary; any future headless front-end sets `interactive=False` and gets safe behavior by construction.
+- **Robustness:** Task 5 moves blocking execution off the request path; Task 6 keeps the UI honest while it runs.
+- **Type consistency:** `materialize_workspace_core(workspace_id, user_id, job_id)` is referenced identically in Tasks 1/2/3/runner; tool name `run_materialization` is consistent across MCP (interactive) and headless. `RecipeRunner(..., run=, job_id=)` is consistent across Tasks 4/5.
+- **Open confirmations for the implementer (verify against code, do not assume):** exact Procrastinate `App`/`@task` import path (reuse `materialize_workspace`'s); the schema-status prompt function's real name/params near `base.py:225`; the frontend recipe hook filename; existing test helper names (`_make_*`). None change the design.

--- a/frontend/src/pages/RecipesPage/RecipeRunDetail.tsx
+++ b/frontend/src/pages/RecipesPage/RecipeRunDetail.tsx
@@ -83,7 +83,7 @@ export function RecipeRunDetail({ recipe, run, onBack, onUpdateRun }: RecipeRunD
           <p className="text-sm text-muted-foreground">{recipe.name}</p>
           <div className="flex items-center gap-3">
             <h1 className="text-2xl font-bold">Run Details</h1>
-            <Badge className={getStatusBadgeClass(run.status)}>
+            <Badge className={getStatusBadgeClass(run.status)} data-testid="run-detail-status">
               {run.status}
             </Badge>
           </div>

--- a/frontend/src/pages/RecipesPage/RecipesPage.tsx
+++ b/frontend/src/pages/RecipesPage/RecipesPage.tsx
@@ -58,6 +58,22 @@ export function RecipesPage() {
     }
   }, [id, fetchRecipe, fetchRuns])
 
+  // Recipe execution is a background task: POST /run/ returns 202 with a PENDING
+  // run, so while viewing a run that is still pending/running we poll the runs
+  // list until it reaches a terminal status (completed/failed). Depending on the
+  // status string (not the array identity) keeps this to one interval that tears
+  // down as soon as the run finishes or we navigate away.
+  const viewedRunStatus =
+    id && runId ? recipeRuns.find((r) => r.id === runId)?.status : undefined
+  useEffect(() => {
+    if (!id || !runId) return
+    if (viewedRunStatus !== "pending" && viewedRunStatus !== "running") return
+    const interval = setInterval(() => {
+      void fetchRuns(id)
+    }, 2000)
+    return () => clearInterval(interval)
+  }, [id, runId, viewedRunStatus, fetchRuns])
+
   const handleView = useCallback(
     (recipe: Recipe) => {
       navigate(`/recipes/${recipe.id}`)

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -24,6 +24,7 @@ import contextlib
 import logging
 import os
 import sys
+import uuid
 from datetime import UTC, datetime
 
 from django.core.exceptions import ValidationError as _ValidationError
@@ -548,6 +549,20 @@ async def run_materialization(
             return tc["result"]
         if not thread_id:
             tc["result"] = error_response(VALIDATION_ERROR, "thread_id is required")
+            return tc["result"]
+
+        # thread_id is injected server-side and must be a real chat Thread UUID.
+        # A non-UUID value (e.g. the recipe runner's synthetic "recipe-run-<id>")
+        # must fail cleanly here rather than crash the UUIDField cast in the
+        # Thread lookup below. This tool is interactive/fire-and-resume only;
+        # headless callers (recipes) use the blocking agent-side materialize
+        # tool, which never reaches this code path.
+        try:
+            uuid.UUID(str(thread_id))
+        except (ValueError, AttributeError, TypeError):
+            tc["result"] = error_response(
+                VALIDATION_ERROR, "thread_id must be a valid thread identifier"
+            )
             return tc["result"]
 
         # Authorization guard: confirms the user has at least one tenant

--- a/tests/test_agent_graph.py
+++ b/tests/test_agent_graph.py
@@ -114,6 +114,27 @@ class TestHeadlessMode:
         assert "end your turn" not in headless.lower()
         assert "block" in headless.lower()
 
+    @pytest.mark.django_db(transaction=True)
+    @pytest.mark.asyncio
+    async def test_headless_in_progress_prompt_does_not_trigger_second_materialization(
+        self, tenant, user
+    ):
+        """When a materialization is already in progress, the headless prompt
+        must NOT tell the agent "no data loaded → call run_materialization" (that
+        starts a 2nd parallel run). It gets distinct in-progress guidance."""
+        from apps.agents.graph.base import _fetch_schema_context
+        from apps.workspaces.models import SchemaState, TenantSchema
+
+        await TenantSchema.objects.acreate(
+            tenant=tenant, schema_name="t_inprog", state=SchemaState.MATERIALIZING
+        )
+        msg = await _fetch_schema_context(tenant, user, interactive=False)
+
+        assert "run_materialization" in msg  # still the only path to data, headless
+        assert "no data has been loaded" not in msg.lower()  # would imply "start one"
+        assert "end your turn" not in msg.lower()  # no async resume in headless
+        assert "in progress" in msg.lower()  # acknowledges the in-flight load
+
 
 class TestSystemPrompt:
     """Verify the system prompt includes data availability instructions."""

--- a/tests/test_agent_graph.py
+++ b/tests/test_agent_graph.py
@@ -66,6 +66,55 @@ class TestTeardownSchemaUnbound:
         assert "list_tables" in tool_names
 
 
+class TestHeadlessMode:
+    """interactive=False swaps the interactive MCP run_materialization (fire-and-
+    ack) for the headless blocking tool, and emits blocking prompt guidance."""
+
+    def _fake_mcp_tool(self, name):
+        t = MagicMock()
+        t.name = name
+        return t
+
+    def test_build_tools_headless_swaps_in_blocking_materialization(self):
+        from apps.agents.graph.base import _build_tools
+
+        mcp_tools = [self._fake_mcp_tool("query"), self._fake_mcp_tool("run_materialization")]
+        workspace = SimpleNamespace(id="ws-1", system_prompt="")
+
+        headless = _build_tools(workspace, None, mcp_tools, interactive=False, job_id=7)
+        rm = [t for t in headless if t.name == "run_materialization"]
+        assert len(rm) == 1, "exactly one run_materialization tool"
+        # The headless tool replaces the MCP one (different object identity).
+        assert rm[0] not in mcp_tools
+        assert callable(getattr(rm[0], "coroutine", None))  # async StructuredTool
+
+    def test_build_tools_interactive_keeps_mcp_materialization(self):
+        from apps.agents.graph.base import _build_tools
+
+        mcp_rm = self._fake_mcp_tool("run_materialization")
+        mcp_tools = [self._fake_mcp_tool("query"), mcp_rm]
+        workspace = SimpleNamespace(id="ws-1", system_prompt="")
+
+        interactive = _build_tools(workspace, None, mcp_tools, interactive=True)
+        rm = [t for t in interactive if t.name == "run_materialization"]
+        assert rm == [mcp_rm], "interactive path keeps the original MCP tool untouched"
+
+    @pytest.mark.django_db(transaction=True)
+    @pytest.mark.asyncio
+    async def test_headless_no_data_prompt_is_blocking_not_resume(self, tenant, user):
+        from apps.agents.graph.base import _fetch_schema_context
+
+        interactive = await _fetch_schema_context(tenant, user, interactive=True)
+        headless = await _fetch_schema_context(tenant, user, interactive=False)
+
+        assert "run_materialization" in headless
+        # Interactive tells the agent to end its turn and wait for an async resume.
+        assert "end your turn" in interactive.lower()
+        # Headless must NOT — it has no resume path; it blocks and continues.
+        assert "end your turn" not in headless.lower()
+        assert "block" in headless.lower()
+
+
 class TestSystemPrompt:
     """Verify the system prompt includes data availability instructions."""
 

--- a/tests/test_materialization_tool.py
+++ b/tests/test_materialization_tool.py
@@ -1,0 +1,54 @@
+"""Tests for the headless blocking materialization agent-side tool."""
+
+import pytest
+
+from apps.agents.tools.materialization_tool import create_materialization_tool
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_headless_materialization_tool_blocks_and_reports_completion(
+    workspace, user, monkeypatch
+):
+    """The headless tool calls materialize_workspace_core, blocks on it, and
+    returns a completion summary the agent can act on in the same run — unlike
+    the interactive fire-and-ack MCP tool."""
+
+    async def _fake_core(workspace_id, user_id="", job_id=None):
+        assert workspace_id == str(workspace.id)
+        assert job_id == 99
+        return {
+            "all_succeeded": True,
+            "tenants": [{"tenant": "t1", "success": True}],
+            "view_schema": None,
+        }
+
+    monkeypatch.setattr("apps.workspaces.tasks.materialize_workspace_core", _fake_core)
+
+    tool = create_materialization_tool(workspace, user, job_id=99)
+    assert tool.name == "run_materialization"
+
+    result = await tool.ainvoke({})
+    assert result["status"] == "completed"
+    assert result["tenants_loaded"] == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_headless_materialization_tool_reports_failure(workspace, user, monkeypatch):
+    """When no tenant loads, the tool reports failed so the agent can stop
+    rather than query an empty schema."""
+
+    async def _fake_core(workspace_id, user_id="", job_id=None):
+        return {
+            "all_succeeded": False,
+            "tenants": [{"tenant": "t1", "success": False, "error": "boom"}],
+            "view_schema": None,
+        }
+
+    monkeypatch.setattr("apps.workspaces.tasks.materialize_workspace_core", _fake_core)
+
+    tool = create_materialization_tool(workspace, user)
+    result = await tool.ainvoke({})
+    assert result["status"] == "failed"
+    assert result["tenants_loaded"] == 0

--- a/tests/test_materialization_tool.py
+++ b/tests/test_materialization_tool.py
@@ -23,7 +23,7 @@ async def test_headless_materialization_tool_blocks_and_reports_completion(
             "view_schema": None,
         }
 
-    monkeypatch.setattr("apps.workspaces.tasks.materialize_workspace_core", _fake_core)
+    monkeypatch.setattr("apps.workspaces.tasks.materialize_workspace_blocking", _fake_core)
 
     tool = create_materialization_tool(workspace, user, job_id=99)
     assert tool.name == "run_materialization"
@@ -46,7 +46,7 @@ async def test_headless_materialization_tool_reports_failure(workspace, user, mo
             "view_schema": None,
         }
 
-    monkeypatch.setattr("apps.workspaces.tasks.materialize_workspace_core", _fake_core)
+    monkeypatch.setattr("apps.workspaces.tasks.materialize_workspace_blocking", _fake_core)
 
     tool = create_materialization_tool(workspace, user)
     result = await tool.ainvoke({})

--- a/tests/test_materialize_workspace_task.py
+++ b/tests/test_materialize_workspace_task.py
@@ -303,6 +303,78 @@ async def test_materialize_workspace_core_runs_without_deferring_resume(
     defer_mock.assert_not_awaited()  # core must never defer the resume task
 
 
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_materialize_workspace_blocking_runs_immediately_when_idle(
+    workspace, tenant, tenant_membership_obj, monkeypatch
+):
+    """With no in-progress materialization, the headless blocking entrypoint
+    runs the core immediately without waiting."""
+    core = {"n": 0}
+
+    async def fake_core(wid, uid="", jid=None):
+        core["n"] += 1
+        return {"all_succeeded": True, "tenants": [], "view_schema": None}
+
+    slept = {"n": 0}
+
+    async def fake_sleep(_delay):
+        slept["n"] += 1
+
+    monkeypatch.setattr(workspaces_tasks, "materialize_workspace_core", fake_core)
+    monkeypatch.setattr("apps.workspaces.tasks.asyncio.sleep", fake_sleep)
+
+    result = await workspaces_tasks.materialize_workspace_blocking(str(workspace.id))
+
+    assert slept["n"] == 0  # nothing in progress → no waiting
+    assert core["n"] == 1
+    assert result["all_succeeded"] is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_materialize_workspace_blocking_waits_out_in_progress_run(
+    workspace, tenant, tenant_membership_obj, monkeypatch
+):
+    """If a materialization is already ACTIVE for one of the workspace's
+    tenants, the blocking entrypoint WAITS for it to clear before starting its
+    own — never running two in parallel against the same tenant schema."""
+    schema = await TenantSchema.objects.acreate(
+        tenant=tenant, schema_name="t_wait", state=SchemaState.MATERIALIZING
+    )
+    run = await MaterializationRun.objects.acreate(
+        tenant_schema=schema,
+        pipeline="commcare_sync",
+        state=MaterializationRun.RunState.LOADING,
+    )
+
+    core = {"n": 0, "when_slept": None}
+
+    async def fake_core(wid, uid="", jid=None):
+        core["n"] += 1
+        core["when_slept"] = slept["n"]
+        return {"all_succeeded": True, "tenants": [], "view_schema": None}
+
+    slept = {"n": 0}
+
+    async def fake_sleep(_delay):
+        # Clear the in-progress run on the first poll so the wait loop exits.
+        slept["n"] += 1
+        await MaterializationRun.objects.filter(id=run.id).aupdate(
+            state=MaterializationRun.RunState.COMPLETED
+        )
+
+    monkeypatch.setattr(workspaces_tasks, "materialize_workspace_core", fake_core)
+    monkeypatch.setattr("apps.workspaces.tasks.asyncio.sleep", fake_sleep)
+
+    result = await workspaces_tasks.materialize_workspace_blocking(str(workspace.id))
+
+    assert slept["n"] >= 1  # it waited for the in-progress run
+    assert core["n"] == 1  # then ran its own
+    assert core["when_slept"] >= 1  # core ran AFTER the wait, not before
+    assert result["all_succeeded"] is True
+
+
 # ---------------------------------------------------------------------------
 # _run_pipeline_with_progress closure
 # ---------------------------------------------------------------------------

--- a/tests/test_materialize_workspace_task.py
+++ b/tests/test_materialize_workspace_task.py
@@ -275,6 +275,34 @@ async def test_materialize_workspace_breaks_on_cancel(
     assert result["tenants"][0]["cancelled"] is True
 
 
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_materialize_workspace_core_runs_without_deferring_resume(
+    workspace, tenant_membership_obj
+):
+    """materialize_workspace_core does the tenant loop + view rebuild but does
+    NOT defer any chat-resume task — headless callers (recipes) invoke it
+    directly and block on the return value. The fire-and-resume deferral lives
+    only in the materialize_workspace task wrapper."""
+    with (
+        patch("apps.workspaces.tasks.aresolve_credential", new_callable=AsyncMock) as mock_cred,
+        patch("apps.workspaces.tasks.get_registry", return_value=_mock_registry("commcare")),
+        patch(
+            "apps.workspaces.tasks._run_pipeline_with_progress",
+            return_value={"status": "completed"},
+        ),
+        patch("apps.workspaces.tasks._defer_resume_for_job", new_callable=AsyncMock) as defer_mock,
+    ):
+        mock_cred.return_value = {"type": "api_key", "value": "k"}
+        result = await workspaces_tasks.materialize_workspace_core(
+            str(workspace.id), user_id="", job_id=None
+        )
+
+    assert result["all_succeeded"] is True
+    assert result["tenants"][0]["success"] is True
+    defer_mock.assert_not_awaited()  # core must never defer the resume task
+
+
 # ---------------------------------------------------------------------------
 # _run_pipeline_with_progress closure
 # ---------------------------------------------------------------------------

--- a/tests/test_recipe_materialization_integration.py
+++ b/tests/test_recipe_materialization_integration.py
@@ -1,0 +1,80 @@
+"""End-to-end: a recipe whose agent calls run_materialization runs headlessly
+through the REAL agent graph (interactive=False) without the synthetic-thread_id
+crash, using the blocking materialize tool instead of the chat fire-and-ack one.
+
+This is the capstone for the recipe-materialization fix: it exercises the real
+wiring (RecipeRunner -> build_agent_graph(interactive=False) -> _build_tools tool
+swap -> injecting node -> blocking run_materialization -> materialize_workspace_
+core), with only the LLM and the pipeline core stubbed.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from langchain_core.messages import AIMessage
+
+from apps.chat.models import Thread, ThreadJob
+from apps.recipes.models import Recipe, RecipeRunStatus
+from apps.recipes.services.runner import RecipeRunner
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_recipe_agent_materializes_headlessly_without_crash(workspace, user, monkeypatch):
+    recipe = await Recipe.objects.acreate(
+        workspace=workspace,
+        name="Refresh & Build",
+        description="",
+        prompt="Refresh the data, then build a dashboard.",
+        variables=[],
+        created_by=user,
+    )
+
+    # Stub the pipeline core so no real materialization runs, and record that the
+    # BLOCKING path was taken (proves the headless tool ran, not the MCP one).
+    core_calls = {"n": 0, "job_id": None}
+
+    async def fake_core(workspace_id, user_id="", job_id=None):
+        core_calls["n"] += 1
+        core_calls["job_id"] = job_id
+        return {
+            "all_succeeded": True,
+            "tenants": [{"tenant": "t1", "success": True}],
+            "view_schema": None,
+        }
+
+    monkeypatch.setattr("apps.workspaces.tasks.materialize_workspace_core", fake_core)
+
+    # Stub the LLM: turn 1 calls run_materialization; turn 2 finishes the run.
+    llm_calls = {"n": 0}
+
+    async def fake_ainvoke(messages, *args, **kwargs):
+        llm_calls["n"] += 1
+        if llm_calls["n"] == 1:
+            return AIMessage(
+                content="",
+                tool_calls=[{"name": "run_materialization", "args": {}, "id": "call_mat"}],
+            )
+        return AIMessage(content="Data refreshed and dashboard built.", id="ai-final")
+
+    mock_bound = MagicMock()
+    mock_bound.ainvoke = AsyncMock(side_effect=fake_ainvoke)
+    mock_llm = MagicMock()
+    mock_llm.bind_tools.return_value = mock_bound
+
+    with (
+        patch("apps.recipes.services.runner.get_mcp_tools", new=AsyncMock(return_value=[])),
+        patch("apps.recipes.services.runner.get_user_oauth_tokens", new=AsyncMock(return_value={})),
+        patch("apps.agents.graph.base.ChatAnthropic", return_value=mock_llm),
+    ):
+        run = await RecipeRunner(recipe, {}, user, job_id=55).execute_async()
+
+    # No UUID crash — the run completed.
+    assert run.status == RecipeRunStatus.COMPLETED, run.step_results
+    # The blocking materialize actually executed (and got the run's job_id).
+    assert core_calls["n"] == 1
+    assert core_calls["job_id"] == 55
+    assert "run_materialization" in run.step_results[0]["tools_used"]
+    # Headless: no chat Thread/ThreadJob created anywhere in the flow.
+    assert not await Thread.objects.aexists()
+    assert not await ThreadJob.objects.aexists()

--- a/tests/test_recipe_materialization_integration.py
+++ b/tests/test_recipe_materialization_integration.py
@@ -14,7 +14,7 @@ import pytest
 from langchain_core.messages import AIMessage
 
 from apps.chat.models import Thread, ThreadJob
-from apps.recipes.models import Recipe, RecipeRunStatus
+from apps.recipes.models import Recipe, RecipeRun, RecipeRunStatus
 from apps.recipes.services.runner import RecipeRunner
 
 
@@ -67,7 +67,14 @@ async def test_recipe_agent_materializes_headlessly_without_crash(workspace, use
         patch("apps.recipes.services.runner.get_user_oauth_tokens", new=AsyncMock(return_value={})),
         patch("apps.agents.graph.base.ChatAnthropic", return_value=mock_llm),
     ):
-        run = await RecipeRunner(recipe, {}, user, job_id=55).execute_async()
+        run_row = await RecipeRun.objects.acreate(
+            recipe=recipe,
+            run_by=user,
+            status=RecipeRunStatus.PENDING,
+            variable_values={},
+            step_results=[],
+        )
+        run = await RecipeRunner(recipe, {}, user, run=run_row, job_id=55).execute_async()
 
     # No UUID crash — the run completed.
     assert run.status == RecipeRunStatus.COMPLETED, run.step_results

--- a/tests/test_recipe_runner.py
+++ b/tests/test_recipe_runner.py
@@ -16,7 +16,7 @@ from langchain_core.messages import AIMessage, ToolMessage
 from langchain_mcp_adapters.tools import load_mcp_tools
 from mcp.shared.memory import create_connected_server_and_client_session
 
-from apps.recipes.models import Recipe, RecipeRunStatus
+from apps.recipes.models import Recipe, RecipeRun, RecipeRunStatus
 from apps.recipes.services.runner import RecipeRunner
 from mcp_server.server import mcp as scout_mcp
 
@@ -108,7 +108,16 @@ async def test_execute_async_builds_real_graph_and_flows_workspace_id(recipe, us
                 return_value=_fake_llm_driving_get_schema_status(),
             ),
         ):
-            run = await RecipeRunner(recipe=recipe, variable_values=values, user=user).execute_async()
+            run_row = await RecipeRun.objects.acreate(
+                recipe=recipe,
+                run_by=user,
+                status=RecipeRunStatus.PENDING,
+                variable_values=values,
+                step_results=[],
+            )
+            run = await RecipeRunner(
+                recipe=recipe, variable_values=values, user=user, run=run_row
+            ).execute_async()
 
     assert run.status == RecipeRunStatus.COMPLETED, run.step_results
     step = run.step_results[0]

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -585,12 +585,32 @@ class TestRecipeRunModel:
 class TestRecipeRunner:
     """Tests for the RecipeRunner async path with a provided (mocked) agent graph."""
 
+    def test_validate_and_default_applies_defaults(self, recipe):
+        """validate_and_default returns a copy with recipe defaults filled in,
+        so the view can validate + default without constructing a runner."""
+        values = RecipeRunner.validate_and_default(recipe, {"start_date": "2024-01-01"})
+        assert values["region"] == "North"  # default applied
+        assert values["limit"] == 10  # default applied
+        assert values["start_date"] == "2024-01-01"
+
+    def test_validate_and_default_raises_on_missing_required(self, recipe):
+        """start_date has no default, so omitting it is a validation error."""
+        with pytest.raises(VariableValidationError):
+            RecipeRunner.validate_and_default(recipe, {"region": "North", "limit": 10})
+
     @pytest.mark.asyncio
     async def test_recipe_runner_validates_variables(self, recipe, user, recipe_step_1):
         """RecipeRunner.execute_async raises VariableValidationError on missing vars."""
         invalid_values = {"region": "North", "limit": 10}  # start_date missing
+        run = await RecipeRun.objects.acreate(
+            recipe=recipe,
+            run_by=user,
+            status=RecipeRunStatus.PENDING,
+            variable_values=invalid_values,
+            step_results=[],
+        )
 
-        runner = RecipeRunner(recipe, invalid_values, user, graph=Mock())
+        runner = RecipeRunner(recipe, invalid_values, user, run=run, graph=Mock())
         with pytest.raises(VariableValidationError):
             await runner.execute_async()
 
@@ -612,7 +632,14 @@ class TestRecipeRunner:
         stub_graph.ainvoke = AsyncMock(return_value={"messages": []})
         mock_build.return_value = stub_graph
 
-        await RecipeRunner(recipe, values, user, job_id=123).execute_async()
+        run = await RecipeRun.objects.acreate(
+            recipe=recipe,
+            run_by=user,
+            status=RecipeRunStatus.PENDING,
+            variable_values=values,
+            step_results=[],
+        )
+        await RecipeRunner(recipe, values, user, run=run, job_id=123).execute_async()
 
         kwargs = mock_build.await_args.kwargs
         assert kwargs["interactive"] is False
@@ -628,7 +655,14 @@ class TestRecipeRunner:
             return_value={"messages": [Mock(content="Result", tool_calls=[])]}
         )
 
-        run = await RecipeRunner(recipe, values, user, graph=mock_graph).execute_async()
+        _run = await RecipeRun.objects.acreate(
+            recipe=recipe,
+            run_by=user,
+            status=RecipeRunStatus.PENDING,
+            variable_values=values,
+            step_results=[],
+        )
+        run = await RecipeRunner(recipe, values, user, run=_run, graph=mock_graph).execute_async()
 
         assert run is not None
         assert isinstance(run, RecipeRun)
@@ -645,7 +679,14 @@ class TestRecipeRunner:
             return_value={"messages": [Mock(content="Mocked response", tool_calls=[])]}
         )
 
-        run = await RecipeRunner(recipe, values, user, graph=mock_graph).execute_async()
+        _run = await RecipeRun.objects.acreate(
+            recipe=recipe,
+            run_by=user,
+            status=RecipeRunStatus.PENDING,
+            variable_values=values,
+            step_results=[],
+        )
+        run = await RecipeRunner(recipe, values, user, run=_run, graph=mock_graph).execute_async()
 
         assert len(run.step_results) == 1
         assert run.step_results[0]["step_order"] == 1
@@ -662,7 +703,14 @@ class TestRecipeRunner:
             return_value={"messages": [Mock(content="Mocked response", tool_calls=[])]}
         )
 
-        run = await RecipeRunner(recipe, values, user, graph=mock_graph).execute_async()
+        _run = await RecipeRun.objects.acreate(
+            recipe=recipe,
+            run_by=user,
+            status=RecipeRunStatus.PENDING,
+            variable_values=values,
+            step_results=[],
+        )
+        run = await RecipeRunner(recipe, values, user, run=_run, graph=mock_graph).execute_async()
 
         step_result = run.step_results[0]
         assert "East" in step_result["prompt"]
@@ -675,7 +723,14 @@ class TestRecipeRunner:
         mock_graph = Mock()
         mock_graph.ainvoke = AsyncMock(side_effect=Exception("Agent execution failed"))
 
-        run = await RecipeRunner(recipe, values, user, graph=mock_graph).execute_async()
+        _run = await RecipeRun.objects.acreate(
+            recipe=recipe,
+            run_by=user,
+            status=RecipeRunStatus.PENDING,
+            variable_values=values,
+            step_results=[],
+        )
+        run = await RecipeRunner(recipe, values, user, run=_run, graph=mock_graph).execute_async()
 
         assert run.status == RecipeRunStatus.FAILED
         assert len(run.step_results) > 0
@@ -691,7 +746,14 @@ class TestRecipeRunner:
             return_value={"messages": [Mock(content="Success", tool_calls=[])]}
         )
 
-        run = await RecipeRunner(recipe, values, user, graph=mock_graph).execute_async()
+        _run = await RecipeRun.objects.acreate(
+            recipe=recipe,
+            run_by=user,
+            status=RecipeRunStatus.PENDING,
+            variable_values=values,
+            step_results=[],
+        )
+        run = await RecipeRunner(recipe, values, user, run=_run, graph=mock_graph).execute_async()
 
         assert run.status == RecipeRunStatus.COMPLETED
         assert run.completed_at is not None

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -595,6 +595,31 @@ class TestRecipeRunner:
             await runner.execute_async()
 
     @pytest.mark.asyncio
+    @patch("apps.recipes.services.runner.build_agent_graph", new_callable=AsyncMock)
+    @patch("apps.recipes.services.runner.get_mcp_tools", new_callable=AsyncMock)
+    @patch("apps.recipes.services.runner.get_user_oauth_tokens", new_callable=AsyncMock)
+    async def test_recipe_runner_builds_headless_graph(
+        self, mock_oauth, mock_mcp, mock_build, recipe, user, recipe_step_1
+    ):
+        """The runner must build the agent graph in HEADLESS mode (interactive=
+        False), with no checkpointer, passing its job_id — so the agent gets the
+        blocking materialize tool instead of the chat fire-and-ack one that would
+        crash on the recipe's synthetic thread_id."""
+        values = {"region": "North", "limit": 10, "start_date": "2024-01-01"}
+        mock_mcp.return_value = []
+        mock_oauth.return_value = {}
+        stub_graph = Mock()
+        stub_graph.ainvoke = AsyncMock(return_value={"messages": []})
+        mock_build.return_value = stub_graph
+
+        await RecipeRunner(recipe, values, user, job_id=123).execute_async()
+
+        kwargs = mock_build.await_args.kwargs
+        assert kwargs["interactive"] is False
+        assert kwargs["job_id"] == 123
+        assert kwargs["checkpointer"] is None
+
+    @pytest.mark.asyncio
     async def test_recipe_runner_creates_run_record(self, recipe, user, recipe_step_1):
         """RecipeRunner creates a RecipeRun record."""
         values = {"region": "North", "limit": 10, "start_date": "2024-01-01"}

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -12,8 +12,8 @@ from django.contrib.auth import get_user_model
 from django.db import IntegrityError
 from django.test import AsyncClient
 from django.utils import timezone
-from langchain_core.messages import AIMessage
 
+from apps.recipes import tasks as recipe_tasks
 from apps.recipes.models import Recipe, RecipeRun, RecipeRunStatus, RecipeStep
 from apps.recipes.services.runner import RecipeRunner, VariableValidationError
 
@@ -835,35 +835,74 @@ class TestRecipeRunView:
     """Tests for the async recipe run endpoint."""
 
     @pytest.mark.asyncio
-    async def test_run_endpoint_returns_201_with_real_graph(self, recipe, user, recipe_step_1):
-        """POST run/ builds the real graph (LLM mocked, no MCP tools) and returns 201."""
-
-        async def fake_ainvoke(messages, *args, **kwargs):
-            return AIMessage(content="done", id="ai-1")
-
-        mock_bound = MagicMock()
-        mock_bound.ainvoke = AsyncMock(side_effect=fake_ainvoke)
-        mock_llm = MagicMock()
-        mock_llm.bind_tools.return_value = mock_bound
-
+    async def test_run_endpoint_returns_202_and_defers_task(self, recipe, user, recipe_step_1):
+        """POST run/ creates a PENDING RecipeRun, defers the background task, and
+        returns 202 — execution is async because a recipe may block on a
+        materialization that must not hold the HTTP connection open."""
         client = AsyncClient()
         await sync_to_async(client.login)(email="test@example.com", password="testpass123")
 
         url = f"/api/workspaces/{recipe.workspace_id}/recipes/{recipe.id}/run/"
         body = {"variable_values": {"region": "North", "limit": 10, "start_date": "2024-01-01"}}
 
-        with (
-            patch(
-                "apps.recipes.services.runner.get_mcp_tools",
-                new=AsyncMock(return_value=[]),
-            ),
-            patch("apps.agents.graph.base.ChatAnthropic", return_value=mock_llm),
-        ):
+        with patch("apps.recipes.api.views.run_recipe") as mock_task:
+            mock_task.defer_async = AsyncMock()
             resp = await client.post(url, data=body, content_type="application/json")
 
-        assert resp.status_code == 201, resp.content
+        assert resp.status_code == 202, resp.content
         data = resp.json()
-        assert data["status"] == RecipeRunStatus.COMPLETED
+        assert data["status"] == RecipeRunStatus.PENDING
+        run = await RecipeRun.objects.aget(id=data["id"])
+        assert run.status == RecipeRunStatus.PENDING
+        mock_task.defer_async.assert_awaited_once_with(recipe_run_id=str(run.id))
+
+    @pytest.mark.asyncio
+    async def test_run_endpoint_rejects_invalid_variables_before_dispatch(
+        self, recipe, user, recipe_step_1
+    ):
+        """Variable validation happens in the request (400) — we must not create
+        a run or defer a task for an invalid request."""
+        client = AsyncClient()
+        await sync_to_async(client.login)(email="test@example.com", password="testpass123")
+        url = f"/api/workspaces/{recipe.workspace_id}/recipes/{recipe.id}/run/"
+        body = {"variable_values": {"region": "North", "limit": 10}}  # start_date missing
+
+        with patch("apps.recipes.api.views.run_recipe") as mock_task:
+            mock_task.defer_async = AsyncMock()
+            resp = await client.post(url, data=body, content_type="application/json")
+
+        assert resp.status_code == 400, resp.content
+        assert not await RecipeRun.objects.filter(recipe=recipe).aexists()
+        mock_task.defer_async.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_run_recipe_task_executes_and_finalizes(
+        self, recipe, user, recipe_step_1, monkeypatch
+    ):
+        """The run_recipe task runs the (mocked) runner against the pre-created
+        run and the run reaches a terminal status."""
+        run = await RecipeRun.objects.acreate(
+            recipe=recipe,
+            run_by=user,
+            status=RecipeRunStatus.PENDING,
+            variable_values={"region": "North", "limit": 10, "start_date": "2024-01-01"},
+            step_results=[],
+        )
+
+        async def _fake_exec(self):
+            self._run.status = RecipeRunStatus.COMPLETED
+            await self._run.asave(update_fields=["status"])
+            return self._run
+
+        monkeypatch.setattr("apps.recipes.services.runner.RecipeRunner.execute_async", _fake_exec)
+        ctx = MagicMock()
+        ctx.job.id = 7
+
+        result = await recipe_tasks.run_recipe(ctx, str(run.id))
+
+        await run.arefresh_from_db()
+        assert run.status == RecipeRunStatus.COMPLETED
+        assert result["status"] == RecipeRunStatus.COMPLETED
 
     @pytest.mark.asyncio
     async def test_run_endpoint_forbids_non_member(self, recipe, other_user, recipe_step_1):

--- a/tests/test_run_materialization_fire_and_ack.py
+++ b/tests/test_run_materialization_fire_and_ack.py
@@ -16,6 +16,35 @@ User = get_user_model()
 
 @pytest.mark.asyncio
 @pytest.mark.django_db(transaction=True)
+async def test_run_materialization_rejects_non_uuid_thread_id():
+    """A non-UUID thread_id (e.g. the recipe runner's synthetic
+    "recipe-run-<id>") must fail cleanly with a validation error instead of
+    raising ValueError out of the Thread UUIDField cast. Regression guard for
+    the recipe materialization crash (SCOUT-DJANGO-1R/1S)."""
+    user = await User.objects.acreate_user(email="nonuuid@b.c", password="x")
+    ws = await Workspace.objects.acreate(name="W-nonuuid", created_by=user)
+    tenant = await Tenant.objects.acreate(
+        external_id="tnu", provider="commcare", canonical_name="NonUUID Tenant"
+    )
+    await WorkspaceTenant.objects.acreate(workspace=ws, tenant=tenant)
+    await TenantMembership.objects.acreate(tenant=tenant, user=user)
+
+    result = await run_materialization(
+        workspace_id=str(ws.id),
+        user_id=str(user.id),
+        thread_id="recipe-run-f3be369b-d867-4ef8-aa0d-a74f21101c18",
+        tool_call_id="tc-nonuuid",
+    )
+
+    assert result["success"] is False
+    assert result["error"]["code"] == "VALIDATION_ERROR"
+    assert "thread" in result["error"]["message"].lower()
+    # Must not have raised, and must not have created any ThreadJob.
+    assert not await ThreadJob.objects.aexists()
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
 async def test_run_materialization_returns_started_immediately_and_creates_threadjob():
     user = await User.objects.acreate_user(email="a@b.c", password="x")
     ws = await Workspace.objects.acreate(name="W", created_by=user)


### PR DESCRIPTION
## Summary

Recipe runs that needed fresh data were crashing in production (SCOUT-DJANGO-1R / 1S). The recipe agent followed its prompt and called `run_materialization`, which cast the recipe's **synthetic** `thread_id` (`recipe-run-<uuid>`) to a `Thread` UUID and raised `ValidationError: "…" is not a valid UUID`.

The real problem is a **category error**: `run_materialization` is an *interactive, fire-and-resume* tool that only works for a caller owning a persisted chat `Thread` + checkpointer + async-resume loop. A recipe is a *one-shot, headless, thread-less, checkpointer-less* run. This PR makes recipe execution explicitly **headless**: it gets a *blocking* materialize that runs the pipeline inline and returns, then continues building the dashboard — no Thread, no checkpointer, no resume needed (a headless run has no interactive turn to protect).

**Verified against live prod:** the failing id `f3be369b-…` is a `RecipeRun` (status=`failed`), there is **no** `chat_thread` row with that id, and the stored step error is the exact crash — so patching the UUID alone was never enough (the Thread lookup would still miss).

## Root cause

| When | Commit | Effect |
|---|---|---|
| Feb 5 | `befce76` | Recipe runner born with `checkpointer=None` + synthetic `thread_id`. Harmless — no thread-coupled tools yet. |
| May 20–21 | `af2e353`, `aa908d1` | `run_materialization` becomes fire-and-ack + adds `Thread.objects.filter(id=thread_id)`. **Arms the bomb.** |
| Jun 16 | `6e866de` (arch #238) | Fixes the recipe runner so recipes actually run for the first time → first materializing recipe **detonates** the latent crash. |

Systemic root: the agent graph had an **implicit, unenforced contract** — every caller must invoke it on behalf of a real persisted `Thread` + checkpointer. Chat honored it; the recipe runner (the only headless, only contract-violating front-end) did not. The contract lived only in chat's helpers, invisible at the call boundary.

## The fix (defense in depth + systemic close)

1. **Guard** (`mcp_server/server.py`): `run_materialization` rejects a non-UUID `thread_id` with a clean validation error instead of a 500 — stops the crash for *any* caller.
2. **Headless blocking tool** (`apps/agents/tools/materialization_tool.py`): runs `materialize_workspace_core` inline and blocks until done (core extracted from the `materialize_workspace` task, which keeps its resume deferral).
3. **Explicit mode** (`apps/agents/graph/base.py`): `build_agent_graph(interactive=...)`. Headless swaps the MCP fire-and-ack `run_materialization` for the blocking tool and emits "this blocks and returns" prompt guidance instead of "end your turn, you'll be resumed". **Closes the bug class** — any future headless front-end is safe by construction.
4. **Headless execution** (`apps/recipes/`): the runner builds the headless graph; recipe execution moves to a background `run_recipe` task (it could block on materialization, which must not hold the HTTP request open). The endpoint returns **202** with a PENDING run; the frontend polls to completion.

## Test plan

- Backend: **1303 passed, 5 skipped, 0 failures** (full suite).
- Frontend: **eslint clean**, **`vite build` exit 0**.
- Task-0 regression test red-green verified (reproduces the exact prod `ValidationError`, then passes).
- Capstone e2e (`tests/test_recipe_materialization_integration.py`) drives the **real** graph wiring: a recipe agent calling `run_materialization` completes, the blocking core runs with the run's `job_id`, and **no `Thread`/`ThreadJob`** is created.
- Live prod DB confirmation (above).

## Deploy notes

- `run_recipe` runs on a dedicated `recipes` queue. The default worker processes all queues, so it works as-is; if recipe + chat-materialization load contend, run a dedicated worker (`--queues recipes`) or raise worker concurrency.
- API contract change: `POST .../recipes/<id>/run/` now returns **202 + PENDING run** (was 201 + completed). The frontend already polls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)