### PR TITLE
fix(docker): set DJANGO_SETTINGS_MODULE for build-time collectstatic (prod deploy hotfix)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,14 @@ COPY . .
 # Install the project itself (fast — deps already installed)
 RUN uv pip install --system --no-deps -e .
 
-# Collect static files at build time (not on every container start)
-RUN DJANGO_SECRET_KEY=build-placeholder python manage.py collectstatic --noinput
+# Collect static files at build time (not on every container start).
+# DJANGO_SETTINGS_MODULE is set inline (build-layer scope only, never leaks to the
+# runtime container) because manage.py now refuses to default to development
+# settings (see config/settings_guard.py, arch #248/08#5) and .env is .dockerignore'd.
+# The static manifest (whitenoise CompressedManifestStaticFilesStorage) lives in
+# base.py, so the collected output is identical across settings modules.
+RUN DJANGO_SETTINGS_MODULE=config.settings.development DJANGO_SECRET_KEY=build-placeholder \
+    python manage.py collectstatic --noinput
 
 # Create non-root user
 RUN useradd -m -u 1000 appuser && chown -R appuser:appuser /app


### PR DESCRIPTION
## Production deploy hotfix

The **Deploy Scout (Production)** workflow has failed at **Build and push API image** on every merge since **#298**, so the last code actually deployed to production is **#294** (11:48). The merged fixes **#246, #248, #245** — including #245's OCS PII-scope **security** fix — built but **never shipped**.

### Root cause
`#298` (arch #248, finding `08#5`) made `manage.py` refuse to default to development settings (`config/settings_guard.py`) — correct hardening. But `Dockerfile` runs `collectstatic` at **build time** with no `DJANGO_SETTINGS_MODULE`, and `.env` is `.dockerignore`d, so the build container has no fallback:

```
RuntimeError: DJANGO_SETTINGS_MODULE environment variable is required. ...
ERROR: process "... python manage.py collectstatic --noinput" did not complete successfully: exit code: 1
```

The #298 sibling sweep covered runtime entrypoints but missed the **build-time** `manage.py` call in the Dockerfile.

### Fix
Set `DJANGO_SETTINGS_MODULE=config.settings.development` **inline on the RUN** (build-layer scope only — it does **not** leak to the runtime container, which sets the module explicitly via `deploy*.yml`). This restores the exact pre-#298 behavior. The whitenoise `CompressedManifestStaticFilesStorage` lives in `base.py`, so the collected/hashed static output is identical regardless of settings module.

A global `ENV DJANGO_SETTINGS_MODULE=...development` was deliberately **avoided** — it would leak development settings to the runtime container and reintroduce the permissive-default risk #298 closed.

### Verification (no local Docker; Deploy builds only on push to main)
Ran the exact build command in an **`.env`-less worktree** (faithful to the build container):
- **With the fix:** `165 static files copied, 475 post-processed` ✅
- **Without the module (un-fixed):** reproduces the `settings_guard.py` `RuntimeError` ✅ (load-bearing)

On merge, the production Deploy re-runs and ships the #246/#248/#245 backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
