### PR TITLE
Connect form-aware staging: deliver-app schema → typed stg_visits columns + auto column notes

### DIFF
--- a/apps/knowledge/services/column_note_generator.py
+++ b/apps/knowledge/services/column_note_generator.py
@@ -7,12 +7,13 @@ _extract_form_definitions in apps/transformations/services/commcare_staging.py):
     {<xmlns>: {"questions": [{"label": str, "value": str, "type": str, "repeat": bool,
                                "options"?: list | None, "choices"?: list | None}, ...]}, ...}
 
-Derives column names using the same _column_name_from_path helper as Task 3
-(staging column construction) so names stay aligned.
+Derives column names using visit_column_map from connect_staging so that
+the final deduped column names always match the staging columns produced by
+_generate_stg_visits — including collision-suffixed names like ``status_2``.
 """
 
 from apps.knowledge.models import TableKnowledge
-from apps.transformations.services.commcare_staging import _column_name_from_path
+from apps.transformations.services.connect_staging import visit_column_map
 
 
 async def sync_column_notes(workspace, table_name: str, form_definitions: dict) -> TableKnowledge:
@@ -21,37 +22,28 @@ async def sync_column_notes(workspace, table_name: str, form_definitions: dict) 
     from question label + type + choices/options across all forms in
     *form_definitions*.
 
-    Column names are derived via _column_name_from_path to match the staging
-    column names produced by Task 3 exactly.
+    Column names are derived via visit_column_map to match the staging column
+    names produced by _generate_stg_visits exactly, including any collision-
+    suffixed names (e.g. ``status_2`` when ``status`` is a base column).
 
     Returns the upserted TableKnowledge instance.
     """
     column_notes: dict[str, str] = {}
 
-    for _xmlns, form_def in form_definitions.items():
-        for question in form_def.get("questions", []):
-            # Skip repeat groups — they stage to separate tables
-            if question.get("repeat"):
-                continue
+    for question, col_name in visit_column_map(form_definitions):
+        label = question.get("label", col_name)
+        qtype = question.get("type", "")
 
-            value_path = question.get("value", "")
-            if not value_path:
-                continue
+        # Build note string: "label — type" (optionally "; values: a, b, c")
+        note = f"{label} — {qtype}"
 
-            col_name = _column_name_from_path(value_path)
-            label = question.get("label", col_name)
-            qtype = question.get("type", "")
+        # Accept either "options" or "choices" key (tolerate missing / None)
+        raw_choices = question.get("options") or question.get("choices")
+        if raw_choices:
+            values_str = ", ".join(str(c) for c in raw_choices)
+            note = f"{note}; values: {values_str}"
 
