### PR TITLE
One identifier helper: 63-byte + collision guard on every minted name (arch #235)

### DIFF
--- a/apps/agents/graph/base.py
+++ b/apps/agents/graph/base.py
@@ -320,7 +320,7 @@ async def _fetch_schema_context(tenant, user, interactive: bool = True) -> str:
 
     # Try full schema with columns
     try:
-        ctx = await load_tenant_context(tenant.external_id)
+        ctx = await load_tenant_context(tenant.external_id, tenant.provider)
         from apps.workspaces.models import TenantMetadata
 
         tenant_metadata = await TenantMetadata.objects.filter(

--- a/apps/common/identifiers.py
+++ b/apps/common/identifiers.py
@@ -1,0 +1,160 @@
+"""Single helper for minting valid PostgreSQL identifiers (arch #235).
+
+Every Postgres name Scout creates — tenant schema, read-only/dbt role, refresh
+schema, dbt model/column alias — routes through here so the 63-byte limit
+(``NAMEDATALEN - 1``) and the ``(provider, external_id)`` collision class are
+guarded in exactly one place. PR #227 fixed view names only; this closes the rest.
+
+Two guard modes:
+
+- ``always_hash`` (``tenant_schema_name``): a digest of the identity key is ALWAYS
+  woven in, so distinct keys never collide even when their sanitized bases match
+  (Connect ``'123'`` vs OCS ``'123'``; ``'a-b'`` vs ``'a_b'``) or fit comfortably.
+- hash-on-overflow (``readonly_role_name``, ``dbt_role_name``, dbt names): the
+  plain ``{base}{suffix}`` is returned verbatim when it fits 63 bytes — preserving
+  existing prod names so no data migration is needed — and a digest is woven in
+  only when truncation would otherwise silently collapse two names into one.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+PG_MAX_IDENTIFIER_BYTES = 63
+_DIGEST_LEN = 8
+# Cap minted schema names below the hard limit so derived names (``_ro``,
+# ``_dbt``, ``_r{8hex}``) still fit within 63 bytes without their own truncation.
+_SCHEMA_NAME_MAX_BYTES = 50
+
+
+def sanitize_identifier(raw: str) -> str:
+    """Reduce an arbitrary string to a safe lowercase PostgreSQL identifier body.
+
+    Lowercases, maps ``-`` to ``_``, drops every other non-alphanumeric/underscore
+    character, and prefixes ``t_`` when the result would start with a digit.
+    Returns ``"unknown"`` if nothing survives. This is the historical
+    ``_sanitize_schema_name`` contract, kept byte-identical so existing view names
+    (which route through it) do not change — collision-safety comes from the
+    digest in :func:`tenant_schema_name`, not from the sanitizer being injective.
+    """
+    name = raw.lower().replace("-", "_")
+    name = "".join(c for c in name if c.isalnum() or c == "_")
+    if name and name[0].isdigit():
+        name = f"t_{name}"
+    return name or "unknown"
+
+
+def _digest(key: str) -> str:
+    return hashlib.sha256(key.encode("utf-8")).hexdigest()[:_DIGEST_LEN]
+
+
+def _truncate_to_bytes(s: str, max_bytes: int) -> str:
+    if max_bytes <= 0:
+        return ""
+    encoded = s.encode("utf-8")
+    if len(encoded) <= max_bytes:
+        return s
+    # Identifier chars are ASCII after sanitization, but decode defensively on a
+    # byte boundary so a multibyte char is never split.
+    return encoded[:max_bytes].decode("utf-8", errors="ignore")
+
+
+def fit_identifier(
+    base: str,
+    *,
+    suffix: str = "",
+    unique_key: str | None = None,
+    max_bytes: int = PG_MAX_IDENTIFIER_BYTES,
+    always_hash: bool = False,
+) -> str:
+    """Compose a valid PostgreSQL identifier of at most ``max_bytes`` bytes.
+
+    ``base`` is sanitized; ``suffix`` (assumed already safe, e.g. ``"_ro"``) is
+    appended verbatim. When ``always_hash`` is set, or when the plain form would
+    exceed ``max_bytes``, an 8-char digest of ``unique_key`` (falling back to
+    ``base``) is woven in before the suffix. The digest and suffix are always
+    preserved; only the human-readable head is trimmed to fit.
+    """
+    head = sanitize_identifier(base)
+    plain = f"{head}{suffix}"
+    if not always_hash and len(plain.encode("utf-8")) <= max_bytes:
+        return plain
+
+    digest = _digest(unique_key if unique_key is not None else base)
+    tail = f"_{digest}{suffix}"
+    head = _truncate_to_bytes(head, max_bytes - len(tail.encode("utf-8"))).rstrip("_")
+    if not head or head[0].isdigit():
+        head = f"t{head}" if head else "t"
+    return f"{head}{tail}"
+
+
+def tenant_schema_name(provider: str, external_id: str) -> str:
+    """Mint the schema name for a tenant, unique per ``(provider, external_id)``.
+
+    Always carries the identity digest, so a cross-provider duplicate external_id
+    or a punctuation/length collision can never route one tenant into another's
+    physical schema.
+    """
+    return fit_identifier(
+        external_id,
+        unique_key=f"{provider}\x00{external_id}",
+        max_bytes=_SCHEMA_NAME_MAX_BYTES,
+        always_hash=True,
+    )
+
+
+def refresh_schema_name(provider: str, external_id: str, *, token: str) -> str:
+    """Mint a unique schema name for one background refresh of a tenant.
+
+    ``token`` (a short random hex string from the caller) makes the name unique
+    per refresh; the identity digest keeps it tied to the tenant. The whole name
+    stays within 63 bytes so its derived ``_ro``/``_dbt`` roles never truncate.
+    """
+    return fit_identifier(
+        external_id,
+        suffix=f"_r{token}",
+        unique_key=f"{provider}\x00{external_id}",
+        always_hash=True,
+    )
+
+
+def readonly_role_name(schema_name: str) -> str:
+    """Derive the read-only role name for a schema (``{schema}_ro`` when it fits)."""
+    return fit_identifier(schema_name, suffix="_ro", unique_key=schema_name)
+
+
+def dbt_role_name(schema_name: str) -> str:
+    """Derive the low-privilege dbt role name for a schema (issue #241).
+
+    dbt assumes this role (via ``SET ROLE`` in its profile) when materializing
+    transformation assets, so user-authored SQL runs with rights on this schema
+    only — never as the full ``MANAGED_DATABASE_URL`` superuser.
+    """
+    return fit_identifier(schema_name, suffix="_dbt", unique_key=schema_name)
+
+
+def dbt_model_name(name: str) -> str:
+    """Guard a fully-composed dbt model name to <=63 bytes (cap+hash on overflow).
+
+    The caller builds the readable name (``stg_case_<slug>`` etc.); this ensures
+    two long names sharing a 63-byte prefix become distinct physical relations
+    rather than one silently overwriting the other.
+    """
+    return fit_identifier(name, unique_key=name)
+
+
+def dbt_column_alias(base: str, seen: dict[str, int]) -> str:
+    """Return a unique dbt column alias, capped to 63 bytes.
+
+    Duplicates are disambiguated (``base``, ``base_2``, ...) and only THEN passed
+    through the byte guard — so distinct long property names cannot collapse to
+    one physical column the way ``_unique_alias`` (which disambiguated *before*
+    truncation) allowed.
+    """
+    if base in seen:
+        seen[base] += 1
+        unique = f"{base}_{seen[base]}"
+    else:
+        seen[base] = 1
+        unique = base
+    return fit_identifier(unique, unique_key=unique)

--- a/apps/transformations/services/commcare_staging.py
+++ b/apps/transformations/services/commcare_staging.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import logging
 import re
 
+from apps.common.identifiers import dbt_column_alias, dbt_model_name
 from apps.transformations.models import TransformationAsset, TransformationScope
 
 logger = logging.getLogger(__name__)
@@ -86,15 +87,6 @@ def _column_name_from_path(value_path: str) -> str:
     return slugify_model_name(value_path.rsplit("/", 1)[-1])
 
 
-def _unique_alias(base: str, seen: dict[str, int]) -> str:
-    """Return a unique column alias, appending ``_2``, ``_3`` etc. on collision."""
-    if base not in seen:
-        seen[base] = 1
-        return base
-    seen[base] += 1
-    return f"{base}_{seen[base]}"
-
-
 def _typed_expression(expr: str, question_type: str | None) -> str:
     """Wrap *expr* with a NULLIF + cast if the question type requires it."""
     cast = _TYPE_CAST.get(question_type or "")
@@ -137,14 +129,14 @@ def _generate_case_type_asset(
             select_parts.append(f"    {expr}")
 
     for prop in properties:
-        col = _unique_alias(slugify_model_name(prop), seen_aliases)
+        col = dbt_column_alias(slugify_model_name(prop), seen_aliases)
         select_parts.append(f"    properties->>'{_sql_escape(prop)}' AS \"{col}\"")
 
     lines.append(",\n".join(select_parts))
     lines.append("FROM raw_cases")
     lines.append(f"WHERE case_type = '{_sql_escape(case_type_name)}'")
 
-    model_name = f"stg_case_{slugify_model_name(case_type_name)}"
+    model_name = dbt_model_name(f"stg_case_{slugify_model_name(case_type_name)}")
     return TransformationAsset(
         name=model_name,
         description=f"Staging model for {case_type_name} cases",
@@ -189,7 +181,7 @@ def _generate_form_asset(
         if not value_path:
             continue
         json_path = _question_path_to_json_path(value_path)
-        col_name = _unique_alias(_column_name_from_path(value_path), seen_aliases)
+        col_name = dbt_column_alias(_column_name_from_path(value_path), seen_aliases)
         raw_expr = f"form_data #>> {json_path}"
         q_type = q.get("type")
         select_parts.append(f'    {_typed_expression(raw_expr, q_type)} AS "{col_name}"')
@@ -198,7 +190,7 @@ def _generate_form_asset(
     lines.append("FROM raw_forms")
     lines.append(f"WHERE xmlns = '{_sql_escape(form_xmlns)}'")
 
-    model_name = f"stg_form_{model_name_slug}"
+    model_name = dbt_model_name(f"stg_form_{model_name_slug}")
     return TransformationAsset(
         name=model_name,
         description=f"Staging model for form: {form_def.get('name', form_xmlns)}",
@@ -218,7 +210,9 @@ def _generate_repeat_group_asset(
     """Generate a staging asset for a repeat group child table."""
     group_json_path = _question_path_to_json_path(group_path)
     group_slug = slugify_model_name(group_path.rsplit("/", 1)[-1])
-    parent_model = f"stg_form_{form_name_slug}"
+    # Must match the parent form asset's (possibly hash-bounded) name so ref()
+    # resolves — both derive from the same slug via the same helper.
+    parent_model = dbt_model_name(f"stg_form_{form_name_slug}")
 
     lines = ["SELECT"]
     select_parts: list[str] = [
@@ -233,7 +227,7 @@ def _generate_repeat_group_asset(
         if not value_path:
             continue
         leaf_name = value_path.rsplit("/", 1)[-1]
-        col_name = _unique_alias(_column_name_from_path(value_path), seen_aliases)
+        col_name = dbt_column_alias(_column_name_from_path(value_path), seen_aliases)
         raw_expr = f"elem.value->>'{_sql_escape(leaf_name)}'"
         q_type = q.get("type")
         select_parts.append(f'    {_typed_expression(raw_expr, q_type)} AS "{col_name}"')
@@ -245,7 +239,7 @@ def _generate_repeat_group_asset(
     lines.append(") WITH ORDINALITY AS elem(value, ordinality)")
     lines.append(f"WHERE f.form_data #> {group_json_path} IS NOT NULL")
 
-    model_name = f"{parent_model}__repeat_{group_slug}"
+    model_name = dbt_model_name(f"{parent_model}__repeat_{group_slug}")
     return TransformationAsset(
         name=model_name,
         description=f"Repeat group '{group_slug}' from {parent_model}",

--- a/apps/transformations/views.py
+++ b/apps/transformations/views.py
@@ -156,6 +156,11 @@ class TransformationRunViewSet(viewsets.ReadOnlyModelViewSet):
             if not workspace:
                 raise PermissionDenied("Workspace not found or you are not a member.")
 
+        # NOTE (arch #235, 04#6): this runs the dbt pipeline INLINE in the request
+        # thread, serialized only by an in-process threading.Lock in dbt_runner —
+        # so a worker-side materialization and an API trigger on the same schema
+        # are not mutually serialized across processes. The async-trigger redesign
+        # is tracked separately and is out of scope for the identifier-helper work.
         run = run_transformation_pipeline(
             tenant=tenant,
             schema_name=ts.schema_name,

--- a/apps/workspaces/services/schema_manager.py
+++ b/apps/workspaces/services/schema_manager.py
@@ -17,32 +17,26 @@ import psycopg.sql
 from django.conf import settings
 from django.utils import timezone
 
+from apps.common.identifiers import (
+    PG_MAX_IDENTIFIER_BYTES,
+    dbt_role_name,
+    readonly_role_name,
+    refresh_schema_name,
+    sanitize_identifier,
+    tenant_schema_name,
+)
 from apps.users.models import Tenant
 from apps.workspaces.models import SchemaState, TenantSchema, WorkspaceViewSchema
 
 logger = logging.getLogger(__name__)
 
-# PostgreSQL truncates identifiers to 63 bytes (NAMEDATALEN - 1). Tenant view
+# Postgres truncates identifiers to 63 bytes (NAMEDATALEN - 1). Tenant view
 # names are composed as ``{prefix}__{table}``; we cap the prefix well below this
 # so a generous table-name budget remains, and hard-fail if a final name still
-# exceeds the limit.
-_PG_MAX_IDENTIFIER_BYTES = 63
+# exceeds the limit. The 63-byte limit and all name minting now live in
+# ``apps.common.identifiers`` (arch #235); ``readonly_role_name`` / ``dbt_role_name``
+# are imported above and re-exported here for existing call sites.
 _MAX_VIEW_PREFIX_LEN = 32
-
-
-def readonly_role_name(schema_name: str) -> str:
-    """Derive the read-only PostgreSQL role name for a schema."""
-    return f"{schema_name}_ro"
-
-
-def dbt_role_name(schema_name: str) -> str:
-    """Derive the low-privilege dbt role name for a schema (issue #241).
-
-    dbt assumes this role (via ``SET ROLE`` in its profile) when materializing
-    transformation assets, so user-authored SQL runs with rights on this schema
-    only — never as the full ``MANAGED_DATABASE_URL`` superuser.
-    """
-    return f"{schema_name}_dbt"
 
 
 def get_managed_db_connection():
@@ -67,40 +61,73 @@ class SchemaManager:
     def provision(self, tenant) -> TenantSchema:
         """Get or create a schema for the tenant.
 
-        Checks for an existing active schema by schema_name so that multiple
-        users in the same tenant share one schema rather than colliding on the
-        unique constraint.
+        Matches an existing schema by the ``tenant`` foreign key — never by
+        schema_name (arch #235). Matching by name let a sanitized-name collision
+        (Connect ``123`` / OCS ``123``; ``a-b`` / ``a_b``) hand one tenant another
+        tenant's live ACTIVE schema. Multiple users in the same tenant still share
+        one schema because they share the tenant FK.
+
+        Resolution order, all scoped to this tenant:
+
+        1. The current live schema (ACTIVE/MATERIALIZING), most-recently-accessed.
+           A blue-green refresh's not-yet-promoted ``_r`` schema is PROVISIONING
+           during its load, so it is correctly skipped here and the old base is
+           returned; once promoted (ACTIVE, freshly touched) it sorts first and
+           becomes the resolved schema.
+        2. Otherwise resurrect the most-recently-active EXPIRED record in place,
+           reusing its stored name (preserves the physical schema; this is the
+           tenant's own row, so no cross-tenant risk).
+        3. Otherwise mint a brand-new collision-safe name via
+           ``tenant_schema_name`` (keyed on ``(provider, external_id)``).
+
+        Existing records keep their stored name, so live physical schemas need no
+        rename/migration.
         """
         from django.db import IntegrityError
 
-        schema_name = self._sanitize_schema_name(tenant.external_id)
-
-        existing = TenantSchema.objects.filter(
-            schema_name=schema_name,
-            state__in=[SchemaState.ACTIVE, SchemaState.MATERIALIZING],
-        ).first()
-
-        if existing:
+        live = (
+            TenantSchema.objects.filter(
+                tenant=tenant,
+                state__in=[SchemaState.ACTIVE, SchemaState.MATERIALIZING],
+            )
+            .order_by("-last_accessed_at")
+            .first()
+        )
+        if live:
             # Ensure the physical schema still exists — it may have been
             # dropped externally while the Django record remained ACTIVE.
-            self._ensure_physical_schema(schema_name)
-            existing.touch()
-            return existing
+            self._ensure_physical_schema(live.schema_name)
+            live.touch()
+            return live
 
-        try:
-            ts = TenantSchema.objects.create(
-                tenant=tenant,
-                schema_name=schema_name,
-                state=SchemaState.PROVISIONING,
-            )
-        except IntegrityError:
-            # Race condition: another process created the record between our
-            # filter and create. Re-fetch and return it.
-            ts = TenantSchema.objects.get(schema_name=schema_name)
-            if ts.state in (SchemaState.ACTIVE, SchemaState.MATERIALIZING):
-                return ts
-            # Fall through: record exists but isn't active yet; let this
-            # caller attempt the CREATE SCHEMA (IF NOT EXISTS is safe).
+        resurrectable = (
+            TenantSchema.objects.filter(tenant=tenant, state=SchemaState.EXPIRED)
+            .order_by("-last_accessed_at")
+            .first()
+        )
+        if resurrectable:
+            schema_name = resurrectable.schema_name
+            ts = resurrectable
+            created = False
+        else:
+            schema_name = tenant_schema_name(tenant.provider, tenant.external_id)
+            created = True
+            try:
+                ts = TenantSchema.objects.create(
+                    tenant=tenant,
+                    schema_name=schema_name,
+                    state=SchemaState.PROVISIONING,
+                )
+            except IntegrityError:
+                # Race: another process created this tenant's record between our
+                # lookup and create. The name is deterministic per tenant, so
+                # this row belongs to the same tenant — re-fetch and return it.
+                created = False
+                ts = TenantSchema.objects.get(schema_name=schema_name)
+                if ts.state in (SchemaState.ACTIVE, SchemaState.MATERIALIZING):
+                    return ts
+                # Fall through: record exists but isn't active yet; let this
+                # caller attempt the CREATE SCHEMA (IF NOT EXISTS is safe).
 
         try:
             conn = get_managed_db_connection()
@@ -116,9 +143,11 @@ class SchemaManager:
             finally:
                 conn.close()
         except Exception:
-            # Clean up the PROVISIONING record so the next attempt can retry
-            # rather than hitting the unique constraint.
-            ts.delete()
+            # Clean up only a record WE created this call, so the next attempt
+            # can retry rather than hitting the unique constraint. A resurrected
+            # pre-existing record is left in place.
+            if created:
+                ts.delete()
             raise
 
         # Activating here covers both the fresh-create path and the
@@ -183,7 +212,9 @@ class SchemaManager:
         is responsible for creating the physical schema and dispatching the
         Celery task (refresh_tenant_schema) to run the materialization.
         """
-        schema_name = f"{self._sanitize_schema_name(tenant.external_id)}_r{uuid.uuid4().hex[:8]}"
+        schema_name = refresh_schema_name(
+            tenant.provider, tenant.external_id, token=uuid.uuid4().hex[:8]
+        )
         return TenantSchema.objects.create(
             tenant=tenant,
             schema_name=schema_name,
@@ -288,7 +319,7 @@ class SchemaManager:
             ts.tenant_id: ts
             for ts in TenantSchema.objects.filter(tenant__in=tenants, state=SchemaState.ACTIVE)
         }
-        tenant_schemas: list[tuple[str, str]] = []  # (schema_name, tenant_external_id)
+        tenant_schemas: list[tuple[str, Tenant]] = []  # (schema_name, tenant)
         for tenant in tenants:
             ts = active_schemas.get(tenant.id)
             if ts is None:
@@ -296,7 +327,7 @@ class SchemaManager:
                     f"Tenant '{tenant.external_id}' has no active schema. "
                     "Run a data refresh for this tenant before building the view schema."
                 )
-            tenant_schemas.append((ts.schema_name, tenant.external_id))
+            tenant_schemas.append((ts.schema_name, tenant))
 
         view_schema_name = self._view_schema_name(workspace.id)
 
@@ -326,8 +357,11 @@ class SchemaManager:
             tenant_prefixes: list[
                 tuple[str, str, str]
             ] = []  # (schema_name, tenant_external_id, prefix)
-            for schema_name, tenant_external_id in tenant_schemas:
-                tenant_obj = Tenant.objects.get(external_id=tenant_external_id)
+            for schema_name, tenant_obj in tenant_schemas:
+                tenant_external_id = tenant_obj.external_id
+                # Use the tenant object threaded from above — NOT a lookup by
+                # external_id, which raises MultipleObjectsReturned when the id is
+                # shared across providers (arch #235).
                 prefix = self._view_prefix(tenant_obj)
                 if prefix in prefix_to_tenant:
                     raise ValueError(
@@ -356,7 +390,7 @@ class SchemaManager:
                 )
                 for (table_name,) in cursor.fetchall():
                     view_name = f"{prefix}__{table_name}"
-                    if len(view_name.encode("utf-8")) > _PG_MAX_IDENTIFIER_BYTES:
+                    if len(view_name.encode("utf-8")) > PG_MAX_IDENTIFIER_BYTES:
                         oversized_views.append(view_name)
                         continue
                     if view_name in seen_view_names:
@@ -758,9 +792,10 @@ class SchemaManager:
             )
 
     def _sanitize_schema_name(self, tenant_id: str) -> str:
-        """Convert a tenant_id to a valid PostgreSQL schema name."""
-        name = tenant_id.lower().replace("-", "_")
-        name = "".join(c for c in name if c.isalnum() or c == "_")
-        if name and name[0].isdigit():
-            name = f"t_{name}"
-        return name or "unknown"
+        """Sanitize an arbitrary string into a PostgreSQL identifier body.
+
+        Thin delegate to the shared ``sanitize_identifier`` (arch #235). Retained
+        because ``_view_prefix`` and tests reference it; collision-safe minting of
+        full schema names goes through ``tenant_schema_name``.
+        """
+        return sanitize_identifier(tenant_id)

--- a/docs/superpowers/specs/2026-06-18-identifier-helper-design.md
+++ b/docs/superpowers/specs/2026-06-18-identifier-helper-design.md
@@ -1,0 +1,101 @@
+# One identifier helper — 63-byte + collision guard (#235)
+
+_2026-06-18 · branch `arch/235-identifier-helper` · Closes #235_
+
+## Problem
+
+PR #227 fixed Postgres-identifier length/collision guards for **view names only**.
+The sibling sites that mint every other name are unguarded, so the cross-tenant
+collision class is still open (same family as the 2026-06-10 incident):
+
+- **00#3** — `Tenant` is unique on `(provider, external_id)`, but `provision()`
+  resolves an existing `TenantSchema` by `schema_name` **alone**, and
+  `_sanitize_schema_name` maps distinct external_ids to one name
+  (Connect `123` & OCS `123` → `t_123`; `a-b`/`a_b`/`a.b` collide). A tenant can
+  be routed into another tenant's live ACTIVE schema (cross-tenant destruction +
+  disclosure). `load_tenant_context` filters `tenant__external_id` with **no
+  provider predicate**; `build_view_schema` does `Tenant.objects.get(external_id=)`
+  → `MultipleObjectsReturned` breaks multi-tenant builds.
+- **00#4** — schema / `_ro` role / `_dbt` role / `_r{hex}` refresh names have **no
+  63-byte guard**. Postgres silently truncates to 63 bytes → distinct Django rows,
+  one physical schema; `_ro` and refresh suffixes truncate *differently*, so a
+  shared truncated `_ro` role becomes a cross-tenant read primitive. Live exposure
+  = free-text CommCare domains.
+- **04#6** — dbt model names + column aliases from CommCare metadata have no
+  63-byte guard; `_unique_alias` disambiguates **before** truncation, so long
+  names still collide in the physical relation. (Secondary, **out of scope**: the
+  synchronous `/runs/trigger/` per-process `threading.Lock` — note only.)
+
+## Design
+
+### New module `apps/common/identifiers.py` — the single chokepoint
+
+`mcp_server` already imports `apps.*`, so this is reachable from every minting site.
+
+```python
+fit_identifier(base, *, suffix="", unique_key=None, max_bytes=63) -> str
+```
+Sanitize `base` (lowercase; `-`/`.`/space → `_`; strip non-alnum; ensure a leading
+letter), append `suffix`, cap to `max_bytes` (byte length, UTF-8). When
+`unique_key` is given, weave a deterministic 8-char `sha256(unique_key)` digest in
+so distinct keys never collide — even when sanitized bases match or the name
+truncates. **The hash and suffix are always preserved; only the readable head is
+trimmed to fit.**
+
+Public minting functions, all built on `fit_identifier`:
+
+| Function | Keyed on | Behaviour |
+|---|---|---|
+| `tenant_schema_name(provider, external_id)` | `(provider, external_id)` | **always** carries the digest → Connect `123` ≠ OCS `123`. Capped ~50 bytes so suffixes still fit. |
+| `refresh_schema_name(provider, external_id)` | identity + random token | per-refresh-unique, ≤63. |
+| `readonly_role_name(schema_name)` | `schema_name` | returns plain `{schema}_ro` when it fits ≤63 (**byte-identical to today**); digest-fit only on overflow. |
+| `dbt_role_name(schema_name)` | `schema_name` | same treatment for `_dbt`. |
+| `dbt_model_name(base)` | full pre-truncation name | cap+hash **before** truncation. |
+| `dbt_column_alias(base, seen)` | full pre-truncation name | unique-disambiguate **then** cap+hash. |
+| view prefix / view name | reuse `fit_identifier` | dedups #227's bespoke truncation; hash keyed on `(provider, external_id)`. |
+
+### Correctness fixes (00#3)
+
+- `provision()` matches an existing schema by **`tenant` FK** (not `schema_name`).
+  Removes cross-tenant sharing **and** preserves existing physical schemas verbatim.
+- `load_tenant_context(external_id, provider)` — `provider` becomes a **required
+  predicate**, threaded from its two callers (`load_workspace_context` and
+  `apps/agents/graph/base.py`), both of which already hold the `Tenant`.
+- `build_view_schema` threads the **tenant object** through instead of
+  re-`get(external_id=)` → kills the `MultipleObjectsReturned` break.
+
+### Migration: none
+
+Existing schemas are **left untouched**. `provision()` FK-matches and reuses the
+stored `schema_name`, and the derived-name functions are byte-identical for the
+short names that exist in prod, so queries keep working with no interruption. The
+inactivity TTL expires old-shape schemas; the next access mints the new
+collision-safe shape — within ~a week prod is all new-shape names. The only
+non-seamless case is an existing >60-byte schema name (the latent-bug zone): its
+role name changes → queries **fail closed** until TTL regen, which is the correct
+secure outcome (better than a shared truncated `_ro`) and self-heals.
+
+## Testing (real-DB, `@pytest.mark.django_db(transaction=True)` where DDL runs)
+
+1. **Cross-provider same external_id → distinct schemas** — Connect `123` & OCS
+   `123` provision to two different physical schemas; neither sees the other's data.
+2. **Punctuation collision** — `a-b` / `a_b` / `a.b` (same provider, distinct
+   tenants) → distinct schemas.
+3. **>63-byte external_id → distinct, ≤63-byte, hash-suffixed schemas** — two long
+   ids sharing a 63-byte prefix get distinct physical schemas.
+4. **Derived names ≤63 bytes & injective** — `_ro` / `_dbt` / `_r{hex}` of a
+   max-length schema all stay ≤63 and distinct per schema; short names stay
+   byte-identical (`t_123_ro`).
+5. **`provision()` matches by tenant FK** — second tenant computing a colliding
+   sanitized base does **not** receive the first tenant's schema.
+6. **`load_tenant_context` provider predicate** — two tenants sharing external_id
+   across providers resolve to their own schema.
+7. **dbt model/alias 63-byte guard** — long form/case names and long property
+   paths produce distinct ≤63-byte relations/aliases.
+8. **Sibling-sweep grep** — a test (or PR-body grep) shows no raw schema/role/view/
+   dbt name minting bypasses the helper.
+
+## Out of scope
+
+The async-trigger redesign for `TransformationRunViewSet.trigger` (the per-process
+`threading.Lock`). Left with a `# note` only.

--- a/mcp_server/context.py
+++ b/mcp_server/context.py
@@ -12,6 +12,7 @@ from urllib.parse import parse_qs, unquote, urlparse
 
 from django.conf import settings
 
+from apps.common.identifiers import readonly_role_name
 from apps.workspaces.models import SchemaState, TenantSchema, Workspace, WorkspaceViewSchema
 
 
@@ -27,8 +28,12 @@ class QueryContext:
 
     @property
     def readonly_role(self) -> str:
-        """Derive the read-only PostgreSQL role name for this context's schema."""
-        return f"{self.schema_name}_ro"
+        """Derive the read-only PostgreSQL role name for this context's schema.
+
+        Routes through the shared helper (arch #235) so the name stays within
+        Postgres's 63-byte limit even for a maximal schema name.
+        """
+        return readonly_role_name(self.schema_name)
 
 
 @dataclass(frozen=True)
@@ -44,17 +49,21 @@ class TenantContext:
     max_query_timeout_seconds: int = 30
 
 
-async def load_tenant_context(tenant_id: str) -> QueryContext:
+async def load_tenant_context(tenant_id: str, provider: str) -> QueryContext:
     """Load a QueryContext for a tenant from the managed database.
 
-    Uses the tenant_id (domain name) to find the TenantSchema and builds
-    a QueryContext pointing at the managed DB with the tenant's schema.
+    Uses ``(provider, external_id)`` — the tenant's full identity — to find the
+    TenantSchema and builds a QueryContext pointing at the managed DB with the
+    tenant's schema. ``provider`` is required (arch #235): external_id alone is
+    ambiguous, since a Connect opp and an OCS experiment can share an id and
+    would otherwise resolve to an arbitrary one of the two schemas.
     Resets the schema's inactivity TTL via touch().
 
     Raises ValueError if the tenant schema is not found or not active.
     """
     ts = await TenantSchema.objects.filter(
         tenant__external_id=tenant_id,
+        tenant__provider=provider,
         state__in=[SchemaState.ACTIVE, SchemaState.MATERIALIZING],
     ).afirst()
 
@@ -83,7 +92,7 @@ async def load_tenant_context(tenant_id: str) -> QueryContext:
 async def load_workspace_context(workspace_id: str) -> QueryContext:
     """Load a QueryContext for a workspace, routing correctly for multi-tenant.
 
-    - Single-tenant workspace (1 tenant): delegates to load_tenant_context(tenant.external_id).
+    - Single-tenant workspace (1 tenant): delegates to load_tenant_context(external_id, provider).
     - Multi-tenant workspace (2+ tenants): uses the WorkspaceViewSchema.
 
     Invariant: for a workspace, exactly one routing target exists at a time —
@@ -108,7 +117,7 @@ async def load_workspace_context(workspace_id: str) -> QueryContext:
 
     if tenant_count == 1:
         tenant = await workspace.tenants.afirst()
-        return await load_tenant_context(tenant.external_id)
+        return await load_tenant_context(tenant.external_id, tenant.provider)
 
     # Multi-tenant: use the view schema
     try:

--- a/tests/test_commcare_staging_generator.py
+++ b/tests/test_commcare_staging_generator.py
@@ -793,3 +793,51 @@ class TestUpsertSystemAssets:
         upsert_system_assets(tenant, tenant_metadata)
 
         assert TransformationAsset.objects.filter(id=user_asset.id).exists()
+
+
+class TestDbtNameLengthGuard:
+    """arch #235 — dbt model names from provider-controlled metadata must stay
+    within Postgres's 63-byte identifier limit, and long names sharing a 63-byte
+    prefix must remain distinct physical relations."""
+
+    def test_long_case_type_name_is_bounded(self, tenant):
+        long_name = "a" * 100
+        assets = generate_system_assets(tenant, _make_metadata(case_types=[{"name": long_name}]))
+        assert len(assets) == 1
+        assert len(assets[0].name.encode("utf-8")) <= 63
+
+    def test_two_long_case_names_sharing_prefix_are_distinct(self, tenant):
+        n1 = "z" * 80 + "_alpha"
+        n2 = "z" * 80 + "_beta"
+        assets = generate_system_assets(
+            tenant, _make_metadata(case_types=[{"name": n1}, {"name": n2}])
+        )
+        names = {a.name for a in assets}
+        assert len(names) == 2
+        for a in assets:
+            assert len(a.name.encode("utf-8")) <= 63
+
+    def test_repeat_group_ref_matches_bounded_parent_form_name(self, tenant):
+        """When a long form name forces the parent model name to be hashed, the
+        repeat child's ref() must still point at the SAME bounded parent name.
+        (At this extreme length the child name is also truncated, so identify the
+        assets by generation order: parent first, then its repeat child.)"""
+        long_form = "f" * 90
+        metadata = _make_metadata(
+            form_definitions={
+                "http://x/long": {
+                    "name": long_form,
+                    "questions": [
+                        {"value": "/data/rg/child_name", "repeat": "/data/rg"},
+                    ],
+                }
+            }
+        )
+        assets = generate_system_assets(tenant, metadata)
+        assert len(assets) == 2
+        parent, child = assets[0], assets[1]
+        assert len(parent.name.encode("utf-8")) <= 63
+        assert len(child.name.encode("utf-8")) <= 63
+        assert parent.name != child.name
+        # ref() integrity: the child references the parent's actual (bounded) name.
+        assert f"ref('{parent.name}')" in child.sql_content

--- a/tests/test_identifiers.py
+++ b/tests/test_identifiers.py
@@ -1,0 +1,174 @@
+"""Unit tests for the single identifier-minting helper (arch #235).
+
+Pure logic — no DB. Every Postgres identifier Scout mints (schema, role, refresh
+schema, dbt model/alias) routes through this module so the 63-byte limit and the
+(provider, external_id) collision class are guarded in exactly one place.
+"""
+
+from apps.common.identifiers import (
+    PG_MAX_IDENTIFIER_BYTES,
+    dbt_column_alias,
+    dbt_model_name,
+    dbt_role_name,
+    fit_identifier,
+    readonly_role_name,
+    refresh_schema_name,
+    sanitize_identifier,
+    tenant_schema_name,
+)
+
+
+def _nbytes(s: str) -> int:
+    return len(s.encode("utf-8"))
+
+
+def _is_valid_pg_identifier(s: str) -> bool:
+    # Lowercase, starts with a letter, only [a-z0-9_], <= 63 bytes.
+    import re
+
+    return bool(re.match(r"^[a-z][a-z0-9_]*$", s)) and _nbytes(s) <= PG_MAX_IDENTIFIER_BYTES
+
+
+class TestSanitizeIdentifier:
+    def test_lowercases_and_maps_dashes(self):
+        # Matches the historical _sanitize_schema_name contract so _view_prefix
+        # (and thus existing view names) stay byte-identical. Collision-safety
+        # comes from the digest in tenant_schema_name, not from the sanitizer.
+        assert sanitize_identifier("My-Domain") == "my_domain"
+
+    def test_strips_dots_and_spaces(self):
+        assert sanitize_identifier("a.b c") == "abc"
+
+    def test_strips_other_punctuation(self):
+        assert sanitize_identifier("foo (bar)!") == "foobar"
+
+    def test_prefixes_leading_digit_with_t(self):
+        assert sanitize_identifier("123") == "t_123"
+
+    def test_empty_becomes_unknown(self):
+        assert sanitize_identifier("!!!") == "unknown"
+
+
+class TestFitIdentifier:
+    def test_short_name_returned_verbatim(self):
+        assert fit_identifier("t_123", suffix="_ro") == "t_123_ro"
+
+    def test_always_hash_appends_digest_even_when_short(self):
+        out = fit_identifier("t_123", unique_key="a:123", always_hash=True)
+        assert out.startswith("t_123_")
+        assert out != "t_123"
+        assert _is_valid_pg_identifier(out)
+
+    def test_distinct_unique_keys_produce_distinct_names(self):
+        a = fit_identifier("t_123", unique_key="commcare_connect:123", always_hash=True)
+        b = fit_identifier("t_123", unique_key="ocs:123", always_hash=True)
+        assert a != b
+
+    def test_deterministic(self):
+        a = fit_identifier("t_123", unique_key="ocs:123", always_hash=True)
+        b = fit_identifier("t_123", unique_key="ocs:123", always_hash=True)
+        assert a == b
+
+    def test_overflow_is_truncated_with_hash_and_keeps_suffix(self):
+        long = "x" * 200
+        out = fit_identifier(long, suffix="_ro", unique_key=long)
+        assert _nbytes(out) <= PG_MAX_IDENTIFIER_BYTES
+        assert out.endswith("_ro")
+        assert _is_valid_pg_identifier(out)
+
+    def test_two_long_bases_sharing_head_get_distinct_names(self):
+        a = fit_identifier("y" * 100 + "_a", unique_key="y" * 100 + "_a")
+        b = fit_identifier("y" * 100 + "_b", unique_key="y" * 100 + "_b")
+        assert a != b
+        assert _nbytes(a) <= PG_MAX_IDENTIFIER_BYTES
+        assert _nbytes(b) <= PG_MAX_IDENTIFIER_BYTES
+
+
+class TestTenantSchemaName:
+    def test_is_valid_identifier(self):
+        assert _is_valid_pg_identifier(tenant_schema_name("commcare", "my-domain"))
+
+    def test_cross_provider_same_external_id_distinct(self):
+        connect = tenant_schema_name("commcare_connect", "123")
+        ocs = tenant_schema_name("ocs", "123")
+        assert connect != ocs
+
+    def test_punctuation_collision_distinct(self):
+        # 'a-b' / 'a_b' / 'a.b' all sanitize to the same base; the digest must
+        # keep them distinct.
+        names = {
+            tenant_schema_name("commcare", "a-b"),
+            tenant_schema_name("commcare", "a_b"),
+            tenant_schema_name("commcare", "a.b"),
+        }
+        assert len(names) == 3
+
+    def test_long_external_ids_sharing_prefix_distinct_and_bounded(self):
+        a = tenant_schema_name("commcare", "z" * 200 + "a")
+        b = tenant_schema_name("commcare", "z" * 200 + "b")
+        assert a != b
+        assert _nbytes(a) <= PG_MAX_IDENTIFIER_BYTES
+        assert _nbytes(b) <= PG_MAX_IDENTIFIER_BYTES
+
+    def test_leaves_room_for_derived_suffixes(self):
+        # The _ro / _dbt / _r{8hex} suffixes must still fit within 63 bytes.
+        schema = tenant_schema_name("commcare", "z" * 200)
+        assert _nbytes(readonly_role_name(schema)) <= PG_MAX_IDENTIFIER_BYTES
+        assert _nbytes(dbt_role_name(schema)) <= PG_MAX_IDENTIFIER_BYTES
+        assert _nbytes(refresh_schema_name("commcare", "z" * 200, token="a1b2c3d4")) <= (
+            PG_MAX_IDENTIFIER_BYTES
+        )
+
+    def test_deterministic(self):
+        assert tenant_schema_name("ocs", "42") == tenant_schema_name("ocs", "42")
+
+
+class TestDerivedRoleNames:
+    def test_readonly_role_short_is_verbatim(self):
+        # Preserves existing prod role names (byte-identical), so no migration.
+        assert readonly_role_name("t_123") == "t_123_ro"
+
+    def test_dbt_role_short_is_verbatim(self):
+        assert dbt_role_name("t_123") == "t_123_dbt"
+
+    def test_readonly_role_overflow_is_bounded_and_injective(self):
+        s1 = "a" * 62
+        s2 = "a" * 61 + "b"
+        r1 = readonly_role_name(s1)
+        r2 = readonly_role_name(s2)
+        assert _nbytes(r1) <= PG_MAX_IDENTIFIER_BYTES
+        assert r1.endswith("_ro")
+        # Distinct schemas must not share a truncated _ro role.
+        assert r1 != r2
+
+    def test_refresh_schema_is_unique_per_token(self):
+        a = refresh_schema_name("commcare", "dom", token="aaaaaaaa")
+        b = refresh_schema_name("commcare", "dom", token="bbbbbbbb")
+        assert a != b
+        assert _is_valid_pg_identifier(a)
+
+
+class TestDbtNames:
+    def test_short_model_name_verbatim(self):
+        assert dbt_model_name("stg_case_patient") == "stg_case_patient"
+
+    def test_long_model_names_sharing_head_distinct_and_bounded(self):
+        a = dbt_model_name("stg_form_" + "q" * 100 + "_a")
+        b = dbt_model_name("stg_form_" + "q" * 100 + "_b")
+        assert a != b
+        assert _nbytes(a) <= PG_MAX_IDENTIFIER_BYTES
+        assert _nbytes(b) <= PG_MAX_IDENTIFIER_BYTES
+
+    def test_column_alias_disambiguates_then_fits(self):
+        seen: dict[str, int] = {}
+        a = dbt_column_alias("colname", seen)
+        b = dbt_column_alias("colname", seen)
+        assert a != b  # second occurrence disambiguated
+
+    def test_long_aliases_sharing_head_distinct_and_bounded(self):
+        seen: dict[str, int] = {}
+        a = dbt_column_alias("p" * 100 + "_a", seen)
+        b = dbt_column_alias("p" * 100 + "_b", seen)
+        assert a != b
+        assert _nbytes(a) <= PG_MAX_IDENTIFIER_BYTES
+        assert _nbytes(b) <= PG_MAX_IDENTIFIER_BYTES

--- a/tests/test_identifiers.py
+++ b/tests/test_identifiers.py
@@ -5,6 +5,8 @@ schema, dbt model/alias) routes through this module so the 63-byte limit and the
 (provider, external_id) collision class are guarded in exactly one place.
 """
 
+import re
+
 from apps.common.identifiers import (
     PG_MAX_IDENTIFIER_BYTES,
     dbt_column_alias,
@@ -24,8 +26,6 @@ def _nbytes(s: str) -> int:
 
 def _is_valid_pg_identifier(s: str) -> bool:
     # Lowercase, starts with a letter, only [a-z0-9_], <= 63 bytes.
-    import re
-
     return bool(re.match(r"^[a-z][a-z0-9_]*$", s)) and _nbytes(s) <= PG_MAX_IDENTIFIER_BYTES
 
 

--- a/tests/test_mcp_context.py
+++ b/tests/test_mcp_context.py
@@ -1,0 +1,20 @@
+"""Unit tests for mcp_server.context value objects (no DB, no async)."""
+
+from apps.common.identifiers import readonly_role_name
+from mcp_server.context import QueryContext
+
+
+class TestQueryContextReadonlyRole:
+    """The readonly_role property must route through the shared helper so an
+    overflow schema name yields a <=63-byte role (arch #235)."""
+
+    def test_short_schema_role_is_verbatim(self):
+        ctx = QueryContext(tenant_id="t", schema_name="t_123", connection_params={})
+        assert ctx.readonly_role == "t_123_ro"
+        assert ctx.readonly_role == readonly_role_name("t_123")
+
+    def test_overflow_schema_role_is_bounded(self):
+        long_schema = readonly_role_name("a" * 80)  # already a fitted, <=63-byte name
+        ctx = QueryContext(tenant_id="t", schema_name=long_schema, connection_params={})
+        assert len(ctx.readonly_role.encode("utf-8")) <= 63
+        assert ctx.readonly_role == readonly_role_name(long_schema)

--- a/tests/test_mcp_tenant_tools.py
+++ b/tests/test_mcp_tenant_tools.py
@@ -15,11 +15,12 @@ from django.test import override_settings
 from apps.users.models import Tenant
 from apps.workspaces.models import (
     SchemaState,
+    TenantSchema,
     Workspace,
     WorkspaceTenant,
     WorkspaceViewSchema,
 )
-from mcp_server.context import QueryContext
+from mcp_server.context import QueryContext, load_tenant_context
 from mcp_server.envelope import NOT_FOUND, VALIDATION_ERROR
 from mcp_server.server import get_schema_status
 
@@ -525,9 +526,6 @@ class TestLoadTenantContext:
 
     async def test_schema_name_in_context(self, tenant_membership):
         """Verify the schema name from TenantSchema flows into QueryContext.schema_name."""
-        from apps.workspaces.models import SchemaState, TenantSchema
-        from mcp_server.context import load_tenant_context
-
         await TenantSchema.objects.acreate(
             tenant=tenant_membership.tenant,
             schema_name="dimagi",
@@ -535,7 +533,7 @@ class TestLoadTenantContext:
         )
 
         with override_settings(MANAGED_DATABASE_URL="postgresql://user:pass@localhost:5432/scout"):
-            ctx = await load_tenant_context("test-domain")
+            ctx = await load_tenant_context("test-domain", "commcare")
 
         assert ctx.schema_name == "dimagi"
         assert ctx.tenant_id == "test-domain"
@@ -544,15 +542,10 @@ class TestLoadTenantContext:
         assert "search_path=dimagi" in ctx.connection_params["options"]
 
     async def test_raises_when_no_active_schema(self, tenant_membership):
-        from mcp_server.context import load_tenant_context
-
         with pytest.raises(ValueError, match="No active schema"):
-            await load_tenant_context("dimagi")
+            await load_tenant_context("dimagi", "commcare")
 
     async def test_raises_when_no_managed_db_url(self, tenant_membership):
-        from apps.workspaces.models import SchemaState, TenantSchema
-        from mcp_server.context import load_tenant_context
-
         await TenantSchema.objects.acreate(
             tenant=tenant_membership.tenant,
             schema_name="dimagi",
@@ -561,7 +554,30 @@ class TestLoadTenantContext:
 
         with override_settings(MANAGED_DATABASE_URL=""):
             with pytest.raises(ValueError, match="MANAGED_DATABASE_URL"):
-                await load_tenant_context("test-domain")
+                await load_tenant_context("test-domain", "commcare")
+
+    async def test_provider_predicate_resolves_correct_tenant(self):
+        """Two tenants sharing an external_id across providers must each resolve
+        to their OWN schema — external_id alone is ambiguous (arch #235)."""
+        connect = await Tenant.objects.acreate(
+            provider="commcare_connect", external_id="123", canonical_name="Opp 123"
+        )
+        ocs = await Tenant.objects.acreate(
+            provider="ocs", external_id="123", canonical_name="Bot 123"
+        )
+        await TenantSchema.objects.acreate(
+            tenant=connect, schema_name="connect_123", state=SchemaState.ACTIVE
+        )
+        await TenantSchema.objects.acreate(
+            tenant=ocs, schema_name="ocs_123", state=SchemaState.ACTIVE
+        )
+
+        with override_settings(MANAGED_DATABASE_URL="postgresql://u:p@localhost:5432/scout"):
+            connect_ctx = await load_tenant_context("123", "commcare_connect")
+            ocs_ctx = await load_tenant_context("123", "ocs")
+
+        assert connect_ctx.schema_name == "connect_123"
+        assert ocs_ctx.schema_name == "ocs_123"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_workspace_context.py
+++ b/tests/test_mcp_workspace_context.py
@@ -28,7 +28,9 @@ async def test_load_workspace_context_single_tenant_delegates_to_tenant_context(
 
         result = await load_workspace_context(str(ws.id))
 
-    mock_ltc.assert_called_once_with("ctx-domain")
+    # provider is threaded through so a cross-provider duplicate external_id
+    # resolves unambiguously (arch #235).
+    mock_ltc.assert_called_once_with("ctx-domain", "commcare")
     assert result.schema_name == "ctx_domain"
 
 

--- a/tests/test_schema_manager.py
+++ b/tests/test_schema_manager.py
@@ -6,6 +6,8 @@ import psycopg.sql
 import pytest
 from django.utils import timezone
 
+from apps.common.identifiers import tenant_schema_name
+from apps.users.models import Tenant
 from apps.workspaces.models import SchemaState, TenantSchema, WorkspaceViewSchema
 from apps.workspaces.services.schema_manager import SchemaManager, readonly_role_name
 
@@ -24,7 +26,10 @@ class TestSchemaManager:
             mgr = SchemaManager()
             ts = mgr.provision(tenant_membership.tenant)
 
-        assert ts.schema_name == mgr._sanitize_schema_name(tenant_membership.tenant.external_id)
+        tenant = tenant_membership.tenant
+        # Schema names are now minted by the shared collision-safe helper, keyed
+        # on (provider, external_id) — not the bare sanitized external_id.
+        assert ts.schema_name == tenant_schema_name(tenant.provider, tenant.external_id)
         assert ts.state == "active"
         assert TenantSchema.objects.count() == 1
         # Verify DDL was executed
@@ -120,6 +125,124 @@ def test_provision_resurrects_expired_schema_and_refreshes_ttl(tenant_membership
     assert ts.last_accessed_at >= before
     # The stale timestamp must be gone.
     assert ts.last_accessed_at > stale
+
+
+@pytest.mark.django_db(transaction=True)
+class TestProvisionCollisionSafety:
+    """arch #235 — provision() must never route one tenant into another's schema.
+
+    The managed-DB connection is mocked (no physical DDL); these assertions are
+    purely about which TenantSchema row each tenant gets.
+    """
+
+    @staticmethod
+    def _mock_conn():
+        conn = MagicMock()
+        cursor = MagicMock()
+        conn.cursor.return_value = cursor
+        cursor.fetchone.return_value = None  # roles don't exist yet
+        return conn
+
+    def test_cross_provider_same_external_id_distinct_schemas(self, db):
+        """Connect opp '123' and OCS experiment '123' must get different schemas."""
+        connect = Tenant.objects.create(
+            provider="commcare_connect", external_id="123", canonical_name="Opp 123"
+        )
+        ocs = Tenant.objects.create(provider="ocs", external_id="123", canonical_name="Bot 123")
+
+        mgr = SchemaManager()
+        with patch(
+            "apps.workspaces.services.schema_manager.get_managed_db_connection",
+            return_value=self._mock_conn(),
+        ):
+            ts_connect = mgr.provision(connect)
+            ts_ocs = mgr.provision(ocs)
+
+        assert ts_connect.schema_name != ts_ocs.schema_name
+        assert ts_connect.tenant_id == connect.id
+        assert ts_ocs.tenant_id == ocs.id
+        assert TenantSchema.objects.count() == 2
+
+    def test_punctuation_collision_distinct_schemas(self, db):
+        """external_ids that sanitize to the same base must still get distinct schemas."""
+        t1 = Tenant.objects.create(provider="commcare", external_id="a-b", canonical_name="A B")
+        t2 = Tenant.objects.create(provider="commcare", external_id="a_b", canonical_name="A_B")
+
+        mgr = SchemaManager()
+        with patch(
+            "apps.workspaces.services.schema_manager.get_managed_db_connection",
+            return_value=self._mock_conn(),
+        ):
+            ts1 = mgr.provision(t1)
+            ts2 = mgr.provision(t2)
+
+        assert ts1.schema_name != ts2.schema_name
+        assert TenantSchema.objects.count() == 2
+
+    def test_provision_matches_by_tenant_fk_not_schema_name(self, db):
+        """A second tenant must NOT be handed the first tenant's existing schema
+        even if both sanitize to the same legacy name."""
+        first = Tenant.objects.create(provider="commcare", external_id="dom", canonical_name="Dom")
+        # Simulate a legacy row created under the old bare-sanitized scheme.
+        TenantSchema.objects.create(tenant=first, schema_name="dom", state=SchemaState.ACTIVE)
+        second = Tenant.objects.create(provider="ocs", external_id="dom", canonical_name="Dom OCS")
+
+        mgr = SchemaManager()
+        with patch(
+            "apps.workspaces.services.schema_manager.get_managed_db_connection",
+            return_value=self._mock_conn(),
+        ):
+            ts_second = mgr.provision(second)
+
+        assert ts_second.tenant_id == second.id
+        assert ts_second.schema_name != "dom"
+
+    def test_existing_schema_matched_by_fk_keeps_its_name(self, db):
+        """An existing ACTIVE schema is returned by tenant FK and keeps its stored
+        (possibly legacy) name — no rename, so no data migration is required."""
+        tenant = Tenant.objects.create(
+            provider="commcare", external_id="legacy-dom", canonical_name="Legacy"
+        )
+        legacy = TenantSchema.objects.create(
+            tenant=tenant, schema_name="legacy_dom", state=SchemaState.ACTIVE
+        )
+
+        mgr = SchemaManager()
+        with patch(
+            "apps.workspaces.services.schema_manager.get_managed_db_connection",
+            return_value=self._mock_conn(),
+        ):
+            ts = mgr.provision(tenant)
+
+        assert ts.pk == legacy.pk
+        assert ts.schema_name == "legacy_dom"
+        assert TenantSchema.objects.count() == 1
+
+    def test_provision_ignores_in_flight_refresh_schema(self, db):
+        """A blue-green refresh creates a transient PROVISIONING ``_r`` schema for
+        the same tenant (with last_accessed_at NULL — which sorts first). provision
+        must return the live ACTIVE base, NOT the half-built refresh schema."""
+        tenant = Tenant.objects.create(provider="commcare", external_id="dom", canonical_name="Dom")
+        base = TenantSchema.objects.create(
+            tenant=tenant,
+            schema_name="dom_base",
+            state=SchemaState.ACTIVE,
+            last_accessed_at=timezone.now() - timedelta(hours=1),
+        )
+        # In-flight refresh row: PROVISIONING, last_accessed_at left NULL.
+        TenantSchema.objects.create(
+            tenant=tenant, schema_name="dom_r1a2b3c4", state=SchemaState.PROVISIONING
+        )
+
+        mgr = SchemaManager()
+        with patch(
+            "apps.workspaces.services.schema_manager.get_managed_db_connection",
+            return_value=self._mock_conn(),
+        ):
+            ts = mgr.provision(tenant)
+
+        assert ts.pk == base.pk
+        assert ts.schema_name == "dom_base"
 
 
 @pytest.mark.django_db
@@ -360,6 +483,36 @@ class TestSchemaManagerRoleTeardown:
             pytest.raises(RuntimeError),
         ):
             SchemaManager().teardown(ts)
+
+
+@pytest.mark.django_db
+class TestBuildViewSchemaProviderSafety:
+    """arch #235 — build_view_schema must not break when an external_id is shared
+    across providers (the old Tenant.objects.get(external_id=) raised
+    MultipleObjectsReturned and broke the whole multi-tenant build)."""
+
+    def test_tolerates_cross_provider_duplicate_external_id(self, workspace, tenant):
+        # The workspace's tenant is (commcare, test-domain). A stray tenant under
+        # another provider shares the external_id.
+        Tenant.objects.create(
+            provider="ocs", external_id=tenant.external_id, canonical_name="OCS dup"
+        )
+        TenantSchema.objects.create(tenant=tenant, schema_name="test_domain", state="active")
+
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.cursor.return_value = mock_cursor
+        mock_conn.closed = False
+        mock_cursor.fetchall.return_value = []  # no tables
+        mock_cursor.fetchone.return_value = None
+
+        with patch(
+            "apps.workspaces.services.schema_manager.get_managed_db_connection",
+            return_value=mock_conn,
+        ):
+            vs = SchemaManager().build_view_schema(workspace)
+
+        assert vs.state == SchemaState.ACTIVE
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Closes #235.

PR #227 fixed Postgres-identifier length/collision guards for **view names only**. This adds **`apps/common/identifiers.py`** as the single chokepoint that every minted Postgres name routes through, closing the whole cross-tenant collision class (same family as the 2026-06-10 incident).

## What changed

**New helper `apps/common/identifiers.py`** (`mcp_server` already imports `apps.*`, so it's reachable everywhere):

| Function | Keyed on | Behaviour |
|---|---|---|
| `tenant_schema_name(provider, external_id)` | `(provider, external_id)` | **always** carries an 8-char digest → Connect `123` ≠ OCS `123`; `a-b`/`a_b`/`a.b` distinct. Capped so `_ro`/`_dbt`/`_r…` still fit 63 bytes. |
| `refresh_schema_name(provider, external_id, token=)` | identity + random token | per-refresh unique, ≤63 |
| `readonly_role_name` / `dbt_role_name` | `schema_name` | **byte-identical** to today when it fits 63 (`t_123_ro`); digest woven in only on overflow → no rename, no migration |
| `dbt_model_name` / `dbt_column_alias` | full pre-truncation name | cap+hash **before** truncation (fixes `_unique_alias` ordering bug) |

**Correctness fixes (00#3):**
- `provision()` matches an existing schema by **`tenant` FK**, never `schema_name`. It resolves the live (ACTIVE/MATERIALIZING) schema first — so a blue-green refresh's not-yet-promoted `_r` schema (PROVISIONING, `last_accessed_at` NULL) is never grabbed — resurrects an EXPIRED record in place, else mints a fresh collision-safe name.
- `load_tenant_context(external_id, provider)` — `provider` is now a **required predicate**, threaded from both callers (`load_workspace_context`, `apps/agents/graph/base.py`).
- `build_view_schema` threads the **tenant object** instead of `Tenant.objects.get(external_id=)` → fixes the `MultipleObjectsReturned` that broke multi-tenant builds.

**Out of scope (per issue):** the sync `/runs/trigger/` `threading.Lock` redesign — left with a `# NOTE` only.

## Migration: none
Existing schemas are left untouched — `provision()` FK-matches and reuses their stored name, and the derived-name functions are byte-identical for the short names in prod, so queries keep working. The inactivity TTL ages out old-shape schemas; the next access mints the new collision-safe shape, so within ~a week prod is all new-shape names. The only non-seamless case is an existing >60-byte schema (the latent-bug zone): its role name changes → queries fail **closed** until TTL regen, which is the correct secure outcome.

## Sibling sweep (#268 pattern: grep for every sibling minting site)
`grep -rnE '_ro"|_dbt"|_r\{|f"t_|f"stg_|f"\{.*\}__|_sanitize_schema_name' apps/ mcp_server/` (excluding the helper + tests):

| Site | Disposition |
|---|---|
| `schema_manager.py` schema / `_ro` / `_dbt` / refresh names | ✅ routed through helper |
| `mcp_server/context.py` `readonly_role` property | ✅ routed through `readonly_role_name` |
| `commcare_staging.py` `stg_case_`/`stg_form_`/`__repeat_` model names + column aliases | ✅ wrapped in `dbt_model_name`/`dbt_column_alias` |
| `executor.py` dbt confinement role | ✅ already uses `dbt_role_name` |
| `schema_manager.py:build_view_schema` `{prefix}__{table}` view names | ✅ #227 exemplar — keeps its specialized multi-tenant `__`-delimiter + prefix-collision guard, now shares `PG_MAX_IDENTIFIER_BYTES` + `sanitize_identifier` (via `_view_prefix`) |
| `_view_schema_name` `ws_{16hex}` | ⏸️ keyed on workspace UUID, already bounded (19 bytes) — not part of the (provider, external_id) class |
| `knowledge/api/views.py` `f"{field}__icontains"` | n/a — Django ORM lookup key, not a Postgres identifier |

## Tests
`apps/common/identifiers.py` is fully unit-tested (25 cases). DB-backed routing tests cover: cross-provider same external_id → distinct schemas; punctuation collision → distinct; >63-byte external_id → distinct hashed schemas; provision matches by FK (not name) + ignores in-flight `_r` refresh schema; `load_tenant_context` provider predicate; `build_view_schema` cross-provider duplicate tolerance; dbt long-name bounding + `ref()` integrity. Full suite: **1373 passed**.

Design spec: `docs/superpowers/specs/2026-06-18-identifier-helper-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
