### PR TITLE
fix(transformations): restore green main — use dbt_column_alias in connect_staging (#302↔#235 collision)

### DIFF
--- a/apps/transformations/services/connect_staging.py
+++ b/apps/transformations/services/connect_staging.py
@@ -12,13 +12,13 @@ from __future__ import annotations
 
 import logging
 
+from apps.common.identifiers import dbt_column_alias
 from apps.transformations.models import TransformationAsset, TransformationScope
 from apps.transformations.services.commcare_staging import (
     _column_name_from_path,
     _question_path_to_json_path,
     _sql_escape,
     _typed_expression,
-    _unique_alias,
     slugify_model_name,
 )
 
@@ -42,7 +42,7 @@ _VISIT_BASE_COLUMNS = [
 def visit_column_map(form_definitions: dict) -> list[tuple[dict, str]]:
     """Return an ordered list of (question, final_column_name) for stg_visits.
 
-    Applies the same base-column seeding and :func:`_unique_alias` deduplication
+    Applies the same base-column seeding and :func:`~apps.common.identifiers.dbt_column_alias` deduplication
     that :func:`_generate_stg_visits` uses, guaranteeing that the column names
     returned here are byte-for-byte identical to those emitted in the staging SQL.
 
@@ -58,7 +58,7 @@ def visit_column_map(form_definitions: dict) -> list[tuple[dict, str]]:
             value_path = q.get("value", "")
             if not value_path:
                 continue
-            col_name = _unique_alias(_column_name_from_path(value_path), seen_aliases)
+            col_name = dbt_column_alias(_column_name_from_path(value_path), seen_aliases)
             result.append((q, col_name))
     return result
 
@@ -123,7 +123,7 @@ def _generate_connect_repeat_group_asset(
         if not value_path:
             continue
         leaf_name = value_path.rsplit("/", 1)[-1]
-        col_name = _unique_alias(_column_name_from_path(value_path), seen_aliases)
+        col_name = dbt_column_alias(_column_name_from_path(value_path), seen_aliases)
         raw_expr = f"elem.value->>'{_sql_escape(leaf_name)}'"
         q_type = q.get("type")
         select_parts.append(f'    {_typed_expression(raw_expr, q_type)} AS "{col_name}"')


### PR DESCRIPTION
## What & why

`main` has been **red since 2026-06-24**, blocking all production deploys. The test gate fails at `makemigrations --check` with:

```
ImportError: cannot import name '_unique_alias' from apps.transformations.services.commcare_staging
```

**Cross-workstream collision:** #302 (Cube — Connect form-aware staging, `connect_staging.py`) imports `_unique_alias`, but arch **#235/#299** removed it — alias dedup moved to `apps.common.identifiers.dbt_column_alias` (finding `04#6`). The merge was textually clean but semantically broken; CI fails at import → deploy job skipped (the #233 gate correctly kept it out of prod). Last green deploy was #300.

## Fix

Swap the removed `_unique_alias(base, seen)` for the drop-in **`dbt_column_alias(base, seen)`** at both call sites in `connect_staging.py`. `seen_aliases` is already a `dict[str, int]`, matching the signature exactly. `dbt_column_alias` is strictly better — it caps/hashes to 63 bytes **after** disambiguation (the ordering bug #235 fixed), so distinct long Connect property names can't collapse to one physical column. This is the same migration #235 applied to `commcare_staging.py`.

## Sibling sweep (per #268)

```
git grep -n "_unique_alias" -- '*.py'
```
→ After the fix, the only remaining hit is a **prose docstring** in `apps/common/identifiers.py:151` (historical note explaining what `dbt_column_alias` improved on) — not a code reference. `connect_staging.py` was the only code site still calling the removed helper. The five other names `connect_staging` imports from `commcare_staging` (`_column_name_from_path`, `_question_path_to_json_path`, `_sql_escape`, `_typed_expression`, `slugify_model_name`) all still exist.

## Test evidence

- **`makemigrations --check --dry-run` → exit 0** ("No changes detected") — the exact failing CI step now passes; #302 added no missing migrations.
- **Import-smoke** of all four #302-touched modules (`connect_staging`, `mcp_server.services.materializer`, `mcp_server.loaders.connect_metadata`, `apps.knowledge.services.column_note_generator`) — all import cleanly, ruling out a second collision behind the first import error (`materializer.py` overlaps #241/#237).
- **8 passed**: `tests/test_connect_staging.py`, `tests/test_connect_transform_wiring.py`, `tests/test_connect_metadata_loader.py`.
- `ruff check` + `ruff format --check` clean.

> Note: this only fixes `main`. emdash's stacked Cube branches (#303/#304/#306, `cube-stack-rebased`) still carry the same `_unique_alias` import and will need the same swap when they re-land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
