### PR TITLE
Sibling-sweep as fix policy on every incident-fix PR (arch #268)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,36 @@
+<!--
+Thanks for the PR! Fill in the sections below. Delete any that don't apply,
+EXCEPT "Sibling sweep" on a bug/incident fix — that one is required (see CONTRIBUTING.md).
+-->
+
+## What & why
+
+<!-- What does this change do, and why? Link the issue: "Closes #123". -->
+
+## Sibling sweep (required on bug/incident fixes)
+
+<!--
+The single most predictive source of repeat incidents is "fixed where it bit":
+patching the one call site that broke while identical sibling sites stay broken
+(arch #268). Before merging a fix, grep for the rest of the pattern and account
+for every hit — fix it, or explicitly tick it off with a reason.
+
+Canonical example: #235 / PR #299 — PR #227 had byte-capped *view* names only;
+the sibling sweep found schema, role, refresh, and dbt names with the same
+unguarded pattern and routed them all through one helper.
+
+Delete this section only for changes that fix nothing (docs, pure refactors,
+new features with no prior buggy sibling).
+-->
+
+- **Grep used:** <!-- e.g. `grep -rnE '_ro"|_dbt"|f"stg_' apps/ mcp_server/` -->
+- **Sibling sites found & disposition:**
+  - [ ] `path/to/site` — fixed / not applicable because …
+
+## Testing
+
+<!-- How did you verify this? New/updated tests, manual steps, etc. -->
+
+## Notes for reviewers
+
+<!-- Anything out of scope, follow-ups, risk areas, or deploy/migration concerns. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,43 @@
+# Contributing to Scout
+
+See `CLAUDE.md` for architecture, commands, and code style. This file covers one
+process rule that the PR template enforces.
+
+## The sibling-sweep rule (arch #268)
+
+**Every bug or incident fix must sweep for sibling sites and account for each one.**
+
+Across Scout's incident history, the single most predictive source of repeat
+incidents is **"fixed where it bit"** — patching the one call site that happened
+to break while identical sibling sites are left with the same latent bug. The
+fix looks complete, the same class of bug recurs from a neighbour weeks later.
+
+So before you merge a fix:
+
+1. **Find the pattern.** What category of thing was wrong? (A missing guard, an
+   unsafe call, a wrong predicate, an unbounded value…)
+2. **Grep for every sibling.** Search the codebase for the same pattern, not just
+   the file you touched. Write the grep down — it goes in the PR.
+3. **Account for every hit.** Either fix it in this PR, or explicitly tick it off
+   with a one-line reason it's safe/out of scope. Silent omission is the failure
+   mode this rule exists to prevent.
+
+The PR template has a **Sibling sweep** section for exactly this: paste the grep
+and list each site with its disposition.
+
+### Canonical example — #235
+
+PR #227 fixed Postgres's 63-byte identifier truncation for **view names**. It was
+correct, but it fixed only the site that bit. The sibling sweep for #235 grepped
+for every minted Postgres identifier and found the same unguarded pattern on
+schema names, read-only and dbt role names, refresh-schema names, and dbt
+model/column names — any of which could collapse two tenants onto one physical
+object. #235 routed them all through one helper (`apps/common/identifiers.py`)
+and listed the full grep in [PR #299](https://github.com/dimagi-rad/scout/pull/299).
+That is the bar: find the class, sweep it, close it.
+
+### When it doesn't apply
+
+Pure docs changes, mechanical refactors, and brand-new features with no
+pre-existing buggy sibling don't need a sweep — delete the section from the PR.
+When in doubt, do the grep anyway; it's cheap and occasionally surprising.


### PR DESCRIPTION
Closes #268.

Pattern 1 from the arch review — **"fixed where it bit"** — is the single most predictive generator of repeat incidents: a fix patches the one call site that broke while identical sibling sites keep the same latent bug. This codifies a sweep step so every bug/incident fix has to find and account for its siblings.

## What changed
- **`.github/pull_request_template.md`** (new — the repo had none): adds a required **Sibling sweep** section — paste the grep, list each sibling site with its disposition (fixed / not-applicable-because…). Plus light What/Testing/Notes scaffolding.
- **`CONTRIBUTING.md`** (new): documents the rule and the three steps (find the pattern → grep for siblings → account for every hit), with #235 / PR #299 as the canonical worked example and a short "when it doesn't apply" note.

## Why #235 is the exemplar
PR #227 byte-capped **view** names only. The #235 sweep grepped for every minted Postgres identifier and found the same unguarded pattern on schema, role, refresh, and dbt names — and routed them all through one helper, with the full grep table in [PR #299](https://github.com/dimagi-rad/scout/pull/299). That PR's "Sibling sweep" section is the shape this template asks every fix to follow.

Docs-only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