-            # Build note string: "label — type" (optionally "; values: a, b, c")
-            note = f"{label} — {qtype}"
-
-            # Accept either "options" or "choices" key (tolerate missing / None)
-            raw_choices = question.get("options") or question.get("choices")
-            if raw_choices:
-                values_str = ", ".join(str(c) for c in raw_choices)
-                note = f"{note}; values: {values_str}"
-
-            column_notes[col_name] = note
+        column_notes[col_name] = note
 
     existing = await TableKnowledge.objects.filter(
         workspace=workspace, table_name=table_name

--- a/apps/knowledge/services/column_note_generator.py
+++ b/apps/knowledge/services/column_note_generator.py
@@ -53,11 +53,17 @@ async def sync_column_notes(workspace, table_name: str, form_definitions: dict) 
 
             column_notes[col_name] = note
 
+    existing = await TableKnowledge.objects.filter(
+        workspace=workspace, table_name=table_name
+    ).afirst()
+    merged_notes = {**(existing.column_notes if existing else {}), **column_notes}
+
     tk, _created = await TableKnowledge.objects.aupdate_or_create(
         workspace=workspace,
         table_name=table_name,
-        defaults={
-            "column_notes": column_notes,
+        defaults={"column_notes": merged_notes},
+        create_defaults={
+            "column_notes": merged_notes,
             "description": f"Auto-generated column notes for {table_name}.",
         },
     )

--- a/apps/knowledge/services/column_note_generator.py
+++ b/apps/knowledge/services/column_note_generator.py
@@ -1,0 +1,64 @@
+"""
+Auto-populate TableKnowledge.column_notes from Connect form_definitions.
+
+Iterates non-repeat questions across form_definitions (shape produced by
+_extract_form_definitions in apps/transformations/services/commcare_staging.py):
+
+    {<xmlns>: {"questions": [{"label": str, "value": str, "type": str, "repeat": bool,
+                               "options"?: list | None, "choices"?: list | None}, ...]}, ...}
+
+Derives column names using the same _column_name_from_path helper as Task 3
+(staging column construction) so names stay aligned.
+"""
+
+from apps.knowledge.models import TableKnowledge
+from apps.transformations.services.commcare_staging import _column_name_from_path
+
+
+async def sync_column_notes(workspace, table_name: str, form_definitions: dict) -> TableKnowledge:
+    """
+    Upsert TableKnowledge for *table_name*, merging per-column notes derived
+    from question label + type + choices/options across all forms in
+    *form_definitions*.
+
+    Column names are derived via _column_name_from_path to match the staging
+    column names produced by Task 3 exactly.
+
+    Returns the upserted TableKnowledge instance.
+    """
+    column_notes: dict[str, str] = {}
+
+    for _xmlns, form_def in form_definitions.items():
+        for question in form_def.get("questions", []):
+            # Skip repeat groups — they stage to separate tables
+            if question.get("repeat"):
+                continue
+
+            value_path = question.get("value", "")
+            if not value_path:
+                continue
+
+            col_name = _column_name_from_path(value_path)
+            label = question.get("label", col_name)
+            qtype = question.get("type", "")
+
+            # Build note string: "label — type" (optionally "; values: a, b, c")
+            note = f"{label} — {qtype}"
+
+            # Accept either "options" or "choices" key (tolerate missing / None)
+            raw_choices = question.get("options") or question.get("choices")
+            if raw_choices:
+                values_str = ", ".join(str(c) for c in raw_choices)
+                note = f"{note}; values: {values_str}"
+
+            column_notes[col_name] = note
+
+    tk, _created = await TableKnowledge.objects.aupdate_or_create(
+        workspace=workspace,
+        table_name=table_name,
+        defaults={
+            "column_notes": column_notes,
+            "description": f"Auto-generated column notes for {table_name}.",
+        },
+    )
+    return tk

--- a/apps/transformations/services/connect_staging.py
+++ b/apps/transformations/services/connect_staging.py
@@ -1,0 +1,172 @@
+"""Generate system-scoped TransformationAsset records from Connect deliver-app metadata.
+
+Each asset holds the SQL for a dbt staging model that flattens
+``raw_visits.form_json`` into typed, human-labeled columns.  One ``stg_visits``
+asset is produced (non-repeat questions), plus one
+``stg_visits__repeat_<group>`` asset per repeat group.
+
+Assets are unsaved — callers must persist them.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from apps.transformations.models import TransformationAsset, TransformationScope
+from apps.transformations.services.commcare_staging import (
+    _column_name_from_path,
+    _question_path_to_json_path,
+    _typed_expression,
+    _unique_alias,
+    slugify_model_name,
+)
+
+logger = logging.getLogger(__name__)
+
+# Base columns always present on raw_visits.
+_VISIT_BASE_COLUMNS = [
+    "visit_id",
+    "opportunity_id",
+    "user_id",
+    "entity_id",
+    "status",
+    "deliver_unit_id",
+    "form_json",
+]
+
+
+# ── Visit staging asset ──────────────────────────────────────────────────────
+
+
+def _generate_stg_visits(tenant, form_definitions: dict) -> TransformationAsset:
+    """Generate the ``stg_visits`` staging asset for all deliver-app forms.
+
+    Non-repeat questions from every form definition contribute a typed, aliased
+    column extracted from ``form_json``.  Repeat questions are skipped here and
+    handled by :func:`_generate_repeat_group_asset`.
+    """
+    lines = ["SELECT"]
+    select_parts: list[str] = [f"    {col}" for col in _VISIT_BASE_COLUMNS]
+
+    # Seed seen_aliases from base column names so question aliases that collide
+    # get a numeric suffix.
+    seen_aliases: dict[str, int] = {col: 1 for col in _VISIT_BASE_COLUMNS}
+
+    for _deliver_unit, form_def in form_definitions.items():
+        for q in form_def.get("questions", []):
+            if q.get("repeat"):
+                continue
+            value_path = q.get("value", "")
+            if not value_path:
+                continue
+            json_path = _question_path_to_json_path(value_path)
+            col_name = _unique_alias(_column_name_from_path(value_path), seen_aliases)
+            raw_expr = f"form_json #>> {json_path}"
+            q_type = q.get("type")
+            select_parts.append(f'    {_typed_expression(raw_expr, q_type)} AS "{col_name}"')
+
+    lines.append(",\n".join(select_parts))
+    lines.append("FROM raw_visits")
+
+    return TransformationAsset(
+        name="stg_visits",
+        description="Staging model for Connect raw_visits with typed form_json columns",
+        scope=TransformationScope.SYSTEM,
+        tenant=tenant,
+        sql_content="\n".join(lines),
+        created_by=None,
+    )
+
+
+# ── Repeat-group asset ───────────────────────────────────────────────────────
+
+
+def _generate_connect_repeat_group_asset(
+    tenant, group_path: str, child_questions: list[dict]
+) -> TransformationAsset:
+    """Generate a ``stg_visits__repeat_<group>`` asset for a repeat group.
+
+    Mirrors ``commcare_staging._generate_repeat_group_asset`` but targets
+    ``stg_visits`` as the parent and ``form_json`` as the JSON column.
+    """
+    group_json_path = _question_path_to_json_path(group_path)
+    group_slug = slugify_model_name(group_path.rsplit("/", 1)[-1])
+    parent_model = "stg_visits"
+
+    lines = ["SELECT"]
+    select_parts: list[str] = [
+        "    f.visit_id",
+        '    row_number() OVER (PARTITION BY f.visit_id ORDER BY elem.ordinality) AS "repeat_index"',
+    ]
+    seen_aliases: dict[str, int] = {"visit_id": 1, "repeat_index": 1}
+
+    for q in child_questions:
+        value_path = q.get("value", "")
+        if not value_path:
+            continue
+        leaf_name = value_path.rsplit("/", 1)[-1]
+        col_name = _unique_alias(_column_name_from_path(value_path), seen_aliases)
+        raw_expr = f"elem.value->>'{leaf_name}'"
+        q_type = q.get("type")
+        select_parts.append(f'    {_typed_expression(raw_expr, q_type)} AS "{col_name}"')
+
+    lines.append(",\n".join(select_parts))
+    lines.append(f"FROM {{{{ ref('{parent_model}') }}}} f,")
+    lines.append("LATERAL jsonb_array_elements(")
+    lines.append(f"    f.form_json #> {group_json_path}")
+    lines.append(") WITH ORDINALITY AS elem(value, ordinality)")
+    lines.append(f"WHERE f.form_json #> {group_json_path} IS NOT NULL")
+
+    model_name = f"{parent_model}__repeat_{group_slug}"
+    return TransformationAsset(
+        name=model_name,
+        description=f"Repeat group '{group_slug}' from {parent_model}",
+        scope=TransformationScope.SYSTEM,
+        tenant=tenant,
+        sql_content="\n".join(lines),
+        created_by=None,
+    )
+
+
+# ── Public API ───────────────────────────────────────────────────────────────
+
+
+def generate_connect_assets(form_definitions: dict, tenant) -> list[TransformationAsset]:
+    """Generate unsaved TransformationAsset instances for Connect staging.
+
+    Args:
+        form_definitions: dict keyed by deliver_unit slug, each value having
+            ``name``, ``deliver_unit``, and ``questions`` (list of dicts with
+            ``label``, ``value``, ``type``, ``repeat``, ``options`` keys).
+            Shape matches what ``_extract_form_definitions`` produces for the
+            Connect deliver app.
+        tenant: a ``users.Tenant`` instance with provider ``commcare_connect``.
+
+    Returns:
+        Unsaved :class:`~apps.transformations.models.TransformationAsset`
+        instances:
+        - one ``stg_visits`` asset (non-repeat questions only)
+        - one ``stg_visits__repeat_<group>`` asset per repeat group
+    """
+    assets: list[TransformationAsset] = []
+
+    # Main stg_visits asset (non-repeat columns only)
+    assets.append(_generate_stg_visits(tenant, form_definitions))
+
+    # Collect repeat groups across all form definitions
+    repeat_groups: dict[str, list[dict]] = {}
+    for _deliver_unit, form_def in form_definitions.items():
+        for q in form_def.get("questions", []):
+            if not q.get("repeat"):
+                continue
+            value_path = q.get("value", "")
+            if not value_path:
+                continue
+            # Group path is everything up to (but not including) the leaf segment
+            group_path = value_path.rsplit("/", 1)[0]
+            repeat_groups.setdefault(group_path, []).append(q)
+
+    for group_path, child_qs in repeat_groups.items():
+        assets.append(_generate_connect_repeat_group_asset(tenant, group_path, child_qs))
+
+    return assets

--- a/apps/transformations/services/connect_staging.py
+++ b/apps/transformations/services/connect_staging.py
@@ -16,6 +16,7 @@ from apps.transformations.models import TransformationAsset, TransformationScope
 from apps.transformations.services.commcare_staging import (
     _column_name_from_path,
     _question_path_to_json_path,
+    _sql_escape,
     _typed_expression,
     _unique_alias,
     slugify_model_name,
@@ -106,7 +107,7 @@ def _generate_connect_repeat_group_asset(
             continue
         leaf_name = value_path.rsplit("/", 1)[-1]
         col_name = _unique_alias(_column_name_from_path(value_path), seen_aliases)
-        raw_expr = f"elem.value->>'{leaf_name}'"
+        raw_expr = f"elem.value->>'{_sql_escape(leaf_name)}'"
         q_type = q.get("type")
         select_parts.append(f'    {_typed_expression(raw_expr, q_type)} AS "{col_name}"')
 

--- a/apps/transformations/services/connect_staging.py
+++ b/apps/transformations/services/connect_staging.py
@@ -36,6 +36,33 @@ _VISIT_BASE_COLUMNS = [
 ]
 
 
+# ── Single source of truth for stg_visits column naming ──────────────────────
+
+
+def visit_column_map(form_definitions: dict) -> list[tuple[dict, str]]:
+    """Return an ordered list of (question, final_column_name) for stg_visits.
+
+    Applies the same base-column seeding and :func:`_unique_alias` deduplication
+    that :func:`_generate_stg_visits` uses, guaranteeing that the column names
+    returned here are byte-for-byte identical to those emitted in the staging SQL.
+
+    Only non-repeat questions with a non-empty ``value`` path are included —
+    repeat-group children are staged in separate tables and excluded here.
+    """
+    seen_aliases: dict[str, int] = {col: 1 for col in _VISIT_BASE_COLUMNS}
+    result: list[tuple[dict, str]] = []
+    for _deliver_unit, form_def in form_definitions.items():
+        for q in form_def.get("questions", []):
+            if q.get("repeat"):
+                continue
+            value_path = q.get("value", "")
+            if not value_path:
+                continue
+            col_name = _unique_alias(_column_name_from_path(value_path), seen_aliases)
+            result.append((q, col_name))
+    return result
+
+
 # ── Visit staging asset ──────────────────────────────────────────────────────
 
 
@@ -49,22 +76,12 @@ def _generate_stg_visits(tenant, form_definitions: dict) -> TransformationAsset:
     lines = ["SELECT"]
     select_parts: list[str] = [f"    {col}" for col in _VISIT_BASE_COLUMNS]
 
-    # Seed seen_aliases from base column names so question aliases that collide
-    # get a numeric suffix.
-    seen_aliases: dict[str, int] = {col: 1 for col in _VISIT_BASE_COLUMNS}
-
-    for _deliver_unit, form_def in form_definitions.items():
-        for q in form_def.get("questions", []):
-            if q.get("repeat"):
-                continue
-            value_path = q.get("value", "")
-            if not value_path:
-                continue
-            json_path = _question_path_to_json_path(value_path)
-            col_name = _unique_alias(_column_name_from_path(value_path), seen_aliases)
-            raw_expr = f"form_json #>> {json_path}"
-            q_type = q.get("type")
-            select_parts.append(f'    {_typed_expression(raw_expr, q_type)} AS "{col_name}"')
+    for q, col_name in visit_column_map(form_definitions):
+        value_path = q.get("value", "")
+        json_path = _question_path_to_json_path(value_path)
+        raw_expr = f"form_json #>> {json_path}"
+        q_type = q.get("type")
+        select_parts.append(f'    {_typed_expression(raw_expr, q_type)} AS "{col_name}"')
 
     lines.append(",\n".join(select_parts))
     lines.append("FROM raw_visits")

--- a/apps/transformations/services/connect_staging.py
+++ b/apps/transformations/services/connect_staging.py
@@ -132,6 +132,54 @@ def _generate_connect_repeat_group_asset(
 # ── Public API ───────────────────────────────────────────────────────────────
 
 
+def upsert_connect_assets(tenant, tenant_metadata) -> dict:
+    """Generate and upsert system staging TransformationAssets for a Connect tenant.
+
+    Mirrors :func:`~apps.transformations.services.commcare_staging.upsert_system_assets`
+    exactly but for the Connect deliver-app staging models (``stg_visits`` +
+    repeat-group children).
+
+    Calls :func:`generate_connect_assets`, then ``update_or_create`` for each asset,
+    and finally deletes any SYSTEM-scoped asset for this tenant whose model is no
+    longer generated from the current metadata (orphan sweep).
+
+    Only SYSTEM-scoped assets for this tenant are swept — user-authored
+    TENANT/WORKSPACE assets are never touched.
+
+    Returns ``{"created": int, "updated": int, "deleted": int, "total": int}``.
+    """
+    form_definitions = (tenant_metadata.metadata or {}).get("form_definitions", {})
+    assets = generate_connect_assets(form_definitions, tenant)
+
+    created = 0
+    updated = 0
+
+    for asset in assets:
+        _, was_created = TransformationAsset.objects.update_or_create(
+            name=asset.name,
+            scope=TransformationScope.SYSTEM,
+            tenant=tenant,
+            defaults={
+                "description": asset.description,
+                "sql_content": asset.sql_content,
+                "created_by": None,
+            },
+        )
+        if was_created:
+            created += 1
+        else:
+            updated += 1
+
+    current_names = {a.name for a in assets}
+    deleted, _ = (
+        TransformationAsset.objects.filter(tenant=tenant, scope=TransformationScope.SYSTEM)
+        .exclude(name__in=current_names)
+        .delete()
+    )
+
+    return {"created": created, "updated": updated, "deleted": deleted, "total": len(assets)}
+
+
 def generate_connect_assets(form_definitions: dict, tenant) -> list[TransformationAsset]:
     """Generate unsaved TransformationAsset instances for Connect staging.
 

--- a/docs/superpowers/plans/2026-06-18-cube-semantic-layer-auto-modeling.md
+++ b/docs/superpowers/plans/2026-06-18-cube-semantic-layer-auto-modeling.md
@@ -34,10 +34,10 @@
 - Test: `tests/test_connect_metadata_loader.py` (create if absent)
 
 **Interfaces:**
-- Consumes: `ConnectBaseLoader._get(url)` (returns `requests.Response`, raises `ConnectAuthError` on 401/403); `self.base_url`, `self.opportunity_id`.
-- Produces: `ConnectMetadataLoader.load()` returns a dict that now ALSO contains key `form_definitions: dict[str, FormDef]` where `FormDef = {"name": str, "module_name": str, "deliver_unit": str, "questions": [{"label": str, "value": str, "type": str, "repeat": bool, "options": list[str] | None}]}`, keyed by a stable form key (xmlns or deliver_unit slug). This matches the CommCare `form_definitions` shape consumed by `_build_jsonb_annotations` and the new Connect staging (Task 4).
+- Consumes: `ConnectBaseLoader._get(url)` (returns `requests.Response`, raises `ConnectAuthError` on 401/403); `self.base_url`, `self.opportunity_id`. **Reuses** `mcp_server.loaders.commcare_metadata._extract_form_definitions` (module-level fn taking a list of HQ app JSON dicts → `form_definitions` keyed by xmlns) and `_extract_case_types`.
+- Produces: `ConnectMetadataLoader.load()` returns a dict that now ALSO contains `form_definitions: dict[str, FormDef]` **in the exact CommCare shape** produced by `_extract_form_definitions` — keyed by xmlns, each `FormDef = {"name", "app_name", "module_name", "case_type", "questions": [...]}`. This is identical to what `_build_jsonb_annotations` and CommCare staging already consume, maximizing reuse.
 
-**Connect endpoint:** `GET {base_url}/export/opportunity/{id}/app_structure/` returns the deliver-app form schema (single object). Normalize it to the `form_definitions` shape above.
+**Connect endpoint (verified in `dimagi/commcare-connect` `data_export` app):** `GET {base_url}/export/opportunity/{id}/app_structure/?app_type=both` returns `{"learn_app": <HQ app JSON | null>, "deliver_app": <HQ app JSON | null>}`. Each app is the full CommCare HQ application structure (`{"id", "name", "modules": [{"name", "forms": [{"xmlns", "name", "questions": [...]}]}]}`). **Connect proxies to HQ server-side via the opportunity's stored `api_key`** — the caller needs only the Connect OAuth `export` scope; NO CommCare HQ credentials. Normalize by passing the non-null apps as a list straight into the existing `_extract_form_definitions([...])`.
 
 - [ ] **Step 1: Write the failing test**
 
@@ -47,21 +47,32 @@ from unittest import mock
 
 from mcp_server.loaders.connect_metadata import ConnectMetadataLoader
 
+# Real Connect /app_structure/ shape: {"learn_app": <HQ app JSON>, "deliver_app": <HQ app JSON>}
+# Each app is HQ application JSON: app -> modules -> forms -> questions.
 APP_STRUCTURE_PAYLOAD = {
-    "deliver_units": [
-        {
-            "slug": "muac_visit",
-            "name": "MUAC Visit",
-            "module_name": "Delivery",
-            "xmlns": "http://openrosa.org/formdesigner/muac1",
-            "questions": [
-                {"label": "MUAC (cm)", "value": "/data/muac_group/muac",
-                 "type": "Decimal", "repeat": False},
-                {"label": "MUAC confirmed", "value": "/data/muac_group/muac_confirmed",
-                 "type": "Select", "repeat": False, "options": ["yes", "no"]},
-            ],
-        }
-    ]
+    "learn_app": None,
+    "deliver_app": {
+        "id": "app_deliver",
+        "name": "MUAC Deliver",
+        "modules": [
+            {
+                "name": "Delivery",
+                "case_type": "beneficiary",
+                "forms": [
+                    {
+                        "xmlns": "http://openrosa.org/formdesigner/muac1",
+                        "name": "MUAC Visit",
+                        "questions": [
+                            {"label": "MUAC (cm)", "value": "/data/muac_group/muac",
+                             "tag": "input", "type": "Decimal", "repeat": False},
+                            {"label": "MUAC confirmed", "value": "/data/muac_group/muac_confirmed",
+                             "tag": "select1", "type": "Select", "repeat": False},
+                        ],
+                    }
+                ],
+            }
+        ],
+    },
 }
 
 
@@ -73,20 +84,20 @@ def _loader():
     )
 
 
-def test_load_includes_normalized_form_definitions():
+def test_load_includes_form_definitions_from_app_structure():
     loader = _loader()
     with mock.patch.object(loader, "_fetch_org_data", return_value={"organizations": [], "programs": [], "opportunities": []}), \
          mock.patch.object(loader, "_fetch_opportunity_detail", return_value={"name": "Demo", "id": 1237}), \
          mock.patch.object(loader, "_fetch_app_structure", return_value=APP_STRUCTURE_PAYLOAD):
         result = loader.load()
 
+    # _extract_form_definitions keys by xmlns (CommCare shape):
     fd = result["form_definitions"]
-    assert "muac_visit" in fd
-    form = fd["muac_visit"]
-    assert form["deliver_unit"] == "muac_visit"
+    assert "http://openrosa.org/formdesigner/muac1" in fd
+    form = fd["http://openrosa.org/formdesigner/muac1"]
     q = {item["value"]: item for item in form["questions"]}
     assert q["/data/muac_group/muac"]["type"] == "Decimal"
-    assert q["/data/muac_group/muac_confirmed"]["options"] == ["yes", "no"]
+    assert q["/data/muac_group/muac_confirmed"]["label"] == "MUAC confirmed"
 ```
 
 - [ ] **Step 2: Run test to verify it fails**
@@ -100,40 +111,10 @@ Expected: FAIL — `ConnectMetadataLoader` has no `_fetch_app_structure`, and `l
 # mcp_server/loaders/connect_metadata.py
 import logging
 
+from mcp_server.loaders.commcare_metadata import _extract_case_types, _extract_form_definitions
 from mcp_server.loaders.connect_base import ConnectBaseLoader
 
 logger = logging.getLogger(__name__)
-
-
-def _normalize_app_structure(payload: dict) -> dict:
-    """Normalize a Connect /app_structure/ payload into form_definitions shape.
-
-    Keyed by deliver-unit slug. Each value carries name, module_name, deliver_unit,
-    and a list of question dicts: {label, value, type, repeat, options}.
-    """
-    form_definitions: dict[str, dict] = {}
-    for du in payload.get("deliver_units", []):
-        slug = du.get("slug") or du.get("xmlns") or du.get("name", "")
-        if not slug:
-            continue
-        questions = []
-        for q in du.get("questions", []):
-            questions.append(
-                {
-                    "label": q.get("label", q.get("value", "")),
-                    "value": q.get("value", ""),
-                    "type": q.get("type", "Text"),
-                    "repeat": bool(q.get("repeat", False)),
-                    "options": q.get("options"),
-                }
-            )
-        form_definitions[slug] = {
-            "name": du.get("name", slug),
-            "module_name": du.get("module_name", ""),
-            "deliver_unit": slug,
-            "questions": questions,
-        }
-    return form_definitions
 
 
 class ConnectMetadataLoader(ConnectBaseLoader):
@@ -142,15 +123,20 @@ class ConnectMetadataLoader(ConnectBaseLoader):
     def load(self) -> dict:
         org_data = self._fetch_org_data()
         opp_detail = self._fetch_opportunity_detail()
+        form_definitions: dict = {}
+        case_types: list = []
         try:
             app_structure = self._fetch_app_structure()
-            form_definitions = _normalize_app_structure(app_structure)
+            # Real Connect returns {"learn_app": <HQ app JSON|null>, "deliver_app": ...}.
+            # Each app is HQ application JSON; reuse the CommCare extractors verbatim.
+            apps = [a for a in (app_structure.get("deliver_app"), app_structure.get("learn_app")) if a]
+            form_definitions = _extract_form_definitions(apps)
+            case_types = _extract_case_types(apps)
         except Exception:
             logger.exception(
                 "Failed to fetch app_structure for opportunity %s; continuing without form_definitions",
                 self.opportunity_id,
             )
-            form_definitions = {}
 
         logger.info(
             "Loaded metadata for Connect opportunity %s: %s (%d forms)",
@@ -164,6 +150,7 @@ class ConnectMetadataLoader(ConnectBaseLoader):
             "programs": org_data.get("programs", []),
             "all_opportunities": org_data.get("opportunities", []),
             "form_definitions": form_definitions,
+            "case_types": case_types,
         }
 
     def _fetch_org_data(self) -> dict:
@@ -176,8 +163,10 @@ class ConnectMetadataLoader(ConnectBaseLoader):
 
     def _fetch_app_structure(self) -> dict:
         url = f"{self.base_url}/export/opportunity/{self.opportunity_id}/app_structure/"
-        return self._get(url).json()
+        return self._get(url, params={"app_type": "both"}).json()
 ```
+
+> **Verify at task start:** confirm `_extract_form_definitions` / `_extract_case_types` are importable module-level names in `mcp_server/loaders/commcare_metadata.py` (the verbatim extract shows they are called from `CommCareMetadataLoader.load`). Confirm `ConnectBaseLoader._get` accepts a `params=` kwarg; if it does not, add the query string to the URL instead.
 
 - [ ] **Step 4: Run test to verify it passes**
 

--- a/docs/superpowers/plans/2026-06-18-cube-semantic-layer-auto-modeling.md
+++ b/docs/superpowers/plans/2026-06-18-cube-semantic-layer-auto-modeling.md
@@ -1,0 +1,661 @@
+# Auto-modeled Cube Semantic Layer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stand up an auto-modeled Cube.dev semantic layer over Scout's Connect data, let the agent query governed metrics (falling back to raw SQL), and prove via an eval whether governed querying beats free-SQL.
+
+**Architecture:** Scout's existing Connect pipeline materializes `raw_*` tables; the deliver-app form schema is fetched into `TenantMetadata.metadata`. An auto-modeling engine stages `raw_visits.form_json` into typed/labeled columns and generates a version-controlled Cube model. Cube Core (Docker) fronts the managed Postgres and exposes a pg-wire SQL API; a new `semantic_query` MCP tool lets the agent query governed measures. An eval framework compares free-SQL vs via-Cube answers. A self-improving loop promotes learnings into the model behind a PR-based curation gate.
+
+**Tech Stack:** Django 5 (async ORM), psycopg 3, FastMCP, dbt, Cube Core (Docker), Postgres, pytest/pytest-asyncio, React (eval report viewing only, later).
+
+**Spec:** `docs/superpowers/specs/2026-06-18-cube-semantic-layer-auto-modeling-design.md`
+
+## Global Constraints
+
+- **Async-first** (CLAUDE.md): new views `async def` with native async ORM (`.aget()`, `.afirst()`, `acreate()`, `async for`); never call sync ORM from async. `await request.auser()`. `sync_to_async` only for external API calls / dbt / atomic write blocks.
+- **Imports at module level only** (CLAUDE.md). Exceptions: optional deps guarded by `try/except ImportError`; code before `django.setup()`. When moving an inline import to module level, update `mock.patch()` targets to the consuming module.
+- **Python style:** ruff (line-length=100, target py311, rules E/F/I/UP/B/ASYNC/DJ/S/SIM/TRY/RUF/PTH). Run `uv run ruff check .` and `uv run ruff format .` before each commit.
+- **Async tests** require `@pytest.mark.asyncio` + `@pytest.mark.django_db(transaction=True)`; use `AsyncClient`; fixtures stay sync. Run tests with `uv run pytest`. If port 5432 is taken, the test DB is on **5433** (see memory: scout-test-db-port-conflict).
+- **data-testid** on new interactive UI elements (`{component}-{element}`, kebab-case) — only relevant to M4 report UI if built.
+- **Commit cadence:** one commit per task (TDD: failing test → impl → passing → commit). Co-author trailer per repo convention.
+- **No secrets in code.** Cube/DB creds via env; PATs via Fernet-encrypted `TenantConnection`.
+- **Cube model lives in** `cube/model/*.yml`, version-controlled (the durable knowledge artifact).
+
+---
+
+# PHASE M1 — Real Connect ingestion + deliver-app app_structure
+
+**Outcome:** A real Connect opportunity materializes `raw_*` tables AND its deliver-app form schema lands in `TenantMetadata.metadata` under `form_definitions`, ready for auto-modeling.
+
+### Task 1: Fetch deliver-app `app_structure` in ConnectMetadataLoader
+
+**Files:**
+- Modify: `mcp_server/loaders/connect_metadata.py` (currently lines 1-45: `ConnectMetadataLoader` with `load()`, `_fetch_org_data()`, `_fetch_opportunity_detail()`)
+- Test: `tests/test_connect_metadata_loader.py` (create if absent)
+
+**Interfaces:**
+- Consumes: `ConnectBaseLoader._get(url)` (returns `requests.Response`, raises `ConnectAuthError` on 401/403); `self.base_url`, `self.opportunity_id`.
+- Produces: `ConnectMetadataLoader.load()` returns a dict that now ALSO contains key `form_definitions: dict[str, FormDef]` where `FormDef = {"name": str, "module_name": str, "deliver_unit": str, "questions": [{"label": str, "value": str, "type": str, "repeat": bool, "options": list[str] | None}]}`, keyed by a stable form key (xmlns or deliver_unit slug). This matches the CommCare `form_definitions` shape consumed by `_build_jsonb_annotations` and the new Connect staging (Task 4).
+
+**Connect endpoint:** `GET {base_url}/export/opportunity/{id}/app_structure/` returns the deliver-app form schema (single object). Normalize it to the `form_definitions` shape above.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_connect_metadata_loader.py
+from unittest import mock
+
+from mcp_server.loaders.connect_metadata import ConnectMetadataLoader
+
+APP_STRUCTURE_PAYLOAD = {
+    "deliver_units": [
+        {
+            "slug": "muac_visit",
+            "name": "MUAC Visit",
+            "module_name": "Delivery",
+            "xmlns": "http://openrosa.org/formdesigner/muac1",
+            "questions": [
+                {"label": "MUAC (cm)", "value": "/data/muac_group/muac",
+                 "type": "Decimal", "repeat": False},
+                {"label": "MUAC confirmed", "value": "/data/muac_group/muac_confirmed",
+                 "type": "Select", "repeat": False, "options": ["yes", "no"]},
+            ],
+        }
+    ]
+}
+
+
+def _loader():
+    return ConnectMetadataLoader(
+        opportunity_id=1237,
+        credential={"type": "api_key", "value": "tok"},
+        base_url="https://connect.example",
+    )
+
+
+def test_load_includes_normalized_form_definitions():
+    loader = _loader()
+    with mock.patch.object(loader, "_fetch_org_data", return_value={"organizations": [], "programs": [], "opportunities": []}), \
+         mock.patch.object(loader, "_fetch_opportunity_detail", return_value={"name": "Demo", "id": 1237}), \
+         mock.patch.object(loader, "_fetch_app_structure", return_value=APP_STRUCTURE_PAYLOAD):
+        result = loader.load()
+
+    fd = result["form_definitions"]
+    assert "muac_visit" in fd
+    form = fd["muac_visit"]
+    assert form["deliver_unit"] == "muac_visit"
+    q = {item["value"]: item for item in form["questions"]}
+    assert q["/data/muac_group/muac"]["type"] == "Decimal"
+    assert q["/data/muac_group/muac_confirmed"]["options"] == ["yes", "no"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_connect_metadata_loader.py -v`
+Expected: FAIL — `ConnectMetadataLoader` has no `_fetch_app_structure`, and `load()` returns no `form_definitions`.
+
+- [ ] **Step 3: Implement `_fetch_app_structure` + normalization, wire into `load()`**
+
+```python
+# mcp_server/loaders/connect_metadata.py
+import logging
+
+from mcp_server.loaders.connect_base import ConnectBaseLoader
+
+logger = logging.getLogger(__name__)
+
+
+def _normalize_app_structure(payload: dict) -> dict:
+    """Normalize a Connect /app_structure/ payload into form_definitions shape.
+
+    Keyed by deliver-unit slug. Each value carries name, module_name, deliver_unit,
+    and a list of question dicts: {label, value, type, repeat, options}.
+    """
+    form_definitions: dict[str, dict] = {}
+    for du in payload.get("deliver_units", []):
+        slug = du.get("slug") or du.get("xmlns") or du.get("name", "")
+        if not slug:
+            continue
+        questions = []
+        for q in du.get("questions", []):
+            questions.append(
+                {
+                    "label": q.get("label", q.get("value", "")),
+                    "value": q.get("value", ""),
+                    "type": q.get("type", "Text"),
+                    "repeat": bool(q.get("repeat", False)),
+                    "options": q.get("options"),
+                }
+            )
+        form_definitions[slug] = {
+            "name": du.get("name", slug),
+            "module_name": du.get("module_name", ""),
+            "deliver_unit": slug,
+            "questions": questions,
+        }
+    return form_definitions
+
+
+class ConnectMetadataLoader(ConnectBaseLoader):
+    """Fetch metadata for a Connect opportunity."""
+
+    def load(self) -> dict:
+        org_data = self._fetch_org_data()
+        opp_detail = self._fetch_opportunity_detail()
+        try:
+            app_structure = self._fetch_app_structure()
+            form_definitions = _normalize_app_structure(app_structure)
+        except Exception:
+            logger.exception(
+                "Failed to fetch app_structure for opportunity %s; continuing without form_definitions",
+                self.opportunity_id,
+            )
+            form_definitions = {}
+
+        logger.info(
+            "Loaded metadata for Connect opportunity %s: %s (%d forms)",
+            self.opportunity_id,
+            opp_detail.get("name", "unknown"),
+            len(form_definitions),
+        )
+        return {
+            "opportunity": opp_detail,
+            "organizations": org_data.get("organizations", []),
+            "programs": org_data.get("programs", []),
+            "all_opportunities": org_data.get("opportunities", []),
+            "form_definitions": form_definitions,
+        }
+
+    def _fetch_org_data(self) -> dict:
+        url = f"{self.base_url}/export/opp_org_program_list/"
+        return self._get(url).json()
+
+    def _fetch_opportunity_detail(self) -> dict:
+        url = f"{self.base_url}/export/opportunity/{self.opportunity_id}/"
+        return self._get(url).json()
+
+    def _fetch_app_structure(self) -> dict:
+        url = f"{self.base_url}/export/opportunity/{self.opportunity_id}/app_structure/"
+        return self._get(url).json()
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_connect_metadata_loader.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+uv run ruff check mcp_server/loaders/connect_metadata.py tests/test_connect_metadata_loader.py
+uv run ruff format mcp_server/loaders/connect_metadata.py tests/test_connect_metadata_loader.py
+git add mcp_server/loaders/connect_metadata.py tests/test_connect_metadata_loader.py
+git commit -m "feat(connect): fetch deliver-app app_structure into form_definitions"
+```
+
+> **Note on graceful degradation:** `load()` swallows app_structure errors so existing real-Connect ingestion never regresses if the endpoint is missing for a given opp. The discover phase (`materializer._run_discover_phase`, lines 525-558) already stores `loader.load()` verbatim into `TenantMetadata.metadata`, so `form_definitions` lands automatically — no materializer change needed for M1.
+
+### Task 2: Verify end-to-end discover persists form_definitions (integration)
+
+**Files:**
+- Test: `tests/test_connect_discover_integration.py` (create)
+
+**Interfaces:**
+- Consumes: `mcp_server.services.materializer._run_discover_phase(tenant_membership, credential, pipeline)`; `PipelineRegistry.get_by_provider("commcare_connect")`; `TenantMetadata`.
+
+- [ ] **Step 1: Write the failing test** — patch `ConnectMetadataLoader.load` to return a dict containing `form_definitions`, call `_run_discover_phase` for a `commcare_connect` membership, assert `TenantMetadata.metadata["form_definitions"]` persisted.
+
+```python
+# tests/test_connect_discover_integration.py
+import pytest
+from unittest import mock
+
+from mcp_server.services import materializer
+from mcp_server.pipeline_registry import PipelineRegistry
+
+
+@pytest.mark.django_db(transaction=True)
+def test_discover_persists_form_definitions(connect_tenant_membership):
+    pipeline = PipelineRegistry().get_by_provider("commcare_connect")
+    fake = {"opportunity": {"name": "Demo"}, "organizations": [], "programs": [],
+            "all_opportunities": [], "form_definitions": {"muac_visit": {"questions": []}}}
+    with mock.patch.object(materializer.ConnectMetadataLoader, "load", return_value=fake):
+        result = materializer._run_discover_phase(
+            connect_tenant_membership, {"type": "api_key", "value": "t"}, pipeline
+        )
+    from apps.workspaces.models import TenantMetadata
+    tm = TenantMetadata.objects.get(tenant_membership=connect_tenant_membership)
+    assert "muac_visit" in tm.metadata["form_definitions"]
+    assert result["form_definitions"]["muac_visit"] == {"questions": []}
+```
+
+(Add a `connect_tenant_membership` fixture in `tests/conftest.py` creating a `Tenant(provider="commcare_connect", external_id="1237")`, a `User`, and a `TenantMembership` — follow existing tenant fixtures in the suite.)
+
+- [ ] **Step 2:** Run → FAIL (fixture/behavior missing). `uv run pytest tests/test_connect_discover_integration.py -v`
+- [ ] **Step 3:** Add the fixture; no production change expected (Task 1 already wired it).
+- [ ] **Step 4:** Run → PASS.
+- [ ] **Step 5:** Commit.
+
+```bash
+git add tests/test_connect_discover_integration.py tests/conftest.py
+git commit -m "test(connect): verify discover persists form_definitions"
+```
+
+---
+
+# PHASE M2 — Connect form_json staging + auto column_notes
+
+**Outcome:** `raw_visits.form_json` is staged into typed, human-labeled columns (with repeat-group child tables and choice-list awareness) driven by `form_definitions`; `TableKnowledge.column_notes` is auto-populated. The raw-SQL agent immediately improves; the eval baseline lifts.
+
+### Task 3: Connect staging generator (`connect_staging.py`)
+
+**Files:**
+- Create: `apps/transformations/services/connect_staging.py`
+- Reuse (import from): `apps/transformations/services/commcare_staging.py` helpers — `_question_path_to_json_path`, `_column_name_from_path`, `_typed_expression`, `slugify_model_name`, `_unique_alias` (verify exact names/signatures in that file before importing; if private, lift the needed helpers into a shared `apps/transformations/services/_form_staging.py` module and have both import from it).
+- Test: `tests/test_connect_staging.py`
+
+**Interfaces:**
+- Consumes: `form_definitions` (shape from Task 1); `TransformationAsset` model (scope/tenant/name/sql_content/test_yaml).
+- Produces: `generate_connect_assets(form_definitions: dict, tenant) -> list[TransformationAsset]` — one staging asset `stg_visits` flattening `raw_visits.form_json` into typed columns (one per non-repeat question, labeled by column name derived from the question path), plus one `stg_visits__repeat_<group>` asset per repeat group. SQL conventions mirror `commcare_staging` form/repeat SQL (Postgres `#>>`/`jsonb_array_elements ... WITH ORDINALITY`).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_connect_staging.py
+import pytest
+
+from apps.transformations.services.connect_staging import generate_connect_assets
+
+FORM_DEFS = {
+    "muac_visit": {
+        "name": "MUAC Visit",
+        "deliver_unit": "muac_visit",
+        "questions": [
+            {"label": "MUAC (cm)", "value": "/data/muac_group/muac", "type": "Decimal", "repeat": False, "options": None},
+            {"label": "Confirmed", "value": "/data/muac_group/muac_confirmed", "type": "Select", "repeat": False, "options": ["yes", "no"]},
+            {"label": "Child name", "value": "/data/children/child_name", "type": "Text", "repeat": True, "options": None},
+        ],
+    }
+}
+
+
+@pytest.mark.django_db(transaction=True)
+def test_generates_visit_staging_with_typed_columns(connect_tenant):
+    assets = generate_connect_assets(FORM_DEFS, connect_tenant)
+    by_name = {a.name: a for a in assets}
+
+    assert "stg_visits" in by_name
+    sql = by_name["stg_visits"].sql_content
+    # Non-repeat questions become typed, aliased columns from form_json:
+    assert "form_json" in sql
+    assert "muac" in sql                 # column derived from /data/muac_group/muac
+    assert "muac_confirmed" in sql
+    # Repeat question is NOT inlined into stg_visits:
+    assert "child_name" not in sql
+
+    # Repeat group becomes its own child asset:
+    assert "stg_visits__repeat_children" in by_name
+    rsql = by_name["stg_visits__repeat_children"].sql_content
+    assert "jsonb_array_elements" in rsql
+    assert "child_name" in rsql
+```
+
+- [ ] **Step 2:** Run → FAIL (`connect_staging` missing). `uv run pytest tests/test_connect_staging.py -v`
+
+- [ ] **Step 3: Implement `generate_connect_assets`** — adapt `commcare_staging`'s form/repeat generators to read from `form_definitions` and target `raw_visits.form_json` (instead of `raw_forms.form_data` keyed by xmlns). Group questions by repeat status; non-repeat → typed columns on `stg_visits`; each repeat path prefix → a `stg_visits__repeat_<group>` asset using `jsonb_array_elements(... form_json #> ...) WITH ORDINALITY`. Use the shared typed-expression helper so `Decimal/Int/Date` map to the same casts as CommCare staging. Set `scope=TransformationScope.SYSTEM`, `tenant=tenant`.
+
+(Full implementation mirrors `_generate_form_asset` / `_generate_repeat_group_asset` from `commcare_staging.py`; reuse those helpers rather than re-deriving the JSON-path and casting logic.)
+
+- [ ] **Step 4:** Run → PASS. `uv run pytest tests/test_connect_staging.py -v`
+- [ ] **Step 5:** Lint + commit.
+
+```bash
+git add apps/transformations/services/connect_staging.py tests/test_connect_staging.py
+# include _form_staging.py + commcare_staging.py if helpers were extracted
+git commit -m "feat(transform): stage raw_visits.form_json into typed/labeled columns"
+```
+
+### Task 4: Auto-populate `TableKnowledge.column_notes` from form_definitions
+
+**Files:**
+- Create: `apps/knowledge/services/column_note_generator.py`
+- Test: `tests/test_column_note_generator.py`
+
+**Interfaces:**
+- Consumes: `form_definitions` (Task 1 shape); `TableKnowledge` model (`workspace`, `table_name`, `column_notes` dict, `unique_together=[workspace, table_name]`).
+- Produces: `async def sync_column_notes(workspace, table_name: str, form_definitions: dict) -> TableKnowledge` — upserts `TableKnowledge` and merges per-column notes derived from question label+type+options, e.g. `{"muac": "MUAC (cm) — Decimal", "muac_confirmed": "Confirmed — Select; values: yes, no"}`. Column name derived via the same path→column helper used in Task 3.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_column_note_generator.py
+import pytest
+
+from apps.knowledge.services.column_note_generator import sync_column_notes
+
+FORM_DEFS = {
+    "muac_visit": {"questions": [
+        {"label": "MUAC (cm)", "value": "/data/muac_group/muac", "type": "Decimal", "options": None, "repeat": False},
+        {"label": "Confirmed", "value": "/data/muac_group/muac_confirmed", "type": "Select", "options": ["yes", "no"], "repeat": False},
+    ]}
+}
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_sync_column_notes_populates_from_form_defs(workspace):
+    tk = await sync_column_notes(workspace, "stg_visits", FORM_DEFS)
+    assert "Decimal" in tk.column_notes["muac"]
+    assert "yes, no" in tk.column_notes["muac_confirmed"]
+```
+
+- [ ] **Step 2:** Run → FAIL. `uv run pytest tests/test_column_note_generator.py -v`
+- [ ] **Step 3: Implement** `sync_column_notes` using `await TableKnowledge.objects.aupdate_or_create(workspace=..., table_name=..., defaults={"column_notes": merged, "description": ...})`. Build notes by iterating non-repeat questions, deriving column name from path, formatting `f"{label} — {type}"` (+ `; values: ...` when `options`). Async ORM only.
+- [ ] **Step 4:** Run → PASS.
+- [ ] **Step 5:** Commit.
+
+```bash
+git add apps/knowledge/services/column_note_generator.py tests/test_column_note_generator.py
+git commit -m "feat(knowledge): auto-populate column_notes from Connect form_definitions"
+```
+
+> `KnowledgeRetriever._format_table_knowledge()` (retriever.py lines ~70-113) already renders `column_notes` into the agent prompt — no retriever change needed. This is why M2 lifts the raw-SQL baseline for free.
+
+### Task 5: Wire Connect staging + column notes into the materializer transform phase
+
+**Files:**
+- Modify: `mcp_server/services/materializer.py` — the TRANSFORM phase, where CommCare staging is invoked (find the call to `upsert_system_assets`/`generate_system_assets`; add a `commcare_connect` branch).
+- Test: `tests/test_connect_transform_wiring.py`
+
+**Interfaces:**
+- Consumes: discovered `metadata["form_definitions"]`; `generate_connect_assets` (Task 3); `sync_column_notes` (Task 4); existing dbt asset upsert/run path.
+
+- [ ] **Step 1:** Write a failing test asserting that, for a `commcare_connect` pipeline with `form_definitions` present, the transform phase creates a `stg_visits` `TransformationAsset` and a `TableKnowledge` row with column notes. Patch dbt execution.
+- [ ] **Step 2:** Run → FAIL.
+- [ ] **Step 3:** Add a branch in the transform phase: when `pipeline.provider == "commcare_connect"`, call `generate_connect_assets(metadata["form_definitions"], tenant)`, upsert via the existing asset-upsert helper, and call `sync_column_notes(...)` for `stg_visits`. Follow the existing CommCare staging invocation pattern exactly (same scope/tenant, same dbt run trigger).
+- [ ] **Step 4:** Run → PASS.
+- [ ] **Step 5:** Commit.
+
+```bash
+git add mcp_server/services/materializer.py tests/test_connect_transform_wiring.py
+git commit -m "feat(transform): generate Connect staging + column notes during materialization"
+```
+
+**M1+M2 acceptance:** materialize a real Connect opportunity → `raw_visits` present, `stg_visits` (+ repeat children) generated, `TableKnowledge.column_notes` populated, and the chat agent answers a form-field question (e.g. "average MUAC by status") using the labeled staging columns — all WITHOUT Cube yet. This is the baseline the eval (M4) measures against.
+
+---
+
+# PHASE M3 — Cube Core + generated model + `semantic_query`
+
+> **Detail note:** M3 task *interfaces, files, and tests* are concrete below. The per-step body of the **model generator** (Task 7) is contract-defined (it drives an LLM), so its steps test the output contract, not literal generated YAML. Expand any remaining literal code against the concrete `stg_visits` schema M2 produces.
+
+### Task 6: Cube Core service + project skeleton
+
+**Files:**
+- Create: `cube/model/.gitkeep`, `cube/cube.js` (or `cube/.env` config), `cube/README.md`
+- Modify: `docker-compose.yml` (add `cube` service), `.env.example` (Cube env vars)
+- Test: `tests/test_cube_service_smoke.py` (skipped unless `CUBE_URL` set — a connectivity smoke test)
+
+**Interfaces:**
+- Produces: a running Cube Core container reading `cube/model/`, connected to `MANAGED_DATABASE_URL`, exposing the SQL API (pg-wire) on a configured port and the REST API on `:4000`. Env: `CUBEJS_DB_TYPE=postgres`, `CUBEJS_DB_*` from managed DB, `CUBEJS_API_SECRET`, `CUBEJS_PG_SQL_PORT` (SQL API).
+
+- [ ] **Step 1:** Add the `cube` service to `docker-compose.yml`:
+
+```yaml
+  cube:
+    image: cubejs/cube:latest
+    ports:
+      - "4000:4000"      # REST/playground
+      - "15432:15432"    # SQL API (pg-wire)
+    environment:
+      CUBEJS_DEV_MODE: "true"
+      CUBEJS_DB_TYPE: postgres
+      CUBEJS_DB_HOST: ${MANAGED_DB_HOST}
+      CUBEJS_DB_PORT: ${MANAGED_DB_PORT}
+      CUBEJS_DB_NAME: ${MANAGED_DB_NAME}
+      CUBEJS_DB_USER: ${MANAGED_DB_USER}
+      CUBEJS_DB_PASS: ${MANAGED_DB_PASS}
+      CUBEJS_API_SECRET: ${CUBEJS_API_SECRET}
+      CUBEJS_PG_SQL_PORT: "15432"
+    volumes:
+      - ./cube/model:/cube/conf/model
+```
+
+- [ ] **Step 2:** `docker compose up cube` → confirm playground at `http://localhost:4000` and SQL API reachable: `psql "host=localhost port=15432 user=cube password=$CUBEJS_API_SECRET dbname=cube" -c "SELECT 1"` (expect `1`).
+- [ ] **Step 3:** Document env in `.env.example` and `cube/README.md` (how to run, where models live, schema/search_path note: scope Cube to the tenant/view schema).
+- [ ] **Step 4:** Commit.
+
+```bash
+git add docker-compose.yml .env.example cube/
+git commit -m "feat(cube): add Cube Core service + project skeleton"
+```
+
+### Task 7: Cube model generator (schema + form_definitions + knowledge → YAML)
+
+**Files:**
+- Create: `apps/transformations/services/cube_model_generator.py`
+- Create: `apps/transformations/services/cube_model_schema.py` (Pydantic models validating generated YAML)
+- Test: `tests/test_cube_model_generator.py`
+
+**Interfaces:**
+- Consumes: staged-schema column list (from `pipeline_describe_table`/information_schema for `stg_visits` & children), `form_definitions`, `KnowledgeEntry` metric definitions, declared `RelationshipConfig`s, plus seed KPI hints (`muac_confirmation_rate`, `approval_rate`, `flag_rate`).
+- Produces: `async def generate_cube_model(tenant, staged_tables: list[dict], form_definitions: dict, knowledge: str) -> list[CubeFile]` where `CubeFile = {"path": "cube/model/visits.yml", "yaml": str}`. Each generated cube validates against `cube_model_schema.CubeModel` (cubes with `name`, `sql_table`/`sql`, `dimensions[]`, `measures[]`, `joins[]`; optional `views[]`). Writes files to `cube/model/` and records a `TransformationAssetRun`-style audit row.
+
+**Generated-YAML contract** (what tests assert):
+- One cube per staged table (`visits` ← `stg_visits`, `flws` ← `raw_users`, etc.).
+- Dimensions: every staged column → dimension with `type` mapped from question type; choice-list questions → `type: string` dimensions; the question `label` carried into a `title`/`description`.
+- Joins: from `RelationshipConfig` (e.g. `visits.username = flws.username`, `many_to_one`).
+- Measures: `count`; plus seeded measures from KPI hints (e.g. `muac_confirmation_rate` as `type: number, sql: AVG(CASE WHEN muac_confirmed='yes' THEN 1.0 ELSE 0 END)`), and any `KnowledgeEntry` tagged `metric` translated to a measure.
+- A `program_health` view including curated measures/dimensions.
+
+- [ ] **Step 1:** Write tests asserting the **contract** on a generated model for a fixed input (validate with `cube_model_schema`, assert presence of the `visits` cube, a `count` measure, a `muac_confirmation_rate` measure, and a `visits→flws` join). Use a stubbed/mock LLM so the test is deterministic — the generator takes an injectable `model_client` and the test passes a fake returning canned YAML; the generator's job under test is: prompt assembly, YAML parse, schema validation, file emission.
+- [ ] **Step 2:** Run → FAIL.
+- [ ] **Step 3:** Implement: assemble prompt from inputs; call `model_client`; parse YAML; validate against `cube_model_schema`; on validation failure, one repair round-trip; write `CubeFile`s; return them. Use `langchain-anthropic` consistent with `apps/agents` (default to the latest Claude model). LLM call wrapped per async conventions.
+- [ ] **Step 4:** Run → PASS.
+- [ ] **Step 5:** Commit.
+
+```bash
+git add apps/transformations/services/cube_model_generator.py apps/transformations/services/cube_model_schema.py tests/test_cube_model_generator.py
+git commit -m "feat(cube): generate validated Cube model from schema + form defs + knowledge"
+```
+
+### Task 8: `semantic_query` + `semantic_catalog` MCP tools
+
+**Files:**
+- Create: `mcp_server/services/semantic.py` (Cube SQL-API connection + catalog fetch)
+- Modify: `mcp_server/server.py` (register two `@mcp.tool()` tools, mirroring the `query` tool at lines 335-378)
+- Test: `tests/test_semantic_query.py`
+
+**Interfaces:**
+- Consumes: Cube SQL-API connection params (host/port `CUBEJS_PG_SQL_PORT`/secret from settings); `_resolve_mcp_context(workspace_id)`; `success_response`/`error_response`/`tool_context` envelope helpers used by existing tools.
+- Produces:
+  - `semantic_query(sql: str, workspace_id: str = "") -> dict` — runs Semantic SQL (`MEASURE(...)`) against Cube's pg-wire endpoint via psycopg, returns the same envelope shape as `query` (`columns`, `rows`, `row_count`, `sql_executed`). Tenant scoping passed to Cube (security context / schema).
+  - `semantic_catalog(workspace_id: str = "") -> dict` — returns available cubes/views with their measures & dimensions (from Cube REST `/v1/meta`), so the agent knows what it can ask for.
+
+- [ ] **Step 1:** Write a test that patches the Cube SQL connection to return a fake result and asserts `semantic_query` returns the standard success envelope with `columns`/`rows`; and that `semantic_catalog` (patching `/v1/meta`) returns measures/dimensions.
+- [ ] **Step 2:** Run → FAIL.
+- [ ] **Step 3:** Implement `semantic.py` (psycopg connect to Cube pg-wire; httpx GET `/v1/meta`); register both tools in `server.py` using the existing `tool_context` + `success_response` pattern verbatim from the `query` tool.
+- [ ] **Step 4:** Run → PASS.
+- [ ] **Step 5:** Commit.
+
+```bash
+git add mcp_server/services/semantic.py mcp_server/server.py tests/test_semantic_query.py
+git commit -m "feat(mcp): add semantic_query + semantic_catalog tools backed by Cube"
+```
+
+### Task 9: Agent routing — prefer governed measures, fall back to raw SQL, record fallbacks
+
+**Files:**
+- Modify: `apps/agents/graph/base.py` (tool binding/prompt) and the agent system prompt source.
+- Create: `apps/agents/services/fallback_log.py` (record an "unmodeled question" signal when the agent uses raw `query` for a metric-style question).
+- Test: `tests/test_agent_semantic_routing.py`
+
+**Interfaces:**
+- Consumes: `semantic_catalog` output (inject available measures into the prompt); existing tool-binding mechanism (`INJECTED_TOOL_PARAMS`, `@mcp.tool` registration).
+- Produces: prompt guidance "prefer `semantic_query` for governed metrics; use `query` only when no measure fits"; a `record_fallback(workspace, question, sql)` hook persisting a lightweight `ModelGapSignal` row (define minimal model) consumed by M5.
+
+- [ ] **Step 1:** Test: given a workspace with a populated `semantic_catalog`, the assembled system prompt contains the catalog and the routing instruction; `record_fallback` writes a `ModelGapSignal`.
+- [ ] **Step 2:** Run → FAIL.
+- [ ] **Step 3:** Implement prompt injection + `ModelGapSignal` model/migration + `record_fallback`.
+- [ ] **Step 4:** Run → PASS.
+- [ ] **Step 5:** Commit.
+
+```bash
+git add apps/agents/ tests/test_agent_semantic_routing.py
+git commit -m "feat(agent): route to governed measures with raw-SQL fallback + gap logging"
+```
+
+**M3 acceptance:** with Cube running and a generated model, the agent answers "MUAC confirmation rate by FLW archetype" via `semantic_query` (governed measure), and a question with no matching measure falls back to raw SQL and logs a `ModelGapSignal`.
+
+---
+
+# PHASE M4 — Eval framework (the adoption verdict)
+
+### Task 10: `apps/evals` models — `GoldenQuery` + `EvalRun`
+
+**Files:**
+- Create: `apps/evals/__init__.py`, `apps/evals/models.py`, `apps/evals/apps.py`, migration
+- Modify: `config/settings/base.py` (add `apps.evals`)
+- Test: `tests/test_evals_models.py`
+
+**Interfaces:**
+- Produces:
+  - `GoldenQuery(workspace, title, question, reference_sql, expected_summary, source)`
+  - `EvalRun(workspace, golden_query, free_sql, free_sql_result(JSON), free_sql_ms, cube_query, cube_result(JSON), cube_ms, result_match(bool), match_confidence(float), semantic_equivalence(choices: exact/approximate/failed), used_preaggregation(bool), created_at)`
+
+- [ ] Steps 1-5: failing test for model creation/fields → add models + migration (`uv run python manage.py makemigrations evals`) → passing test → commit.
+
+```bash
+git add apps/evals/ config/settings/base.py tests/test_evals_models.py
+git commit -m "feat(evals): GoldenQuery + EvalRun models"
+```
+
+### Task 11: Eval runner — answer both ways, compare, judge
+
+**Files:**
+- Create: `apps/evals/services/runner.py`, `apps/evals/services/judge.py`
+- Test: `tests/test_eval_runner.py`
+
+**Interfaces:**
+- Consumes: the agent (free-SQL path via raw `query`; Cube path via `semantic_query`), `GoldenQuery`, an LLM judge.
+- Produces: `async def run_eval(golden_query, *, runs: int = 3, use_preagg: bool = False) -> list[EvalRun]` — executes each path `runs` times, compares result sets deterministically, calls `judge.semantic_equivalence(free_result, cube_result)` for an LLM verdict, records latency and `used_preaggregation`, persists `EvalRun`s.
+
+- [ ] Steps 1-5: failing test (mock both agent paths + judge; assert `EvalRun` rows with `result_match` and latency) → implement → passing → commit.
+
+```bash
+git add apps/evals/services/ tests/test_eval_runner.py
+git commit -m "feat(evals): runner comparing free-SQL vs Cube with LLM judge"
+```
+
+### Task 12: Seed golden questions + scorecard command
+
+**Files:**
+- Create: `apps/evals/management/commands/run_eval.py`, `apps/evals/fixtures/golden_questions.yml`
+- Create: `apps/evals/services/scorecard.py`
+- Test: `tests/test_eval_scorecard.py`
+
+**Interfaces:**
+- Produces: `python manage.py run_eval --workspace <id> [--preagg]` → loads ~8-15 seed `GoldenQuery`s, runs the runner, prints a scorecard (correctness %, consistency/variance, mean latency, # Cube-answerable, preagg speedup) and writes a JSON report under `docs/superpowers/evals/`.
+
+- [ ] Steps 1-5: failing test for `scorecard.summarize(eval_runs)` → implement command + scorecard → passing → commit.
+
+```bash
+git add apps/evals/management/ apps/evals/fixtures/ apps/evals/services/scorecard.py tests/test_eval_scorecard.py
+git commit -m "feat(evals): seed golden questions + scorecard command (incl. pre-agg dimension)"
+```
+
+> **Pre-aggregations dimension:** Task 12 runs the suite twice (`--preagg` off/on). Add a pre-aggregation declaration to the generated `program_health` view (Task 7 can emit a default rollup) so the scorecard reports the caching speedup — completing the adoption verdict (governance *and* performance).
+
+**M4 acceptance:** `run_eval` produces a scorecard comparing free-SQL vs Cube on correctness, consistency, and latency (with/without pre-aggregations) — the go/no-go evidence.
+
+---
+
+# PHASE M5 — Self-improving loop + PR-based curation gate
+
+### Task 13: Promote model gaps + learnings into candidate measures
+
+**Files:**
+- Create: `apps/transformations/services/measure_proposer.py`
+- Test: `tests/test_measure_proposer.py`
+
+**Interfaces:**
+- Consumes: `ModelGapSignal` rows (Task 9), `AgentLearning` (category `aggregation`/`join_pattern`, high confidence), the current Cube model.
+- Produces: `async def propose_measures(workspace) -> list[CubeFile]` — LLM proposes new measures/dimensions as a YAML diff over the existing model, validated against `cube_model_schema`; deduped against existing measures.
+
+- [ ] Steps 1-5: failing test (mock LLM + seeded gaps/learnings; assert proposed measure validates and is novel) → implement → passing → commit.
+
+```bash
+git add apps/transformations/services/measure_proposer.py tests/test_measure_proposer.py
+git commit -m "feat(cube): propose new measures from model gaps + agent learnings"
+```
+
+### Task 14: PR-based curation gate
+
+**Files:**
+- Create: `apps/transformations/services/cube_curation_pr.py`
+- Create: `apps/transformations/management/commands/propose_cube_measures.py`
+- Test: `tests/test_cube_curation_pr.py`
+
+**Interfaces:**
+- Consumes: `propose_measures` output.
+- Produces: `python manage.py propose_cube_measures --workspace <id>` → writes proposed YAML into a branch and opens a PR via `gh` (the human approves/merges = the curation gate). On merge, `cube/model/` updates and Cube reloads. Never auto-merges.
+
+- [ ] Steps 1-5: failing test (mock `gh`/git; assert a branch+PR are created with the proposed diff and a descriptive body citing the originating gap/learning) → implement (shell out to `git`/`gh`, `sync_to_async` for the subprocess) → passing → commit.
+
+```bash
+git add apps/transformations/services/cube_curation_pr.py apps/transformations/management/commands/propose_cube_measures.py tests/test_cube_curation_pr.py
+git commit -m "feat(cube): PR-based curation gate for proposed measures"
+```
+
+**M5 acceptance:** a logged model gap produces a candidate measure, which opens a PR for human review; merging it grows the governed model — the "persist knowledge over time" loop, closed.
+
+---
+
+# PHASE M1b — connect-labs synthetic source (parallel, after connect-labs#637)
+
+> Non-blocking. Reuses all of M2-M5. Only adds a second data source.
+
+### Task 15: connect-labs credential + base-URL override
+
+**Files:**
+- Modify: `apps/users/models.py` (`PROVIDER_CHOICES` — add `commcare_connect_labs` or reuse `commcare_connect` with a stored base URL), credential resolver if needed.
+- Modify: `mcp_server/loaders/connect_base.py` — already accepts `base_url`; ensure it is threaded from a per-tenant setting (the synthetic base URL) rather than only `settings.CONNECT_API_URL`.
+- Test: `tests/test_connect_labs_credential.py`
+
+- [ ] Steps 1-5: failing test (a connect-labs membership resolves a PAT credential and a synthetic base URL) → implement → passing → commit.
+
+### Task 16: `connect_labs_sync` pipeline + discovery
+
+**Files:**
+- Create: `pipelines/connect_labs_sync.yml` (same sources as `connect_sync.yml`, provider routes to Connect loaders with the synthetic base URL).
+- Modify: `mcp_server/services/materializer.py::_load_connect_source` to pass the per-tenant `base_url` into loaders.
+- Test: `tests/test_connect_labs_pipeline.py`
+
+- [ ] Steps 1-5: failing test (synthetic opp materializes `raw_visits` + `app_structure` from `/api/export/...`) → implement → passing → commit.
+
+**M1b acceptance:** a synthetic opportunity from connect-labs#637 flows through the identical M2-M5 machinery; the M4 eval gains a ground-truth dataset (manifest KPIs/anomalies) for a higher-confidence verdict.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §4.1a real Connect + app_structure → M1 (Tasks 1-2). ✓
+- §4.1b synthetic → M1b (Tasks 15-16). ✓
+- §4.2a enriched staging + column_notes → M2 (Tasks 3-5). ✓
+- §4.2b Cube model generation → M3 (Task 7). ✓
+- §4.3 Cube Core deployment → M3 (Task 6). ✓
+- §4.4 agent↔Cube interface 1 + fallback → M3 (Tasks 8-9). ✓
+- §4.5 eval framework (+ ground-truth note) → M4 (Tasks 10-12). ✓
+- §4.6 self-improving loop + PR curation → M5 (Tasks 13-14). ✓
+- §7 pre-aggregations eval dimension → M4 Task 12 note + Task 7 rollup. ✓
+- §7 curation-gate mechanism (PR-based) → M5 Task 14. ✓
+
+**Placeholder scan:** M1/M2 steps carry complete, grounded code. M3-M5 tasks are contract-defined where they drive an LLM (Tasks 7, 11, 13) — tests assert output contracts, which is the correct way to plan non-deterministic steps; not placeholders. Literal infra/model/tool code (Tasks 6, 8, 10, 14) is concrete.
+
+**Type consistency:** `form_definitions` shape is defined once in Task 1 and consumed identically in Tasks 3, 4, 7. `CubeFile`/`CubeModel` defined in Task 7, reused in Tasks 13-14. Envelope helpers (`success_response`/`tool_context`) reused verbatim from the existing `query` tool in Task 8.
+
+**Known verification points (resolve at task start, not plan-time):**
+- Exact helper names/visibility in `commcare_staging.py` before importing in Task 3 (extract to `_form_staging.py` if private).
+- The real Connect `/export/opportunity/{id}/app_structure/` payload shape (Task 1 normalizer assumes `deliver_units[].questions[]`; adjust to the actual response).
+- Where `upsert_system_assets` is invoked in the transform phase (Task 5).

--- a/docs/superpowers/specs/2026-06-18-cube-semantic-layer-auto-modeling-design.md
+++ b/docs/superpowers/specs/2026-06-18-cube-semantic-layer-auto-modeling-design.md
@@ -43,25 +43,35 @@ evaluation harness.
 ## 2. Goals / non-goals
 
 **Goals**
-- Get synthetic Connect data into Scout as a real data source (test fuel).
+- **Run the POC first and foremost against real CommCare Connect data.** Scout already has a
+  working Connect pipeline (`pipelines/connect_sync.yml`, `ConnectMetadataLoader`), so the POC
+  is not blocked on any external work.
 - **Auto-model** a Cube semantic layer from Connect/CommCare **app structure** (form schemas)
   + Scout's existing knowledge — not hand-written YAML.
 - Let the agent query governed measures, falling back to raw SQL when unmodeled (seamless to
   the user — "it's just magic").
 - Produce an **evaluation** comparing free-SQL vs via-Cube answers → an adoption verdict.
 - Build the **self-improving loop** that grows the model from usage (persist knowledge).
+- **Secondarily**, add synthetic connect-labs data as a reproducible alternate source (same
+  Connect export shape) once connect-labs#637 lands — primarily to strengthen the eval (§4.5).
+
+**Data-source priority.** Real Connect is the primary POC fuel; connect-labs synthetic is a
+follow-on. The auto-modeling, Cube, agent, and eval components are **data-source-agnostic** —
+they operate on whatever Connect data is materialized, so adding the synthetic source later is
+purely an additional loader/credential, not a redesign.
 
 **Non-goals**
 - Cube Cloud / hosted MCP / D3 (we use Cube Core in Docker).
 - Replacing raw-SQL access wholesale — Cube is additive; we migrate domains incrementally.
 - Exposing Cube or any modeling concept to end users. Users only ever chat.
-- Real (non-synthetic) Connect ingestion changes beyond what reuse naturally provides.
+- Blocking the POC on the synthetic connect-labs source.
 
 ## 3. End-state architecture
 
 ```
-connect-labs /api/export/  (incl. app_structure)            [external dep: connect-labs#637]
-      │   Scout Connect loader, re-pointed at synthetic base URL + PAT
+PRIMARY:  real CommCare Connect  (existing Connect pipeline + deliver-app CommCare app structure)
+SECONDARY: connect-labs /api/export/ (incl. app_structure)   [external dep: connect-labs#637]
+      │   Scout Connect loader (same export shape; synthetic = different base URL + PAT)
       ▼
 managed Postgres:  raw_visits, raw_users, raw_completed_works, raw_completed_module
       +  TenantMetadata.metadata.app_structure   ← deliver-app form schema (semantic source)
@@ -83,33 +93,47 @@ managed Postgres:  raw_visits, raw_users, raw_completed_works, raw_completed_mod
 
 ## 4. Components
 
-### 4.1 Connect-labs synthetic source (M1)
+### 4.1 Connect data source
 
-**Reuse first.** Scout already has a Connect pipeline (`pipelines/connect_sync.yml`,
-provider `commcare_connect`) and Connect loaders incl. a `ConnectMetadataLoader`, plus a base
-loader (`mcp_server/loaders/commcare_base.py`) that already supports OAuth Bearer **and** API
-key/PAT auth and TastyPie-style pagination. The synthetic source is the *same Connect export
-shape* at a different base URL with a different token.
+The auto-modeling thesis needs two things from the data source: the materialized `raw_*` tables
+**and** the deliver-app **form schema** (the semantic source). Both come from Connect.
 
-Work:
-- **Credential / connection:** add a connection type for the connect-labs synthetic API —
-  base URL + MCP PAT, stored via the existing Fernet-encrypted `TenantConnection`
-  (`apps/users/models.py`) and resolved by `credential_resolver`. (PAT minted at
-  `connect-labs /labs/mcp/tokens/`.)
-- **Pipeline:** `pipelines/connect_labs_sync.yml` (or parameterize `connect_sync.yml` with a
-  base URL) covering sources `visits`, `users`, `completed_works`, `completed_module`.
-  Pagination envelope is `{results, next, count}`; honor `?page_size=`.
-- **app_structure fetch (the key gap):** extend the Connect metadata loader to call
-  `GET /api/export/opportunity/{id}/app_structure/` and store the deliver-app form schema into
-  `TenantMetadata.metadata` (same JSONB slot CommCare app structure uses), normalized to the
-  `form_definitions` shape (`questions: [{label, value, type, repeat, options?}]`).
-- **Discovery:** use `GET /api/export/opportunities/` to enumerate accessible synthetic opps.
+#### 4.1a Real CommCare Connect — PRIMARY (M1)
 
-Acceptance: a synthetic opp materializes `raw_*` tables into the managed schema and its
-deliver-app form schema lands in `TenantMetadata.metadata`.
+**Reuse first.** Scout already has a Connect pipeline (`pipelines/connect_sync.yml`, provider
+`commcare_connect`) and Connect loaders incl. a `ConnectMetadataLoader`, plus a base loader
+(`mcp_server/loaders/commcare_base.py`) supporting OAuth Bearer / API-key auth and pagination.
+A real Connect opportunity is already connectable in Scout via existing CommCare Connect OAuth.
 
-> **Decoupling:** M1 can develop against a recorded fixture/stub of the #637 API so Scout work
-> is not blocked on connect-labs landing.
+The one real gap: **`ConnectMetadataLoader` fetches org/program structure but NOT the deliver-app
+form definitions** (per code review). A Connect opportunity is backed by a CommCare **deliver
+app**; its form schema is fetchable via the CommCare Application API (`/a/{domain}/api/v0.5/
+application/`) — which Scout's `commcare_metadata.py` *already* knows how to parse into
+`form_definitions`. Work:
+- Resolve the opportunity's deliver-app id/domain and fetch its CommCare app structure, storing
+  normalized `form_definitions` into `TenantMetadata.metadata` (same slot CommCare ingestion uses).
+- Confirm sources `visits`, `users`, `completed_works`, `completed_module` materialize for a real
+  opportunity (largely existing behavior).
+
+Acceptance: a real Connect opportunity materializes `raw_*` tables **and** its deliver-app form
+schema lands in `TenantMetadata.metadata`, ready for auto-modeling (§4.2).
+
+#### 4.1b connect-labs synthetic — SECONDARY (after #637)
+
+Same Connect export shape at a different base URL with a PAT — so it's an additional
+loader/credential, not a redesign. Useful as reproducible demo data and, importantly, for the
+eval (§4.5) because the synthetic manifest carries **known ground truth** (declared KPIs, seeded
+anomalies). Work, once connect-labs#637 lands:
+- **Credential:** base URL + MCP PAT (minted at `connect-labs /labs/mcp/tokens/`), stored via the
+  existing Fernet-encrypted `TenantConnection` and resolved by `credential_resolver`.
+- **Pipeline:** `pipelines/connect_labs_sync.yml` (or parameterize `connect_sync.yml` with a base
+  URL) hitting `/api/export/...`; envelope `{results, next, count}`; honor `?page_size=`.
+- **app_structure:** read it directly from `GET /api/export/opportunity/{id}/app_structure/`
+  (the generator emits it per #637) into the same `form_definitions` slot.
+- **Discovery:** `GET /api/export/opportunities/`.
+
+> Until #637 lands, the synthetic path can also be stubbed against a recorded fixture — but it is
+> not on the POC critical path; real Connect is.
 
 ### 4.2 Auto-modeling engine (M2 + M3 output) — the heart
 
@@ -171,8 +195,12 @@ New `apps/evals` (no existing eval framework in Scout today):
 - **Runner:** answers each golden question both ways via the agent, deterministically compares
   result sets, and uses an LLM judge for semantic equivalence; aggregates a scorecard
   (correctness, consistency across runs, latency, and # questions Cube could answer at all).
-- **Seed set:** ~8–15 representative questions over the synthetic MUAC/CHW domain (counts,
-  rates by archetype/week, flagged-visit analysis, payment reconciliation).
+- **Seed set:** ~8–15 representative questions over the connected opportunity's domain (counts,
+  rates by worker/time, flagged-visit analysis, payment reconciliation).
+- **Ground truth:** real Connect has none, so its eval scores via reference-SQL + LLM-judge.
+  The synthetic connect-labs source (§4.1b) is materially better here — its manifest declares
+  KPIs and seeded anomalies, giving objective ground truth — so when #637 lands, the eval should
+  add a synthetic opportunity for a higher-confidence verdict. Real-Connect eval runs first.
 - Output: a report that is the **go/no-go evidence** for adoption.
 
 ### 4.6 Self-improving loop + curation (M5) — persist knowledge over time
@@ -191,17 +219,22 @@ New `apps/evals` (no existing eval framework in Scout today):
 
 | Phase | Delivers | Reuse / build | Independent value |
 |---|---|---|---|
-| M1 | Connect-labs loader/pipeline → `raw_*` + `app_structure` | Reuse Connect loader/creds/pipeline; add app_structure | Synthetic Connect data in Scout |
+| M1 | **Real Connect** ingestion → `raw_*` + deliver-app `app_structure` | Reuse Connect pipeline; add deliver-app form-schema fetch | Real Connect data ready to auto-model |
 | M2 | Enriched auto-staging + auto `column_notes` | Improve `commcare_staging.py` | Better answers *without* Cube; lifts eval baseline |
 | M3 | Cube Core + generated model + `semantic_query`/`semantic_catalog` | New + generator | Governed-metric querying |
 | M4 | Eval framework: free-SQL vs Cube | New (`apps/evals`) | **Adoption decision, with data** |
 | M5 | Self-improving loop + curation gate | New | Persist knowledge over time |
+| M1b | connect-labs **synthetic** source (parallel/after #637) | Add loader/credential; reuse all of M2–M5 | Reproducible demo + ground-truth eval |
+
+M1–M5 run against real Connect and are the critical path. **M1b is parallel and non-blocking** —
+it slots a second data source under the same M2–M5 machinery once connect-labs#637 lands.
 
 ## 6. External dependency
 
 - **connect-labs#637** — expose authenticated `/api/export/` endpoints serving synthetic data,
-  including a generator-emitted `app_structure.json`. Tracked separately; Scout develops M1
-  against a recorded fixture until it lands.
+  including a generator-emitted `app_structure.json`. **Gates only the secondary synthetic
+  source (M1b), not the POC.** The M1–M5 critical path runs against real Connect and does not
+  depend on it.
 
 ## 7. Risks & open questions (resolve during planning)
 

--- a/docs/superpowers/specs/2026-06-18-cube-semantic-layer-auto-modeling-design.md
+++ b/docs/superpowers/specs/2026-06-18-cube-semantic-layer-auto-modeling-design.md
@@ -1,0 +1,226 @@
+# Auto-modeled Cube semantic layer over Connect data
+
+**Status:** Design — approved for planning
+**Date:** 2026-06-18
+**Author:** Jonathan Jackson (with Claude)
+
+## 1. Context & motivation
+
+Today, when a Scout user asks a question, the LangGraph agent free-writes SQL against
+whatever materialized tables exist. This has three structural weaknesses:
+
+1. **Metric definitions live nowhere durable.** "MUAC confirmation rate" is re-derived
+   per chat and can be subtly wrong or inconsistent between answers.
+2. **No caching.** Every question is a live warehouse scan.
+3. **The LLM's query surface is the entire raw schema** — large, ambiguous, easy to get
+   wrong (bad joins, wrong grain, fan-out double-counting).
+
+We want to evaluate adopting **[Cube](https://cube.dev) (Core, open-source)** as a
+**semantic layer**: a governed, version-controlled definition of metrics, dimensions, and
+relationships that the agent queries *by name* instead of writing raw SQL. Cube does not
+store a copy of the data — it sits in front of Scout's existing managed Postgres, compiles
+governed queries to correct SQL (or serves them from pre-aggregation cache), and exposes
+them over a Postgres-wire **SQL API**.
+
+This is a strong fit because **Scout has already hand-built ~60% of what Cube is** (an MCP
+query surface, an informal knowledge layer, materialization + dbt staging, multi-tenant
+access control). Cube is a principled replacement for the missing pieces — *governed metric
+definitions* and *caching* — and the SQL API slots into Scout's existing psycopg query path.
+
+The Cube model also directly serves a standing goal: **persist knowledge over time.** The
+version-controlled model becomes the durable, blessed crystallization of what Scout's
+knowledge layer (`KnowledgeEntry`, `TableKnowledge`, `AgentLearning`) accumulates informally.
+
+### Primary question this work answers
+
+> Is a governed semantic layer worth adopting for Scout — does querying governed metrics
+> produce more correct/consistent agent answers than free-SQL, and is the modeling cost
+> acceptable (can the model be **auto-generated** rather than hand-authored)?
+
+To answer it credibly we build the whole spine, with the early phases doubling as the
+evaluation harness.
+
+## 2. Goals / non-goals
+
+**Goals**
+- Get synthetic Connect data into Scout as a real data source (test fuel).
+- **Auto-model** a Cube semantic layer from Connect/CommCare **app structure** (form schemas)
+  + Scout's existing knowledge — not hand-written YAML.
+- Let the agent query governed measures, falling back to raw SQL when unmodeled (seamless to
+  the user — "it's just magic").
+- Produce an **evaluation** comparing free-SQL vs via-Cube answers → an adoption verdict.
+- Build the **self-improving loop** that grows the model from usage (persist knowledge).
+
+**Non-goals**
+- Cube Cloud / hosted MCP / D3 (we use Cube Core in Docker).
+- Replacing raw-SQL access wholesale — Cube is additive; we migrate domains incrementally.
+- Exposing Cube or any modeling concept to end users. Users only ever chat.
+- Real (non-synthetic) Connect ingestion changes beyond what reuse naturally provides.
+
+## 3. End-state architecture
+
+```
+connect-labs /api/export/  (incl. app_structure)            [external dep: connect-labs#637]
+      │   Scout Connect loader, re-pointed at synthetic base URL + PAT
+      ▼
+managed Postgres:  raw_visits, raw_users, raw_completed_works, raw_completed_module
+      +  TenantMetadata.metadata.app_structure   ← deliver-app form schema (semantic source)
+      │
+      │   AUTO-MODELING ENGINE  (staged schema + form definitions + Scout knowledge)
+      ├──►  enriched dbt staging   (flatten form_json → typed/labeled cols; repeats → child
+      │        tables; choice lists → enum dims)  +  auto-populated TableKnowledge.column_notes
+      └──►  generated Cube model   (cubes / views / measures)  →  committed to  cube/  (durable)
+      │
+   Cube Core (Docker)  over managed Postgres  ──exposes──►  SQL API (pg-wire)
+      │
+   Scout agent  ──prefers governed measures via semantic_query; falls back to raw SQL──►  chat
+      │
+   EVAL framework   golden questions answered free-SQL vs via-Cube → scored = adoption verdict
+      │
+   SELF-IMPROVING LOOP   AgentLearning + unmodeled-question detection → proposed measures
+                          → curation gate → merged into cube/ → redeploy
+```
+
+## 4. Components
+
+### 4.1 Connect-labs synthetic source (M1)
+
+**Reuse first.** Scout already has a Connect pipeline (`pipelines/connect_sync.yml`,
+provider `commcare_connect`) and Connect loaders incl. a `ConnectMetadataLoader`, plus a base
+loader (`mcp_server/loaders/commcare_base.py`) that already supports OAuth Bearer **and** API
+key/PAT auth and TastyPie-style pagination. The synthetic source is the *same Connect export
+shape* at a different base URL with a different token.
+
+Work:
+- **Credential / connection:** add a connection type for the connect-labs synthetic API —
+  base URL + MCP PAT, stored via the existing Fernet-encrypted `TenantConnection`
+  (`apps/users/models.py`) and resolved by `credential_resolver`. (PAT minted at
+  `connect-labs /labs/mcp/tokens/`.)
+- **Pipeline:** `pipelines/connect_labs_sync.yml` (or parameterize `connect_sync.yml` with a
+  base URL) covering sources `visits`, `users`, `completed_works`, `completed_module`.
+  Pagination envelope is `{results, next, count}`; honor `?page_size=`.
+- **app_structure fetch (the key gap):** extend the Connect metadata loader to call
+  `GET /api/export/opportunity/{id}/app_structure/` and store the deliver-app form schema into
+  `TenantMetadata.metadata` (same JSONB slot CommCare app structure uses), normalized to the
+  `form_definitions` shape (`questions: [{label, value, type, repeat, options?}]`).
+- **Discovery:** use `GET /api/export/opportunities/` to enumerate accessible synthetic opps.
+
+Acceptance: a synthetic opp materializes `raw_*` tables into the managed schema and its
+deliver-app form schema lands in `TenantMetadata.metadata`.
+
+> **Decoupling:** M1 can develop against a recorded fixture/stub of the #637 API so Scout work
+> is not blocked on connect-labs landing.
+
+### 4.2 Auto-modeling engine (M2 + M3 output) — the heart
+
+Inputs: the materialized `raw_*`/staged schema, the deliver-app **form definitions** (labels,
+types, choice lists, groups, repeat flags), and Scout's existing knowledge
+(`KnowledgeEntry`, `TableKnowledge`, `AgentLearning`).
+
+**(a) Enriched staging — improve, don't replace.**
+`apps/transformations/services/commcare_staging.py` already generates dbt staging from form
+definitions but skips the semantic richness. Extend it to:
+- Flatten `form_json` / case `properties` into **typed, human-labeled** columns driven by the
+  question schema (e.g. `muac` → `Decimal`, labeled "MUAC measurement (cm)", group `muac_group`).
+- Materialize **repeat groups** into child tables (currently skipped at
+  `commcare_staging.py:186`).
+- Turn **choice/option lists** (`Select`/`MultiSelect`) into enum/lookup dimensions.
+- **Auto-populate `TableKnowledge.column_notes`** (today manual-only) from question
+  labels/types — this immediately improves the *raw-SQL* agent via `KnowledgeRetriever`, and
+  lifts the eval baseline.
+- Optionally enrich `metadata.py::_build_jsonb_annotations` to map columns → question labels.
+
+**(b) Cube model generation.**
+A generator turns staged schema + form semantics + knowledge into Cube YAML:
+- **Dimensions** from labeled columns (type-mapped; choice lists → categorical dims).
+- **Joins** from the pipeline's declared `RelationshipConfig`s (correct cardinality).
+- **Measures** seeded from: known KPI patterns (the synthetic manifest's `kpi_config` is a gift
+  here — `muac_confirmation_rate`, approval/flag rates), Scout `KnowledgeEntry` metric
+  definitions, and golden queries. LLM-assisted, but every measure is reviewable YAML.
+- **Views** (e.g. `program_health`) curate query-ready surfaces over the cubes.
+- Output committed to `cube/model/*.yml` (version-controlled = the durable knowledge asset).
+
+A `TransformationAssetRun`-style record tracks each generation run.
+
+### 4.3 Cube Core deployment (M3)
+
+- Add a `cube` service to `docker-compose` (and dev `Procfile`), reading `cube/model/`,
+  configured against `MANAGED_DATABASE_URL` + the synthetic schema (`search_path`).
+- Expose the **SQL API** (Postgres wire). Pre-aggregations optional — include a toggle so the
+  eval can measure the caching win.
+- Multi-tenancy: scope Cube to the workspace's schema (mirrors Scout's existing schema routing).
+
+### 4.4 Agent ↔ Cube integration — interface 1, SQL API (M3)
+
+The 1-vs-2 interface choice is **invisible to users**; we pick the lowest-friction one.
+- New MCP tool **`semantic_query`** that connects to Cube's pg-wire SQL endpoint (parallel to
+  the existing raw `query` tool in `mcp_server/server.py`), reusing the validation/LIMIT/
+  read-only patterns where applicable.
+- New **`semantic_catalog`** tool (or prompt injection) exposing available measures/dimensions
+  so the agent knows what it may ask for.
+- **Routing/fallback:** the agent prefers `semantic_query` for governed metrics and falls back
+  to raw `query` when a question isn't modeled — so the user never sees a gap. Every fallback
+  is recorded as an "unmodeled question" signal for the self-improving loop (4.6).
+
+### 4.5 Evaluation framework (M4) — the adoption verdict
+
+New `apps/evals` (no existing eval framework in Scout today):
+- **Models:** `GoldenQuery` (title, NL question, reference intent/SQL, expected-result summary,
+  source) and `EvalRun` (per question: free-SQL path result + Cube path result, each run N
+  times; equivalence verdict, consistency/variance, latency).
+- **Runner:** answers each golden question both ways via the agent, deterministically compares
+  result sets, and uses an LLM judge for semantic equivalence; aggregates a scorecard
+  (correctness, consistency across runs, latency, and # questions Cube could answer at all).
+- **Seed set:** ~8–15 representative questions over the synthetic MUAC/CHW domain (counts,
+  rates by archetype/week, flagged-visit analysis, payment reconciliation).
+- Output: a report that is the **go/no-go evidence** for adoption.
+
+### 4.6 Self-improving loop + curation (M5) — persist knowledge over time
+
+- **Detect** model gaps: fallback-to-SQL events (4.4) + mined `AgentLearning` corrections
+  (join patterns, aggregations, type fixes).
+- **Propose** new measures/dimensions (LLM) as candidate Cube YAML diffs.
+- **Curation gate:** a human approves before merge — governance is the whole point; auto-merging
+  unreviewed metrics would destroy the correctness guarantee. (Mechanism: lightweight review UI
+  or PR-based; decided in planning.)
+- **Apply & redeploy:** approved candidates merged into `cube/`, Cube reloads.
+- The loop closes the knowledge story: `KnowledgeEntry`/`AgentLearning` are the raw accumulating
+  knowledge; the Cube model is its blessed, governed form.
+
+## 5. Build sequence (one plan, five phases)
+
+| Phase | Delivers | Reuse / build | Independent value |
+|---|---|---|---|
+| M1 | Connect-labs loader/pipeline → `raw_*` + `app_structure` | Reuse Connect loader/creds/pipeline; add app_structure | Synthetic Connect data in Scout |
+| M2 | Enriched auto-staging + auto `column_notes` | Improve `commcare_staging.py` | Better answers *without* Cube; lifts eval baseline |
+| M3 | Cube Core + generated model + `semantic_query`/`semantic_catalog` | New + generator | Governed-metric querying |
+| M4 | Eval framework: free-SQL vs Cube | New (`apps/evals`) | **Adoption decision, with data** |
+| M5 | Self-improving loop + curation gate | New | Persist knowledge over time |
+
+## 6. External dependency
+
+- **connect-labs#637** — expose authenticated `/api/export/` endpoints serving synthetic data,
+  including a generator-emitted `app_structure.json`. Tracked separately; Scout develops M1
+  against a recorded fixture until it lands.
+
+## 7. Risks & open questions (resolve during planning)
+
+- **Cube model generation quality** — does LLM-generated YAML produce correct measures? Mitigated
+  by reviewable YAML + the eval harness as a feedback signal.
+- **Semantic SQL reliability** — if the agent fumbles `MEASURE()` SQL (interface 1), the fallback
+  is interface 2 (structured `cube_query` tool). Eval will reveal whether this is needed.
+- **Repeat-group flattening** — child-table modeling and how Cube joins to them needs care
+  (grain/fan-out).
+- **Cube as a hot-path runtime dependency** — new service to run/deploy/keep healthy; weigh in
+  the adoption verdict.
+- **Curation-gate mechanism** (UI vs PR-based) — decide in planning.
+- **Pre-aggregations** — in/out of the POC scope for measuring caching benefit.
+
+## 8. Testing
+
+- Unit: loader pagination/auth, app_structure normalization, staging flattening (typed/labeled
+  cols, repeats, choice lists), `column_notes` auto-population, Cube-model generator output shape.
+- Integration: end-to-end materialize → stage → generate model → `semantic_query` returns
+  governed metric; fallback path engages on unmodeled question.
+- Async tests follow Scout conventions (`AsyncClient`, `transaction=True`).
+- The eval framework is itself a test of the thesis (not a unit test, but the decision artifact).

--- a/docs/superpowers/specs/2026-06-18-cube-semantic-layer-auto-modeling-design.md
+++ b/docs/superpowers/specs/2026-06-18-cube-semantic-layer-auto-modeling-design.md
@@ -106,14 +106,18 @@ The auto-modeling thesis needs two things from the data source: the materialized
 A real Connect opportunity is already connectable in Scout via existing CommCare Connect OAuth.
 
 The one real gap: **`ConnectMetadataLoader` fetches org/program structure but NOT the deliver-app
-form definitions** (per code review). A Connect opportunity is backed by a CommCare **deliver
-app**; its form schema is fetchable via the CommCare Application API (`/a/{domain}/api/v0.5/
-application/`) — which Scout's `commcare_metadata.py` *already* knows how to parse into
-`form_definitions`. Work:
-- Resolve the opportunity's deliver-app id/domain and fetch its CommCare app structure, storing
-  normalized `form_definitions` into `TenantMetadata.metadata` (same slot CommCare ingestion uses).
+form definitions** (per code review). Real Connect exposes
+`GET /export/opportunity/{id}/app_structure/?app_type=both` (verified in `dimagi/commcare-connect`
+`data_export`), returning `{"learn_app": <HQ app JSON|null>, "deliver_app": <HQ app JSON|null>}`.
+**Connect proxies to CommCare HQ server-side using the opportunity's stored API key**, so the caller
+needs only the Connect OAuth `export` scope — **no CommCare HQ credentials.** Each app is HQ
+application JSON, the exact shape Scout's `commcare_metadata.py::_extract_form_definitions` already
+parses into `form_definitions`. Work:
+- Add `_fetch_app_structure()` to `ConnectMetadataLoader`, pass the non-null `learn_app`/`deliver_app`
+  into the existing `_extract_form_definitions`, and include the result in the metadata dict so the
+  discover phase stores it in `TenantMetadata.metadata` (same slot CommCare ingestion uses).
 - Confirm sources `visits`, `users`, `completed_works`, `completed_module` materialize for a real
-  opportunity (largely existing behavior).
+  opportunity (existing behavior — no new loaders).
 
 Acceptance: a real Connect opportunity materializes `raw_*` tables **and** its deliver-app form
 schema lands in `TenantMetadata.metadata`, ready for auto-modeling (§4.2).

--- a/mcp_server/loaders/connect_metadata.py
+++ b/mcp_server/loaders/connect_metadata.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 
+from mcp_server.loaders.commcare_metadata import _extract_case_types, _extract_form_definitions
 from mcp_server.loaders.connect_base import ConnectBaseLoader
 
 logger = logging.getLogger(__name__)
@@ -19,26 +20,46 @@ class ConnectMetadataLoader(ConnectBaseLoader):
     def load(self) -> dict:
         org_data = self._fetch_org_data()
         opp_detail = self._fetch_opportunity_detail()
+        form_definitions: dict = {}
+        case_types: list = []
+        try:
+            app_structure = self._fetch_app_structure()
+            # Real Connect returns {"learn_app": <HQ app JSON|null>, "deliver_app": ...}.
+            # Each app is HQ application JSON; reuse the CommCare extractors verbatim.
+            apps = [
+                a for a in (app_structure.get("deliver_app"), app_structure.get("learn_app")) if a
+            ]
+            form_definitions = _extract_form_definitions(apps)
+            case_types = _extract_case_types(apps)
+        except Exception:
+            logger.exception(
+                "Failed to fetch app_structure for opportunity %s; continuing without form_definitions",
+                self.opportunity_id,
+            )
 
         logger.info(
-            "Loaded metadata for Connect opportunity %s: %s",
+            "Loaded metadata for Connect opportunity %s: %s (%d forms)",
             self.opportunity_id,
             opp_detail.get("name", "unknown"),
+            len(form_definitions),
         )
-
         return {
             "opportunity": opp_detail,
             "organizations": org_data.get("organizations", []),
             "programs": org_data.get("programs", []),
             "all_opportunities": org_data.get("opportunities", []),
+            "form_definitions": form_definitions,
+            "case_types": case_types,
         }
 
     def _fetch_org_data(self) -> dict:
         url = f"{self.base_url}/export/opp_org_program_list/"
-        resp = self._get(url)
-        return resp.json()
+        return self._get(url).json()
 
     def _fetch_opportunity_detail(self) -> dict:
         url = f"{self.base_url}/export/opportunity/{self.opportunity_id}/"
-        resp = self._get(url)
-        return resp.json()
+        return self._get(url).json()
+
+    def _fetch_app_structure(self) -> dict:
+        url = f"{self.base_url}/export/opportunity/{self.opportunity_id}/app_structure/"
+        return self._get(url, params={"app_type": "both"}).json()

--- a/mcp_server/services/materializer.py
+++ b/mcp_server/services/materializer.py
@@ -46,11 +46,14 @@ from collections.abc import Callable, Iterator
 from datetime import UTC, datetime
 from typing import Any
 
+from asgiref.sync import async_to_sync
 from django.utils import timezone
 from psycopg import sql as psql
 
+from apps.knowledge.services.column_note_generator import sync_column_notes
 from apps.transformations.models import TransformationAsset
 from apps.transformations.services.commcare_staging import upsert_system_assets
+from apps.transformations.services.connect_staging import upsert_connect_assets
 from apps.transformations.services.executor import run_transformation_pipeline
 from apps.workspaces.models import MaterializationRun, TenantMetadata, TenantSchema
 from apps.workspaces.services.schema_manager import SchemaManager, get_managed_db_connection
@@ -246,6 +249,30 @@ def run_pipeline(
             except Exception:
                 logger.exception(
                     "Failed to generate system assets for %s; continuing pipeline",
+                    tenant_membership.tenant.external_id,
+                )
+
+        # Generate Connect staging assets + column notes from discovered metadata.
+        # Failures are isolated — the pipeline continues regardless.
+        if pipeline.provider == "commcare_connect":
+            try:
+                tenant_meta = TenantMetadata.objects.filter(
+                    tenant_membership=tenant_membership
+                ).first()
+                if tenant_meta:
+                    asset_result = upsert_connect_assets(tenant_membership.tenant, tenant_meta)
+                    logger.info(
+                        "Connect assets for %s: %d created, %d updated",
+                        tenant_membership.tenant.external_id,
+                        asset_result["created"],
+                        asset_result["updated"],
+                    )
+                    form_defs = (tenant_meta.metadata or {}).get("form_definitions", {})
+                    for ws in tenant_membership.tenant.workspaces.all():
+                        async_to_sync(sync_column_notes)(ws, "stg_visits", form_defs)
+            except Exception:
+                logger.exception(
+                    "Failed to generate Connect assets for %s; continuing pipeline",
                     tenant_membership.tenant.external_id,
                 )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,6 +48,26 @@ def tenant_membership(db, user, tenant):
 
 
 @pytest.fixture
+def connect_tenant_membership(db):
+    """Create a TenantMembership for a commcare_connect tenant."""
+    from django.contrib.auth import get_user_model
+
+    from apps.users.models import Tenant, TenantMembership
+
+    User = get_user_model()
+    connect_user = User.objects.create_user(
+        email="connect@example.com",
+        password="testpass123",
+        first_name="Connect",
+        last_name="User",
+    )
+    connect_tenant = Tenant.objects.create(
+        provider="commcare_connect", external_id="1237", canonical_name="Connect Opp 1237"
+    )
+    return TenantMembership.objects.create(user=connect_user, tenant=connect_tenant)
+
+
+@pytest.fixture
 def other_user(db):
     User = get_user_model()
     return User.objects.create_user(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,8 @@ Pytest configuration and fixtures for Scout tests.
 import pytest
 from django.contrib.auth import get_user_model
 
+from apps.users.models import Tenant, TenantMembership
+
 
 @pytest.fixture
 def user(db):
@@ -50,10 +52,6 @@ def tenant_membership(db, user, tenant):
 @pytest.fixture
 def connect_tenant_membership(db):
     """Create a TenantMembership for a commcare_connect tenant."""
-    from django.contrib.auth import get_user_model
-
-    from apps.users.models import Tenant, TenantMembership
-
     User = get_user_model()
     connect_user = User.objects.create_user(
         email="connect@example.com",

--- a/tests/test_column_note_generator.py
+++ b/tests/test_column_note_generator.py
@@ -1,0 +1,32 @@
+import pytest
+
+from apps.knowledge.services.column_note_generator import sync_column_notes
+
+FORM_DEFS = {
+    "muac_visit": {
+        "questions": [
+            {
+                "label": "MUAC (cm)",
+                "value": "/data/muac_group/muac",
+                "type": "Decimal",
+                "options": None,
+                "repeat": False,
+            },
+            {
+                "label": "Confirmed",
+                "value": "/data/muac_group/muac_confirmed",
+                "type": "Select",
+                "options": ["yes", "no"],
+                "repeat": False,
+            },
+        ]
+    }
+}
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_sync_column_notes_populates_from_form_defs(workspace):
+    tk = await sync_column_notes(workspace, "stg_visits", FORM_DEFS)
+    assert "Decimal" in tk.column_notes["muac"]
+    assert "yes, no" in tk.column_notes["muac_confirmed"]

--- a/tests/test_column_note_generator.py
+++ b/tests/test_column_note_generator.py
@@ -1,5 +1,6 @@
 import pytest
 
+from apps.knowledge.models import TableKnowledge
 from apps.knowledge.services.column_note_generator import sync_column_notes
 
 FORM_DEFS = {
@@ -30,3 +31,18 @@ async def test_sync_column_notes_populates_from_form_defs(workspace):
     tk = await sync_column_notes(workspace, "stg_visits", FORM_DEFS)
     assert "Decimal" in tk.column_notes["muac"]
     assert "yes, no" in tk.column_notes["muac_confirmed"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_sync_column_notes_merges_and_preserves_human_data(workspace):
+    await sync_column_notes(workspace, "stg_visits", FORM_DEFS)
+    tk = await TableKnowledge.objects.aget(workspace=workspace, table_name="stg_visits")
+    tk.column_notes["supervisor_note"] = "Added by human"
+    tk.description = "Human description"
+    await tk.asave()
+
+    tk2 = await sync_column_notes(workspace, "stg_visits", FORM_DEFS)
+    assert tk2.column_notes.get("supervisor_note") == "Added by human"  # human note survives
+    assert "muac" in tk2.column_notes  # auto note still present
+    assert tk2.description == "Human description"  # human description NOT clobbered

--- a/tests/test_connect_discover_integration.py
+++ b/tests/test_connect_discover_integration.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 import pytest
 
+from apps.workspaces.models import TenantMetadata
 from mcp_server.pipeline_registry import PipelineRegistry
 from mcp_server.services import materializer
 
@@ -22,8 +23,6 @@ def test_discover_persists_form_definitions(connect_tenant_membership):
         result = materializer._run_discover_phase(
             connect_tenant_membership, {"type": "api_key", "value": "t"}, pipeline
         )
-    from apps.workspaces.models import TenantMetadata
-
     tm = TenantMetadata.objects.get(tenant_membership=connect_tenant_membership)
     assert "muac_visit" in tm.metadata["form_definitions"]
     assert result["form_definitions"]["muac_visit"] == {"questions": []}

--- a/tests/test_connect_discover_integration.py
+++ b/tests/test_connect_discover_integration.py
@@ -1,0 +1,29 @@
+"""Integration test: discover phase persists form_definitions for commcare_connect."""
+
+from unittest import mock
+
+import pytest
+
+from mcp_server.pipeline_registry import PipelineRegistry
+from mcp_server.services import materializer
+
+
+@pytest.mark.django_db(transaction=True)
+def test_discover_persists_form_definitions(connect_tenant_membership):
+    pipeline = PipelineRegistry().get_by_provider("commcare_connect")
+    fake = {
+        "opportunity": {"name": "Demo"},
+        "organizations": [],
+        "programs": [],
+        "all_opportunities": [],
+        "form_definitions": {"muac_visit": {"questions": []}},
+    }
+    with mock.patch.object(materializer.ConnectMetadataLoader, "load", return_value=fake):
+        result = materializer._run_discover_phase(
+            connect_tenant_membership, {"type": "api_key", "value": "t"}, pipeline
+        )
+    from apps.workspaces.models import TenantMetadata
+
+    tm = TenantMetadata.objects.get(tenant_membership=connect_tenant_membership)
+    assert "muac_visit" in tm.metadata["form_definitions"]
+    assert result["form_definitions"]["muac_visit"] == {"questions": []}

--- a/tests/test_connect_metadata_loader.py
+++ b/tests/test_connect_metadata_loader.py
@@ -1,9 +1,49 @@
+from unittest import mock
+
 import pytest
 import requests_mock as rm
 
 from mcp_server.loaders.connect_metadata import ConnectMetadataLoader
 
 BASE = "https://connect.example.com"
+
+# Real Connect /app_structure/ shape: {"learn_app": <HQ app JSON>, "deliver_app": <HQ app JSON>}
+# Each app is HQ application JSON: app -> modules -> forms -> questions.
+APP_STRUCTURE_PAYLOAD = {
+    "learn_app": None,
+    "deliver_app": {
+        "id": "app_deliver",
+        "name": "MUAC Deliver",
+        "modules": [
+            {
+                "name": "Delivery",
+                "case_type": "beneficiary",
+                "forms": [
+                    {
+                        "xmlns": "http://openrosa.org/formdesigner/muac1",
+                        "name": "MUAC Visit",
+                        "questions": [
+                            {
+                                "label": "MUAC (cm)",
+                                "value": "/data/muac_group/muac",
+                                "tag": "input",
+                                "type": "Decimal",
+                                "repeat": False,
+                            },
+                            {
+                                "label": "MUAC confirmed",
+                                "value": "/data/muac_group/muac_confirmed",
+                                "tag": "select1",
+                                "type": "Select",
+                                "repeat": False,
+                            },
+                        ],
+                    }
+                ],
+            }
+        ],
+    },
+}
 
 
 @pytest.fixture
@@ -12,6 +52,14 @@ def loader():
         opportunity_id=814,
         credential={"type": "oauth", "value": "test-token"},
         base_url=BASE,
+    )
+
+
+def _loader():
+    return ConnectMetadataLoader(
+        opportunity_id=1237,
+        credential={"type": "api_key", "value": "tok"},
+        base_url="https://connect.example",
     )
 
 
@@ -44,6 +92,10 @@ class TestConnectMetadataLoader:
                     "is_active": True,
                 },
             )
+            m.get(
+                f"{BASE}/export/opportunity/814/app_structure/",
+                json={"learn_app": None, "deliver_app": None},
+            )
 
             metadata = loader.load()
             assert metadata["opportunity"]["id"] == 814
@@ -51,3 +103,27 @@ class TestConnectMetadataLoader:
             assert len(metadata["organizations"]) == 1
             assert len(metadata["programs"]) == 1
             assert metadata["organizations"][0]["slug"] == "dimagi"
+
+
+def test_load_includes_form_definitions_from_app_structure():
+    loader = _loader()
+    with (
+        mock.patch.object(
+            loader,
+            "_fetch_org_data",
+            return_value={"organizations": [], "programs": [], "opportunities": []},
+        ),
+        mock.patch.object(
+            loader, "_fetch_opportunity_detail", return_value={"name": "Demo", "id": 1237}
+        ),
+        mock.patch.object(loader, "_fetch_app_structure", return_value=APP_STRUCTURE_PAYLOAD),
+    ):
+        result = loader.load()
+
+    # _extract_form_definitions keys by xmlns (CommCare shape):
+    fd = result["form_definitions"]
+    assert "http://openrosa.org/formdesigner/muac1" in fd
+    form = fd["http://openrosa.org/formdesigner/muac1"]
+    q = {item["value"]: item for item in form["questions"]}
+    assert q["/data/muac_group/muac"]["type"] == "Decimal"
+    assert q["/data/muac_group/muac_confirmed"]["label"] == "MUAC confirmed"

--- a/tests/test_connect_staging.py
+++ b/tests/test_connect_staging.py
@@ -1,0 +1,69 @@
+"""Tests for Connect staging SQL generator (Milestone 4 / Task 3)."""
+
+from __future__ import annotations
+
+import pytest
+
+from apps.transformations.services.connect_staging import generate_connect_assets
+from apps.users.models import Tenant
+
+FORM_DEFS = {
+    "muac_visit": {
+        "name": "MUAC Visit",
+        "deliver_unit": "muac_visit",
+        "questions": [
+            {
+                "label": "MUAC (cm)",
+                "value": "/data/muac_group/muac",
+                "type": "Decimal",
+                "repeat": False,
+                "options": None,
+            },
+            {
+                "label": "Confirmed",
+                "value": "/data/muac_group/muac_confirmed",
+                "type": "Select",
+                "repeat": False,
+                "options": ["yes", "no"],
+            },
+            {
+                "label": "Child name",
+                "value": "/data/children/child_name",
+                "type": "Text",
+                "repeat": True,
+                "options": None,
+            },
+        ],
+    }
+}
+
+
+@pytest.fixture
+def connect_tenant(db):
+    """Create a Tenant with provider commcare_connect."""
+    return Tenant.objects.create(
+        provider="commcare_connect",
+        external_id="1237",
+        canonical_name="Connect Opp 1237",
+    )
+
+
+@pytest.mark.django_db(transaction=True)
+def test_generates_visit_staging_with_typed_columns(connect_tenant):
+    assets = generate_connect_assets(FORM_DEFS, connect_tenant)
+    by_name = {a.name: a for a in assets}
+
+    assert "stg_visits" in by_name
+    sql = by_name["stg_visits"].sql_content
+    # Non-repeat questions become typed, aliased columns from form_json:
+    assert "form_json" in sql
+    assert "muac" in sql  # column derived from /data/muac_group/muac
+    assert "muac_confirmed" in sql
+    # Repeat question is NOT inlined into stg_visits:
+    assert "child_name" not in sql
+
+    # Repeat group becomes its own child asset:
+    assert "stg_visits__repeat_children" in by_name
+    rsql = by_name["stg_visits__repeat_children"].sql_content
+    assert "jsonb_array_elements" in rsql
+    assert "child_name" in rsql

--- a/tests/test_connect_staging.py
+++ b/tests/test_connect_staging.py
@@ -67,3 +67,5 @@ def test_generates_visit_staging_with_typed_columns(connect_tenant):
     rsql = by_name["stg_visits__repeat_children"].sql_content
     assert "jsonb_array_elements" in rsql
     assert "child_name" in rsql
+    assert "muac" not in rsql
+    assert "muac_confirmed" not in rsql

--- a/tests/test_connect_transform_wiring.py
+++ b/tests/test_connect_transform_wiring.py
@@ -80,7 +80,7 @@ def test_upsert_connect_assets_creates_stg_visits(connect_tenant):
     tenant_meta = _FakeTenantMeta(FORM_DEFS)
     result = upsert_connect_assets(connect_tenant, tenant_meta)
 
-    assert result["created"] >= 1
+    assert result["created"] == 1
     assert result["total"] >= 1
 
     asset = TransformationAsset.objects.get(
@@ -137,7 +137,7 @@ def test_upsert_connect_assets_sweeps_orphaned_assets(connect_tenant):
 
     # Re-upsert with same (no-repeat) form_defs — orphan should be swept
     result = upsert_connect_assets(connect_tenant, tenant_meta)
-    assert result["deleted"] >= 1
+    assert result["deleted"] == 1
     assert not TransformationAsset.objects.filter(
         name="stg_visits__repeat_old_group",
         scope=TransformationScope.SYSTEM,

--- a/tests/test_connect_transform_wiring.py
+++ b/tests/test_connect_transform_wiring.py
@@ -161,12 +161,14 @@ def test_column_note_wiring_loop_populates_table_knowledge(connect_tenant, conne
     for ws in connect_tenant.workspaces.all():
         async_to_sync(sync_column_notes)(ws, "stg_visits", form_defs)
 
-    # Assert TableKnowledge exists for the workspace
+    # Assert TableKnowledge exists for the workspace.
+    # "/data/status" collides with the base column "status" so visit_column_map
+    # dedupes it to "status_2" — note key must match the actual staging column name.
     tk = TableKnowledge.objects.get(workspace=connect_workspace, table_name="stg_visits")
     assert "muac" in tk.column_notes
     assert "Decimal" in tk.column_notes["muac"]
-    assert "status" in tk.column_notes
-    assert "green" in tk.column_notes["status"]
+    assert "status_2" in tk.column_notes
+    assert "green" in tk.column_notes["status_2"]
 
 
 @pytest.mark.django_db(transaction=True)

--- a/tests/test_connect_transform_wiring.py
+++ b/tests/test_connect_transform_wiring.py
@@ -1,0 +1,186 @@
+"""Tests for Connect staging upsert + column-note wiring (Task 5).
+
+Covers:
+1. upsert_connect_assets — creates a stg_visits TransformationAsset, re-runs
+   update rather than duplicate, and sweeps orphaned SYSTEM assets.
+2. Column-note wiring — after upsert + loop, a workspace linked to the tenant
+   has a TableKnowledge row with column_notes populated from form_definitions.
+"""
+
+from __future__ import annotations
+
+import django.contrib.auth
+import pytest
+from asgiref.sync import async_to_sync
+
+from apps.knowledge.models import TableKnowledge
+from apps.knowledge.services.column_note_generator import sync_column_notes
+from apps.transformations.models import TransformationAsset, TransformationScope
+from apps.transformations.services.connect_staging import upsert_connect_assets
+from apps.users.models import Tenant
+from apps.workspaces.models import Workspace, WorkspaceTenant
+
+FORM_DEFS = {
+    "muac_visit": {
+        "name": "MUAC Visit",
+        "deliver_unit": "muac_visit",
+        "questions": [
+            {
+                "label": "MUAC (cm)",
+                "value": "/data/muac_group/muac",
+                "type": "Decimal",
+                "repeat": False,
+                "options": None,
+            },
+            {
+                "label": "Status",
+                "value": "/data/status",
+                "type": "Select",
+                "repeat": False,
+                "options": ["green", "yellow", "red"],
+            },
+        ],
+    }
+}
+
+
+class _FakeTenantMeta:
+    """Minimal stand-in for TenantMetadata.metadata container."""
+
+    def __init__(self, form_definitions: dict):
+        self.metadata = {"form_definitions": form_definitions}
+
+
+@pytest.fixture
+def connect_tenant(db):
+    """Create a Tenant with provider commcare_connect."""
+    return Tenant.objects.create(
+        provider="commcare_connect",
+        external_id="99001",
+        canonical_name="Connect Opp 99001",
+    )
+
+
+@pytest.fixture
+def connect_workspace(db, connect_tenant):
+    """Create a Workspace linked to connect_tenant via WorkspaceTenant."""
+    User = django.contrib.auth.get_user_model()
+    user = User.objects.create_user(email="wiring@example.com", password="pass")
+    ws = Workspace.objects.create(name="Wiring Test WS", created_by=user)
+    WorkspaceTenant.objects.create(workspace=ws, tenant=connect_tenant)
+    return ws
+
+
+# ── upsert_connect_assets ─────────────────────────────────────────────────────
+
+
+@pytest.mark.django_db(transaction=True)
+def test_upsert_connect_assets_creates_stg_visits(connect_tenant):
+    """upsert_connect_assets persists a SYSTEM stg_visits asset for the tenant."""
+    tenant_meta = _FakeTenantMeta(FORM_DEFS)
+    result = upsert_connect_assets(connect_tenant, tenant_meta)
+
+    assert result["created"] >= 1
+    assert result["total"] >= 1
+
+    asset = TransformationAsset.objects.get(
+        name="stg_visits",
+        scope=TransformationScope.SYSTEM,
+        tenant=connect_tenant,
+    )
+    assert "form_json" in asset.sql_content
+    assert "muac" in asset.sql_content
+
+
+@pytest.mark.django_db(transaction=True)
+def test_upsert_connect_assets_updates_not_duplicates(connect_tenant):
+    """Running upsert_connect_assets twice updates, not re-creates."""
+    tenant_meta = _FakeTenantMeta(FORM_DEFS)
+    r1 = upsert_connect_assets(connect_tenant, tenant_meta)
+    r2 = upsert_connect_assets(connect_tenant, tenant_meta)
+
+    assert r1["created"] >= 1
+    # Second run: all updates, no new creates
+    assert r2["created"] == 0
+    assert r2["updated"] >= 1
+
+    # Exactly one stg_visits asset per tenant
+    count = TransformationAsset.objects.filter(
+        name="stg_visits",
+        scope=TransformationScope.SYSTEM,
+        tenant=connect_tenant,
+    ).count()
+    assert count == 1
+
+
+@pytest.mark.django_db(transaction=True)
+def test_upsert_connect_assets_sweeps_orphaned_assets(connect_tenant):
+    """Assets no longer generated from current metadata are deleted."""
+    # First upsert with a form that creates stg_visits
+    tenant_meta = _FakeTenantMeta(FORM_DEFS)
+    upsert_connect_assets(connect_tenant, tenant_meta)
+
+    # Manually plant an orphan SYSTEM asset for this tenant
+    TransformationAsset.objects.create(
+        name="stg_visits__repeat_old_group",
+        description="Orphaned repeat group",
+        scope=TransformationScope.SYSTEM,
+        tenant=connect_tenant,
+        sql_content="SELECT 1",
+        created_by=None,
+    )
+    assert TransformationAsset.objects.filter(
+        name="stg_visits__repeat_old_group",
+        scope=TransformationScope.SYSTEM,
+        tenant=connect_tenant,
+    ).exists()
+
+    # Re-upsert with same (no-repeat) form_defs — orphan should be swept
+    result = upsert_connect_assets(connect_tenant, tenant_meta)
+    assert result["deleted"] >= 1
+    assert not TransformationAsset.objects.filter(
+        name="stg_visits__repeat_old_group",
+        scope=TransformationScope.SYSTEM,
+        tenant=connect_tenant,
+    ).exists()
+
+
+# ── Column-note wiring loop ───────────────────────────────────────────────────
+
+
+@pytest.mark.django_db(transaction=True)
+def test_column_note_wiring_loop_populates_table_knowledge(connect_tenant, connect_workspace):
+    """The documented per-workspace loop creates a TableKnowledge row with column_notes."""
+    tenant_meta = _FakeTenantMeta(FORM_DEFS)
+
+    # Run the asset upsert
+    upsert_connect_assets(connect_tenant, tenant_meta)
+
+    # Run the column-note loop exactly as documented in the dispatch
+    form_defs = (tenant_meta.metadata or {}).get("form_definitions", {})
+    for ws in connect_tenant.workspaces.all():
+        async_to_sync(sync_column_notes)(ws, "stg_visits", form_defs)
+
+    # Assert TableKnowledge exists for the workspace
+    tk = TableKnowledge.objects.get(workspace=connect_workspace, table_name="stg_visits")
+    assert "muac" in tk.column_notes
+    assert "Decimal" in tk.column_notes["muac"]
+    assert "status" in tk.column_notes
+    assert "green" in tk.column_notes["status"]
+
+
+@pytest.mark.django_db(transaction=True)
+def test_column_note_wiring_no_workspace_is_noop(connect_tenant):
+    """If the tenant has no workspaces, the loop runs zero iterations without error."""
+    tenant_meta = _FakeTenantMeta(FORM_DEFS)
+    upsert_connect_assets(connect_tenant, tenant_meta)
+
+    form_defs = (tenant_meta.metadata or {}).get("form_definitions", {})
+    count = 0
+    for ws in connect_tenant.workspaces.all():
+        async_to_sync(sync_column_notes)(ws, "stg_visits", form_defs)
+        count += 1
+
+    # connect_tenant has no workspace in this test — loop body never runs
+    assert count == 0
+    assert not TableKnowledge.objects.filter(table_name="stg_visits").exists()

--- a/tests/test_materializer.py
+++ b/tests/test_materializer.py
@@ -564,6 +564,80 @@ class TestRunPipeline:
         # Sanity-check that update_fields includes result/state.
         assert "result" in result_kwargs.get("update_fields", [])
 
+    def test_commcare_connect_branch_invokes_upsert_and_sync_column_notes(self):
+        """The commcare_connect staging branch in run_pipeline must:
+        1. Call upsert_connect_assets once with the tenant, given a TenantMetadata row.
+        2. Call sync_column_notes once per workspace linked to the tenant.
+        Regression guard: catches guard/variable typos and missing calls.
+        """
+        from mcp_server.pipeline_registry import PipelineConfig, SourceConfig
+        from mcp_server.services.materializer import run_pipeline
+
+        pipeline = PipelineConfig(
+            name="commcare_connect",
+            description="",
+            version="1.0",
+            provider="commcare_connect",
+            sources=[SourceConfig(name="users")],
+        )
+        tm = self._make_tm(tenant_id="42")
+
+        # Fake workspace so the per-workspace loop fires once.
+        fake_workspace = MagicMock()
+        tm.tenant.workspaces.all.return_value = [fake_workspace]
+
+        with (
+            patch("mcp_server.services.materializer.SchemaManager") as mock_mgr,
+            patch("mcp_server.services.materializer.MaterializationRun") as mock_run_cls,
+            patch("mcp_server.services.materializer.TenantMetadata") as mock_tenant_meta_cls,
+            patch("mcp_server.services.materializer.TransformationAsset") as mock_asset_cls,
+            patch("mcp_server.services.materializer.ConnectMetadataLoader") as mock_meta,
+            patch("mcp_server.services.materializer.ConnectUserLoader") as mock_users,
+            patch("mcp_server.services.materializer.get_managed_db_connection") as mock_conn,
+            patch(
+                "mcp_server.services.materializer.upsert_connect_assets"
+            ) as mock_upsert,
+            patch(
+                "mcp_server.services.materializer.sync_column_notes"
+            ) as mock_sync,
+        ):
+            schema = self._make_schema()
+            mock_mgr.return_value.provision.return_value = schema
+            self._setup_run_mock(mock_run_cls)
+            mock_meta.return_value.load.return_value = {}
+            mock_users.return_value.load_pages.return_value = iter([])
+
+            # Wire TenantMetadata.objects.filter(...).first() to return a
+            # non-None sentinel so the if-tenant_meta branch is entered.
+            fake_tenant_meta = MagicMock()
+            fake_tenant_meta.metadata = {"form_definitions": {"visit_form": {}}}
+            mock_tenant_meta_cls.objects.filter.return_value.first.return_value = (
+                fake_tenant_meta
+            )
+
+            mock_asset_cls.objects.filter.return_value.exists.return_value = False
+            mock_upsert.return_value = {"created": 1, "updated": 0, "deleted": 0, "total": 1}
+            # sync_column_notes is an async function; mock as a regular callable
+            # since async_to_sync wraps it inside run_pipeline.
+            mock_sync.return_value = None
+
+            conn = MagicMock()
+            mock_conn.return_value = conn
+            conn.cursor.return_value = MagicMock()
+
+            result = run_pipeline(tm, {"type": "api_key", "value": "x"}, pipeline)
+
+        assert result["status"] == "completed"
+
+        # Branch guard: upsert_connect_assets called exactly once with the tenant.
+        mock_upsert.assert_called_once_with(tm.tenant, fake_tenant_meta)
+
+        # Per-workspace loop: sync_column_notes called once for the one workspace.
+        assert mock_sync.call_count == 1
+        sync_call = mock_sync.call_args
+        assert sync_call.args[0] == fake_workspace
+        assert sync_call.args[1] == "stg_visits"
+
     def test_failed_first_source_marks_run_failed_not_partial(self):
         """If the very first source fails, no source has committed, so the
         run is marked FAILED (not PARTIAL).

--- a/tests/test_materializer.py
+++ b/tests/test_materializer.py
@@ -1,5 +1,5 @@
 from datetime import timedelta
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from django.utils import timezone
@@ -594,11 +594,10 @@ class TestRunPipeline:
             patch("mcp_server.services.materializer.ConnectMetadataLoader") as mock_meta,
             patch("mcp_server.services.materializer.ConnectUserLoader") as mock_users,
             patch("mcp_server.services.materializer.get_managed_db_connection") as mock_conn,
+            patch("mcp_server.services.materializer.upsert_connect_assets") as mock_upsert,
             patch(
-                "mcp_server.services.materializer.upsert_connect_assets"
-            ) as mock_upsert,
-            patch(
-                "mcp_server.services.materializer.sync_column_notes"
+                "mcp_server.services.materializer.sync_column_notes",
+                new_callable=AsyncMock,
             ) as mock_sync,
         ):
             schema = self._make_schema()
@@ -611,15 +610,10 @@ class TestRunPipeline:
             # non-None sentinel so the if-tenant_meta branch is entered.
             fake_tenant_meta = MagicMock()
             fake_tenant_meta.metadata = {"form_definitions": {"visit_form": {}}}
-            mock_tenant_meta_cls.objects.filter.return_value.first.return_value = (
-                fake_tenant_meta
-            )
+            mock_tenant_meta_cls.objects.filter.return_value.first.return_value = fake_tenant_meta
 
             mock_asset_cls.objects.filter.return_value.exists.return_value = False
             mock_upsert.return_value = {"created": 1, "updated": 0, "deleted": 0, "total": 1}
-            # sync_column_notes is an async function; mock as a regular callable
-            # since async_to_sync wraps it inside run_pipeline.
-            mock_sync.return_value = None
 
             conn = MagicMock()
             mock_conn.return_value = conn


### PR DESCRIPTION
## What this does

Makes Scout **form-aware** for CommCare Connect data. Previously the agent saw `raw_visits.form_json` as an opaque JSON blob; now it sees typed, human-labeled staging columns with auto-generated notes — which lifts answer quality on **every** Connect opportunity.

Two pieces:

**1. Fetch the deliver-app form schema (M1).** `ConnectMetadataLoader` now calls Connect's `GET /export/opportunity/{id}/app_structure/?app_type=both` (Connect proxies to CommCare HQ server-side — no HQ credentials needed) and reuses the existing `_extract_form_definitions` to parse the `{learn_app, deliver_app}` HQ app JSON into `form_definitions`, stored in `TenantMetadata`. Degrades gracefully if the endpoint is unavailable.

**2. Stage `form_json` into typed/labeled columns (M2).**
- `connect_staging.py` generates a `stg_visits` dbt asset flattening `raw_visits.form_json` into typed columns (one per non-repeat question, cast by question type), plus `stg_visits__repeat_<group>` child assets for repeat groups — mirroring the existing `commcare_staging` conventions, with a shared `visit_column_map` as the single source of truth for column naming.
- `column_note_generator.py` auto-populates `TableKnowledge.column_notes` from the form questions (labels, types, choice lists). It's **merge-safe**: re-syncs preserve human-edited column notes and never clobber a human-written table `description` (Django 5 `create_defaults`). These notes already flow into the agent prompt via the existing `KnowledgeRetriever` — no retriever change needed.
- Wired into the materializer's transform phase as an additive `commcare_connect` branch (existing provider behavior untouched).

## Why land it on its own

This is independently valuable regardless of any downstream work: the agent now understands `muac` is a `Decimal` labeled "MUAC (cm)" instead of guessing at a JSON blob. It is the first step of a larger semantic-layer exploration (design + roadmap under `docs/superpowers/`), but it stands alone and improves Connect data handling today.

## Testing

~45 new tests, all green: app_structure parsing, discover persistence, staging SQL (typed columns + repeat groups + SQL-escaping), column-note merge/idempotency, and the materializer branch wiring (drives `run_pipeline` for `commcare_connect`). No model/migration changes.

Reviewed task-by-task plus a final whole-branch review (async correctness, SQL safety, orphan-sweep scoping, and staging↔notes column-name alignment incl. the collision case all verified).

## Deferred follow-up

- Repeat-group child tables (`stg_visits__repeat_*`) are staged but not yet annotated with column notes — a small follow-up, intentionally out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
