### PR TITLE
fix(auth): mark trusted-provider OAuth emails verified

### DIFF
--- a/apps/users/providers/commcare/provider.py
+++ b/apps/users/providers/commcare/provider.py
@@ -8,6 +8,7 @@ Example of implementing a custom OAuth2 provider for django-allauth.
 Follow this pattern for other identity providers.
 """
 
+from allauth.account.models import EmailAddress
 from allauth.socialaccount.providers.base import ProviderAccount
 from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
 
@@ -86,6 +87,22 @@ class CommCareProvider(OAuth2Provider):
             "first_name": data.get("first_name", ""),
             "last_name": data.get("last_name", ""),
         }
+
+    def extract_email_addresses(self, data: dict) -> list[EmailAddress]:
+        """Return the user's email as a verified address.
+
+        allauth's base implementation returns ``[]``, which makes allauth fall
+        back to creating an *unverified* EmailAddress from ``User.email``. CommCare
+        HQ uses the email as the login identifier and confirms it at signup, so we
+        trust it as verified. A verified address is what lets the cross-provider
+        account-link/merge (see ``apps.users.signals.reconcile_existing_user_on_login``)
+        recognise the same person across providers instead of stranding a
+        duplicate, email-less account.
+        """
+        email = data.get("email")
+        if not email:
+            return []
+        return [EmailAddress(email=email, verified=True, primary=True)]
 
 
 # Required by django-allauth to discover this provider

--- a/apps/users/providers/commcare_connect/provider.py
+++ b/apps/users/providers/commcare_connect/provider.py
@@ -1,5 +1,6 @@
 """CommCare Connect OAuth2 provider for django-allauth."""
 
+from allauth.account.models import EmailAddress
 from allauth.socialaccount.providers.base import ProviderAccount
 from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
 
@@ -53,6 +54,21 @@ class CommCareConnectProvider(OAuth2Provider):
             "first_name": name,
             "last_name": "",
         }
+
+    def extract_email_addresses(self, data: dict) -> list[EmailAddress]:
+        """Return the user's email as a verified address.
+
+        Connect enforces mandatory email verification for web users (allauth
+        ``ACCOUNT_EMAIL_VERIFICATION = "mandatory"``), and the mobile email field
+        is read-only (sourced from ConnectID), so an email Connect returns is
+        verified upstream regardless of domain. Without this override allauth marks
+        every social email unverified, which strands email-less duplicate accounts
+        that the cross-provider merge then refuses to reconcile.
+        """
+        email = data.get("email") or None
+        if not email:
+            return []
+        return [EmailAddress(email=email, verified=True, primary=True)]
 
 
 provider_classes = [CommCareConnectProvider]

--- a/apps/users/providers/ocs/provider.py
+++ b/apps/users/providers/ocs/provider.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from allauth.account.models import EmailAddress
 from allauth.socialaccount.providers.base import ProviderAccount
 from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
 
@@ -38,6 +39,20 @@ class OCSProvider(OAuth2Provider):
             "first_name": data.get("given_name", ""),
             "last_name": data.get("family_name", ""),
         }
+
+    def extract_email_addresses(self, data: dict) -> list[EmailAddress]:
+        """Return the user's email, trusted as verified only when OCS says so.
+
+        Unlike CommCare HQ/Connect, OCS exposes per-login verification via the
+        ``email_verified`` OIDC claim (open-chat-studio#3647). We mirror it rather
+        than trusting wholesale: ``verified=True`` only when OCS asserts the claim.
+        The claim is absent until that OCS change deploys, so this defaults closed
+        (unverified) — never over-trusting an email OCS hasn't confirmed.
+        """
+        email = data.get("email") or None
+        if not email:
+            return []
+        return [EmailAddress(email=email, verified=bool(data.get("email_verified")), primary=True)]
 
 
 provider_classes = [OCSProvider]

--- a/tests/test_provider_email_verification.py
+++ b/tests/test_provider_email_verification.py
@@ -1,0 +1,75 @@
+"""Provider ``extract_email_addresses``: trusted IdPs assert verified emails.
+
+allauth's base ``extract_email_addresses`` returns ``[]``, which makes allauth
+fall back to an *unverified* EmailAddress. That unverified state is what made the
+cross-provider account merge refuse to reconcile, stranding email-less duplicate
+accounts. Each Scout provider now asserts verification per its upstream IdP:
+CommCare HQ and Connect verify emails themselves (trusted unconditionally); OCS
+exposes an ``email_verified`` OIDC claim that we mirror (default closed).
+"""
+
+import pytest
+from allauth.account.models import EmailAddress
+from allauth.socialaccount.models import SocialApp
+
+from apps.users.providers.commcare.provider import CommCareProvider
+from apps.users.providers.commcare_connect.provider import CommCareConnectProvider
+from apps.users.providers.ocs.provider import OCSProvider
+
+
+def _addresses(provider_cls, data: dict) -> list[EmailAddress]:
+    # allauth's provider __init__ requires a non-None app, but
+    # extract_email_addresses only reads ``data`` — an unsaved SocialApp
+    # instance suffices, so these stay pure unit tests (no DB).
+    app = SocialApp(provider=provider_cls.id, name="test", client_id="x", secret="x")
+    return provider_cls(request=None, app=app).extract_email_addresses(data)
+
+
+@pytest.mark.parametrize(
+    "provider_cls",
+    [CommCareProvider, CommCareConnectProvider],
+    ids=["commcare", "commcare_connect"],
+)
+def test_trusted_provider_marks_email_verified(provider_cls):
+    addrs = _addresses(provider_cls, {"email": "user@dimagi.com"})
+    assert len(addrs) == 1
+    assert addrs[0].email == "user@dimagi.com"
+    assert addrs[0].verified is True
+    assert addrs[0].primary is True
+
+
+@pytest.mark.parametrize(
+    "provider_cls, data",
+    [
+        (CommCareProvider, {}),
+        (CommCareProvider, {"email": ""}),
+        (CommCareConnectProvider, {"email": None}),
+        (CommCareConnectProvider, {"name": "Ajeet"}),
+        (OCSProvider, {"email_verified": True}),
+    ],
+    ids=["cc-missing", "cc-empty", "connect-none", "connect-no-email", "ocs-no-email"],
+)
+def test_no_email_returns_empty(provider_cls, data):
+    assert _addresses(provider_cls, data) == []
+
+
+def test_ocs_trusts_email_only_when_claim_true():
+    addrs = _addresses(OCSProvider, {"email": "user@dimagi.com", "email_verified": True})
+    assert len(addrs) == 1
+    assert addrs[0].email == "user@dimagi.com"
+    assert addrs[0].verified is True
+    assert addrs[0].primary is True
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        {"email": "user@dimagi.com", "email_verified": False},
+        {"email": "user@dimagi.com"},  # claim absent (pre open-chat-studio#3647 deploy)
+    ],
+    ids=["claim-false", "claim-absent"],
+)
+def test_ocs_email_unverified_without_true_claim(data):
+    addrs = _addresses(OCSProvider, data)
+    assert len(addrs) == 1
+    assert addrs[0].verified is False


### PR DESCRIPTION
## Problem
Workspace sharing fails with **"User is not part of this workspace's tenants"** even for users who are members in Connect. One root cause: allauth's base `Provider.extract_email_addresses` returns `[]`, so allauth falls back to creating an **unverified** `EmailAddress` from `User.email` for every social login. None of Scout's three providers overrode it.

That unverified state makes the cross-provider account-link/merge (`apps.users.signals.reconcile_existing_user_on_login`) **refuse** to reconcile — it requires the canonical account to own a *verified* email. So a person with, e.g., a CommCare HQ account and a separate Connect account stays split, with their Connect tenant memberships stranded on an email-less duplicate row. Share-by-email then finds the wrong (email-less) row → the error.

(Two such live prod splits — `nheynes` and `bderenzi` — were already cleaned up via operator merge; this prevents new ones from forming.)

## Change
Override `extract_email_addresses` in each provider to assert verification per its upstream IdP:

- **CommCare HQ & Connect** → `verified=True`. Both verify email upstream: HQ uses the email as the login identifier; Connect enforces `ACCOUNT_EMAIL_VERIFICATION = "mandatory"` for web users and its mobile email field is read-only (ConnectID-sourced).
- **OCS** → mirrors the `email_verified` OIDC claim added in dimagi/open-chat-studio#3647 (merged). Defaults **closed** (unverified) until that change deploys, so we never over-trust an email OCS hasn't confirmed.

## Safety
Trust is anchored on each IdP's own verification, not on the email string or domain — so this is safe even though Connect/OCS are intentionally **not** domain-restricted.

## Tests
`tests/test_provider_email_verification.py` — pure unit tests: `verified=True` for HQ/Connect, OCS claim gating (true / false / absent), and the no-email → `[]` path.

## Follow-up (not in this PR)
`reconcile_existing_user_on_login` reads the incoming `extra_data["email"]` without checking it's verified. Now that providers assert verification, a defense-in-depth check there could be added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
