### PR TITLE
fix: respect BASE_PATH on labs /scout deploy + harden deploy-env (arch #248)

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -14,6 +14,33 @@ Pushes to `main` trigger an automated deployment via GitHub Actions.
 All infrastructure is defined in `infra/scout-stack.yml` (CloudFormation) and deployed
 as the `scout-production` stack in `us-east-1`.
 
+> **This describes the Scout *production* environment only.** The CloudFormation
+> template above is **not** a source of truth for the connect-labs deployment —
+> see [Connect-labs (ECS Fargate)](#connect-labs-ecs-fargate) below.
+
+### Connect-labs (ECS Fargate)
+
+Scout also runs on the **connect-labs** environment, which is a separate deploy
+target with **no in-repo IaC** (issue #248, finding 11#1):
+
+- **Compute:** ECS Fargate (cluster `labs-jj-cluster`; services
+  `labs-jj-scout-web`, `labs-jj-scout-mcp`, `labs-jj-scout-worker`) — **not**
+  EC2/Kamal like production.
+- **AWS account:** `858923557655` (ECR registry
+  `858923557655.dkr.ecr.us-east-1.amazonaws.com`) — distinct from the
+  Scout-production account.
+- **Path prefix:** served under `/scout` via `FORCE_SCRIPT_NAME`
+  (`config/settings/connectlabs.py`) and the nginx `/scout/...` locations
+  (`frontend/nginx.prod.conf`). Frontend builds set `VITE_BASE_PATH=/scout`.
+- **Deploy workflow:** `.github/workflows/deploy-labs.yml` only **builds and
+  pushes images and updates the ECS services**. The Fargate task definitions,
+  ALB, VPC/networking, and IAM roles for that account are managed **outside this
+  repository** and are not represented in `infra/scout-stack.yml`.
+
+Because of this drift, changes to the labs runtime topology (task definitions,
+ALB routing, scaling) must be made in that external infrastructure, not in this
+repo's CloudFormation template.
+
 ### Services (Kamal configs in `config/`)
 
 | Service | Config | Port | Public? |

--- a/apps/artifacts/views.py
+++ b/apps/artifacts/views.py
@@ -225,6 +225,14 @@ SANDBOX_HTML_TEMPLATE = """<!DOCTYPE html>
     <script id="artifact-data" type="application/json" nonce="{{CSP_NONCE}}">{{ARTIFACT_DATA}}</script>
 
     <script nonce="{{CSP_NONCE}}">
+        // Base path Scout is mounted under (e.g. "/scout" on the labs deploy via
+        // FORCE_SCRIPT_NAME, "" at the root). Injected server-side so the
+        // in-iframe live-query fetch resolves under the deploy prefix instead of
+        // the host root (issue #248, 04#8b).
+        const API_BASE = "{{API_BASE}}";
+    </script>
+
+    <script nonce="{{CSP_NONCE}}">
         // Artifact rendering system
         const ArtifactRenderer = {
             container: null,
@@ -265,7 +273,7 @@ SANDBOX_HTML_TEMPLATE = """<!DOCTYPE html>
                 if (artifact.has_live_queries) {
                     this.showLoading('Querying database...');
                     try {
-                        const resp = await fetch('/api/workspaces/' + artifact.workspace_id + '/artifacts/' + artifact.id + '/query-data/', {
+                        const resp = await fetch(API_BASE + '/api/workspaces/' + artifact.workspace_id + '/artifacts/' + artifact.id + '/query-data/', {
                             credentials: 'include',
                         });
                         if (!resp.ok) {
@@ -748,8 +756,14 @@ class ArtifactSandboxView(LoginRequiredJsonMixin, View):
         # Escape </script> in JSON to prevent breaking out of the script tag
         artifact_json = artifact_json.replace("</", "<\\/")
 
-        # Inject the nonce and artifact data into the template
+        # Base prefix Scout is mounted under (FORCE_SCRIPT_NAME on the labs
+        # deploy → SCRIPT_NAME in the request meta). Trailing slash trimmed so
+        # the in-iframe fetch builds "<prefix>/api/..." without a double slash.
+        api_base = request.META.get("SCRIPT_NAME", "").rstrip("/")
+
+        # Inject the nonce, base prefix, and artifact data into the template.
         html_content = SANDBOX_HTML_TEMPLATE.replace("{{CSP_NONCE}}", csp_nonce)
+        html_content = html_content.replace("{{API_BASE}}", api_base)
         html_content = html_content.replace("{{ARTIFACT_DATA}}", artifact_json)
 
         response = HttpResponse(html_content, content_type="text/html")

--- a/config/asgi.py
+++ b/config/asgi.py
@@ -11,6 +11,9 @@ import os
 
 from django.core.asgi import get_asgi_application
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings.development")
+from config.settings_guard import require_settings_module
+
+# Fail fast rather than defaulting to development settings (issue #248, 08#5).
+require_settings_module(os.environ)
 
 application = get_asgi_application()

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -33,16 +33,34 @@ SECRET_KEY = env("DJANGO_SECRET_KEY")
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = env("DJANGO_DEBUG", default=True)
 
+# Settings modules that carry the production security posture. connectlabs
+# inherits from production.py (see config/settings/connectlabs.py) so it must be
+# labeled "production" for telemetry even though its module name is not
+# ".production". Keep this list in sync with any new prod-posture module.
+PRODUCTION_SETTINGS_MODULES = (
+    "config.settings.production",
+    "config.settings.connectlabs",
+)
+
+
+def resolve_deploy_environment(settings_module: str) -> str:
+    """Map a DJANGO_SETTINGS_MODULE name to a deploy-environment label.
+
+    Any module that *is* or *inherits from* production (see
+    PRODUCTION_SETTINGS_MODULES) resolves to "production"; everything else is
+    "development". Matching the full module name — not just an ".production"
+    suffix — is what lets connectlabs (prod posture, non-".production" name) be
+    correctly tagged as production for Sentry / Task Badger (issue #248, 08#5).
+    """
+    return "production" if settings_module in PRODUCTION_SETTINGS_MODULES else "development"
+
+
 # Default deployment environment label for Sentry / Task Badger. Derived from the
 # settings module (set before settings load) rather than DEBUG: base.py defaults
 # DEBUG to True and production.py only flips it after this file is imported, so a
 # DEBUG-based default would freeze to "development" even under production settings.
 # An explicit SENTRY_ENVIRONMENT / TASKBADGER_ENVIRONMENT env var still wins.
-DEPLOY_ENVIRONMENT = (
-    "production"
-    if os.environ.get("DJANGO_SETTINGS_MODULE", "").endswith(".production")
-    else "development"
-)
+DEPLOY_ENVIRONMENT = resolve_deploy_environment(os.environ.get("DJANGO_SETTINGS_MODULE", ""))
 
 ALLOWED_HOSTS = env("DJANGO_ALLOWED_HOSTS")
 

--- a/config/settings_guard.py
+++ b/config/settings_guard.py
@@ -1,0 +1,36 @@
+"""Fail-fast guard for the DJANGO_SETTINGS_MODULE environment variable.
+
+The asgi / wsgi / manage entrypoints previously fell back to
+``config.settings.development`` via ``os.environ.setdefault`` when
+DJANGO_SETTINGS_MODULE was unset. In a production/labs deployment a dropped env
+var would then silently boot the process with the permissive *development*
+settings (DEBUG=True, insecure cookies). The MCP entrypoint already refuses to
+start in that case; this helper gives the Django entrypoints the same posture.
+
+Kept dependency-free (no Django imports) so it can run before ``django.setup()``
+and be unit-tested without a settings load.
+"""
+
+
+def require_settings_module(environ) -> str:
+    """Return DJANGO_SETTINGS_MODULE or raise if it is unset/empty.
+
+    Args:
+        environ: a mapping (e.g. ``os.environ``).
+
+    Returns:
+        The configured settings module name.
+
+    Raises:
+        RuntimeError: if DJANGO_SETTINGS_MODULE is missing or empty.
+    """
+    module = environ.get("DJANGO_SETTINGS_MODULE")
+    if not module:
+        raise RuntimeError(
+            "DJANGO_SETTINGS_MODULE environment variable is required. "
+            "Set it explicitly (e.g. 'config.settings.production', "
+            "'config.settings.connectlabs', or 'config.settings.development'). "
+            "Refusing to default to development settings to avoid accidentally "
+            "running with DEBUG=True / insecure cookies in production."
+        )
+    return module

--- a/config/wsgi.py
+++ b/config/wsgi.py
@@ -11,6 +11,9 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings.development")
+from config.settings_guard import require_settings_module
+
+# Fail fast rather than defaulting to development settings (issue #248, 08#5).
+require_settings_module(os.environ)
 
 application = get_wsgi_application()

--- a/frontend/nginx.prod-kamal.conf
+++ b/frontend/nginx.prod-kamal.conf
@@ -73,6 +73,22 @@ server {
         proxy_send_timeout 120s;
     }
 
+    # Serve the embed widget SDK with CORS so cross-origin host pages can load
+    # it (issue #248, 04#8d). Without an explicit location it falls through to
+    # `location /` and is served without Access-Control-Allow-Origin, so a
+    # cross-origin <script src> embed is blocked.
+    location = /widget.js {
+        alias /usr/share/nginx/html/widget.js;
+        add_header Access-Control-Allow-Origin *;
+        add_header Cache-Control "public, max-age=300";
+        # Re-declare inherited security headers (nginx drops them when a
+        # location defines its own add_header). X-Frame-Options omitted so the
+        # script can be embedded cross-origin.
+        add_header X-Content-Type-Options nosniff always;
+        add_header Referrer-Policy strict-origin-when-cross-origin always;
+        add_header Permissions-Policy "camera=(), microphone=()" always;
+    }
+
     location /static/ {
         proxy_pass http://$api_upstream:8000;
         proxy_set_header Host $host;

--- a/frontend/public/widget.js
+++ b/frontend/public/widget.js
@@ -1,7 +1,7 @@
 (function () {
   "use strict";
 
-  var SCOUT_WIDGET_VERSION = "0.3.0-popup-fix";
+  var SCOUT_WIDGET_VERSION = "0.4.0-live-mode-theme";
 
   // Detect base URL from the script src, including any path prefix (e.g. /scout)
   var SCOUT_BASE = (function () {
@@ -144,6 +144,10 @@
 
   ScoutWidgetInstance.prototype.setMode = function (mode) {
     this._postMessage("scout:set-mode", { mode: mode });
+  };
+
+  ScoutWidgetInstance.prototype.setTheme = function (theme) {
+    this._postMessage("scout:set-theme", { theme: theme });
   };
 
   ScoutWidgetInstance.prototype.destroy = function () {

--- a/frontend/src/components/ArtifactPanel/ArtifactPanel.tsx
+++ b/frontend/src/components/ArtifactPanel/ArtifactPanel.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useRef } from "react"
 import { useAppStore } from "@/store/store"
 import { X, Eye, Database, RefreshCw, Loader2, FileDown } from "lucide-react"
 import { api } from "@/api/client"
+import { withBasePath } from "@/config"
 
 interface QueryResult {
   name: string
@@ -204,7 +205,7 @@ export function ArtifactPanel() {
             <iframe
               ref={iframeRef}
               key={artifactId}
-              src={activeDomainId ? `/api/workspaces/${activeDomainId}/artifacts/${artifactId}/sandbox/` : ""}
+              src={activeDomainId ? withBasePath(`/api/workspaces/${activeDomainId}/artifacts/${artifactId}/sandbox/`) : ""}
               className="flex-1 w-full"
               // SECURITY: deliberately NO allow-same-origin. The sandbox doc is
               // served same-origin and session-authenticated, and it executes

--- a/frontend/src/components/EmbedLayout/EmbedLayout.tsx
+++ b/frontend/src/components/EmbedLayout/EmbedLayout.tsx
@@ -2,13 +2,16 @@ import { Outlet } from "react-router-dom"
 import { Sidebar } from "@/components/Sidebar"
 import { ErrorBoundary } from "@/components/ErrorBoundary"
 import { ArtifactPanel } from "@/components/ArtifactPanel/ArtifactPanel"
-import { useEmbedParams } from "@/hooks/useEmbedParams"
 import { useAutoResize } from "@/hooks/useAutoResize"
 import { useAppStore } from "@/store/store"
 import { WorkspaceJobsProvider } from "@/contexts/WorkspaceJobsContext"
+import { useEmbedSettings } from "@/contexts/EmbedSettingsContext"
 
 export function EmbedLayout() {
-  const { mode } = useEmbedParams()
+  // Live mode from the embed settings context so the widget's runtime
+  // scout:set-mode command takes effect (issue #248, 06#6), rather than the
+  // value frozen at first URL read.
+  const { mode } = useEmbedSettings()
   const showSidebar = mode === "full"
   const showArtifacts = mode === "full" || mode === "chat+artifacts"
   const activeDomainId = useAppStore((s) => s.activeDomainId)

--- a/frontend/src/components/LoginForm/LoginForm.tsx
+++ b/frontend/src/components/LoginForm/LoginForm.tsx
@@ -45,8 +45,15 @@ export function LoginForm() {
   // the OAuth provider's consent page isn't constrained to the iframe.
   // After login, LOGIN_REDIRECT_URL sends the user back to the embed page
   // and the iframe picks up the session cookie (same-origin, no popup needed).
+  //
+  // Prefer the embedding host page (document.referrer) so OAuth returns to
+  // wherever Scout is actually embedded. When the referrer is unavailable
+  // (e.g. a strict referrer policy), fall back to the app's own base path
+  // rather than a hardcoded "/labs/scout/" — that hardcode only existed for
+  // the connect-labs host and 404s on any other embedding site (issue #248,
+  // 06#6).
   const oauthReturnUrl = isEmbed
-    ? (document.referrer ? new URL(document.referrer).pathname : "/labs/scout/")
+    ? (document.referrer ? new URL(document.referrer).pathname : `${BASE_PATH}/embed/`)
     : `${BASE_PATH}/`
 
   return (

--- a/frontend/src/config.test.ts
+++ b/frontend/src/config.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest"
+import { joinBase, stripBase, stripBasePath, withBasePath } from "@/config"
+
+// Issue #248, finding 04#8: a number of URLs were built root-relative
+// (e.g. fetch("/health/")) which bypasses VITE_BASE_PATH=/scout on the labs
+// deployment (nginx only proxies /scout/...). These helpers centralize
+// base-path joining/stripping so URLs respect the configured mount point.
+
+describe("joinBase (pure)", () => {
+  it("prefixes a leading-slash path with a non-empty base", () => {
+    expect(joinBase("/scout", "/health/")).toBe("/scout/health/")
+    expect(joinBase("/scout", "/api/chat/threads/shared/tok/")).toBe(
+      "/scout/api/chat/threads/shared/tok/",
+    )
+  })
+
+  it("normalizes a path missing its leading slash", () => {
+    expect(joinBase("/scout", "health/")).toBe("/scout/health/")
+    expect(joinBase("", "health/")).toBe("/health/")
+  })
+
+  it("returns the path unchanged when base is empty", () => {
+    expect(joinBase("", "/health/")).toBe("/health/")
+  })
+})
+
+describe("stripBase (pure)", () => {
+  it("removes a non-empty base prefix", () => {
+    expect(stripBase("/scout", "/scout/shared/threads/tok-123")).toBe(
+      "/shared/threads/tok-123",
+    )
+  })
+
+  it("maps the bare base to root", () => {
+    expect(stripBase("/scout", "/scout")).toBe("/")
+  })
+
+  it("does not strip a base that is only a substring prefix", () => {
+    // "/scoutland" must NOT be treated as base "/scout" + "/land"
+    expect(stripBase("/scout", "/scoutland/x")).toBe("/scoutland/x")
+  })
+
+  it("returns the pathname unchanged when base is empty", () => {
+    expect(stripBase("", "/shared/threads/tok-123")).toBe("/shared/threads/tok-123")
+  })
+})
+
+// The exported helpers close over BASE_PATH, which is "" in the test env
+// (VITE_BASE_PATH unset), so they behave as identity-ish here.
+describe("withBasePath / stripBasePath (env-bound, BASE_PATH === '')", () => {
+  it("withBasePath normalizes but does not prefix", () => {
+    expect(withBasePath("/health/")).toBe("/health/")
+    expect(withBasePath("health/")).toBe("/health/")
+  })
+
+  it("stripBasePath returns the pathname unchanged", () => {
+    expect(stripBasePath("/shared/threads/tok-123")).toBe("/shared/threads/tok-123")
+  })
+})

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -7,3 +7,46 @@
  *   connect-labs: "/scout"
  */
 export const BASE_PATH = (import.meta.env.VITE_BASE_PATH || "").replace(/\/$/, "")
+
+/**
+ * Join an app-absolute path (e.g. "/health/", "/api/...") onto a base prefix.
+ *
+ * Pure helper so it can be unit-tested with an explicit base. Prefer
+ * {@link withBasePath} in app code, which closes over the configured
+ * {@link BASE_PATH}.
+ */
+export function joinBase(base: string, path: string): string {
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`
+  if (!base) return normalizedPath
+  return `${base}${normalizedPath}`
+}
+
+/**
+ * Strip a base prefix from a pathname (e.g. "/scout/shared/x" → "/shared/x").
+ *
+ * Pure helper so it can be unit-tested with an explicit base. Prefer
+ * {@link stripBasePath} in app code.
+ */
+export function stripBase(base: string, pathname: string): string {
+  if (!base) return pathname
+  if (pathname === base) return "/"
+  return pathname.startsWith(`${base}/`) ? pathname.slice(base.length) : pathname
+}
+
+/**
+ * Prefix an app-absolute URL with the configured {@link BASE_PATH} so it
+ * resolves correctly under a deploy mount point (e.g. /scout) where the proxy
+ * only forwards requests under that prefix. Root-relative URLs that skip this
+ * hit the host root and 404 on the labs deployment (issue #248, 04#8).
+ */
+export function withBasePath(path: string): string {
+  return joinBase(BASE_PATH, path)
+}
+
+/**
+ * Remove the configured {@link BASE_PATH} from a pathname before matching it
+ * against app routes (e.g. share-token regexes anchored at ^/shared/).
+ */
+export function stripBasePath(pathname: string): string {
+  return stripBase(BASE_PATH, pathname)
+}

--- a/frontend/src/contexts/EmbedSettingsContext.test.tsx
+++ b/frontend/src/contexts/EmbedSettingsContext.test.tsx
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { act, render, renderHook, screen } from "@testing-library/react"
+import {
+  EmbedSettingsProvider,
+  applyTheme,
+  useEmbedSettings,
+} from "@/contexts/EmbedSettingsContext"
+
+// Issue #248, finding 06#6: the embed widget's setMode()/theme were no-ops —
+// mode was read once from a memoized hook and the set-mode handler only
+// console.logged; theme was parsed but never applied. These tests pin live,
+// settable mode + applied theme.
+
+describe("applyTheme", () => {
+  beforeEach(() => {
+    document.documentElement.classList.remove("dark")
+  })
+
+  it("adds the dark class for theme=dark", () => {
+    applyTheme("dark")
+    expect(document.documentElement.classList.contains("dark")).toBe(true)
+  })
+
+  it("removes the dark class for theme=light", () => {
+    document.documentElement.classList.add("dark")
+    applyTheme("light")
+    expect(document.documentElement.classList.contains("dark")).toBe(false)
+  })
+
+  it("follows the OS preference for theme=auto", () => {
+    // jsdom's matchMedia reports no match by default → light.
+    document.documentElement.classList.add("dark")
+    applyTheme("auto")
+    expect(document.documentElement.classList.contains("dark")).toBe(false)
+  })
+})
+
+describe("EmbedSettingsProvider", () => {
+  afterEach(() => {
+    document.documentElement.classList.remove("dark")
+  })
+
+  it("seeds mode and theme from the initial values and applies the theme", () => {
+    render(
+      <EmbedSettingsProvider initialMode="full" initialTheme="dark">
+        <Probe />
+      </EmbedSettingsProvider>,
+    )
+    expect(screen.getByTestId("mode").textContent).toBe("full")
+    expect(document.documentElement.classList.contains("dark")).toBe(true)
+  })
+
+  it("updates mode at runtime via setMode (no-op fix)", () => {
+    const { result } = renderHook(() => useEmbedSettings(), {
+      wrapper: ({ children }) => (
+        <EmbedSettingsProvider initialMode="chat" initialTheme="auto">
+          {children}
+        </EmbedSettingsProvider>
+      ),
+    })
+    expect(result.current.mode).toBe("chat")
+    act(() => result.current.setMode("chat+artifacts"))
+    expect(result.current.mode).toBe("chat+artifacts")
+  })
+
+  it("applies a theme change at runtime via setTheme", () => {
+    const { result } = renderHook(() => useEmbedSettings(), {
+      wrapper: ({ children }) => (
+        <EmbedSettingsProvider initialMode="chat" initialTheme="light">
+          {children}
+        </EmbedSettingsProvider>
+      ),
+    })
+    expect(document.documentElement.classList.contains("dark")).toBe(false)
+    act(() => result.current.setTheme("dark"))
+    expect(document.documentElement.classList.contains("dark")).toBe(true)
+  })
+})
+
+function Probe() {
+  const { mode } = useEmbedSettings()
+  return <span data-testid="mode">{mode}</span>
+}

--- a/frontend/src/contexts/EmbedSettingsContext.tsx
+++ b/frontend/src/contexts/EmbedSettingsContext.tsx
@@ -1,0 +1,90 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from "react"
+import type { EmbedMode, EmbedTheme } from "@/hooks/useEmbedParams"
+
+interface EmbedSettingsContextValue {
+  mode: EmbedMode
+  theme: EmbedTheme
+  setMode: (mode: EmbedMode) => void
+  setTheme: (theme: EmbedTheme) => void
+}
+
+const EmbedSettingsContext = createContext<EmbedSettingsContextValue | null>(null)
+
+/**
+ * Apply an embed theme to the document by toggling the Tailwind `.dark` class
+ * on <html>. "auto" follows the OS color-scheme preference. Exported so it can
+ * be unit-tested and reused (issue #248, 06#6: theme was parsed but never
+ * applied).
+ */
+// eslint-disable-next-line react-refresh/only-export-components
+export function applyTheme(theme: EmbedTheme): void {
+  const prefersDark =
+    theme === "dark" ||
+    (theme === "auto" &&
+      typeof window !== "undefined" &&
+      window.matchMedia?.("(prefers-color-scheme: dark)").matches)
+  document.documentElement.classList.toggle("dark", Boolean(prefersDark))
+}
+
+/**
+ * Holds the *live* embed mode and theme so the widget's runtime
+ * `scout:set-mode` command (and theme switches) take effect, instead of being
+ * frozen at the value first read from the URL by a memoized hook.
+ */
+export function EmbedSettingsProvider({
+  initialMode,
+  initialTheme,
+  children,
+}: {
+  initialMode: EmbedMode
+  initialTheme: EmbedTheme
+  children: ReactNode
+}) {
+  const [mode, setMode] = useState<EmbedMode>(initialMode)
+  const [theme, setThemeState] = useState<EmbedTheme>(initialTheme)
+
+  // Apply the current theme, and re-apply on OS preference changes while in
+  // "auto" mode.
+  useEffect(() => {
+    applyTheme(theme)
+    if (theme !== "auto" || typeof window === "undefined" || !window.matchMedia) {
+      return
+    }
+    const mql = window.matchMedia("(prefers-color-scheme: dark)")
+    const onChange = () => applyTheme("auto")
+    mql.addEventListener("change", onChange)
+    return () => mql.removeEventListener("change", onChange)
+  }, [theme])
+
+  const setTheme = useCallback((next: EmbedTheme) => setThemeState(next), [])
+
+  return (
+    <EmbedSettingsContext.Provider value={{ mode, theme, setMode, setTheme }}>
+      {children}
+    </EmbedSettingsContext.Provider>
+  )
+}
+
+/**
+ * Read the live embed settings. Falls back to sensible defaults when used
+ * outside an EmbedSettingsProvider (e.g. the standalone, non-embedded app) so
+ * shared components don't need to special-case the provider's presence.
+ */
+// eslint-disable-next-line react-refresh/only-export-components
+export function useEmbedSettings(): EmbedSettingsContextValue {
+  const ctx = useContext(EmbedSettingsContext)
+  if (ctx) return ctx
+  return {
+    mode: "chat",
+    theme: "auto",
+    setMode: () => {},
+    setTheme: () => {},
+  }
+}

--- a/frontend/src/contexts/NetworkStatusContext.tsx
+++ b/frontend/src/contexts/NetworkStatusContext.tsx
@@ -1,4 +1,5 @@
 import { createContext, useContext, useEffect, useRef, useState } from "react"
+import { withBasePath } from "@/config"
 
 export type NetworkStatus = "online" | "offline" | "reconnecting"
 
@@ -26,7 +27,7 @@ export function NetworkStatusProvider({ children }: { children: React.ReactNode 
     async function checkHealth() {
       if (!polling) return
       try {
-        const res = await fetch("/health/", { method: "GET", cache: "no-store" })
+        const res = await fetch(withBasePath("/health/"), { method: "GET", cache: "no-store" })
         if (res.ok) {
           if (wasOfflineRef.current) {
             wasOfflineRef.current = false

--- a/frontend/src/lib/shareToken.test.ts
+++ b/frontend/src/lib/shareToken.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest"
+import { parseShareToken, shareApiUrl } from "@/lib/shareToken"
+
+// Issue #248, finding 04#8(c): PublicThreadPage / PublicRecipeRunPage derived
+// the share token from the UNSTRIPPED pathname with a regex anchored at
+// ^/shared/. Under the labs base path the pathname is /scout/shared/<token>, so
+// the regex never matched, the token came back undefined, and the page hung on
+// an endless skeleton. The base must be stripped before matching.
+
+describe("parseShareToken", () => {
+  it("parses a thread token at the root mount", () => {
+    expect(parseShareToken("/shared/threads/abc-123", "threads", "")).toBe("abc-123")
+  })
+
+  it("parses a run token at the root mount", () => {
+    expect(parseShareToken("/shared/runs/run-tok", "runs", "")).toBe("run-tok")
+  })
+
+  it("parses a thread token under a /scout base path", () => {
+    expect(parseShareToken("/scout/shared/threads/abc-123", "threads", "/scout")).toBe(
+      "abc-123",
+    )
+  })
+
+  it("parses a run token under a /scout base path with a trailing slash", () => {
+    expect(parseShareToken("/scout/shared/runs/run-tok/", "runs", "/scout")).toBe(
+      "run-tok",
+    )
+  })
+
+  it("ignores trailing path segments", () => {
+    expect(parseShareToken("/shared/threads/tok/extra/stuff", "threads", "")).toBe("tok")
+  })
+
+  it("returns undefined for a non-matching path", () => {
+    expect(parseShareToken("/scout/dashboard", "threads", "/scout")).toBeUndefined()
+  })
+
+  it("does not treat the wrong share kind as a match", () => {
+    expect(parseShareToken("/shared/runs/tok", "threads", "")).toBeUndefined()
+  })
+
+  it("parses a recipe token under a /scout base path", () => {
+    expect(parseShareToken("/scout/shared/recipes/r-tok", "recipes", "/scout")).toBe(
+      "r-tok",
+    )
+  })
+})
+
+describe("shareApiUrl (BASE_PATH === '')", () => {
+  it("maps each share kind to its API path", () => {
+    expect(shareApiUrl("threads", "t")).toBe("/api/chat/threads/shared/t/")
+    expect(shareApiUrl("runs", "r")).toBe("/api/recipes/runs/shared/r/")
+    expect(shareApiUrl("recipes", "rec")).toBe("/api/recipes/shared/rec/")
+  })
+})

--- a/frontend/src/lib/shareToken.ts
+++ b/frontend/src/lib/shareToken.ts
@@ -1,0 +1,38 @@
+import { BASE_PATH, stripBase, withBasePath } from "@/config"
+
+export type ShareKind = "threads" | "runs" | "recipes"
+
+/**
+ * Extract a share token from a `/shared/{kind}/{token}` pathname.
+ *
+ * The base path (e.g. "/scout" on the labs deployment) is stripped first so the
+ * anchored regex matches regardless of the mount point. Returns undefined when
+ * the path is not a share URL of the given kind (issue #248, 04#8c).
+ *
+ * @param pathname  Raw, unstripped pathname (e.g. window.location.pathname).
+ * @param kind      "threads" or "runs".
+ * @param base      Base prefix to strip; defaults to the configured BASE_PATH.
+ */
+export function parseShareToken(
+  pathname: string,
+  kind: ShareKind,
+  base: string = BASE_PATH,
+): string | undefined {
+  const stripped = stripBase(base, pathname)
+  const match = stripped.match(new RegExp(`^/shared/${kind}/([^/]+)`))
+  return match?.[1]
+}
+
+const SHARE_API_PATHS: Record<ShareKind, (token: string) => string> = {
+  threads: (token) => `/api/chat/threads/shared/${token}/`,
+  runs: (token) => `/api/recipes/runs/shared/${token}/`,
+  recipes: (token) => `/api/recipes/shared/${token}/`,
+}
+
+/**
+ * Build the API URL for a shared thread/run/recipe, prefixed with the
+ * configured base path so it resolves under the deploy mount point.
+ */
+export function shareApiUrl(kind: ShareKind, token: string): string {
+  return withBasePath(SHARE_API_PATHS[kind](token))
+}

--- a/frontend/src/pages/EmbedPage.tsx
+++ b/frontend/src/pages/EmbedPage.tsx
@@ -15,7 +15,8 @@ import { ConnectionsPage } from "@/pages/ConnectionsPage"
 import { WorkspacesPage } from "@/pages/WorkspacesPage"
 import { WorkspaceDetailPage } from "@/pages/WorkspaceDetailPage"
 import { useEmbedMessaging } from "@/hooks/useEmbedMessaging"
-import { useEmbedParams } from "@/hooks/useEmbedParams"
+import { useEmbedParams, type EmbedMode, type EmbedTheme } from "@/hooks/useEmbedParams"
+import { EmbedSettingsProvider, useEmbedSettings } from "@/contexts/EmbedSettingsContext"
 
 const embedRouter = createBrowserRouter([
   {
@@ -50,10 +51,20 @@ const embedRouter = createBrowserRouter([
 ], { basename: BASE_PATH || undefined })
 
 export function EmbedPage() {
+  const { mode, theme } = useEmbedParams()
+  return (
+    <EmbedSettingsProvider initialMode={mode} initialTheme={theme}>
+      <EmbedApp />
+    </EmbedSettingsProvider>
+  )
+}
+
+function EmbedApp() {
   const authStatus = useAppStore((s) => s.authStatus)
   const fetchMe = useAppStore((s) => s.authActions.fetchMe)
   const ensureTenant = useAppStore((s) => s.domainActions.ensureTenant)
   const { tenant, provider } = useEmbedParams()
+  const { setMode, setTheme } = useEmbedSettings()
 
   const handleCommand = useCallback((type: string, payload: Record<string, unknown>) => {
     if (type === "scout:set-tenant") {
@@ -64,9 +75,19 @@ export function EmbedPage() {
       }
     }
     if (type === "scout:set-mode") {
-      console.log("[Scout Embed] set-mode:", payload.mode)
+      // Apply the requested mode (and optional theme) live, instead of merely
+      // logging it (issue #248, 06#6).
+      if (typeof payload.mode === "string") {
+        setMode(payload.mode as EmbedMode)
+      }
+      if (typeof payload.theme === "string") {
+        setTheme(payload.theme as EmbedTheme)
+      }
     }
-  }, [ensureTenant])
+    if (type === "scout:set-theme" && typeof payload.theme === "string") {
+      setTheme(payload.theme as EmbedTheme)
+    }
+  }, [ensureTenant, setMode, setTheme])
 
   const { sendEvent } = useEmbedMessaging(handleCommand)
 

--- a/frontend/src/pages/PublicRecipePage.tsx
+++ b/frontend/src/pages/PublicRecipePage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react"
-import { BASE_PATH } from "@/config"
+import { parseShareToken, shareApiUrl } from "@/lib/shareToken"
 import Markdown from "react-markdown"
 import remarkGfm from "remark-gfm"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
@@ -39,9 +39,8 @@ function formatDate(dateString: string): string {
 }
 
 function getTokenFromPath(): string | undefined {
-  // /shared/recipes/{token}/ or /shared/recipes/{token}
-  const match = window.location.pathname.match(/^\/shared\/recipes\/([^/]+)/)
-  return match?.[1]
+  // /shared/recipes/{token}/ or /shared/recipes/{token}, optionally under a base path.
+  return parseShareToken(window.location.pathname, "recipes")
 }
 
 export function PublicRecipePage() {
@@ -52,7 +51,7 @@ export function PublicRecipePage() {
 
   useEffect(() => {
     if (!token) return
-    fetch(`${BASE_PATH}/api/recipes/shared/${token}/`)
+    fetch(shareApiUrl("recipes", token))
       .then((res) => {
         if (!res.ok) throw new Error(res.status === 404 ? "Recipe not found" : "Failed to load recipe")
         return res.json()

--- a/frontend/src/pages/PublicRecipeRunPage.tsx
+++ b/frontend/src/pages/PublicRecipeRunPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react"
-import { BASE_PATH } from "@/config"
+import { parseShareToken, shareApiUrl } from "@/lib/shareToken"
 import Markdown from "react-markdown"
 import remarkGfm from "remark-gfm"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
@@ -47,9 +47,8 @@ const statusStyles: Record<string, string> = {
 }
 
 function getTokenFromPath(): string | undefined {
-  // /shared/runs/{token}/ or /shared/runs/{token}
-  const match = window.location.pathname.match(/^\/shared\/runs\/([^/]+)/)
-  return match?.[1]
+  // /shared/runs/{token}/ or /shared/runs/{token}, optionally under a base path.
+  return parseShareToken(window.location.pathname, "runs")
 }
 
 export function PublicRecipeRunPage() {
@@ -60,7 +59,7 @@ export function PublicRecipeRunPage() {
 
   useEffect(() => {
     if (!token) return
-    fetch(`${BASE_PATH}/api/recipes/runs/shared/${token}/`)
+    fetch(shareApiUrl("runs", token))
       .then((res) => {
         if (!res.ok) throw new Error(res.status === 404 ? "Run not found" : "Failed to load run")
         return res.json()

--- a/frontend/src/pages/PublicThreadPage.tsx
+++ b/frontend/src/pages/PublicThreadPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react"
-import { BASE_PATH } from "@/config"
+import { parseShareToken, shareApiUrl } from "@/lib/shareToken"
 import Markdown from "react-markdown"
 import remarkGfm from "remark-gfm"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
@@ -55,8 +55,7 @@ function formatDateTime(dateString: string): string {
 }
 
 function getTokenFromPath(): string | undefined {
-  const match = window.location.pathname.match(/^\/shared\/threads\/([^/]+)/)
-  return match?.[1]
+  return parseShareToken(window.location.pathname, "threads")
 }
 
 function isArtifactTool(part: MessagePart): boolean {
@@ -231,7 +230,7 @@ export function PublicThreadPage() {
 
   useEffect(() => {
     if (!token) return
-    fetch(`${BASE_PATH}/api/chat/threads/shared/${token}/`)
+    fetch(shareApiUrl("threads", token))
       .then((res) => {
         if (!res.ok) throw new Error(res.status === 404 ? "Thread not found" : "Failed to load thread")
         return res.json()

--- a/infra/scout-stack.yml
+++ b/infra/scout-stack.yml
@@ -1,5 +1,31 @@
 AWSTemplateFormatVersion: '2010-09-09'
-Description: Scout production infrastructure
+Description: Scout production infrastructure (EC2 + Kamal). Does NOT cover the connect-labs deploy.
+
+# ─────────────────────────────────────────────────────────────────────────────
+# DEPLOY-TARGET DRIFT — READ BEFORE ASSUMING THIS DESCRIBES EVERY ENVIRONMENT
+# (issue #248, 11#1, documentation-only)
+#
+# This template describes the *Scout production* stack only: a single EC2
+# instance running all containers via Kamal, plus RDS + ElastiCache, in the
+# Scout-owned AWS account. It is deployed as the `scout-production` stack by
+# `.github/workflows/deploy.yml`.
+#
+# The *connect-labs* deployment is a DIFFERENT, OUT-OF-REPO target:
+#   - ECS Fargate (cluster `labs-jj-cluster`, services labs-jj-scout-web /
+#     -mcp / -worker), NOT EC2/Kamal.
+#   - A separate AWS account: 858923557655 (ECR registry
+#     858923557655.dkr.ecr.us-east-1.amazonaws.com).
+#   - Served under the /scout path prefix (FORCE_SCRIPT_NAME, see
+#     config/settings/connectlabs.py + frontend/nginx.prod.conf).
+#   - Deployed by `.github/workflows/deploy-labs.yml`, which only builds and
+#     pushes images + updates ECS services; the Fargate task definitions,
+#     ALB, networking, and IAM for that account live OUTSIDE this repository.
+#
+# There is therefore no single CloudFormation/IaC source of truth for the labs
+# environment in this repo. Changes to networking, task definitions, or the ALB
+# for connect-labs must be made in that external infra, not here. See
+# DEPLOYMENT.md ("Connect-labs (ECS Fargate)") for the fuller note.
+# ─────────────────────────────────────────────────────────────────────────────
 
 Parameters:
   EC2KeyPairName:

--- a/manage.py
+++ b/manage.py
@@ -3,11 +3,23 @@
 
 import os
 import sys
+from pathlib import Path
+
+import environ
+
+from config.settings_guard import require_settings_module
 
 
 def main():
     """Run administrative tasks."""
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings.development")
+    # Fail fast rather than defaulting to development settings (issue #248, 08#5).
+    # Local dev configures DJANGO_SETTINGS_MODULE in .env (see .env.example), so
+    # honor that file first — matching how config/settings/base.py reads it —
+    # before requiring the variable to be set.
+    env_file = Path(__file__).resolve().parent / ".env"
+    if env_file.exists() and "DJANGO_SETTINGS_MODULE" not in os.environ:
+        environ.Env.read_env(str(env_file))
+    require_settings_module(os.environ)
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -316,6 +316,44 @@ class TestArtifactSandboxView:
                 f"'*'; found: {target_arg!r}"
             )
 
+    def test_sandbox_live_query_fetch_respects_script_prefix(
+        self, authenticated_client, artifact, workspace
+    ):
+        """The in-iframe live-query fetch must honor FORCE_SCRIPT_NAME (issue #248, 04#8b).
+
+        On the labs deployment Scout is mounted under /scout (FORCE_SCRIPT_NAME),
+        and nginx only proxies /scout/api/... A root-relative '/api/...' fetch
+        from the sandbox HTML would hit the host root and 404. The sandbox must
+        prefix the request with the request's SCRIPT_NAME.
+        """
+        response = authenticated_client.get(
+            f"/api/workspaces/{workspace.id}/artifacts/{artifact.id}/sandbox/",
+            SCRIPT_NAME="/scout",
+        )
+
+        assert response.status_code == 200
+        content = response.content.decode()
+
+        # The injected base must be the request's script prefix...
+        assert 'const API_BASE = "/scout";' in content
+        # ...and the live-query fetch must be built from it (not a bare
+        # leading-slash path that bypasses the mount point).
+        assert "fetch(API_BASE + '/api/workspaces/'" in content
+
+    def test_sandbox_live_query_fetch_at_root_mount(
+        self, authenticated_client, artifact, workspace
+    ):
+        """With no script prefix the fetch URL stays root-relative (no double slash)."""
+        response = authenticated_client.get(
+            f"/api/workspaces/{workspace.id}/artifacts/{artifact.id}/sandbox/"
+        )
+
+        assert response.status_code == 200
+        content = response.content.decode()
+        # Empty base → fetch resolves to a clean root-relative URL at runtime.
+        assert 'const API_BASE = "";' in content
+        assert "fetch(API_BASE + '/api/workspaces/'" in content
+
     def test_sandbox_csp_headers(self, authenticated_client, artifact, workspace):
         """Test that CSP headers are set correctly for security."""
         response = authenticated_client.get(

--- a/tests/test_deploy_environment.py
+++ b/tests/test_deploy_environment.py
@@ -1,0 +1,28 @@
+"""Guard that DEPLOY_ENVIRONMENT labels prod-posture settings modules correctly.
+
+Issue #248, finding 08#5: DEPLOY_ENVIRONMENT was 'production' only when the
+settings module ended in '.production'. The connectlabs module
+('config.settings.connectlabs') inherits the full production security posture
+but was mislabeled 'development' for Sentry / Task Badger, so labs errors and
+task telemetry were tagged as a dev environment.
+
+These tests exercise the pure resolver and do NOT need a database.
+"""
+
+import pytest
+
+from config.settings.base import resolve_deploy_environment
+
+
+@pytest.mark.parametrize(
+    ("settings_module", "expected"),
+    [
+        ("config.settings.production", "production"),
+        ("config.settings.connectlabs", "production"),
+        ("config.settings.development", "development"),
+        ("config.settings.test", "development"),
+        ("", "development"),
+    ],
+)
+def test_resolve_deploy_environment(settings_module, expected):
+    assert resolve_deploy_environment(settings_module) == expected

--- a/tests/test_settings_guard.py
+++ b/tests/test_settings_guard.py
@@ -1,0 +1,41 @@
+"""Guard that non-MCP entrypoints fail fast when DJANGO_SETTINGS_MODULE is unset.
+
+Issue #248, finding 08#5: asgi.py / wsgi.py / manage.py used
+``os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings.development")``.
+If the env var is dropped in a deployment, the process boots with the permissive
+*development* settings (DEBUG=True, insecure cookies) instead of refusing to
+start. The MCP entrypoint already fails fast; these tests pin the shared guard
+the other entrypoints now use.
+
+Pure-Python: no database and no Django settings load required.
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+# Load the guard module directly from its file so importing it does NOT trigger
+# config/__init__.py (which imports the procrastinate app and needs Django).
+_GUARD_PATH = Path(__file__).resolve().parent.parent / "config" / "settings_guard.py"
+_spec = importlib.util.spec_from_file_location("config._settings_guard_under_test", _GUARD_PATH)
+_guard = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_guard)
+require_settings_module = _guard.require_settings_module
+
+
+def test_returns_module_when_set():
+    assert (
+        require_settings_module({"DJANGO_SETTINGS_MODULE": "config.settings.production"})
+        == "config.settings.production"
+    )
+
+
+def test_raises_when_missing():
+    with pytest.raises(RuntimeError, match="DJANGO_SETTINGS_MODULE"):
+        require_settings_module({})
+
+
+def test_raises_when_empty():
+    with pytest.raises(RuntimeError, match="DJANGO_SETTINGS_MODULE"):
+        require_settings_module({"DJANGO_SETTINGS_MODULE": ""})


### PR DESCRIPTION
Closes #248

Root-relative URLs and config gaps broke Scout's connect-labs `/scout` deployment (nginx only proxies `/scout/...`) and the embed widget SDK. This fixes the broken-now URL leg and the in-repo config legs, and documents the out-of-repo deploy-target drift.

## Per-finding summary

### 04#8 — root-relative URLs bypass `VITE_BASE_PATH=/scout`
- **Helpers**: added `joinBase`/`stripBase` (pure) + `withBasePath`/`stripBasePath` to `frontend/src/config.ts`, and a shared `frontend/src/lib/shareToken.ts` (`parseShareToken`, `shareApiUrl`). The existing `BASE_PATH` const and the api-client's `${BASE_PATH}${url}` prefixing were already present; this centralizes the remaining raw URLs.
- **(a)** `NetworkStatusContext` `/health/` poll → `withBasePath("/health/")`. Was hitting the host root under `/scout`.
- **(b)** `ArtifactPanel.tsx` iframe `src` → `withBasePath(...)`; and the Django-served sandbox HTML's live-query fetch (`apps/artifacts/views.py`) now prefixes the request with the request's `SCRIPT_NAME` (injected as `API_BASE`), so it resolves under the mount point instead of the host root.
- **(c)** `PublicThreadPage` + `PublicRecipeRunPage` derive the share token via `parseShareToken`, which strips the base **before** matching `^/shared/...`. Under `/scout` the token was `undefined` → endless skeleton. Their fetches use `shareApiUrl`.
- **(d)** Added a `/widget.js` CORS `location` to `frontend/nginx.prod-kamal.conf`. `frontend/nginx.prod.conf` already serves `/scout/widget.js`, so no change needed there.

### 06#6 — widget `setMode()`/theme no-ops; embed OAuth hardcode
- New `frontend/src/contexts/EmbedSettingsContext.tsx` holds **live** `mode` and an **applied** `theme` (toggles the Tailwind `.dark` class; `auto` follows OS + reacts to changes).
- `EmbedPage.tsx` wraps the embed tree in the provider and wires `scout:set-mode` (and new `scout:set-theme`) to actually mutate mode/theme — previously `scout:set-mode` only `console.log`ged and `mode` was read once from a memoized hook.
- `EmbedLayout.tsx` reads the live `mode` from the context.
- `widget.js` gains `setTheme()` (version bumped to `0.4.0-live-mode-theme`).
- `LoginForm.tsx` embed OAuth `next` falls back to `${BASE_PATH}/embed/` instead of the hardcoded `/labs/scout/`, which 404s on any non-connect-labs embedding host.

### 08#5 — deploy-environment mislabeling + permissive boot
- `config/settings/base.py`: extracted `resolve_deploy_environment()` + `PRODUCTION_SETTINGS_MODULES`; `connectlabs` (prod posture, non-`.production` name) now resolves to `"production"` for Sentry / Task Badger.
- `config/settings_guard.py` (new): `require_settings_module()`. `config/asgi.py`, `config/wsgi.py`, and `manage.py` now **fail fast** on a missing `DJANGO_SETTINGS_MODULE` like the MCP entrypoint, instead of `setdefault`ing to development. `manage.py` reads `.env` first so local dev (which sets the module there) keeps working; all deploy targets set the var explicitly (verified in `docker-compose.yml`, `Procfile.dev`, `config/deploy*.yml`).

### 11#1 — OUT-OF-REPO (documented only)
The connect-labs environment is **ECS Fargate** (cluster `labs-jj-cluster`, account `858923557655`), deployed by `.github/workflows/deploy-labs.yml`, which only builds/pushes images and updates ECS services. The Fargate task definitions / ALB / networking / IAM are **not in this repo**; `infra/scout-stack.yml` (CloudFormation) describes the EC2/Kamal **production** stack only. Documented this drift in the CloudFormation template header and a new "Connect-labs (ECS Fargate)" section in `DEPLOYMENT.md`. No code fix possible here.

## Test evidence

Backend (unique DB, no random order):
```
TEST_DATABASE_NAME=scout_test_248 DJANGO_SETTINGS_MODULE=config.settings.test \
  uv run pytest tests/test_deploy_environment.py tests/test_settings_guard.py \
  tests/test_artifacts.py tests/test_async_conventions.py tests/test_auth_settings.py -p no:randomly
# 50 passed
```
- `test_deploy_environment.py` (new): `resolve_deploy_environment` → "production" for production **and** connectlabs; "development" otherwise.
- `test_settings_guard.py` (new): `require_settings_module` returns the module or raises when missing/empty.
- `test_artifacts.py` (added 2): sandbox live-query fetch honors `SCRIPT_NAME` (`API_BASE = "/scout"`) and stays clean at the root mount.

Also verified manually: `asgi`/`wsgi` raise `RuntimeError` when `DJANGO_SETTINGS_MODULE` is unset; boot succeeds when set; `manage.py check` works via `.env`.

Frontend:
```
cd frontend && bun run test --run   # 45 passed (10 files)
bunx tsc --noEmit                    # clean
bun run lint                         # clean
```
- `config.test.ts` (new): `joinBase`/`stripBase` under a `/scout` base (incl. the `/scoutland` non-prefix guard); env-bound helpers.
- `lib/shareToken.test.ts` (new): token parsed correctly when pathname is `/scout/shared/<token>` (threads/runs/recipes); `shareApiUrl` mapping.
- `contexts/EmbedSettingsContext.test.tsx` (new): live `setMode`, applied `setTheme`, `applyTheme` dark/light/auto.

Python lint: `uv run ruff check` + `ruff format --check` clean on all changed files.

## Sibling sweep (arch #268)

Commands run from `frontend/`:
```
grep -rn "fetch(\"/\|fetch('/\|fetch(\`/" src/        # only the 4 share/health fetches, now via helpers
grep -rn "[\"'`]/api/" src/                            # all others go through api.get/post (client prefixes BASE_PATH)
grep -rn "/health/\|/shared/\|/labs/scout\|/accounts/\|/static/" src/
```
Backend:
```
grep -rn "endswith.*production" --include="*.py" .     # none remain (only the one fixed)
grep -rn "setdefault.*DJANGO_SETTINGS_MODULE" --include="*.py" .   # none in entrypoints (only docstrings/tests)
```
Findings + resolution:
- **`PublicRecipePage.tsx`** — found the identical `^/shared/recipes/` unstripped-regex bug (latent: not currently routed). Fixed by extending `ShareKind`/`shareApiUrl` with `recipes` and routing it through `parseShareToken`.
- All `/api/...` calls outside the 4 raw fetches use the `api` client, whose `request()` already prefixes `BASE_PATH` — no change needed.
- No remaining `.endswith('.production')` deploy-env checks and no permissive `DJANGO_SETTINGS_MODULE` `setdefault`s in production entrypoints (`mcp_server` already fails fast).

🤖 Generated with [Claude Code](https://claude.com/claude-code)