### PR TITLE
fix(ocs): scope participant sync to chatbot + disambiguate team-mismatch creds (arch #245)

### DIFF
--- a/apps/users/services/credential_resolver.py
+++ b/apps/users/services/credential_resolver.py
@@ -14,8 +14,26 @@ from apps.users.services.token_refresh import (
     refresh_oauth_token,
     token_needs_refresh,
 )
+from mcp_server.envelope import AUTH_TOKEN_EXPIRED
 
 logger = logging.getLogger(__name__)
+
+
+class CredentialResolutionError(Exception):
+    """Raised when a credential exists but cannot be used for a *known,
+    actionable* reason (e.g. the user's OAuth token is now scoped to a
+    different team than the chatbot they're materializing).
+
+    Distinct from ``aresolve_credential`` returning ``None`` (which means no
+    usable credential could be found for an opaque reason — missing connection,
+    decrypt failure, etc.). Callers should surface ``message`` to the user and
+    may key UI/remediation off ``code`` (an ``mcp_server.envelope`` error code).
+    """
+
+    def __init__(self, code: str, message: str) -> None:
+        self.code = code
+        self.message = message
+        super().__init__(message)
 
 
 def _social_token_qs(user, provider: str):
@@ -89,8 +107,19 @@ async def aresolve_credential(membership) -> dict | None:
         .select_related("account", "app")
         .afirst()
     )
-    if not token_obj or _oauth_team_mismatch(membership, token_obj):
+    if not token_obj:
         return None
+    if _oauth_team_mismatch(membership, token_obj):
+        # The user is signed in to a different team than this chatbot. Fail
+        # closed (never serve another team's token), but surface a distinct,
+        # actionable error so the user is told to re-connect — not the generic
+        # "No credential configured" (arch #245 finding 07#3).
+        raise CredentialResolutionError(
+            AUTH_TOKEN_EXPIRED,
+            "Your sign-in is scoped to a different team than this chatbot's "
+            f"team ({membership.team_slug}). Please re-connect to team "
+            f"'{membership.team_slug}' to materialize it.",
+        )
 
     return await _aresolve_oauth_credential(token_obj, conn.provider)
 

--- a/apps/workspaces/tasks.py
+++ b/apps/workspaces/tasks.py
@@ -21,7 +21,10 @@ from apps.chat.constants import SYSTEM_RESUME_MARKER
 from apps.chat.models import Thread, ThreadJob
 from apps.transformations.models import TransformationRunStatus
 from apps.users.models import TenantMembership
