### PR TITLE
[arch #257] Minimum observability: alarms, real health checks, destruction + audit logging

### DIFF
--- a/apps/chat/stream.py
+++ b/apps/chat/stream.py
@@ -310,12 +310,16 @@ async def langgraph_to_ui_stream(
                 content = _tool_content_to_str(tool_output)
                 tool_name = event.get("name", "unknown")
 
+                # The agent state carries ``workspace_id`` (the projects->workspaces
+                # rename); the old ``project_id`` read was ALWAYS empty, so the
+                # workspace attribution on every audited tool call was blank
+                # (arch #257, finding 08#8).
                 audit_logger.info(
-                    "tool_call tool=%s user_id=%s thread_id=%s project_id=%s",
+                    "tool_call tool=%s user_id=%s thread_id=%s workspace_id=%s",
                     tool_name,
                     input_state.get("user_id", ""),
                     config.get("configurable", {}).get("thread_id", ""),
-                    input_state.get("project_id", ""),
+                    input_state.get("workspace_id", ""),
                 )
 
                 # The ToolMessage carries the authoritative LLM toolu_ id; use

--- a/apps/workspaces/tasks.py
+++ b/apps/workspaces/tasks.py
@@ -646,20 +646,41 @@ async def expire_inactive_schemas(timestamp: int = 0) -> None:
     """
     cutoff = timezone.now() - timedelta(hours=settings.SCHEMA_TTL_HOURS)
 
-    # Expire stale tenant schemas
+    # Expire stale tenant schemas. Log the decision WITH last_accessed_at BEFORE
+    # flipping the row — that timestamp is the exact forensic input the
+    # 2026-06-10 incident review could not recover, because teardown/provision
+    # later overwrites it (arch #257, finding 08#9).
     async for schema in TenantSchema.objects.filter(
         state=SchemaState.ACTIVE,
         last_accessed_at__lt=cutoff,
     ):
+        logger.info(
+            "expire_inactive_schemas: marking tenant schema %s (%s) for teardown — "
+            "last_accessed_at=%s cutoff=%s ttl_hours=%s",
+            schema.id,
+            schema.schema_name,
+            schema.last_accessed_at.isoformat() if schema.last_accessed_at else None,
+            cutoff.isoformat(),
+            settings.SCHEMA_TTL_HOURS,
+        )
         schema.state = SchemaState.TEARDOWN
         await schema.asave(update_fields=["state"])
         await teardown_schema.defer_async(schema_id=str(schema.id))
 
-    # Expire stale view schemas
+    # Expire stale view schemas (same forensic logging as tenant schemas above).
     async for vs in WorkspaceViewSchema.objects.filter(
         state=SchemaState.ACTIVE,
         last_accessed_at__lt=cutoff,
     ):
+        logger.info(
+            "expire_inactive_schemas: marking view schema %s (%s) for teardown — "
+            "last_accessed_at=%s cutoff=%s ttl_hours=%s",
+            vs.id,
+            vs.schema_name,
+            vs.last_accessed_at.isoformat() if vs.last_accessed_at else None,
+            cutoff.isoformat(),
+            settings.SCHEMA_TTL_HOURS,
+        )
         vs.state = SchemaState.TEARDOWN
         await vs.asave(update_fields=["state"])
         await teardown_view_schema_task.defer_async(view_schema_id=str(vs.id))
@@ -726,6 +747,16 @@ async def teardown_view_schema_task(view_schema_id: str) -> None:
         await vs.asave(update_fields=["state"])
         raise
 
+    # Log the successful drop — a destructive op must leave a trace (arch #257,
+    # finding 08#9).
+    logger.info(
+        "teardown_view_schema_task: DROP SCHEMA CASCADE succeeded for view schema %s (%s) — "
+        "last_accessed_at=%s",
+        vs.id,
+        vs.schema_name,
+        vs.last_accessed_at.isoformat() if vs.last_accessed_at else None,
+    )
+
     vs.state = SchemaState.EXPIRED
     await vs.asave(update_fields=["state"])
 
@@ -768,6 +799,17 @@ async def teardown_schema(schema_id: str) -> None:
         schema.state = SchemaState.ACTIVE
         await schema.asave(update_fields=["state"])
         raise
+
+    # A successful DROP SCHEMA CASCADE of data-bearing tables previously emitted
+    # zero log lines, so a destructive operation left no forensic trace (arch
+    # #257, finding 08#9). Record it explicitly.
+    logger.info(
+        "teardown_schema: DROP SCHEMA CASCADE succeeded for tenant schema %s (%s) — "
+        "last_accessed_at=%s",
+        schema.id,
+        schema.schema_name,
+        schema.last_accessed_at.isoformat() if schema.last_accessed_at else None,
+    )
 
     # The physical schema (and its tables) is now dropped. Flip the data-bearing
     # runs to STALE so pipeline_list_tables stops returning ghost entries for
@@ -831,7 +873,19 @@ async def _reconcile_dependent_view_schemas_after_teardown(schema) -> None:
     if tenant_has_surviving_active_schema:
         await _rebuild_dependent_view_schemas([schema.tenant_id])
     else:
-        await _fail_dependent_view_schemas(schema.tenant_id)
+        # The count of sibling workspaces whose views were just broken was
+        # previously discarded — log it so a cascade that silently degrades N
+        # multi-tenant workspaces is visible (arch #257, finding 08#9).
+        failed_count = await _fail_dependent_view_schemas(schema.tenant_id)
+        if failed_count:
+            logger.warning(
+                "teardown_schema: %d dependent multi-tenant view schema(s) flipped to "
+                "FAILED after tenant schema %s (%s) was dropped (their namespaced views "
+                "were cascade-dropped and the tenant has no surviving data)",
+                failed_count,
+                schema.id,
+                schema.schema_name,
+            )
 
 
 async def _fail_dependent_view_schemas(tenant_id) -> int:

--- a/apps/workspaces/views.py
+++ b/apps/workspaces/views.py
@@ -1,13 +1,67 @@
 """
-Views for projects app.
+Views for the workspaces app.
 """
 
+import logging
+
+from asgiref.sync import sync_to_async
+from django.db import connection
 from django.http import JsonResponse
+from procrastinate.contrib.django.models import ProcrastinateJob
+
+logger = logging.getLogger(__name__)
 
 
-def health_check(request):
+async def _check_database() -> None:
+    """Probe the platform database with a trivial query.
+
+    Raises on any failure so the caller surfaces a non-200 readiness response.
+    ``SELECT 1`` on the default connection is an inherently-sync DB operation
+    (not an async-ORM query), so wrapping it in ``sync_to_async`` is the correct
+    bridge here rather than an async ORM call.
     """
-    Simple health check endpoint that returns a 200 JSON response.
-    Used by Docker health checks and load balancers.
+
+    @sync_to_async
+    def _probe() -> None:
+        with connection.cursor() as cur:
+            cur.execute("SELECT 1")
+            cur.fetchone()
+
+    await _probe()
+
+
+async def _check_queue() -> None:
+    """Probe the Procrastinate (PostgreSQL) queue backend.
+
+    Reading the procrastinate jobs table confirms the queue backend is reachable
+    and migrated. Uses the async ORM. Raises on failure.
     """
-    return JsonResponse({"status": "ok"})
+    await ProcrastinateJob.objects.values_list("id", flat=True).afirst()
+
+
+async def health_check(request):
+    """Readiness check: verify the platform DB and the task queue are reachable.
+
+    Returns 200 only when every dependency probe succeeds; otherwise 503 with a
+    per-check breakdown. A static 200 (the old behavior) let a crash-looping
+    container with a dead DB connection or unreachable queue report healthy,
+    which is exactly the blind spot finding 08#7 (arch #257) calls out. Load
+    balancers and the deploy pipeline can gate on a real signal now.
+    """
+    checks: dict[str, str] = {}
+    healthy = True
+
+    for name, probe in (("database", _check_database), ("queue", _check_queue)):
+        try:
+            await probe()
+            checks[name] = "ok"
+        except Exception as exc:  # readiness must catch every failure mode
+            healthy = False
+            checks[name] = "error"
+            logger.warning("health_check: %s probe failed: %s", name, exc)
+
+    status = "ok" if healthy else "unhealthy"
+    return JsonResponse(
+        {"status": status, "checks": checks},
+        status=200 if healthy else 503,
+    )

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -14,7 +14,14 @@ servers:
     options:
       network: "scout_shared"
       network-alias: "scout-web"
-    cmd: "uvicorn config.asgi:application --host 0.0.0.0 --port 8000 --workers 4 --timeout-keep-alive 120 --lifespan off"
+    # --no-access-log: uvicorn's access log writes the full request line —
+    # including share tokens (/api/chat/threads/shared/<token>/,
+    # /api/recipes/runs/shared/<token>/) and OAuth ?code= values — and ships it
+    # to the /scout/api CloudWatch group (30-day retention), where any reader
+    # could harvest live bearer capabilities (arch #257, finding 08#6). Django's
+    # own logging never logged request paths, so disabling the access log drops
+    # no signal we rely on. Errors/app logs are unaffected.
+    cmd: "uvicorn config.asgi:application --host 0.0.0.0 --port 8000 --workers 4 --timeout-keep-alive 120 --lifespan off --no-access-log"
     proxy: false
 
 registry:

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -69,5 +69,23 @@ LOGGING = {
             "level": "INFO",
             "propagate": False,
         },
+        # The agent tool-call audit trail (arch #257, finding 08#8). This is the
+        # ONLY user/thread-attributed record of agent tool calls, emitted at INFO
+        # from apps.chat.stream. Without an explicit logger it falls through to
+        # root (WARNING) and is suppressed entirely in production — exactly the
+        # blind spot the 2026-06-10 forensic review could not see past.
+        "scout.agent.audit": {
+            "handlers": ["console"],
+            "level": "INFO",
+            "propagate": False,
+        },
+        # The MCP-side audit trail. mcp_server.audit propagates to its parent
+        # ``mcp_server`` logger (INFO, console) above, but pin it explicitly so a
+        # future change to the parent's level can't silently mute the audit.
+        "mcp_server.audit": {
+            "handlers": ["console"],
+            "level": "INFO",
+            "propagate": False,
+        },
     },
 }

--- a/frontend/nginx.prod-kamal.conf
+++ b/frontend/nginx.prod-kamal.conf
@@ -54,6 +54,27 @@ server {
         add_header Content-Security-Policy "frame-ancestors 'self' ${EMBED_ALLOWED_ORIGINS}" always;
     }
 
+    # Public share-link endpoints carry the bearer capability in the URL path
+    # (the share token). nginx's access log writes the full request line and
+    # ships it to the /scout/frontend CloudWatch group, where a reader could
+    # harvest live tokens (arch #257, finding 08#6). A regex location (higher
+    # priority than the `location /api/` prefix) disables logging for exactly
+    # these capability-bearing paths while general /api/ logging is unaffected.
+    location ~ ^/api/(chat/threads|recipes/runs)/shared/ {
+        access_log off;
+        proxy_pass http://$api_upstream:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_buffering off;
+        proxy_cache off;
+        chunked_transfer_encoding on;
+        proxy_read_timeout 120s;
+        proxy_send_timeout 120s;
+    }
+
     location /api/ {
         proxy_pass http://$api_upstream:8000;
         proxy_http_version 1.1;
@@ -112,6 +133,11 @@ server {
     }
 
     location /accounts/ {
+        # OAuth callbacks land here carrying ?code=<authorization code> in the
+        # query string; nginx logs the full request line into the /scout/frontend
+        # CloudWatch group. The code is short-lived but is still a bearer secret,
+        # so don't log these requests (arch #257, finding 08#6).
+        access_log off;
         proxy_pass http://$api_upstream:8000;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;

--- a/frontend/nginx.prod.conf
+++ b/frontend/nginx.prod.conf
@@ -12,6 +12,26 @@ server {
         try_files $uri $uri/ /scout/index.html;
     }
 
+    # Public share-link endpoints carry the bearer share token in the URL path.
+    # Disable access logging for exactly these capability-bearing paths so the
+    # token never lands in the access log / CloudWatch (arch #257, finding 08#6).
+    # Higher priority than the `location /scout/api/` prefix below.
+    location ~ ^/scout/api/(chat/threads|recipes/runs)/shared/ {
+        access_log off;
+        rewrite ^/scout/api/(.*)$ /api/$1 break;
+        proxy_pass http://localhost:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+        proxy_buffering off;
+        proxy_cache off;
+        chunked_transfer_encoding on;
+        proxy_read_timeout 600s;
+        proxy_send_timeout 600s;
+    }
+
     # Proxy API requests: /scout/api/* → localhost:8000/api/*
     location /scout/api/ {
         proxy_pass http://localhost:8000/api/;
@@ -48,6 +68,9 @@ server {
 
     # Proxy Django allauth/OAuth: /scout/accounts/* → localhost:8000/accounts/*
     location /scout/accounts/ {
+        # OAuth callbacks carry ?code=<authorization code>; don't log the request
+        # line into the access log / CloudWatch (arch #257, finding 08#6).
+        access_log off;
         proxy_pass http://localhost:8000/accounts/;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;

--- a/infra/scout-stack.yml
+++ b/infra/scout-stack.yml
@@ -47,6 +47,17 @@ Parameters:
     Default: cache.t4g.micro
     AllowedValues: [cache.t4g.micro, cache.t4g.small, cache.t4g.medium]
 
+  AlarmEmail:
+    Type: String
+    Description: >-
+      Email address that receives CloudWatch alarm notifications (subscription
+      must be confirmed via the email AWS sends). Leave blank to skip the
+      subscription (alarms still fire to the SNS topic).
+    Default: ''
+
+Conditions:
+  HasAlarmEmail: !Not [!Equals [!Ref AlarmEmail, '']]
+
 Resources:
 
   # ── VPC & Networking ──────────────────────────────────────────────
@@ -476,6 +487,225 @@ Resources:
                   - secretsmanager:BatchGetSecretValue
                 Resource: '*'
 
+  # ── Observability / detection layer (arch #257, finding 08#7) ────
+  # The stack previously created log groups but NOTHING converted a dead
+  # worker/MCP/process or a destructive operation into an operator signal.
+  # This block adds: an SNS alert topic, metric filters that turn the
+  # structured application logs (the destruction logs added in apps/
+  # workspaces/tasks.py + the audit trail) into CloudWatch metrics, and a
+  # minimal, grounded alarm set. Thresholds are conservative starting points
+  # — tune them against real traffic.
+
+  AlertTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      TopicName: scout-alerts
+      DisplayName: Scout Alerts
+
+  AlertEmailSubscription:
+    Type: AWS::SNS::Subscription
+    Condition: HasAlarmEmail
+    Properties:
+      TopicArn: !Ref AlertTopic
+      Protocol: email
+      Endpoint: !Ref AlarmEmail
+
+  # ── Metric filters: structured app logs -> CloudWatch metrics ──────
+  # ERROR-level lines from each container. Counts let us alarm on an error
+  # spike that Sentry's per-event view does not aggregate into a rate.
+
+  ApiErrorMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref ApiLogGroup
+      FilterPattern: 'ERROR'
+      MetricTransformations:
+        - MetricNamespace: Scout/App
+          MetricName: ApiErrorCount
+          MetricValue: '1'
+          DefaultValue: 0
+
+  WorkerErrorMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref WorkerLogGroup
+      FilterPattern: 'ERROR'
+      MetricTransformations:
+        - MetricNamespace: Scout/App
+          MetricName: WorkerErrorCount
+          MetricValue: '1'
+          DefaultValue: 0
+
+  McpErrorMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref McpLogGroup
+      FilterPattern: 'ERROR'
+      MetricTransformations:
+        - MetricNamespace: Scout/App
+          MetricName: McpErrorCount
+          MetricValue: '1'
+          DefaultValue: 0
+
+  # Liveness signal: every worker task logs at least at INFO, so a healthy
+  # worker emits a steady stream of log events. Count ALL worker log events;
+  # a drop to zero (alarmed below with TreatMissingData: breaching) means the
+  # worker process is dead/stuck — the 2026-06-09 silent-failure mode.
+  WorkerHeartbeatMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref WorkerLogGroup
+      FilterPattern: ''
+      MetricTransformations:
+        - MetricNamespace: Scout/App
+          MetricName: WorkerLogEvents
+          MetricValue: '1'
+          DefaultValue: 0
+
+  # Destructive-operation counter: the successful DROP SCHEMA CASCADE log line
+  # added in apps/workspaces/tasks.py. Surfacing it as a metric makes a teardown
+  # storm (e.g. the 2026-06-10 mass-drop) visible and alarmable.
+  SchemaDropMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref WorkerLogGroup
+      FilterPattern: 'DROP SCHEMA CASCADE succeeded'
+      MetricTransformations:
+        - MetricNamespace: Scout/App
+          MetricName: SchemaDropCount
+          MetricValue: '1'
+          DefaultValue: 0
+
+  # ── Alarms ─────────────────────────────────────────────────────────
+
+  # Worker silence = process death. A healthy worker logs continuously; if no
+  # log events arrive for 15 minutes, the metric reports no data, which we
+  # treat as breaching so a dead worker that emits NOTHING still alarms.
+  WorkerSilenceAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: scout-worker-silent
+      AlarmDescription: >-
+        Worker has emitted no log events for 15 minutes — the process is likely
+        dead or stuck (2026-06-09 silent-failure mode). TreatMissingData is
+        breaching because a dead worker emits nothing at all.
+      Namespace: Scout/App
+      MetricName: WorkerLogEvents
+      Statistic: Sum
+      Period: 900
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: LessThanThreshold
+      TreatMissingData: breaching
+      AlarmActions: [!Ref AlertTopic]
+      OKActions: [!Ref AlertTopic]
+
+  WorkerErrorRateAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: scout-worker-errors
+      AlarmDescription: Worker is logging ERRORs at an elevated rate.
+      Namespace: Scout/App
+      MetricName: WorkerErrorCount
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 5
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+      AlarmActions: [!Ref AlertTopic]
+
+  ApiErrorRateAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: scout-api-errors
+      AlarmDescription: API container is logging ERRORs at an elevated rate.
+      Namespace: Scout/App
+      MetricName: ApiErrorCount
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 10
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+      AlarmActions: [!Ref AlertTopic]
+
+  # Mass schema-drop: more than 5 DROP SCHEMA CASCADE in 15 min is a teardown
+  # storm worth a human look (the 2026-06-10 incident dropped data-bearing
+  # schemas in a tight loop).
+  SchemaDropStormAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: scout-schema-drop-storm
+      AlarmDescription: >-
+        More than 5 schemas were dropped in 15 minutes — possible runaway TTL
+        teardown of data-bearing schemas (arch #257 / 2026-06-10 incident).
+      Namespace: Scout/App
+      MetricName: SchemaDropCount
+      Statistic: Sum
+      Period: 900
+      EvaluationPeriods: 1
+      Threshold: 5
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+      AlarmActions: [!Ref AlertTopic]
+
+  # ── Infrastructure-health alarms (EC2 + RDS) ──────────────────────
+
+  EC2StatusCheckAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: scout-ec2-status-check-failed
+      AlarmDescription: The EC2 instance hosting all Scout containers failed its status check.
+      Namespace: AWS/EC2
+      MetricName: StatusCheckFailed
+      Dimensions:
+        - Name: InstanceId
+          Value: !Ref EC2Instance
+      Statistic: Maximum
+      Period: 60
+      EvaluationPeriods: 3
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: breaching
+      AlarmActions: [!Ref AlertTopic]
+
+  RDSCpuAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: scout-rds-high-cpu
+      AlarmDescription: RDS CPU sustained above 85%.
+      Namespace: AWS/RDS
+      MetricName: CPUUtilization
+      Dimensions:
+        - Name: DBInstanceIdentifier
+          Value: !Ref RDSInstance
+      Statistic: Average
+      Period: 300
+      EvaluationPeriods: 3
+      Threshold: 85
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+      AlarmActions: [!Ref AlertTopic]
+
+  RDSLowStorageAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: scout-rds-low-storage
+      AlarmDescription: RDS free storage below 2 GiB.
+      Namespace: AWS/RDS
+      MetricName: FreeStorageSpace
+      Dimensions:
+        - Name: DBInstanceIdentifier
+          Value: !Ref RDSInstance
+      Statistic: Minimum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 2147483648
+      ComparisonOperator: LessThanThreshold
+      TreatMissingData: notBreaching
+      AlarmActions: [!Ref AlertTopic]
+
 Outputs:
   EC2PublicIP:
     Description: EC2 Elastic IP (use in Kamal configs and DNS)
@@ -500,3 +730,7 @@ Outputs:
   GitHubDeployRoleArn:
     Description: IAM role ARN for GitHub Actions OIDC (use in workflow)
     Value: !GetAtt GitHubDeployRole.Arn
+
+  AlertTopicArn:
+    Description: SNS topic that receives CloudWatch alarm notifications
+    Value: !Ref AlertTopic

--- a/mcp_server/envelope.py
+++ b/mcp_server/envelope.py
@@ -97,7 +97,12 @@ async def tool_context(tool_name: str, context_id: str, **extra_fields: Any):
 
     Args:
         tool_name: Name of the tool being called.
-        context_id: tenant_id or project_id for logging.
+        context_id: The workspace_id (or run_id) the call is scoped to.
+        **extra_fields: Per-tool context recorded in the audit line. Pass
+            ``user_id`` and ``thread_id`` (injected server-side by the agent
+            graph) so the audit trail attributes the call to an actor and a
+            conversation, not just a workspace (arch #257, finding 08#8). Empty
+            values are dropped so context-free/operator calls stay quiet.
     """
     timer = Timer()
     tc: dict[str, Any] = {"timer": timer}
@@ -105,13 +110,14 @@ async def tool_context(tool_name: str, context_id: str, **extra_fields: Any):
         yield tc
     finally:
         status = "success" if tc.get("result", {}).get("success") else "error"
+        # Drop empty actor/context fields so they don't add noise (e.g. operator
+        # or context-free tools that carry no user/thread).
+        fields = {k: v for k, v in scrub_extra_fields(extra_fields).items() if v not in ("", None)}
         audit_logger.info(
             "tool_call tool=%s context_id=%s status=%s timing_ms=%d %s",
             tool_name,
             context_id,
             status,
             timer.elapsed_ms,
-            " ".join(f"{k}={v!r}" for k, v in scrub_extra_fields(extra_fields).items())
-            if extra_fields
-            else "",
+            " ".join(f"{k}={v!r}" for k, v in fields.items()) if fields else "",
         )

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -107,7 +107,7 @@ async def _resolve_pipeline_config(ts, last_run):
 
 
 @mcp.tool()
-async def list_tables(workspace_id: str = "") -> dict:
+async def list_tables(workspace_id: str = "", user_id: str = "", thread_id: str = "") -> dict:
     """List all tables in the workspace's database schema.
 
     Returns table names, types, descriptions, row counts, and materialization timestamps.
@@ -115,8 +115,12 @@ async def list_tables(workspace_id: str = "") -> dict:
 
     Args:
         workspace_id: Workspace UUID (injected server-side by the agent graph).
+        user_id: Acting user UUID (injected server-side; recorded in the audit trail).
+        thread_id: Chat thread UUID (injected server-side; recorded in the audit trail).
     """
-    async with tool_context("list_tables", workspace_id) as tc:
+    async with tool_context(
+        "list_tables", workspace_id, user_id=user_id, thread_id=thread_id
+    ) as tc:
         try:
             ctx = await _resolve_mcp_context(workspace_id)
         except (ValueError, _ValidationError) as e:
@@ -176,7 +180,9 @@ async def list_tables(workspace_id: str = "") -> dict:
 
 
 @mcp.tool()
-async def describe_table(table_name: str, workspace_id: str = "") -> dict:
+async def describe_table(
+    table_name: str, workspace_id: str = "", user_id: str = "", thread_id: str = ""
+) -> dict:
     """Get detailed metadata for a specific table.
 
     Returns columns (name, type, nullable, default, description) and a table description.
@@ -185,8 +191,12 @@ async def describe_table(table_name: str, workspace_id: str = "") -> dict:
     Args:
         table_name: Name of the table to describe.
         workspace_id: Workspace UUID (injected server-side by the agent graph).
+        user_id: Acting user UUID (injected server-side; recorded in the audit trail).
+        thread_id: Chat thread UUID (injected server-side; recorded in the audit trail).
     """
-    async with tool_context("describe_table", workspace_id, table_name=table_name) as tc:
+    async with tool_context(
+        "describe_table", workspace_id, user_id=user_id, thread_id=thread_id, table_name=table_name
+    ) as tc:
         try:
             ctx = await _resolve_mcp_context(workspace_id)
         except (ValueError, _ValidationError) as e:
@@ -231,7 +241,7 @@ async def describe_table(table_name: str, workspace_id: str = "") -> dict:
 
 
 @mcp.tool()
-async def get_metadata(workspace_id: str = "") -> dict:
+async def get_metadata(workspace_id: str = "", user_id: str = "", thread_id: str = "") -> dict:
     """Get a complete metadata snapshot for the workspace's database.
 
     Returns all tables with their columns, descriptions, and table relationships
@@ -239,8 +249,12 @@ async def get_metadata(workspace_id: str = "") -> dict:
 
     Args:
         workspace_id: Workspace UUID (injected server-side by the agent graph).
+        user_id: Acting user UUID (injected server-side; recorded in the audit trail).
+        thread_id: Chat thread UUID (injected server-side; recorded in the audit trail).
     """
-    async with tool_context("get_metadata", workspace_id) as tc:
+    async with tool_context(
+        "get_metadata", workspace_id, user_id=user_id, thread_id=thread_id
+    ) as tc:
         try:
             ctx = await _resolve_mcp_context(workspace_id)
         except (ValueError, _ValidationError) as e:
@@ -289,7 +303,9 @@ async def get_metadata(workspace_id: str = "") -> dict:
 
 
 @mcp.tool()
-async def get_lineage(model_name: str, workspace_id: str = "") -> dict:
+async def get_lineage(
+    model_name: str, workspace_id: str = "", user_id: str = "", thread_id: str = ""
+) -> dict:
     """Get the transformation lineage for a model.
 
     Returns the chain of transformations from the given model back to the raw
@@ -300,8 +316,12 @@ async def get_lineage(model_name: str, workspace_id: str = "") -> dict:
     Args:
         model_name: Name of the model to trace lineage for.
         workspace_id: Workspace UUID (injected server-side by the agent graph).
+        user_id: Acting user UUID (injected server-side; recorded in the audit trail).
+        thread_id: Chat thread UUID (injected server-side; recorded in the audit trail).
     """
-    async with tool_context("get_lineage", workspace_id, model_name=model_name) as tc:
+    async with tool_context(
+        "get_lineage", workspace_id, user_id=user_id, thread_id=thread_id, model_name=model_name
+    ) as tc:
         if not workspace_id:
             tc["result"] = error_response(VALIDATION_ERROR, "workspace_id is required")
             return tc["result"]
@@ -333,7 +353,7 @@ async def get_lineage(model_name: str, workspace_id: str = "") -> dict:
 
 
 @mcp.tool()
-async def query(sql: str, workspace_id: str = "") -> dict:
+async def query(sql: str, workspace_id: str = "", user_id: str = "", thread_id: str = "") -> dict:
     """Execute a read-only SQL query against the workspace's database.
 
     The query is validated for safety (SELECT only, no dangerous functions),
@@ -342,8 +362,12 @@ async def query(sql: str, workspace_id: str = "") -> dict:
     Args:
         sql: A SQL SELECT query to execute.
         workspace_id: Workspace UUID (injected server-side by the agent graph).
+        user_id: Acting user UUID (injected server-side; recorded in the audit trail).
+        thread_id: Chat thread UUID (injected server-side; recorded in the audit trail).
     """
-    async with tool_context("query", workspace_id, sql=sql) as tc:
+    async with tool_context(
+        "query", workspace_id, user_id=user_id, thread_id=thread_id, sql=sql
+    ) as tc:
         try:
             ctx = await _resolve_mcp_context(workspace_id)
         except (ValueError, _ValidationError) as e:
@@ -544,7 +568,9 @@ async def run_materialization(
             server-side); persisted on ThreadJob so the resume task can
             attribute its work to the right call.
     """
-    async with tool_context("run_materialization", workspace_id) as tc:
+    async with tool_context(
+        "run_materialization", workspace_id, user_id=user_id, thread_id=thread_id
+    ) as tc:
         if not workspace_id:
             tc["result"] = error_response(VALIDATION_ERROR, "workspace_id is required")
             return tc["result"]
@@ -665,7 +691,7 @@ async def run_materialization(
 
 
 @mcp.tool()
-async def get_schema_status(workspace_id: str = "") -> dict:
+async def get_schema_status(workspace_id: str = "", user_id: str = "", thread_id: str = "") -> dict:
     """Check whether data has been loaded for this workspace.
 
     Returns schema existence, state, last materialization timestamp, and table
@@ -674,8 +700,12 @@ async def get_schema_status(workspace_id: str = "") -> dict:
 
     Args:
         workspace_id: Workspace UUID (injected server-side by the agent graph).
+        user_id: Acting user UUID (injected server-side; recorded in the audit trail).
+        thread_id: Chat thread UUID (injected server-side; recorded in the audit trail).
     """
-    async with tool_context("get_schema_status", workspace_id) as tc:
+    async with tool_context(
+        "get_schema_status", workspace_id, user_id=user_id, thread_id=thread_id
+    ) as tc:
         if not workspace_id:
             tc["result"] = error_response(VALIDATION_ERROR, "workspace_id is required")
             return tc["result"]

--- a/tests/agents/test_context_injection_contract.py
+++ b/tests/agents/test_context_injection_contract.py
@@ -2,10 +2,12 @@
 
 The agent graph's injecting tool node (`_make_injecting_tool_node` in
 `apps.agents.graph.base`) adds ``workspace_id``, ``user_id``, ``thread_id`` and
-``tool_call_id`` to the args of **every** MCP tool call — including the read
-tools (``list_tables``, ``query``, …) whose signatures declare only
-``workspace_id``. Those calls succeed today only because TWO independent library
-behaviours silently tolerate the extra arguments:
+``tool_call_id`` to the args of **every** MCP tool call. The read tools
+(``list_tables``, ``query``, …) declare ``workspace_id``, ``user_id`` and
+``thread_id`` (the last two carry the actor into the MCP audit trail — arch #257,
+finding 08#8); only the per-call ``tool_call_id`` remains undeclared on them.
+That residual extra succeeds today only because TWO independent library
+behaviours silently tolerate it:
 
 1. **LangChain** — the MCP tools are ``StructuredTool``s whose ``args_schema`` is
    the raw MCP ``inputSchema`` *dict* (not a Pydantic model). ``BaseTool.
@@ -39,10 +41,14 @@ INJECTED_ARGS = {
     "tool_call_id": "tc-1",
 }
 
-# Read tools whose signature declares ONLY ``workspace_id`` — i.e. they declare
-# *none* of the other injected args. ``run_materialization`` is excluded because
-# it deliberately declares all four.
-WORKSPACE_ONLY_TOOLS = ["list_tables", "get_metadata", "get_schema_status"]
+# Read tools whose signature declares the actor set (workspace_id/user_id/
+# thread_id) but NOT the per-call ``tool_call_id`` — so ``tool_call_id`` is the
+# one injected arg they still rely on the libraries to silently drop.
+# ``run_materialization`` is excluded because it deliberately declares all four.
+ACTOR_DECLARED_TOOLS = ["list_tables", "get_metadata", "get_schema_status"]
+
+# The args these tools declare (everything injected except ``tool_call_id``).
+DECLARED_ACTOR_ARGS = {"workspace_id", "user_id", "thread_id"}
 
 
 def test_langchain_parse_input_passes_injected_extras_through_unvalidated():
@@ -78,18 +84,19 @@ def test_langchain_parse_input_passes_injected_extras_through_unvalidated():
         assert key in parsed, f"LangChain dropped/rejected injected arg {key!r}"
 
 
-@pytest.mark.parametrize("tool_name", WORKSPACE_ONLY_TOOLS)
+@pytest.mark.parametrize("tool_name", ACTOR_DECLARED_TOOLS)
 def test_fastmcp_arg_model_accepts_and_ignores_injected_extras(tool_name):
-    """FastMCP half: the server-side arg model for a tool that declares only
-    ``workspace_id`` must accept the full injected arg set (no ValidationError)
-    and silently drop the three undeclared extras before the tool fn runs."""
+    """FastMCP half: the server-side arg model for a read tool must declare the
+    actor set (workspace_id/user_id/thread_id), accept the full injected arg set
+    (no ValidationError), and silently drop the still-undeclared ``tool_call_id``
+    before the tool fn runs."""
     assert tool_name in MCP_TOOL_NAMES  # sanity: this is an injected MCP tool
 
     tool = mcp._tool_manager.get_tool(tool_name)
     arg_model = tool.fn_metadata.arg_model
 
     declared = set(arg_model.model_fields)
-    assert declared == {"workspace_id"}, (
+    assert declared == DECLARED_ACTOR_ARGS, (
         f"{tool_name} now declares {declared}; update this guardrail if the "
         "injected-arg surface changed"
     )
@@ -98,9 +105,9 @@ def test_fastmcp_arg_model_accepts_and_ignores_injected_extras(tool_name):
     # which is exactly the prod-wide breakage we are guarding against.
     validated = arg_model.model_validate(dict(INJECTED_ARGS))
 
-    # FastMCP forwards only the top-level declared fields to the tool fn; the
-    # undeclared injected args must have been dropped here.
+    # FastMCP forwards only the declared fields to the tool fn; the still-
+    # undeclared ``tool_call_id`` must have been dropped here.
     forwarded = validated.model_dump_one_level()
-    assert forwarded == {"workspace_id": INJECTED_ARGS["workspace_id"]}, (
-        f"{tool_name} forwarded {forwarded}; injected extras were not ignored"
+    assert forwarded == {k: INJECTED_ARGS[k] for k in DECLARED_ACTOR_ARGS}, (
+        f"{tool_name} forwarded {forwarded}; injected extras were not handled as expected"
     )

--- a/tests/test_access_log_token_exposure.py
+++ b/tests/test_access_log_token_exposure.py
@@ -1,0 +1,50 @@
+"""Guard that bearer capabilities don't transit access logs (arch #257, 08#6).
+
+Share-token URLs (``/api/chat/threads/shared/<token>/``,
+``/api/recipes/runs/shared/<token>/``) and OAuth callbacks (``?code=``) carry a
+bearer capability in the request line. Uvicorn's access log is on by default and
+ships to CloudWatch (30-day retention), so anyone with CloudWatch read access
+could harvest live share tokens from the access log.
+
+The minimal, grounded fix is to disable uvicorn's access log on the API
+container (Django's own request logging never logged these paths, and request
+metrics come from elsewhere). These tests pin ``--no-access-log`` on the API
+Kamal command so the capability never lands in the access log in the first place.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+_CONFIG_DIR = Path(__file__).resolve().parent.parent / "config"
+
+
+def _load(name: str) -> dict:
+    with (_CONFIG_DIR / name).open() as f:
+        return yaml.safe_load(f)
+
+
+def test_api_uvicorn_disables_access_log():
+    """The API container's uvicorn command must disable the access log so share
+    tokens / OAuth codes in the request line never reach CloudWatch."""
+    cfg = _load("deploy.yml")
+    cmd = cfg["servers"]["web"]["cmd"]
+    assert "uvicorn" in cmd
+    assert "--no-access-log" in cmd, (
+        "API uvicorn must run with --no-access-log; otherwise share tokens and "
+        "OAuth ?code= values in the request line are written to the access log "
+        "and shipped to CloudWatch (finding 08#6)."
+    )
+
+
+@pytest.mark.parametrize("name", ["deploy.yml", "deploy-mcp.yml", "deploy-worker.yml"])
+def test_no_uvicorn_access_log_anywhere(name):
+    """No container should run uvicorn with the access log enabled."""
+    cfg = _load(name)
+    for server in cfg.get("servers", {}).values():
+        cmd = server.get("cmd", "")
+        if "uvicorn" in cmd:
+            assert "--no-access-log" in cmd, f"{name}: uvicorn access log must be disabled"

--- a/tests/test_agent_audit_logging.py
+++ b/tests/test_agent_audit_logging.py
@@ -21,13 +21,14 @@ import logging
 
 import pytest
 
+import config.settings.production as prod
+from apps.chat import stream
+
 
 def test_production_logging_routes_agent_audit_logger():
     """Production LOGGING must configure ``scout.agent.audit`` at INFO so the
     agent tool-call audit trail is actually emitted (not swallowed by root
     WARNING)."""
-    import config.settings.production as prod
-
     # Reload so we read the module's declared LOGGING regardless of which
     # settings module the test session booted under.
     importlib.reload(prod)
@@ -44,8 +45,6 @@ def test_production_logging_routes_agent_audit_logger():
 
 def test_production_logging_routes_mcp_audit_logger():
     """The MCP-side audit logger must likewise be routed in production."""
-    import config.settings.production as prod
-
     importlib.reload(prod)
     loggers = prod.LOGGING["loggers"]
     assert "mcp_server.audit" in loggers or loggers.get("mcp_server", {}).get("level") == "INFO", (
@@ -62,7 +61,6 @@ async def test_stream_audit_line_logs_workspace_id_not_empty_project_id(caplog):
     Regression: the line logged ``input_state.get("project_id")`` which is always
     empty because the state carries ``workspace_id``. It must log the workspace id.
     """
-    from apps.chat import stream
 
     # Minimal fake agent that emits a single on_tool_end event.
     class _FakeOutput:

--- a/tests/test_agent_audit_logging.py
+++ b/tests/test_agent_audit_logging.py
@@ -1,0 +1,101 @@
+"""Tests for the agent tool-call audit trail (arch #257, finding 08#8).
+
+The audit trail is the only user/thread-attributed record of agent tool calls.
+Two defects made it useless in production:
+
+1. ``scout.agent.audit`` logs at INFO, but production LOGGING set root WARNING
+   with only django/apps/mcp_server loggers configured, so the line was
+   suppressed entirely in production.
+2. The Django-side audit line logged ``input_state.get("project_id", "")`` which
+   is ALWAYS empty — the agent state carries ``workspace_id`` (the
+   projects->workspaces rename), so the workspace attribution was blank.
+
+These tests pin the corrected behavior: the production config routes the audit
+logger, and the emitted line carries the real workspace id.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+
+import pytest
+
+
+def test_production_logging_routes_agent_audit_logger():
+    """Production LOGGING must configure ``scout.agent.audit`` at INFO so the
+    agent tool-call audit trail is actually emitted (not swallowed by root
+    WARNING)."""
+    import config.settings.production as prod
+
+    # Reload so we read the module's declared LOGGING regardless of which
+    # settings module the test session booted under.
+    importlib.reload(prod)
+    loggers = prod.LOGGING["loggers"]
+
+    assert "scout.agent.audit" in loggers, (
+        "production LOGGING must declare the 'scout.agent.audit' logger; "
+        "under root WARNING an unconfigured INFO logger is dropped"
+    )
+    cfg = loggers["scout.agent.audit"]
+    assert cfg["level"] == "INFO"
+    assert cfg["handlers"], "audit logger needs a handler to emit anywhere"
+
+
+def test_production_logging_routes_mcp_audit_logger():
+    """The MCP-side audit logger must likewise be routed in production."""
+    import config.settings.production as prod
+
+    importlib.reload(prod)
+    loggers = prod.LOGGING["loggers"]
+    assert "mcp_server.audit" in loggers or loggers.get("mcp_server", {}).get("level") == "INFO", (
+        "mcp_server.audit must be emitted in production (its parent 'mcp_server' "
+        "logger is INFO, but propagate must reach a handler)"
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_stream_audit_line_logs_workspace_id_not_empty_project_id(caplog):
+    """The Django-side audit line must record the real workspace id.
+
+    Regression: the line logged ``input_state.get("project_id")`` which is always
+    empty because the state carries ``workspace_id``. It must log the workspace id.
+    """
+    from apps.chat import stream
+
+    # Minimal fake agent that emits a single on_tool_end event.
+    class _FakeOutput:
+        content = "ok"
+        tool_call_id = "toolu_test"
+
+    class _FakeAgent:
+        def astream_events(self, input_state, config, version):
+            async def _gen():
+                yield {
+                    "event": "on_tool_end",
+                    "run_id": "run-1",
+                    "name": "query",
+                    "data": {"output": _FakeOutput()},
+                }
+
+            return _gen()
+
+    input_state = {
+        "workspace_id": "ws-abc-123",
+        "user_id": "user-9",
+    }
+    config = {"configurable": {"thread_id": "thread-7"}}
+
+    with caplog.at_level(logging.INFO, logger="scout.agent.audit"):
+        async for _ in stream.langgraph_to_ui_stream(_FakeAgent(), input_state, config):
+            pass
+
+    audit_records = [r for r in caplog.records if r.name == "scout.agent.audit"]
+    assert audit_records, "expected an audit log record for the tool call"
+    msg = audit_records[0].getMessage()
+    assert "workspace_id=ws-abc-123" in msg, f"audit line missing workspace id: {msg!r}"
+    assert "user_id=user-9" in msg
+    assert "thread_id=thread-7" in msg
+    # The always-empty project_id key must be gone.
+    assert "project_id=" not in msg, f"audit line still logs project_id: {msg!r}"

--- a/tests/test_health_check.py
+++ b/tests/test_health_check.py
@@ -1,0 +1,59 @@
+"""Tests for the /health/ readiness check (arch #257, finding 08#7).
+
+The old /health/ returned a static 200 with no DB or queue check, so a
+crash-looping container with a dead DB connection or unreachable queue still
+reported healthy. The readiness check must verify the platform DB AND the
+Procrastinate queue (both are PostgreSQL) and return a non-200 status when
+either is unreachable.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from django.test import AsyncClient
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_health_ok_when_db_reachable():
+    client = AsyncClient()
+    resp = await client.get("/health/")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ok"
+    assert body["checks"]["database"] == "ok"
+    assert body["checks"]["queue"] == "ok"
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_health_503_when_db_unreachable():
+    """A failing DB probe must surface as a non-200 readiness failure."""
+    with patch(
+        "apps.workspaces.views._check_database",
+        side_effect=Exception("connection refused"),
+    ):
+        client = AsyncClient()
+        resp = await client.get("/health/")
+    assert resp.status_code == 503
+    body = resp.json()
+    assert body["status"] == "unhealthy"
+    assert body["checks"]["database"] != "ok"
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_health_503_when_queue_unreachable():
+    """A failing queue probe must surface as a non-200 readiness failure."""
+    with patch(
+        "apps.workspaces.views._check_queue",
+        side_effect=Exception("queue table missing"),
+    ):
+        client = AsyncClient()
+        resp = await client.get("/health/")
+    assert resp.status_code == 503
+    body = resp.json()
+    assert body["status"] == "unhealthy"
+    assert body["checks"]["queue"] != "ok"

--- a/tests/test_infra_alarms.py
+++ b/tests/test_infra_alarms.py
@@ -1,0 +1,87 @@
+"""Guard that the CloudFormation template ships a detection layer (08#7).
+
+infra/scout-stack.yml created log groups but no CloudWatch alarm / SNS /
+metric-filter resources, so worker/MCP/process death emitted no operator signal
+(arch #257, finding 08#7). These tests pin a minimal detection layer: an SNS
+alert topic, metric filters that turn the structured app logs into metrics, and
+alarms on infrastructure health (EC2/RDS) plus error rate and worker silence.
+
+Pure YAML parse — no AWS calls.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+_TEMPLATE = Path(__file__).resolve().parent.parent / "infra" / "scout-stack.yml"
+
+
+class _CfnLoader(yaml.SafeLoader):
+    """A SafeLoader that treats CloudFormation ``!Ref`` / ``!GetAtt`` etc. short
+    tags as opaque (None) so the template parses without executing them."""
+
+
+# Render every unknown ``!Tag`` (scalar/sequence/mapping) as None — we only
+# assert on resource structure, not the values inside intrinsic functions.
+_CfnLoader.add_multi_constructor("!", lambda loader, suffix, node: None)
+
+
+@pytest.fixture(scope="module")
+def template() -> dict:
+    with _TEMPLATE.open() as f:
+        return yaml.load(f, Loader=_CfnLoader)  # noqa: S506 — dedicated CFN-tag loader, trusted file
+
+
+def _resources_of_type(template: dict, cfn_type: str) -> dict:
+    return {name: r for name, r in template["Resources"].items() if r.get("Type") == cfn_type}
+
+
+def test_alarm_email_parameter_exists(template):
+    assert "AlarmEmail" in template["Parameters"], (
+        "an AlarmEmail parameter must exist so alarms can notify an operator"
+    )
+
+
+def test_sns_alert_topic_exists(template):
+    topics = _resources_of_type(template, "AWS::SNS::Topic")
+    assert topics, "an SNS topic is required to route alarms to operators (08#7)"
+    subs = _resources_of_type(template, "AWS::SNS::Subscription")
+    has_email_sub = any(
+        s.get("Properties", {}).get("Protocol") == "email" for s in subs.values()
+    ) or any("Subscription" in t.get("Properties", {}) for t in topics.values())
+    assert has_email_sub, "the alert topic must have an email subscription"
+
+
+def test_metric_filters_exist_for_app_logs(template):
+    filters = _resources_of_type(template, "AWS::Logs::MetricFilter")
+    assert filters, "metric filters must convert structured app logs into metrics (08#7)"
+
+
+def test_cloudwatch_alarms_exist(template):
+    alarms = _resources_of_type(template, "AWS::CloudWatch::Alarm")
+    assert len(alarms) >= 3, (
+        f"expected several alarms (EC2/RDS health, error rate, worker silence); found {len(alarms)}"
+    )
+    # Every alarm must route to the SNS topic.
+    for name, alarm in alarms.items():
+        props = alarm.get("Properties", {})
+        assert props.get("AlarmActions"), f"alarm {name} has no AlarmActions (no notification)"
+
+
+def test_worker_silence_alarm_treats_missing_data_as_breaching(template):
+    """Worker death manifests as the ABSENCE of log events, so the worker-health
+    alarm must treat missing data as breaching (otherwise a dead worker that
+    emits nothing never alarms)."""
+    alarms = _resources_of_type(template, "AWS::CloudWatch::Alarm")
+    breaching = [
+        n
+        for n, a in alarms.items()
+        if a.get("Properties", {}).get("TreatMissingData") == "breaching"
+    ]
+    assert breaching, (
+        "at least one alarm must use TreatMissingData: breaching to detect a "
+        "silent (dead) worker/process (08#7)"
+    )

--- a/tests/test_mcp_audit_actor.py
+++ b/tests/test_mcp_audit_actor.py
@@ -14,6 +14,7 @@ import logging
 import pytest
 
 from mcp_server.envelope import tool_context
+from mcp_server.server import query
 
 
 @pytest.mark.asyncio
@@ -51,8 +52,6 @@ async def test_tool_context_omits_empty_actor(caplog):
 async def test_query_tool_threads_actor_into_audit(caplog):
     """The real ``query`` MCP tool must thread the injected user/thread into the
     audit record so the trail has an actor, not just a workspace id."""
-    from mcp_server.server import query
-
     # Empty workspace_id short-circuits with a VALIDATION_ERROR before any DB
     # work, but the audit line is still emitted on context exit — which is where
     # the actor must appear.

--- a/tests/test_mcp_audit_actor.py
+++ b/tests/test_mcp_audit_actor.py
@@ -1,0 +1,71 @@
+"""Tests for actor attribution in the MCP audit trail (arch #257, finding 08#8).
+
+The MCP-side ``tool_context`` audit covered every tool but ``context_id`` was the
+workspace id only — no user or thread — so the trail could not answer "who ran
+this tool, in which conversation". The agent graph already injects ``user_id``
+and ``thread_id`` into every MCP tool call, so threading those through to
+``tool_context`` gives the audit record a real actor.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from mcp_server.envelope import tool_context
+
+
+@pytest.mark.asyncio
+async def test_tool_context_logs_actor_when_provided(caplog):
+    """tool_context records user_id and thread_id when threaded through."""
+    with caplog.at_level(logging.INFO, logger="mcp_server.audit"):
+        async with tool_context(
+            "query", "ws-1", user_id="user-42", thread_id="thread-9", sql="SELECT 1"
+        ) as tc:
+            tc["result"] = {"success": True}
+
+    records = [r for r in caplog.records if r.name == "mcp_server.audit"]
+    assert records, "expected an MCP audit record"
+    msg = records[0].getMessage()
+    assert "user_id='user-42'" in msg, f"audit line missing actor user: {msg!r}"
+    assert "thread_id='thread-9'" in msg, f"audit line missing actor thread: {msg!r}"
+
+
+@pytest.mark.asyncio
+async def test_tool_context_omits_empty_actor(caplog):
+    """Empty actor fields are not noise-logged (context-free / operator tools)."""
+    with caplog.at_level(logging.INFO, logger="mcp_server.audit"):
+        async with tool_context("list_pipelines", "") as tc:
+            tc["result"] = {"success": True}
+
+    records = [r for r in caplog.records if r.name == "mcp_server.audit"]
+    assert records
+    msg = records[0].getMessage()
+    assert "user_id=" not in msg
+    assert "thread_id=" not in msg
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_query_tool_threads_actor_into_audit(caplog):
+    """The real ``query`` MCP tool must thread the injected user/thread into the
+    audit record so the trail has an actor, not just a workspace id."""
+    from mcp_server.server import query
+
+    # Empty workspace_id short-circuits with a VALIDATION_ERROR before any DB
+    # work, but the audit line is still emitted on context exit — which is where
+    # the actor must appear.
+    with caplog.at_level(logging.INFO, logger="mcp_server.audit"):
+        await query(
+            sql="SELECT 1",
+            workspace_id="",
+            user_id="actor-user-1",
+            thread_id="actor-thread-1",
+        )
+
+    records = [r for r in caplog.records if r.name == "mcp_server.audit"]
+    assert records, "expected an MCP audit record from query"
+    msg = records[0].getMessage()
+    assert "user_id='actor-user-1'" in msg, f"query did not thread actor user: {msg!r}"
+    assert "thread_id='actor-thread-1'" in msg, f"query did not thread actor thread: {msg!r}"

--- a/tests/test_schema_destruction_logging.py
+++ b/tests/test_schema_destruction_logging.py
@@ -1,0 +1,119 @@
+"""Tests for structured logging of schema destruction (arch #257, finding 08#9).
+
+Schema destruction was silent on success: ``expire_inactive_schemas`` flipped
+ACTIVE->TEARDOWN with no logging, and the teardown tasks logged only failures —
+so a successful DROP SCHEMA CASCADE of data-bearing schemas emitted zero log
+lines. The forensic question of the 2026-06-10 incident ("why did the janitor
+drop a fresh schema?") was unanswerable because the decision input
+(``last_accessed_at``) is later overwritten and was never logged.
+
+These tests pin explicit log lines at the expire DECISION point (logging
+``last_accessed_at`` BEFORE any overwrite) and on successful teardown/drop, plus
+the dependent-view-schema failure count.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import timedelta
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from django.utils import timezone
+
+from apps.users.models import Tenant
+from apps.workspaces.models import (
+    SchemaState,
+    TenantSchema,
+    Workspace,
+    WorkspaceTenant,
+    WorkspaceViewSchema,
+)
+from apps.workspaces.tasks import expire_inactive_schemas, teardown_schema
+
+
+@pytest.fixture
+def active_schema(db, tenant):
+    return TenantSchema.objects.create(
+        tenant=tenant,
+        schema_name="log_test_schema",
+        state=SchemaState.ACTIVE,
+        last_accessed_at=timezone.now(),
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_expire_logs_decision_with_last_accessed_at(active_schema, caplog):
+    """The expire decision must be logged WITH last_accessed_at and the cutoff,
+    captured BEFORE the row is flipped (that timestamp is the missing forensic
+    input — it is overwritten later)."""
+    stale_ts = timezone.now() - timedelta(hours=25)
+    active_schema.last_accessed_at = stale_ts
+    await active_schema.asave(update_fields=["last_accessed_at"])
+
+    with (
+        patch("apps.workspaces.tasks.teardown_schema.defer_async", new_callable=AsyncMock),
+        caplog.at_level(logging.INFO, logger="apps.workspaces.tasks"),
+    ):
+        await expire_inactive_schemas()
+
+    msgs = [r.getMessage() for r in caplog.records]
+    decision = [m for m in msgs if "log_test_schema" in m and "last_accessed_at" in m]
+    assert decision, f"no expire-decision log line with last_accessed_at; saw: {msgs}"
+    # The schema id must be present for forensic correlation.
+    assert any(str(active_schema.id) in m for m in decision)
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_teardown_logs_successful_drop(active_schema, caplog):
+    """A successful DROP SCHEMA CASCADE must emit a log line (schema id + name)."""
+    active_schema.state = SchemaState.TEARDOWN
+    await active_schema.asave(update_fields=["state"])
+
+    with (
+        patch("apps.workspaces.tasks.SchemaManager") as MockManager,
+        caplog.at_level(logging.INFO, logger="apps.workspaces.tasks"),
+    ):
+        MockManager.return_value.teardown.return_value = None
+        await teardown_schema(schema_id=str(active_schema.id))
+
+    msgs = [r.getMessage() for r in caplog.records]
+    dropped = [m for m in msgs if "log_test_schema" in m and "drop" in m.lower()]
+    assert dropped, f"successful DROP was not logged; saw: {msgs}"
+    assert any(str(active_schema.id) in m for m in dropped)
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_teardown_logs_dependent_view_schema_failure_count(
+    active_schema, tenant, user, caplog
+):
+    """The count of dependent view schemas flipped to FAILED must be logged, not
+    silently discarded."""
+    active_schema.state = SchemaState.TEARDOWN
+    await active_schema.asave(update_fields=["state"])
+
+    extra_tenant = await Tenant.objects.acreate(
+        provider="commcare", external_id="logcount-extra", canonical_name="Log Count Extra"
+    )
+    ws_b = await Workspace.objects.acreate(name="LogCount Sibling B", created_by=user)
+    await WorkspaceTenant.objects.acreate(workspace=ws_b, tenant=tenant)
+    await WorkspaceTenant.objects.acreate(workspace=ws_b, tenant=extra_tenant)
+    await WorkspaceViewSchema.objects.acreate(
+        workspace=ws_b, schema_name="ws_logcount_b", state=SchemaState.ACTIVE
+    )
+
+    with (
+        patch("apps.workspaces.tasks.SchemaManager") as MockManager,
+        caplog.at_level(logging.INFO, logger="apps.workspaces.tasks"),
+    ):
+        MockManager.return_value.teardown.return_value = None
+        await teardown_schema(schema_id=str(active_schema.id))
+
+    msgs = [r.getMessage() for r in caplog.records]
+    failed_log = [
+        m for m in msgs if ("dependent" in m.lower() or "view schema" in m.lower()) and "1" in m
+    ]
+    assert failed_log, f"dependent-view-schema failure count not logged; saw: {msgs}"


### PR DESCRIPTION
## What & why

Closes #257. Minimum observability for the agent/MCP/chat runtime (Cluster C lead; merges before siblings #256/#253/#254). Four findings, each fixed test-first:

### `08#8` (BROKEN-NOW / correctness) — agent audit trail useless in prod
The `scout.agent.audit` logger (the only user/thread-attributed record of agent tool calls) was suppressed in production and logged an always-empty workspace.
- **`config/settings/production.py`** — added explicit `scout.agent.audit` and `mcp_server.audit` loggers at INFO. They were falling through to root (`WARNING`) and dropped entirely.
- **`apps/chat/stream.py`** — the audit line read `input_state.get("project_id")`, always empty since the projects→workspaces rename. Now logs `workspace_id`.
- **`mcp_server/server.py` + `mcp_server/envelope.py`** — the MCP read tools (`query`, `list_tables`, `describe_table`, `get_metadata`, `get_lineage`, `get_schema_status`) now **declare** `user_id`/`thread_id` (the graph already injects them) and thread them into `tool_context`, so the MCP audit record has an actor and a conversation, not just a workspace. `run_materialization` now passes its actor through too. Empty actor fields are dropped to keep operator/context-free tools quiet.

### `08#9` (velocity) — schema destruction silent on success
A successful `DROP SCHEMA CASCADE` of data-bearing schemas emitted zero log lines, so the 2026-06-10 forensic question was unanswerable.
- **`apps/workspaces/tasks.py`** — `expire_inactive_schemas` now logs the expire decision **with `last_accessed_at` BEFORE the row is flipped** (the exact forensic input that gets overwritten later), plus schema id/name/cutoff/ttl. `teardown_schema` and `teardown_view_schema_task` log the successful DROP. `_reconcile_dependent_view_schemas_after_teardown` now logs the dependent-view-schema FAILED count instead of discarding it.

### `08#7` (velocity) — no detection layer
- **`apps/workspaces/views.py`** — `/health/` is now a real readiness check: probes the platform DB **and** the Procrastinate queue, returns **503** with a per-check breakdown on failure (was a static 200, so a crash-looping container with a dead DB/queue reported healthy).
- **`infra/scout-stack.yml`** — added an SNS alert topic (`AlertTopic` + optional email subscription via new `AlarmEmail` param), metric filters that turn the structured app logs into CloudWatch metrics, and a minimal alarm set: **worker-silence** (TreatMissingData: breaching — a dead worker emits nothing), worker/API error rates, a **schema-drop storm** alarm (built on the 08#9 logs), and EC2 status-check / RDS CPU + free-storage alarms. Validated with `cfn-lint` (zero new findings). *Landing the IaC only — not deployed.*

### `08#6` (security) — bearer capabilities in access logs
Share tokens (`/api/chat/threads/shared/<token>/`, `/api/recipes/runs/shared/<token>/`) and OAuth `?code=` transited uvicorn/nginx access logs into CloudWatch (30-day retention).
- **`config/deploy.yml`** — API uvicorn now runs with `--no-access-log` (Django never logged request paths, so no signal is lost).
- **`frontend/nginx.prod-kamal.conf` + `frontend/nginx.prod.conf`** — `access_log off;` on the share-token routes (surgical regex location, general `/api/` logging unaffected) and the OAuth `/accounts/` callback route.

## Sibling sweep (required on bug/incident fixes)

- **Grep used:**
  - `grep -rn "get(.project_id\|\[.project_id" apps/ mcp_server/`
  - `grep -rn "def health\|JsonResponse({.status" apps/`
  - `grep -rn "shared\|<str:share_token\|?code=" config/urls.py apps/*/urls.py`
  - `grep -rn "DROP SCHEMA\|teardown\|\.delete()" apps/workspaces/services/schema_manager.py`
- **Sibling sites found & disposition:**
  - [x] `apps/chat/stream.py` — the only live always-empty `project_id` read. **Fixed.**
  - [x] `mcp_server/envelope.py:50` `success_response(project_id=...)` — display-only optional field, never fed from agent state (defaults to `""` and is omitted). Not a bug; left as-is.
  - [x] `apps/chat/thread_views.py:235` `{"status":"ok"}` — a `thread_viewed` mutation response, not a health endpoint. N/A.
  - [x] Share-token routes (`config/urls.py:102,107`) + OAuth `/accounts/` — both the only capability-in-URL routes; **both covered** (uvicorn + nginx).
  - [x] `schema_manager.py:417,481` DROP SCHEMA — these are view-schema **rebuild** (DROP-then-recreate for idempotency) and partial-cleanup-on-failure, not TTL destruction of data-bearing schemas. Out of scope for 08#9 (no data lost); not logged here.

## Testing

New tests (all green): `tests/test_agent_audit_logging.py`, `tests/test_mcp_audit_actor.py`, `tests/test_schema_destruction_logging.py`, `tests/test_health_check.py` (asserts 503 on DB/queue-down), `tests/test_access_log_token_exposure.py`, `tests/test_infra_alarms.py`. Updated `tests/agents/test_context_injection_contract.py` (the read tools now legitimately declare the actor set; the guardrail's intent — guard against FastMCP `extra='forbid'` on the still-undeclared `tool_call_id` — is preserved).

Full backend suite: **1405 passed, 5 skipped, 1 xpassed** (the pre-existing #238 xfail), 0 failed. `ruff check .` clean. `makemigrations --check` clean (no model changes). `cfn-lint` clean on the template.

## Notes for reviewers

- **Pre-existing main breakage fixed (out of cluster, but it blocked the whole suite):** `apps/transformations/services/connect_staging.py` imported `_unique_alias` from `commcare_staging.py`, which arch #235 (`6e861c1`) deleted when it consolidated naming into `apps/common/identifiers.py`. Repointed to `dbt_column_alias` (drop-in; `seen_aliases` was already the new `dict[str,int]` shape). This was breaking test collection on `origin/main`.
- **Design decisions surfaced (defaults chosen, please confirm):**
  - **Alarm thresholds** are conservative starting points (worker-silence 15 min, worker errors ≥5/5 min, API errors ≥10/5 min, schema-drop storm >5/15 min, RDS CPU >85%, free storage <2 GiB). Tune against real traffic.
  - **Access-log strategy:** I disabled uvicorn's access log entirely on the API container (the minimal grounded option per the finding) plus surgical `access_log off;` on the sensitive nginx routes — rather than building a redaction/filter layer. If you want to keep API access logs for ops, say so and I'll switch to a path/query redaction filter instead.
  - The CFN alarm/SNS resources are landed but **not deployed** (per the issue, deploy is out of scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HpAA218jN8dR5SMJTM3Ur4
