### PR TITLE
[arch] Django admin lockdown + management-command fixes (#260)

### DIFF
--- a/apps/chat/admin.py
+++ b/apps/chat/admin.py
@@ -1,0 +1,34 @@
+"""Admin configuration for chat models (arch #260, 11#5).
+
+Thread and ThreadJob are registered read-only so operators can inspect the rows
+that every recent "stuck Preparing…" / zombie-job incident required examining,
+without being able to mutate the job state machine through the admin.
+"""
+
+from django.contrib import admin
+
+from apps.common.admin import ReadOnlyModelAdmin
+
+from .models import Thread, ThreadJob
+
+
+@admin.register(Thread)
+class ThreadAdmin(ReadOnlyModelAdmin):
+    list_display = ["title", "workspace", "user", "is_shared", "updated_at"]
+    list_filter = ["is_shared", "updated_at"]
+    search_fields = ["title", "user__email", "workspace__name"]
+
+
+@admin.register(ThreadJob)
+class ThreadJobAdmin(ReadOnlyModelAdmin):
+    list_display = [
+        "id",
+        "thread",
+        "job_type",
+        "state",
+        "procrastinate_job_id",
+        "created_at",
+        "completed_at",
+    ]
+    list_filter = ["job_type", "state", "created_at"]
+    search_fields = ["thread__title", "tool_call_id"]

--- a/apps/common/admin.py
+++ b/apps/common/admin.py
@@ -1,0 +1,33 @@
+"""Shared Django admin helpers (arch #260).
+
+``ReadOnlyModelAdmin`` is the in-process equivalent of procrastinate's bundled
+admin: operator models that the team needs to *inspect* during incidents
+(zombie jobs, stuck Preparing…, EXPIRED resurrection, cascade-FAILED view
+schemas) are registered for visibility but can never be added, changed, or
+deleted through the admin. This inverts the prior surface where dangerous
+state-machine rows were fully editable while operator models were absent.
+"""
+
+from django.contrib import admin
+
+
+class ReadOnlyModelAdmin(admin.ModelAdmin):
+    """A ModelAdmin that allows viewing but never add/change/delete.
+
+    All concrete model fields are forced readonly so the change form renders as
+    a read-only detail view. Subclasses set ``list_display`` / ``search_fields``
+    / ``list_filter`` for operator ergonomics.
+    """
+
+    def get_readonly_fields(self, request, obj=None):
+        # Every concrete (non-m2m, editable-or-not) field is readonly.
+        return [f.name for f in self.model._meta.fields]
+
+    def has_add_permission(self, request):
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        return False

--- a/apps/knowledge/admin.py
+++ b/apps/knowledge/admin.py
@@ -1,6 +1,7 @@
 """Admin configuration for Knowledge models."""
 
 from django.contrib import admin
+from django.utils.html import format_html
 
 from .models import (
     AgentLearning,
@@ -139,9 +140,11 @@ class AgentLearningAdmin(admin.ModelAdmin):
             color = "orange"
         else:
             color = "red"
-        return f'<span style="color: {color}; font-weight: bold;">{score:.0%}</span>'
-
-    confidence_badge.allow_tags = True
+        return format_html(
+            '<span style="color: {}; font-weight: bold;">{}</span>',
+            color,
+            f"{score:.0%}",
+        )
 
     @admin.action(description="Approve learnings (activate + increase confidence)")
     def approve_learnings(self, request, queryset):

--- a/apps/recipes/admin.py
+++ b/apps/recipes/admin.py
@@ -1,20 +1,16 @@
 """
 Admin configuration for Recipe models.
+
+The runner executes a single ``Recipe.prompt`` (recipes/services/runner.py),
+not the vestigial ``RecipeStep`` rows. The admin now surfaces ``prompt`` and
+drops the RecipeStep inline / ModelAdmin so operators stop creating step rows
+nothing reads (arch #260, 11#5).
 """
 
 from django.contrib import admin
 from django.utils.html import format_html
 
-from .models import Recipe, RecipeRun, RecipeStep
-
-
-class RecipeStepInline(admin.TabularInline):
-    """Inline admin for recipe steps."""
-
-    model = RecipeStep
-    extra = 1
-    ordering = ["order"]
-    fields = ["order", "prompt_template", "expected_tool", "description"]
+from .models import Recipe, RecipeRun
 
 
 @admin.register(Recipe)
@@ -24,20 +20,27 @@ class RecipeAdmin(admin.ModelAdmin):
     list_display = [
         "name",
         "workspace",
-        "step_count",
+        "prompt_preview",
         "variable_count",
         "is_shared",
         "created_by",
         "updated_at",
     ]
     list_filter = ["is_shared", "created_at", "workspace"]
-    search_fields = ["name", "description"]
+    search_fields = ["name", "description", "prompt"]
     readonly_fields = ["id", "share_token", "created_at", "updated_at"]
     autocomplete_fields = ["created_by"]
-    inlines = [RecipeStepInline]
 
     fieldsets = (
         (None, {"fields": ("id", "name", "description", "workspace")}),
+        (
+            "Prompt",
+            {
+                "fields": ("prompt",),
+                "description": "The prompt template the runner executes. "
+                "Supports {{variable}} placeholders and markdown.",
+            },
+        ),
         (
             "Variables",
             {
@@ -62,32 +65,16 @@ class RecipeAdmin(admin.ModelAdmin):
         ),
     )
 
-    @admin.display(description="Steps")
-    def step_count(self, obj):
-        return obj.steps.count()
+    @admin.display(description="Prompt")
+    def prompt_preview(self, obj):
+        preview = (obj.prompt or "")[:80]
+        if obj.prompt and len(obj.prompt) > 80:
+            preview += "..."
+        return preview or "-"
 
     @admin.display(description="Variables")
     def variable_count(self, obj):
         return len(obj.variables) if obj.variables else 0
-
-
-@admin.register(RecipeStep)
-class RecipeStepAdmin(admin.ModelAdmin):
-    """Admin interface for RecipeStep model."""
-
-    list_display = ["recipe", "order", "prompt_preview", "expected_tool"]
-    list_filter = ["recipe__workspace", "expected_tool"]
-    search_fields = ["prompt_template", "description", "recipe__name"]
-    autocomplete_fields = ["recipe"]
-    ordering = ["recipe", "order"]
-
-    @admin.display(description="Prompt")
-    def prompt_preview(self, obj):
-        """Show a truncated preview of the prompt template."""
-        preview = obj.prompt_template[:100]
-        if len(obj.prompt_template) > 100:
-            preview += "..."
-        return preview
 
 
 @admin.register(RecipeRun)
@@ -165,10 +152,8 @@ class RecipeRunAdmin(admin.ModelAdmin):
 
     @admin.display(description="Progress")
     def step_progress(self, obj):
-        """Show step progress as completed/total."""
-        total_steps = obj.recipe.steps.count()
-        completed_steps = len(obj.step_results)
-        return f"{completed_steps}/{total_steps}"
+        """Show how many step results were recorded for this run."""
+        return f"{len(obj.step_results)} step(s)"
 
     @admin.display(description="Duration")
     def duration_display(self, obj):

--- a/apps/transformations/admin.py
+++ b/apps/transformations/admin.py
@@ -22,7 +22,9 @@ class TransformationRunAdmin(admin.ModelAdmin):
     list_display = ("id", "tenant", "workspace", "status", "started_at", "completed_at")
     list_filter = ("status",)
     inlines = [TransformationAssetRunInline]
-    readonly_fields = ("id", "started_at")
+    # ``status`` is a pipeline state-machine field — editing it via admin can
+    # desync the run record from the physical transform state (arch #260, 11#3).
+    readonly_fields = ("id", "tenant", "workspace", "status", "started_at", "completed_at")
 
 
 @admin.register(TransformationAssetRun)

--- a/apps/users/admin.py
+++ b/apps/users/admin.py
@@ -1,11 +1,39 @@
 """
-Admin configuration for User model.
+Admin configuration for User model and identity-related models.
+
+Hardening (arch #260, 11#3):
+- UserAdmin makes the privilege-escalation fields (is_superuser,
+  user_permissions, groups) readonly so staff with users.change_user cannot
+  self-escalate to superuser through the change form.
+- allauth's auto-registered SocialToken / SocialApp admins are unregistered:
+  they expose every user's plaintext OAuth access/refresh tokens and the
+  platform's OAuth client secrets behind the (weakly throttled) admin login.
+- Operator identity models (Tenant, TenantMembership, TenantConnection) are
+  registered read-only for incident inspection (11#5); TenantConnection never
+  surfaces its encrypted credential.
 """
 
+import contextlib
+
+from allauth.socialaccount.models import SocialApp, SocialToken
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
 
-from .models import User
+from apps.common.admin import ReadOnlyModelAdmin
+from apps.users.admin_login import ThrottledAdminAuthenticationForm
+
+from .models import Tenant, TenantConnection, TenantMembership, User
+
+# Route /admin/login/ through Scout's per-email auth rate limiter (11#3), so an
+# admin brute force is throttled identically to /api/auth/.
+admin.site.login_form = ThrottledAdminAuthenticationForm
+
+# allauth auto-registers these in its AppConfig.ready(); unregister so plaintext
+# tokens / client secrets are never browsable through the admin. Guarded so a
+# future allauth that stops auto-registering doesn't raise NotRegistered.
+for _model in (SocialToken, SocialApp):
+    with contextlib.suppress(admin.sites.NotRegistered):
+        admin.site.unregister(_model)
 
 
 @admin.register(User)
@@ -16,6 +44,11 @@ class UserAdmin(BaseUserAdmin):
     list_filter = ["is_staff", "is_active", "created_at"]
     search_fields = ["email", "first_name", "last_name"]
     ordering = ["email"]
+
+    # is_superuser / user_permissions / groups grant privileges; making them
+    # readonly closes the self-escalation path (staff with change_user can no
+    # longer promote themselves or anyone else to superuser via the admin).
+    readonly_fields = ["is_superuser", "user_permissions", "groups", "last_login", "date_joined"]
 
     fieldsets = (
         (None, {"fields": ("email", "password")}),
@@ -36,3 +69,26 @@ class UserAdmin(BaseUserAdmin):
             },
         ),
     )
+
+
+@admin.register(Tenant)
+class TenantAdmin(ReadOnlyModelAdmin):
+    list_display = ["canonical_name", "provider", "external_id", "created_at"]
+    list_filter = ["provider"]
+    search_fields = ["canonical_name", "external_id"]
+
+
+@admin.register(TenantMembership)
+class TenantMembershipAdmin(ReadOnlyModelAdmin):
+    list_display = ["user", "tenant", "connection", "last_selected_at", "archived_at"]
+    list_filter = ["tenant__provider"]
+    search_fields = ["user__email", "tenant__canonical_name", "tenant__external_id"]
+
+
+@admin.register(TenantConnection)
+class TenantConnectionAdmin(ReadOnlyModelAdmin):
+    # Deliberately excludes ``encrypted_credential`` from list_display so the
+    # ciphertext is not casually surfaced in listings.
+    list_display = ["user", "provider", "credential_type", "created_at"]
+    list_filter = ["provider", "credential_type"]
+    search_fields = ["user__email"]

--- a/apps/users/admin_login.py
+++ b/apps/users/admin_login.py
@@ -1,0 +1,36 @@
+"""Throttled Django-admin login form (arch #260, 11#3).
+
+The default ``/admin/login/`` runs straight through ``ModelBackend`` with no
+throttle, lockout, or 2FA — bypassing the per-email limiter that guards Scout's
+own ``/api/auth/`` endpoints. This form routes admin login attempts through the
+SAME ``check_rate_limit`` / ``record_attempt`` limiter (5 failures / 300s per
+email), so a brute force against a superuser is rate-limited identically.
+"""
+
+from django.contrib.admin.forms import AdminAuthenticationForm
+from django.core.exceptions import ValidationError
+
+from apps.users.rate_limiting import check_rate_limit, record_attempt
+
+
+class ThrottledAdminAuthenticationForm(AdminAuthenticationForm):
+    """AdminAuthenticationForm that enforces Scout's per-email auth rate limit."""
+
+    def clean(self):
+        # ``username`` is the email (USERNAME_FIELD = "email").
+        username = self.cleaned_data.get("username") or self.data.get("username", "")
+        if username and check_rate_limit(username):
+            raise ValidationError(
+                "Too many login attempts. Try again later.",
+                code="rate_limited",
+            )
+        try:
+            cleaned = super().clean()
+        except ValidationError:
+            # A failed credential / permission check counts toward the limit.
+            if username:
+                record_attempt(username, success=False)
+            raise
+        if username:
+            record_attempt(username, success=True)
+        return cleaned

--- a/apps/users/management/commands/setup_oauth_apps.py
+++ b/apps/users/management/commands/setup_oauth_apps.py
@@ -1,7 +1,9 @@
 """Register OAuth SocialApp records from environment variables.
 
-Reads COMMCARE_OAUTH_*, COMMCARE_CONNECT_OAUTH_*, GOOGLE_OAUTH_*, and
-GITHUB_OAUTH_* env vars and upserts the corresponding allauth SocialApp rows.
+Reads ``{PREFIX}_OAUTH_CLIENT_ID`` / ``{PREFIX}_OAUTH_CLIENT_SECRET`` for each
+provider and upserts the corresponding allauth SocialApp rows. The prefixes are:
+COMMCARE_OAUTH_*, CONNECT_OAUTH_*, OCS_OAUTH_*, GOOGLE_OAUTH_*, GITHUB_OAUTH_*
+(matching config/deploy.yml).
 
 Idempotent — safe to re-run after credential rotation or fresh DB setup.
 """
@@ -13,12 +15,15 @@ from django.contrib.sites.models import Site
 from django.core.management.base import BaseCommand
 
 # (provider_id, display_name, env_prefix)
+# The env vars read are ``{env_prefix}_OAUTH_CLIENT_ID`` /
+# ``{env_prefix}_OAUTH_CLIENT_SECRET`` — so the prefix must NOT itself end in
+# ``_OAUTH`` (that produced the double ``_OAUTH_`` bug for Google/GitHub).
 PROVIDERS = [
     ("commcare", "CommCare HQ", "COMMCARE"),
     ("commcare_connect", "CommCare Connect", "CONNECT"),
     ("ocs", "Open Chat Studio", "OCS"),
-    ("google", "Google", "GOOGLE_OAUTH"),
-    ("github", "GitHub", "GITHUB_OAUTH"),
+    ("google", "Google", "GOOGLE"),
+    ("github", "GitHub", "GITHUB"),
 ]
 
 
@@ -47,7 +52,7 @@ class Command(BaseCommand):
             client_secret = os.environ.get(f"{env_prefix}_OAUTH_CLIENT_SECRET", "")
 
             if not client_id or not client_secret:
-                self.stdout.write(f"  skip   {name} ({env_prefix}_CLIENT_ID not set)")
+                self.stdout.write(f"  skip   {name} ({env_prefix}_OAUTH_CLIENT_ID not set)")
                 continue
 
             app, created = SocialApp.objects.update_or_create(

--- a/apps/workspaces/admin.py
+++ b/apps/workspaces/admin.py
@@ -1,21 +1,80 @@
 """
-Admin configuration for projects app.
+Admin configuration for the workspaces app.
+
+State-machine rows (TenantSchema, MaterializationRun) are intentionally
+hardened: their state/identity fields are readonly so an admin edit can never
+re-arm expire_inactive_schemas -> teardown_schema -> DROP SCHEMA CASCADE,
+clobber a live transition, or desync the physical schema from its Django row
+(arch #260, 11#3). Operator models are registered read-only for inspection
+(11#5).
 """
 
 from django.contrib import admin
 
-from .models import MaterializationRun, TenantSchema
+from apps.common.admin import ReadOnlyModelAdmin
+
+from .models import (
+    MaterializationRun,
+    TenantSchema,
+    Workspace,
+    WorkspaceMembership,
+    WorkspaceTenant,
+    WorkspaceViewSchema,
+)
 
 
 @admin.register(TenantSchema)
 class TenantSchemaAdmin(admin.ModelAdmin):
     list_display = ["schema_name", "state", "tenant", "created_at"]
     list_filter = ["state"]
-    readonly_fields = ["id", "created_at"]
+    # state/schema_name/last_accessed_at are part of the schema lifecycle
+    # state machine — editing them via admin is a DROP-SCHEMA / desync footgun.
+    readonly_fields = ["id", "tenant", "schema_name", "state", "last_accessed_at", "created_at"]
+
+    def has_delete_permission(self, request, obj=None):
+        # A default cascade delete would orphan the physical schema + _ro role.
+        return False
 
 
 @admin.register(MaterializationRun)
 class MaterializationRunAdmin(admin.ModelAdmin):
     list_display = ["pipeline", "state", "tenant_schema", "started_at", "completed_at"]
     list_filter = ["state", "pipeline"]
-    readonly_fields = ["id", "started_at"]
+    readonly_fields = [
+        "id",
+        "tenant_schema",
+        "pipeline",
+        "state",
+        "result",
+        "progress",
+        "procrastinate_job_id",
+        "started_at",
+        "completed_at",
+    ]
+
+
+@admin.register(Workspace)
+class WorkspaceAdmin(ReadOnlyModelAdmin):
+    list_display = ["name", "is_auto_created", "created_by", "created_at"]
+    list_filter = ["is_auto_created", "created_at"]
+    search_fields = ["name", "id"]
+
+
+@admin.register(WorkspaceTenant)
+class WorkspaceTenantAdmin(ReadOnlyModelAdmin):
+    list_display = ["workspace", "tenant"]
+    search_fields = ["workspace__name", "tenant__canonical_name", "tenant__external_id"]
+
+
+@admin.register(WorkspaceMembership)
+class WorkspaceMembershipAdmin(ReadOnlyModelAdmin):
+    list_display = ["workspace", "user", "role", "invited_by", "created_at"]
+    list_filter = ["role", "created_at"]
+    search_fields = ["workspace__name", "user__email"]
+
+
+@admin.register(WorkspaceViewSchema)
+class WorkspaceViewSchemaAdmin(ReadOnlyModelAdmin):
+    list_display = ["schema_name", "state", "workspace", "last_accessed_at", "created_at"]
+    list_filter = ["state"]
+    search_fields = ["schema_name", "workspace__name"]

--- a/apps/workspaces/management/commands/backfill_readonly_roles.py
+++ b/apps/workspaces/management/commands/backfill_readonly_roles.py
@@ -18,51 +18,75 @@ logger = logging.getLogger(__name__)
 class Command(BaseCommand):
     help = (
         "Create read-only PostgreSQL roles for all active tenant and view schemas. "
-        "Idempotent — safe to run multiple times."
+        "Idempotent — safe to run multiple times. Each schema is handled "
+        "independently so a single drift (a Django row whose physical schema was "
+        "dropped) does not abort the rest of the backfill."
     )
 
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Log what would be backfilled without issuing any GRANT/CREATE statements.",
+        )
+
     def handle(self, *args, **options):
+        dry_run = options["dry_run"]
+        if dry_run:
+            self.stdout.write(self.style.WARNING("DRY RUN — no changes will be made."))
+
         conn = _schema_manager.get_managed_db_connection()
         cursor = conn.cursor()
         mgr = SchemaManager()
 
+        ok = 0
+        failed = 0
         try:
-            # Backfill tenant schemas
-            tenant_schemas = TenantSchema.objects.filter(
-                state__in=[SchemaState.ACTIVE, SchemaState.MATERIALIZING],
-            )
+            # Backfill tenant schemas. MATERIALIZING is a dead state (the live
+            # pipeline never persists it), so only ACTIVE rows are selected.
+            tenant_schemas = TenantSchema.objects.filter(state=SchemaState.ACTIVE)
             for ts in tenant_schemas:
-                self._backfill_schema(cursor, mgr, ts.schema_name)
-                self.stdout.write(f"  Backfilled role for schema: {ts.schema_name}")
+                # Per-schema isolation: drift (physical schema missing) on one row
+                # must not strand every later schema's _ro role (fail-closed outage).
+                try:
+                    if not dry_run:
+                        self._backfill_schema(cursor, mgr, ts.schema_name)
+                    self.stdout.write(f"  Backfilled role for schema: {ts.schema_name}")
+                    ok += 1
+                except Exception:
+                    failed += 1
+                    logger.exception(
+                        "backfill_readonly_roles: failed for tenant schema '%s'; continuing",
+                        ts.schema_name,
+                    )
+                    self.stderr.write(
+                        self.style.ERROR(f"  SKIP (error) tenant schema: {ts.schema_name}")
+                    )
 
             # Backfill view schemas
             view_schemas = WorkspaceViewSchema.objects.filter(
                 state=SchemaState.ACTIVE,
             ).select_related("workspace")
             for vs in view_schemas:
-                self._backfill_schema(cursor, mgr, vs.schema_name)
-                # Grant access to constituent tenant schemas
-                role = readonly_role_name(vs.schema_name)
-                tenant_schemas_for_ws = TenantSchema.objects.filter(
-                    tenant__in=vs.workspace.tenants.all(),
-                    state=SchemaState.ACTIVE,
-                )
-                for ts in tenant_schemas_for_ws:
-                    cursor.execute(
-                        psycopg.sql.SQL("GRANT USAGE ON SCHEMA {} TO {}").format(
-                            psycopg.sql.Identifier(ts.schema_name),
-                            psycopg.sql.Identifier(role),
-                        )
+                try:
+                    if not dry_run:
+                        self._backfill_view_schema(cursor, mgr, vs)
+                    self.stdout.write(f"  Backfilled role for view schema: {vs.schema_name}")
+                    ok += 1
+                except Exception:
+                    failed += 1
+                    logger.exception(
+                        "backfill_readonly_roles: failed for view schema '%s'; continuing",
+                        vs.schema_name,
                     )
-                    cursor.execute(
-                        psycopg.sql.SQL("GRANT SELECT ON ALL TABLES IN SCHEMA {} TO {}").format(
-                            psycopg.sql.Identifier(ts.schema_name),
-                            psycopg.sql.Identifier(role),
-                        )
+                    self.stderr.write(
+                        self.style.ERROR(f"  SKIP (error) view schema: {vs.schema_name}")
                     )
-                self.stdout.write(f"  Backfilled role for view schema: {vs.schema_name}")
 
-            self.stdout.write(self.style.SUCCESS("Done."))
+            summary = f"Done. {ok} backfilled, {failed} skipped."
+            self.stdout.write(
+                self.style.SUCCESS(summary) if not failed else self.style.WARNING(summary)
+            )
         finally:
             cursor.close()
             conn.close()
@@ -78,3 +102,41 @@ class Command(BaseCommand):
                 psycopg.sql.Identifier(role),
             )
         )
+
+    def _backfill_view_schema(self, cursor, mgr, vs) -> None:
+        """Create the view-schema role and grant it access to constituent tenant schemas.
+
+        Mirrors build_view_schema: the role gets SELECT on existing tables in each
+        constituent tenant schema AND default privileges, so a rematerialization
+        that runs between view rebuilds doesn't leave the new tables unreadable.
+        """
+        self._backfill_schema(cursor, mgr, vs.schema_name)
+        role = readonly_role_name(vs.schema_name)
+        tenant_schemas_for_ws = TenantSchema.objects.filter(
+            tenant__in=vs.workspace.tenants.all(),
+            state=SchemaState.ACTIVE,
+        )
+        for ts in tenant_schemas_for_ws:
+            cursor.execute(
+                psycopg.sql.SQL("GRANT USAGE ON SCHEMA {} TO {}").format(
+                    psycopg.sql.Identifier(ts.schema_name),
+                    psycopg.sql.Identifier(role),
+                )
+            )
+            cursor.execute(
+                psycopg.sql.SQL("GRANT SELECT ON ALL TABLES IN SCHEMA {} TO {}").format(
+                    psycopg.sql.Identifier(ts.schema_name),
+                    psycopg.sql.Identifier(role),
+                )
+            )
+            # Default privileges so tables created later (by a rematerialization
+            # before the view is rebuilt) are still readable through this role.
+            cursor.execute(
+                psycopg.sql.SQL(
+                    "ALTER DEFAULT PRIVILEGES FOR ROLE CURRENT_USER IN SCHEMA {} "
+                    "GRANT SELECT ON TABLES TO {}"
+                ).format(
+                    psycopg.sql.Identifier(ts.schema_name),
+                    psycopg.sql.Identifier(role),
+                )
+            )

--- a/tests/test_admin_lockdown.py
+++ b/tests/test_admin_lockdown.py
@@ -1,0 +1,217 @@
+"""Tests for Django admin hardening (arch #260).
+
+Covers:
+- 11#3 — state-machine / identity fields readonly; SocialToken/SocialApp
+  unregistered or hardened; UserAdmin privilege fields locked down.
+- 11#5 — read-only operator-model registrations; RecipeAdmin surfaces
+  Recipe.prompt and drops the dead RecipeStep scaffolding.
+- 11#6 — AgentLearningAdmin.confidence_badge renders real HTML (format_html).
+"""
+
+import pytest
+from allauth.socialaccount.models import SocialApp, SocialToken
+from django.contrib import admin
+from django.core.cache import cache
+from django.utils.safestring import SafeString
+
+from apps.chat.models import Thread, ThreadJob
+from apps.knowledge.admin import AgentLearningAdmin
+from apps.knowledge.models import AgentLearning
+from apps.recipes.admin import RecipeAdmin
+from apps.recipes.models import RecipeStep
+from apps.transformations.models import TransformationRun
+from apps.users.admin_login import ThrottledAdminAuthenticationForm
+from apps.users.models import (
+    Tenant,
+    TenantConnection,
+    TenantMembership,
+    User,
+)
+from apps.users.rate_limiting import AUTH_MAX_ATTEMPTS
+from apps.workspaces.models import (
+    MaterializationRun,
+    TenantSchema,
+    Workspace,
+    WorkspaceMembership,
+    WorkspaceTenant,
+    WorkspaceViewSchema,
+)
+
+
+class _FakeRequest:
+    """Minimal request stand-in for ModelAdmin method calls."""
+
+    def __init__(self, user=None):
+        self.user = user
+
+
+def _admin_for(model):
+    return admin.site._registry[model]
+
+
+# --- 11#3: dangerous state-machine / identity fields are readonly ---------- #
+
+
+class TestStateMachineFieldsReadonly:
+    def test_tenant_schema_state_fields_readonly(self):
+        model_admin = _admin_for(TenantSchema)
+        ro = set(model_admin.get_readonly_fields(_FakeRequest()))
+        for field in ("schema_name", "state", "last_accessed_at", "tenant"):
+            assert field in ro, f"TenantSchema.{field} must be readonly in admin"
+
+    def test_materialization_run_state_fields_readonly(self):
+        model_admin = _admin_for(MaterializationRun)
+        ro = set(model_admin.get_readonly_fields(_FakeRequest()))
+        for field in ("state", "result", "progress"):
+            assert field in ro, f"MaterializationRun.{field} must be readonly in admin"
+
+    def test_transformation_run_status_readonly(self):
+        model_admin = _admin_for(TransformationRun)
+        ro = set(model_admin.get_readonly_fields(_FakeRequest()))
+        assert "status" in ro, "TransformationRun.status must be readonly in admin"
+
+
+# --- 11#3: SocialToken / SocialApp not exposed in admin --------------------- #
+
+
+class TestOAuthSecretsNotExposed:
+    def test_social_token_admin_unregistered(self):
+        assert SocialToken not in admin.site._registry, (
+            "SocialTokenAdmin exposes plaintext OAuth tokens; it must be unregistered"
+        )
+
+    def test_social_app_admin_unregistered(self):
+        assert SocialApp not in admin.site._registry, (
+            "SocialAppAdmin exposes plaintext client secrets; it must be unregistered"
+        )
+
+
+# --- 11#3: UserAdmin privilege fields locked down -------------------------- #
+
+
+class TestUserAdminPrivilegeLockdown:
+    def test_privilege_fields_readonly(self):
+        model_admin = _admin_for(User)
+        ro = set(model_admin.get_readonly_fields(_FakeRequest()))
+        for field in ("is_superuser", "user_permissions"):
+            assert field in ro, f"UserAdmin.{field} must be readonly (self-escalation guard)"
+
+
+# --- 11#5: operator models registered read-only --------------------------- #
+
+
+OPERATOR_MODELS = [
+    Workspace,
+    WorkspaceTenant,
+    WorkspaceMembership,
+    WorkspaceViewSchema,
+    ThreadJob,
+    Thread,
+    Tenant,
+    TenantMembership,
+    TenantConnection,
+]
+
+
+class TestOperatorModelsRegistered:
+    @pytest.mark.parametrize("model", OPERATOR_MODELS)
+    def test_model_registered(self, model):
+        assert model in admin.site._registry, (
+            f"{model.__name__} should have an admin registration for operator inspection"
+        )
+
+    @pytest.mark.parametrize("model", OPERATOR_MODELS)
+    def test_model_admin_is_read_only(self, model):
+        model_admin = _admin_for(model)
+        req = _FakeRequest()
+        assert model_admin.has_add_permission(req) is False, (
+            f"{model.__name__} admin must not allow adds"
+        )
+        assert model_admin.has_change_permission(req) is False, (
+            f"{model.__name__} admin must not allow changes"
+        )
+        assert model_admin.has_delete_permission(req) is False, (
+            f"{model.__name__} admin must not allow deletes"
+        )
+
+    def test_tenant_connection_does_not_expose_encrypted_credential(self):
+        model_admin = _admin_for(TenantConnection)
+        # The encrypted credential must never be a list_display / editable field.
+        assert "encrypted_credential" not in tuple(model_admin.list_display)
+
+
+# --- 11#5: RecipeAdmin surfaces the live prompt, drops dead RecipeStep ----- #
+
+
+class TestRecipeAdmin:
+    def test_recipe_admin_surfaces_prompt(self):
+        flat_fields = set()
+        for _name, opts in RecipeAdmin.fieldsets:
+            for field in opts.get("fields", ()):
+                flat_fields.add(field)
+        assert "prompt" in flat_fields, "RecipeAdmin must expose Recipe.prompt (the live field)"
+
+    def test_recipe_admin_drops_recipestep_inline(self):
+        assert not RecipeAdmin.inlines, "RecipeAdmin must not inline the dead RecipeStep model"
+
+    def test_recipestep_admin_unregistered(self):
+        assert RecipeStep not in admin.site._registry, (
+            "RecipeStep is vestigial; its admin should be removed"
+        )
+
+
+# --- 11#6: confidence_badge renders real HTML ----------------------------- #
+
+
+@pytest.mark.django_db
+class TestConfidenceBadge:
+    def test_confidence_badge_returns_safe_html(self):
+        learning = AgentLearning(description="x", confidence_score=0.9)
+        admin_obj = AgentLearningAdmin(AgentLearning, admin.site)
+        result = admin_obj.confidence_badge(learning)
+        assert isinstance(result, SafeString), (
+            "confidence_badge must return format_html output, not a raw string"
+        )
+        assert "<span" in result
+        # The literal escaped markup bug would render "&lt;span".
+        assert "&lt;span" not in result
+
+    def test_confidence_badge_has_no_allow_tags(self):
+        assert not hasattr(AgentLearningAdmin.confidence_badge, "allow_tags"), (
+            "allow_tags was removed in Django 2.0 and is a no-op on Django 5"
+        )
+
+
+# --- 11#3: admin login is throttled by the per-email limiter --------------- #
+
+
+class TestAdminLoginThrottle:
+    def test_admin_site_uses_throttled_login_form(self):
+        assert admin.site.login_form is ThrottledAdminAuthenticationForm
+
+    @pytest.mark.django_db
+    def test_rate_limited_email_is_blocked(self):
+        email = "victim@example.com"
+        cache.set(f"auth_attempts:{email}", AUTH_MAX_ATTEMPTS, 300)
+        try:
+            form = ThrottledAdminAuthenticationForm(
+                data={"username": email, "password": "whatever"}
+            )
+            assert not form.is_valid()
+            assert "Too many login attempts" in str(form.errors)
+        finally:
+            cache.delete(f"auth_attempts:{email}")
+
+    @pytest.mark.django_db
+    def test_failed_login_records_attempt(self):
+        email = "nobody@example.com"
+        cache.delete(f"auth_attempts:{email}")
+        try:
+            form = ThrottledAdminAuthenticationForm(
+                data={"username": email, "password": "wrong-password"}
+            )
+            assert not form.is_valid()  # no such user -> invalid login
+            # The failed attempt must have been counted toward the limiter.
+            assert cache.get(f"auth_attempts:{email}", 0) >= 1
+        finally:
+            cache.delete(f"auth_attempts:{email}")

--- a/tests/test_backfill_readonly_roles.py
+++ b/tests/test_backfill_readonly_roles.py
@@ -1,16 +1,16 @@
 from unittest.mock import MagicMock, patch
 
+import psycopg
 import pytest
 from django.core.management import call_command
 
+from apps.workspaces.models import TenantSchema, WorkspaceViewSchema
 from apps.workspaces.services.schema_manager import readonly_role_name
 
 
 @pytest.mark.django_db
 class TestBackfillReadonlyRoles:
     def test_backfills_active_tenant_schemas(self, tenant_membership):
-        from apps.workspaces.models import TenantSchema
-
         ts = TenantSchema.objects.create(
             tenant=tenant_membership.tenant,
             schema_name="test_domain",
@@ -37,8 +37,6 @@ class TestBackfillReadonlyRoles:
         assert any("GRANT SELECT ON ALL TABLES" in c for c in calls)
 
     def test_skips_teardown_schemas(self, tenant_membership):
-        from apps.workspaces.models import TenantSchema
-
         TenantSchema.objects.create(
             tenant=tenant_membership.tenant,
             schema_name="old_domain",
@@ -59,8 +57,6 @@ class TestBackfillReadonlyRoles:
         assert not any("CREATE ROLE" in c for c in calls)
 
     def test_idempotent_existing_role(self, tenant_membership):
-        from apps.workspaces.models import TenantSchema
-
         TenantSchema.objects.create(
             tenant=tenant_membership.tenant,
             schema_name="test_domain",
@@ -83,3 +79,121 @@ class TestBackfillReadonlyRoles:
         assert not any("CREATE ROLE" in c for c in calls)
         # But should still grant (idempotent grants are safe)
         assert any("GRANT USAGE ON SCHEMA" in c for c in calls)
+
+    def test_skips_materializing_state(self, tenant_membership):
+        """The dead MATERIALIZING state must not be selected (11#8)."""
+        TenantSchema.objects.create(
+            tenant=tenant_membership.tenant,
+            schema_name="mat_domain",
+            state="materializing",
+        )
+
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_cursor.fetchone.return_value = None
+        mock_conn.cursor.return_value = mock_cursor
+
+        with patch(
+            "apps.workspaces.services.schema_manager.get_managed_db_connection",
+            return_value=mock_conn,
+        ):
+            call_command("backfill_readonly_roles")
+
+        calls = [str(c) for c in mock_cursor.execute.call_args_list]
+        assert not any("CREATE ROLE" in c for c in calls)
+
+    def test_drift_does_not_abort_remaining_schemas(self, tenant_membership):
+        """One drifted schema (missing physical schema) must not strand the rest (11#8)."""
+        TenantSchema.objects.create(
+            tenant=tenant_membership.tenant,
+            schema_name="aaa_drifted",
+            state="active",
+        )
+        good = TenantSchema.objects.create(
+            tenant=tenant_membership.tenant,
+            schema_name="zzz_good",
+            state="active",
+        )
+
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_cursor.fetchone.return_value = None
+
+        def execute_side_effect(query, *args, **kwargs):
+            text = str(query)
+            if "GRANT USAGE ON SCHEMA" in text and "aaa_drifted" in text:
+                raise psycopg.errors.InvalidSchemaName("schema does not exist")
+
+        mock_cursor.execute.side_effect = execute_side_effect
+        mock_conn.cursor.return_value = mock_cursor
+
+        with patch(
+            "apps.workspaces.services.schema_manager.get_managed_db_connection",
+            return_value=mock_conn,
+        ):
+            call_command("backfill_readonly_roles")
+
+        good_role = readonly_role_name(good.schema_name)
+        calls = [str(c) for c in mock_cursor.execute.call_args_list]
+        # The good schema must still have been processed despite the earlier drift.
+        assert any("CREATE ROLE" in c and good_role in c for c in calls)
+
+    def test_dry_run_makes_no_changes(self, tenant_membership):
+        """--dry-run must not issue any CREATE/GRANT statements (11#8)."""
+        TenantSchema.objects.create(
+            tenant=tenant_membership.tenant,
+            schema_name="dry_domain",
+            state="active",
+        )
+
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_cursor.fetchone.return_value = None
+        mock_conn.cursor.return_value = mock_cursor
+
+        with patch(
+            "apps.workspaces.services.schema_manager.get_managed_db_connection",
+            return_value=mock_conn,
+        ):
+            call_command("backfill_readonly_roles", "--dry-run")
+
+        calls = [str(c) for c in mock_cursor.execute.call_args_list]
+        assert not any("CREATE ROLE" in c for c in calls)
+        assert not any("GRANT" in c for c in calls)
+
+    def test_view_schema_grants_default_privileges_on_tenant_schemas(
+        self, tenant_membership, workspace
+    ):
+        """View role must get ALTER DEFAULT PRIVILEGES on constituent tenant schemas (11#8)."""
+        ts = TenantSchema.objects.create(
+            tenant=tenant_membership.tenant,
+            schema_name="ws_tenant",
+            state="active",
+        )
+        # Attach the tenant to the workspace so the view branch finds it.
+        workspace.tenants.add(tenant_membership.tenant)
+        vs = WorkspaceViewSchema.objects.create(
+            workspace=workspace,
+            schema_name="ws_view",
+            state="active",
+        )
+
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_cursor.fetchone.return_value = None
+        mock_conn.cursor.return_value = mock_cursor
+
+        with patch(
+            "apps.workspaces.services.schema_manager.get_managed_db_connection",
+            return_value=mock_conn,
+        ):
+            call_command("backfill_readonly_roles")
+
+        view_role = readonly_role_name(vs.schema_name)
+        calls = [str(c) for c in mock_cursor.execute.call_args_list]
+        # The view role must hold ALTER DEFAULT PRIVILEGES on the tenant schema so a
+        # rematerialization between view rebuilds doesn't leave new tables unreadable.
+        assert any(
+            "ALTER DEFAULT PRIVILEGES" in c and ts.schema_name in c and view_role in c
+            for c in calls
+        ), "view role needs default privileges on constituent tenant schemas"

--- a/tests/test_setup_oauth_apps.py
+++ b/tests/test_setup_oauth_apps.py
@@ -1,0 +1,68 @@
+"""Tests for the setup_oauth_apps management command (arch #260, 11#7).
+
+Google/GitHub composed a double-``_OAUTH_`` env-var name and could never
+bootstrap. These tests pin the correct env-var spelling for every provider.
+"""
+
+import pytest
+from allauth.socialaccount.models import SocialApp
+from django.core.management import call_command
+
+
+@pytest.mark.django_db
+class TestSetupOAuthApps:
+    def test_google_bootstraps_with_documented_env_vars(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_OAUTH_CLIENT_ID", "g-id")
+        monkeypatch.setenv("GOOGLE_OAUTH_CLIENT_SECRET", "g-secret")
+
+        call_command("setup_oauth_apps")
+
+        app = SocialApp.objects.get(provider="google")
+        assert app.client_id == "g-id"
+        assert app.secret == "g-secret"
+
+    def test_github_bootstraps_with_documented_env_vars(self, monkeypatch):
+        monkeypatch.setenv("GITHUB_OAUTH_CLIENT_ID", "gh-id")
+        monkeypatch.setenv("GITHUB_OAUTH_CLIENT_SECRET", "gh-secret")
+
+        call_command("setup_oauth_apps")
+
+        app = SocialApp.objects.get(provider="github")
+        assert app.client_id == "gh-id"
+        assert app.secret == "gh-secret"
+
+    def test_double_oauth_spelling_is_not_read(self, monkeypatch):
+        # The old buggy name must NOT bootstrap the app.
+        monkeypatch.setenv("GOOGLE_OAUTH_OAUTH_CLIENT_ID", "wrong")
+        monkeypatch.setenv("GOOGLE_OAUTH_OAUTH_CLIENT_SECRET", "wrong")
+
+        call_command("setup_oauth_apps")
+
+        assert not SocialApp.objects.filter(provider="google").exists()
+
+    def test_commcare_connect_ocs_use_deploy_var_names(self, monkeypatch):
+        # Mirrors config/deploy.yml: {PREFIX}_OAUTH_CLIENT_ID.
+        for prefix in ("COMMCARE", "CONNECT", "OCS"):
+            monkeypatch.setenv(f"{prefix}_OAUTH_CLIENT_ID", f"{prefix}-id")
+            monkeypatch.setenv(f"{prefix}_OAUTH_CLIENT_SECRET", f"{prefix}-secret")
+
+        call_command("setup_oauth_apps")
+
+        assert SocialApp.objects.get(provider="commcare").client_id == "COMMCARE-id"
+        assert SocialApp.objects.get(provider="commcare_connect").client_id == "CONNECT-id"
+        assert SocialApp.objects.get(provider="ocs").client_id == "OCS-id"
+
+    def test_skip_message_names_the_real_env_var(self, monkeypatch, capsys):
+        # No env vars set for google -> skip line must reference the real name.
+        for var in (
+            "GOOGLE_OAUTH_CLIENT_ID",
+            "GOOGLE_OAUTH_CLIENT_SECRET",
+            "GOOGLE_OAUTH_OAUTH_CLIENT_ID",
+        ):
+            monkeypatch.delenv(var, raising=False)
+
+        call_command("setup_oauth_apps")
+
+        out = capsys.readouterr().out
+        assert "GOOGLE_OAUTH_CLIENT_ID" in out
+        assert "GOOGLE_OAUTH_OAUTH_CLIENT_ID" not in out


### PR DESCRIPTION
## What & why

Closes #260. Hardens the Django admin — an unguarded privileged-write / identity surface mounted unconditionally in prod — and fixes two broken management commands. Finding-by-finding:

### `11#3` (data-loss) — admin is no longer a parallel privileged-write/identity surface
- **State-machine / identity fields readonly.** `TenantSchemaAdmin` now marks `tenant/schema_name/state/last_accessed_at/created_at` readonly (was only `id/created_at`); `MaterializationRunAdmin` marks `state/result/progress/...` readonly; `TransformationRunAdmin` marks `status/...` readonly. An operator can no longer flip `EXPIRED→ACTIVE` with a stale `last_accessed_at` to re-arm `expire_inactive_schemas → teardown_schema → DROP SCHEMA CASCADE`, clobber a live transition (lost update), or desync the physical schema/`_ro` role. `TenantSchema` admin delete is disabled (default cascade would orphan the physical schema + role).
- **OAuth secrets no longer browsable.** allauth's auto-registered `SocialTokenAdmin` / `SocialAppAdmin` are unregistered in `apps/users/admin.py`, so per-user plaintext access/refresh tokens and platform client secrets are no longer exposed behind the admin login.
- **Self-escalation closed.** `UserAdmin` makes `is_superuser`, `user_permissions`, and `groups` readonly, so staff with `users.change_user` can't promote themselves (or anyone) to superuser.
- **Admin login throttled.** New `ThrottledAdminAuthenticationForm` routes `/admin/login/` through Scout's existing per-email limiter (`check_rate_limit`/`record_attempt`, 5 / 300s), matching the `/api/auth/` guard instead of running unthrottled through `ModelBackend`.

### `11#5` (velocity) — registration inverted the right way
- Added **read-only** admin registrations (new `apps/common/admin.ReadOnlyModelAdmin` — the in-process equivalent of procrastinate's bundled admin) for the operator models every recent incident needed: `Workspace`, `WorkspaceTenant`, `WorkspaceMembership`, `WorkspaceViewSchema` (workspaces), `Thread`, `ThreadJob` (chat), `Tenant`, `TenantMembership`, `TenantConnection` (users). `TenantConnectionAdmin` deliberately never surfaces `encrypted_credential`.
- `RecipeAdmin` now surfaces the live `Recipe.prompt` (the only field the runner executes) and drops the dead `RecipeStep` inline + `RecipeStepAdmin` + `step_count`/`step_progress`-on-`steps` scaffolding.

### `11#6` (cosmetic) — confidence badge renders real HTML
- `AgentLearningAdmin.confidence_badge` uses `django.utils.html.format_html` instead of the removed `allow_tags` (which rendered escaped literal `<span>` text on Django 5).

### `11#7` (velocity) — setup_oauth_apps env-var names
- Google/GitHub prefixes were `GOOGLE_OAUTH`/`GITHUB_OAUTH`, composing the impossible `GOOGLE_OAUTH_OAUTH_CLIENT_ID`. Fixed to `GOOGLE`/`GITHUB` so every provider reads `{PREFIX}_OAUTH_CLIENT_ID` consistently (matches `config/deploy.yml`). Skip message and docstring now name the real var.

### `11#8` (correctness) — backfill_readonly_roles resilience
- Per-schema `try/except + continue` so one drifted schema (physical schema dropped) no longer aborts the whole command and strands every later schema role-less (fail-closed query outage). Dropped the dead `MATERIALIZING` state from selection. Added `--dry-run`. View-role branch now grants `ALTER DEFAULT PRIVILEGES` on constituent tenant schemas so a rematerialization between view rebuilds doesn't leave new tables unreadable.

## Sibling sweep (required on bug/incident fixes)

- **Grep used:** `grep -rn "allow_tags" apps/`; `grep -rn "@admin.register|admin.site.register" apps/`; `grep -rn "os.environ.get(f\"" apps/*/management/`; `grep -rn "_unique_alias|dbt_column_alias" apps/transformations/`
- **Sibling sites found & disposition:**
  - [x] `apps/knowledge/admin.py` `allow_tags` — **only** `allow_tags` site; fixed (11#6).
  - [x] `apps/users/management/commands/setup_oauth_apps.py` — **only** env-var-composing command; fixed (11#7).
  - [x] `apps/artifacts/admin.py` `ArtifactAdmin` — audited; no editable state-machine field (state-machine status lives on `ThreadJob`/runs, not `Artifact`); `version_history_display` builds an internal admin-link f-string from `pk`/`version` (non-user, safe). Not applicable.
  - [x] `apps/transformations/admin.py` — `TransformationRun.status` fixed (11#3); `TransformationAsset`/`TransformationAssetRun` carry no DROP-arming state. Done.
  - [x] **broken-on-main import**: `apps/transformations/services/connect_staging.py` still imported `_unique_alias` after arch #235 (PR #299) renamed it to `dbt_column_alias` in `commcare_staging.py` — the exact #268 "fixed where it bit, missed the sibling" pattern. This broke **all** test collection (procrastinate autodiscover → `tasks.py` → materializer → `connect_staging`). Repointed the import + call sites to `dbt_column_alias`. **Out of Cluster A's lane but required for green CI on this branch.** Flagged for the lead.

## Testing

New/updated tests, all green in isolation:
- `tests/test_admin_lockdown.py` (new, 33 tests) — readonly state/identity fields, SocialToken/SocialApp unregistered, UserAdmin privilege lockdown, operator-model read-only registrations, RecipeAdmin prompt/no-RecipeStep, confidence_badge `format_html`, admin-login throttle.
- `tests/test_setup_oauth_apps.py` (new, 5 tests) — correct env-var spelling per provider; double-`_OAUTH_` no longer read; skip message names the real var.
- `tests/test_backfill_readonly_roles.py` (+5 tests) — skips MATERIALIZING, drift doesn't abort remaining schemas, `--dry-run`, view-role default privileges.

`uv run ruff check .` / `ruff format --check` clean; `makemigrations --check` reports no changes (no model edits). Full-suite local flakiness in unrelated async `transaction=True` tests is DB-contention from serial runs against one shared test DB ("database is being accessed by other users" on teardown) — each fails-in-full but passes in isolation; not from this diff.

## Notes for reviewers

- TDD: failing tests written first, then implementation.
- Cluster A lead PR (merges before siblings #259/#258, which share these files).
- The `connect_staging.py` fix is the one out-of-cluster change — purely an unblock for the broken-main import; no behavior change (renamed helper, identical signature).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HpAA218jN8dR5SMJTM3Ur4