-from apps.users.services.credential_resolver import aresolve_credential
+from apps.users.services.credential_resolver import (
+    CredentialResolutionError,
+    aresolve_credential,
+)
 from apps.workspaces.models import (
     MaterializationRun,
     SchemaState,
@@ -158,7 +161,15 @@ async def refresh_tenant_schema(schema_id: str, membership_id: str) -> dict:
     # Step 2: Resolve credential and run materialization pipeline. This task
     # runs as an async job, so it must use the async resolver — the sync one
     # issues ORM queries that raise SynchronousOnlyOperation here.
-    credential = await aresolve_credential(membership)
+    try:
+        credential = await aresolve_credential(membership)
+    except CredentialResolutionError as e:
+        # Actionable credential failure (e.g. token scoped to a different team).
+        # Surface the distinct message + code so the user is told to re-connect
+        # rather than seeing the generic "No credential available"
+        # (arch #245 finding 07#3).
+        await _drop_schema_and_fail(new_schema)
+        return {"error": e.message, "error_code": e.code}
     if credential is None:
         await _drop_schema_and_fail(new_schema)
         return {"error": "No credential available"}
@@ -277,7 +288,22 @@ async def materialize_workspace_core(
             )
             continue
 
-        credential = await aresolve_credential(tm)
+        try:
+            credential = await aresolve_credential(tm)
+        except CredentialResolutionError as e:
+            # Actionable failure (e.g. token scoped to a different team) —
+            # surface a distinct message + code so the user knows to
+            # re-connect, not the generic "No credential configured"
+            # (arch #245 finding 07#3).
+            tenant_results.append(
+                {
+                    "tenant": tenant_id,
+                    "success": False,
+                    "error": e.message,
+                    "error_code": e.code,
+                }
+            )
+            continue
         if credential is None:
             tenant_results.append(
                 {

--- a/mcp_server/loaders/ocs_participants.py
+++ b/mcp_server/loaders/ocs_participants.py
@@ -23,8 +23,13 @@ The endpoint is cursor-paginated (``{"next": ..., "previous": ...,
         ],
     }
 
-We pass ``chatbot=<experiment_id>`` so the participant list (and each
-participant's ``data`` array) is scoped to this tenant's chatbot.
+We pass ``experiment=<experiment_id>`` so the participant list (and each
+participant's ``data`` array) is scoped to this tenant's chatbot. The OCS
+``ParticipantView`` reads only the ``experiment`` query param
+(``request.query_params.get("experiment")``); an earlier ``chatbot`` param was
+silently ignored, returning the WHOLE team roster plus every chatbot's
+per-participant ``data`` into a single-chatbot tenant schema (cross-chatbot
+PII disclosure — arch #245 finding 12#3).
 """
 
 from __future__ import annotations
@@ -43,8 +48,10 @@ class OCSParticipantLoader(OCSBaseLoader):
     def load_pages(self) -> Iterator[tuple[list[dict], int | None]]:
         url = f"{self.base_url}/api/participants"
         # Scope to this tenant's chatbot so the participant list and each
-        # participant's per-chatbot ``data`` array are limited to it.
-        params = {"chatbot": self.experiment_id}
+        # participant's per-chatbot ``data`` array are limited to it. The OCS
+        # ParticipantView filters on the ``experiment`` query param; ``chatbot``
+        # is silently ignored and leaks the whole team roster (arch #245).
+        params = {"experiment": self.experiment_id}
         total = 0
         # Cursor pagination — no ``count`` field, so totals are always None.
         for raw_page, _page_total in self._paginate(url, params=params):

--- a/pipelines/ocs_sync.yml
+++ b/pipelines/ocs_sync.yml
@@ -14,7 +14,10 @@ sources:
     # counted in sessions because OCS exposes no message total (issue #221).
     progress_unit: sessions
   - name: participants
-    description: "Participants with name, platform, and per-chatbot custom data (from the dedicated participant API)"
+    # Scoped to this tenant's chatbot via the ``experiment`` query param on
+    # /api/participants — NOT ``chatbot`` (which OCS ignores, leaking the whole
+    # team roster + every chatbot's per-participant data; arch #245).
+    description: "Participants with name, platform, and per-chatbot custom data (from the dedicated participant API, scoped to this experiment)"
 
 metadata_discovery:
   description: "Fetch experiment detail from OCS API"

--- a/tests/test_materialize_workspace_task.py
+++ b/tests/test_materialize_workspace_task.py
@@ -9,6 +9,7 @@ from django.utils import timezone
 
 from apps.chat.models import Thread, ThreadJob
 from apps.users.models import Tenant, TenantMembership
+from apps.users.services.credential_resolver import CredentialResolutionError
 from apps.workspaces import tasks as workspaces_tasks
 from apps.workspaces.models import (
     MaterializationRun,
@@ -21,6 +22,7 @@ from apps.workspaces.models import (
     WorkspaceViewSchema,
 )
 from apps.workspaces.tasks import _run_pipeline_with_progress, materialize_workspace
+from mcp_server.envelope import AUTH_TOKEN_EXPIRED
 from mcp_server.services.materializer import MaterializationCancelled
 
 
@@ -110,6 +112,37 @@ async def test_materialize_workspace_records_failure(
     assert result["all_succeeded"] is False
     assert result["tenants"][0]["success"] is False
     assert "upstream API down" in result["tenants"][0]["error"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_materialize_workspace_surfaces_team_mismatch_distinctly(
+    workspace, tenant_membership_obj, context_with_job_id
+):
+    """A team-mismatch credential failure must surface a distinct, actionable
+    re-authorize message — NOT the generic "No credential configured" — so a
+    user logged into the wrong OCS team is told to re-connect (finding 07#3)."""
+    with (
+        patch("apps.workspaces.tasks.aresolve_credential", new_callable=AsyncMock) as mock_cred,
+        patch("apps.workspaces.tasks.get_registry", return_value=_mock_registry("commcare")),
+    ):
+        mock_cred.side_effect = CredentialResolutionError(
+            AUTH_TOKEN_EXPIRED,
+            "Your sign-in is scoped to a different OCS team than this chatbot "
+            "(team-a). Please re-connect to team team-a.",
+        )
+        result = await materialize_workspace(
+            context_with_job_id,
+            workspace_id=str(workspace.id),
+            user_id="",
+        )
+
+    assert result["all_succeeded"] is False
+    tenant_result = result["tenants"][0]
+    assert tenant_result["success"] is False
+    assert "No credential configured" not in tenant_result["error"]
+    assert "re-connect" in tenant_result["error"]
+    assert tenant_result["error_code"] == AUTH_TOKEN_EXPIRED
 
 
 @pytest.fixture

--- a/tests/test_ocs_connections.py
+++ b/tests/test_ocs_connections.py
@@ -18,9 +18,13 @@ from django.utils import timezone
 from apps.users.adapters import encrypt_credential
 from apps.users.models import Tenant, TenantConnection, TenantMembership
 from apps.users.services.api_key_providers.base import TenantDescriptor
-from apps.users.services.credential_resolver import aresolve_credential
+from apps.users.services.credential_resolver import (
+    CredentialResolutionError,
+    aresolve_credential,
+)
 from apps.users.services.ocs_team import adetect_team_from_api_key
 from apps.users.services.tenant_resolution import resolve_ocs_chatbots
+from mcp_server.envelope import AUTH_TOKEN_EXPIRED
 
 
 def _mock_async_client(mocker, fake_get):
@@ -182,6 +186,11 @@ def _mock_token_qs(mocker, *, team, token="tok"):
 @pytest.mark.asyncio
 @pytest.mark.django_db(transaction=True)
 async def test_resolve_oauth_fails_closed_on_team_mismatch(user, mocker):
+    """A team-mismatch must fail closed AND be distinguishable from the
+    generic "no credential" case: it raises CredentialResolutionError with the
+    AUTH_TOKEN_EXPIRED code and an actionable, re-authorize-oriented message so
+    the user is told to re-connect, not just that "no credential is configured"
+    (finding 07#3)."""
     conn = await TenantConnection.objects.acreate(
         user=user, provider="ocs", credential_type=TenantConnection.OAUTH
     )
@@ -190,7 +199,12 @@ async def test_resolve_oauth_fails_closed_on_team_mismatch(user, mocker):
         user=user, tenant=tenant, connection=conn, team_slug="team-a"
     )
     _mock_token_qs(mocker, team="team-b")
-    assert await aresolve_credential(tm) is None
+    with pytest.raises(CredentialResolutionError) as exc_info:
+        await aresolve_credential(tm)
+    assert exc_info.value.code == AUTH_TOKEN_EXPIRED
+    # Distinct, actionable message — not the generic "No credential configured".
+    assert "No credential configured" not in str(exc_info.value)
+    assert "team-a" in str(exc_info.value)
 
 
 @pytest.mark.asyncio
@@ -366,9 +380,10 @@ async def test_remove_connection_archives_memberships(user):
 @pytest.mark.django_db(transaction=True)
 async def test_reported_bug_oauth_team_switch_fails_closed(user, mocker):
     """OAuth team A imports chatbots → add API key for team B → re-login OAuth as
-    team B. The team-A chatbot must resolve to None (NOT the team-B token), while
-    the team-B chatbot resolves via its API key. This is the regression that
-    motivated the feature."""
+    team B. The team-A chatbot must fail closed (NOT serve the team-B token),
+    while the team-B chatbot resolves via its API key. This is the regression
+    that motivated the feature. Fail-closed now surfaces a distinct, actionable
+    re-authorize error rather than a silent None (arch #245 finding 07#3)."""
 
     acct = await SocialAccount.objects.acreate(
         user=user, provider="ocs", uid="u1", extra_data={"team": "team-a"}
@@ -408,7 +423,11 @@ async def test_reported_bug_oauth_team_switch_fails_closed(user, mocker):
     # team-A chatbot fails closed (must NOT fetch with the team-b token → no 404 bug).
     # Mirror the production call sites, which select_related("connection", "user").
     tm_a = await TenantMembership.objects.select_related("connection", "user").aget(id=tm_a.id)
-    assert await aresolve_credential(tm_a) is None
+    with pytest.raises(CredentialResolutionError) as exc_info:
+        await aresolve_credential(tm_a)
+    # Fail closed: the team-b token is never returned; the error is actionable.
+    assert exc_info.value.code == AUTH_TOKEN_EXPIRED
+    assert "team-a" in str(exc_info.value)
     # team-B chatbot still resolves via its own API key
     tm_b = await TenantMembership.objects.select_related("connection", "user").aget(id=tm_b.id)
     assert await aresolve_credential(tm_b) == {"type": "api_key", "value": "kb"}

--- a/tests/test_ocs_data_loaders.py
+++ b/tests/test_ocs_data_loaders.py
@@ -262,7 +262,14 @@ def test_participant_loader_maps_dedicated_endpoint_fields():
 
 
 def test_participant_loader_queries_chatbot_scoped_endpoint():
-    """The loader hits /api/participants filtered by the tenant's chatbot."""
+    """The loader hits /api/participants filtered by the tenant's chatbot.
+
+    The OCS ParticipantView reads ``request.query_params.get("experiment")``
+    (apps/api/views/participants.py), NOT ``chatbot`` — sending ``chatbot``
+    is silently ignored and returns the WHOLE team's participant roster plus
+    every chatbot's per-participant ``data``, a cross-chatbot PII leak. The
+    correct filter param is ``experiment`` keyed to the experiment public id.
+    """
     loader = OCSParticipantLoader(experiment_id="exp-1", credential=CREDENTIAL, base_url=BASE_URL)
     page = MagicMock(status_code=200)
     page.json.return_value = {"results": [], "next": None}
@@ -270,7 +277,9 @@ def test_participant_loader_queries_chatbot_scoped_endpoint():
         list(loader.load_pages())
     args, kwargs = mock_get.call_args
     assert args[0] == f"{BASE_URL}/api/participants"
-    assert kwargs["params"] == {"chatbot": "exp-1"}
+    assert kwargs["params"] == {"experiment": "exp-1"}
+    # Guard against a regression to the ignored param name.
+    assert "chatbot" not in kwargs["params"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #245

Fixes two OCS-scope findings from the architecture review. No redesign (OCS connections redesign was #220; content redesign is #267).

## Finding 12#3 (broken-now, SECURITY) — participant sync loaded the whole team

`OCSParticipantLoader` sent `params={'chatbot': experiment_id}`, but the upstream OCS `ParticipantView` reads only `request.query_params.get("experiment")` — the `chatbot` param was **silently ignored**. Result: every participants materialization loaded the WHOLE OCS team's participant roster **plus every chatbot's per-participant custom `data`** into a single-chatbot tenant schema — cross-chatbot PII disclosure to the agent and workspace members.

**Verified the param name against the OCS source** (`dimagi/open-chat-studio`, checked out locally):
- `apps/api/views/participants.py:103` → `if experiment_uuid := _parse_experiment_uuid(request.query_params.get("experiment")):` — it reads `experiment`, never `chatbot`.
- `apps/api/tests/test_participant_api.py` `test_list_participants_filter_by_experiment` / `..._unknown_returns_empty` / `..._invalid_uuid` all use `?experiment=<public_id>`.
- The `chatbot` name only ever appeared in OCS's `@extend_schema` OpenApi docstring (a doc/code mismatch upstream) — the actual filter is `experiment`.

**Fix:** send `params={"experiment": self.experiment_id}` (`mcp_server/loaders/ocs_participants.py`); updated the loader docstring + `pipelines/ocs_sync.yml` comment to record why.

## Finding 07#3 (debt, correctness) — credential error disambiguation

Team-mismatch, Fernet-decrypt failure, refresh failure, and no-connection all collapsed into the generic `"No credential configured"`, so a user logged into team B materializing a team-A chatbot was never told to re-authorize.

**Fix (minimal):**
- New `CredentialResolutionError(code, message)` in `apps/users/services/credential_resolver.py`. On **team-mismatch only**, `aresolve_credential` raises it with code `AUTH_TOKEN_EXPIRED` (the previously-unused `mcp_server/envelope.py:32` constant) and an actionable, re-connect message naming the team slug. Still fail-closed — the other team's token is never returned. Opaque None-causes (no connection / decrypt fail / refresh fail / no token) keep returning `None`.
- Both call sites in `apps/workspaces/tasks.py` (`materialize_workspace` per-tenant loop and `refresh_tenant_schema`) catch it and surface the distinct `error` message + `error_code` instead of the generic string.

## Tests (TDD — failing first, then fix)

| Test | Asserts |
|------|---------|
| `tests/test_ocs_data_loaders.py::test_participant_loader_queries_chatbot_scoped_endpoint` | loader sends `params == {"experiment": "exp-1"}` and `"chatbot" not in params` |
| `tests/test_ocs_connections.py::test_resolve_oauth_fails_closed_on_team_mismatch` | raises `CredentialResolutionError`, `code == AUTH_TOKEN_EXPIRED`, message names the team, NOT "No credential configured" |
| `tests/test_ocs_connections.py::test_reported_bug_oauth_team_switch_fails_closed` | end-to-end fail-closed now via the distinct error (still never serves the team-B token) |
| `tests/test_materialize_workspace_task.py::test_materialize_workspace_surfaces_team_mismatch_distinctly` | per-tenant result carries the actionable message + `error_code`, not the generic string |

```
$ TEST_DATABASE_NAME=scout_test_245 DJANGO_SETTINGS_MODULE=config.settings.test \
    uv run pytest tests/test_ocs_data_loaders.py tests/test_ocs_connections.py \
    tests/test_materialize_workspace_task.py tests/test_refresh_task.py \
    tests/test_mcp_server.py tests/test_async_conventions.py -p no:randomly
====================== 101 passed, 11 warnings in 26.32s =======================
```
(`tests/test_async_conventions.py` — the async-ORM CI guard — passes; no `sync_to_async`/`async_to_sync` around ORM calls were introduced.)

## Sibling sweep (arch #268 policy)

```bash
# 1. Other request-param senders of "chatbot" (the leak vector):
grep -rn "params=.*chatbot|\"chatbot\":\s*self\.|'chatbot':\s*self\." mcp_server/ pipelines/ apps/
grep -rn "chatbot=" mcp_server/ apps/ pipelines/ frontend/src | grep -iv "test|\.md"
#   → no matches. ocs_participants.py was the only request-param sender. (The
#     'chatbot' tokens in the loader docstring + pipeline yml are response-shape
#     examples / prose, not request params; both updated for accuracy anyway.)

# 2. Other producers of the generic credential strings:
grep -rn "No credential configured|No credential available" apps/ mcp_server/
#   → only the two intended sites in apps/workspaces/tasks.py (kept as the
#     fallback for opaque None-causes); both now sit behind the new
#     CredentialResolutionError catch.

# 3. All aresolve_credential consumers:
grep -rn "aresolve_credential|resolve_credential" apps/ mcp_server/ | grep -v "def |import"
#   → exactly two call sites: apps/workspaces/tasks.py:165 (refresh_tenant_schema)
#     and :293 (materialize_workspace). Both updated.
```

No un-fixed siblings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)