### PR TITLE
fix(chat): stop ToolRuntime from crashing the SSE stream (Sentry SCOUT-DJANGO-1V)

### DIFF
--- a/apps/chat/stream.py
+++ b/apps/chat/stream.py
@@ -79,8 +79,13 @@ def _is_transient_overload(exc: BaseException) -> bool:
 
 
 def _sse(chunk: dict) -> str:
-    """Format a chunk as an SSE data event."""
-    return f"data: {json.dumps(chunk)}\n\n"
+    """Format a chunk as an SSE data event.
+
+    ``default=str`` is a backstop: no single non-serializable value (e.g. a
+    langgraph ToolRuntime that slipped into a tool input) may ever crash the
+    whole stream -- it is coerced to its string form rather than raising.
+    """
+    return f"data: {json.dumps(chunk, default=str)}\n\n"
 
 
 def _tool_content_to_str(output: Any) -> str:
@@ -108,17 +113,41 @@ def _tool_content_to_str(output: Any) -> str:
     return json.dumps(content, default=str)
 
 
+# Params we never surface in the tool-call card. INJECTED_TOOL_PARAMS are the
+# context ids the graph injects; ``runtime`` is the ToolRuntime object that
+# langchain_mcp_adapters/langgraph's ToolNode inject into every MCP tool call
+# (internal plumbing, and not JSON serializable -- it crashed the whole stream,
+# Sentry SCOUT-DJANGO-1V).
+_HIDDEN_TOOL_PARAMS = INJECTED_TOOL_PARAMS | {"runtime"}
+
+
+def _is_json_serializable(value: Any) -> bool:
+    """True if ``value`` can be put on the JSON-encoded SSE wire as-is."""
+    try:
+        json.dumps(value)
+    except (TypeError, ValueError):
+        return False
+    return True
+
+
 def _redact_tool_input(raw_input: Any) -> dict:
     """Strip server-injected context params from a tool's input for display.
 
     The graph injects workspace_id / user_id / thread_id / tool_call_id into
-    every MCP tool call; those are internal ids, not arguments the user typed,
-    so they must not surface in the tool-call card. Returns {} for non-dict
-    input (e.g. positional-only), which the card renders as "no input".
+    every MCP tool call, and langgraph's ToolNode injects a ``runtime`` object;
+    those are internal plumbing, not arguments the user typed, so they must not
+    surface in the tool-call card. Any remaining non-JSON-serializable value is
+    dropped too, so one stray object can neither leak nor break the card.
+    Returns {} for non-dict input (e.g. positional-only), which the card
+    renders as "no input".
     """
     if not isinstance(raw_input, dict):
         return {}
-    return {k: v for k, v in raw_input.items() if k not in INJECTED_TOOL_PARAMS}
+    return {
+        k: v
+        for k, v in raw_input.items()
+        if k not in _HIDDEN_TOOL_PARAMS and _is_json_serializable(v)
+    }
 
 
 def _truncate_tool_output(content: str) -> str:

--- a/tests/test_chat_stream_tool_cards.py
+++ b/tests/test_chat_stream_tool_cards.py
@@ -173,3 +173,85 @@ async def test_tool_output_not_double_indented():
     # Compact: round-trips and has no indentation newlines from indent=2.
     assert json.loads(out) == payload
     assert '\n  "' not in out
+
+
+# --- a non-serializable injected param must not crash the stream (SCOUT-DJANGO-1V)
+
+
+def _make_tool_runtime():
+    """Build a real langgraph ToolRuntime, like ToolNode injects into MCP tools.
+
+    langchain_mcp_adapters gives every MCP tool a ``runtime`` param and
+    langgraph's ToolNode injects a ToolRuntime object into it, which then shows
+    up in the on_tool_start event's input. It is NOT JSON serializable. Fall
+    back to a plain non-serializable object if the internal signature shifts.
+    """
+    try:
+        from langgraph.prebuilt.tool_node import ToolRuntime
+
+        return ToolRuntime(
+            state={},
+            context=None,
+            config={},
+            stream_writer=None,
+            tool_call_id="toolu_RT",
+            store=None,
+        )
+    except Exception:  # pragma: no cover - signature drift fallback
+
+        class _Opaque:
+            pass
+
+        return _Opaque()
+
+
+@pytest.mark.asyncio
+async def test_tool_runtime_in_input_does_not_crash_stream():
+    """Regression for SCOUT-DJANGO-1V: a ToolRuntime injected into the tool
+    input must not crash the SSE stream. The tool-input card must still render
+    with the real input, and the non-serializable ``runtime`` must not leak."""
+    events = [
+        {
+            "event": "on_tool_start",
+            "run_id": "run-1",
+            "name": "query",
+            "data": {
+                "input": {
+                    "sql": "SELECT 1",
+                    "workspace_id": "ws-secret",
+                    "tool_call_id": "toolu_RT",
+                    "runtime": _make_tool_runtime(),
+                }
+            },
+        },
+    ]
+    chunks = await _run(events)
+
+    # The stream must not have degraded into the generic error text.
+    error_deltas = [
+        c
+        for c in chunks
+        if c.get("type") == "text-delta" and "An error occurred" in c.get("delta", "")
+    ]
+    assert not error_deltas, "stream crashed and emitted the generic error text"
+
+    starts = [c for c in chunks if c["type"] == "tool-input-available"]
+    assert starts, "on_tool_start should still emit a tool-input-available chunk"
+    start = starts[0]
+    assert start["toolCallId"] == "toolu_RT"
+    assert start["input"].get("sql") == "SELECT 1"
+    # The injected, non-serializable runtime must not surface in the card.
+    assert "runtime" not in start["input"]
+    assert "workspace_id" not in start["input"]
+
+
+def test_sse_survives_non_serializable_values():
+    """``_sse`` is the last line of defence: no single non-serializable value
+    may ever crash the whole stream, so it falls back to ``default=str``."""
+    chunk = {"type": "tool-input-available", "input": {"runtime": _make_tool_runtime()}}
+    out = stream._sse(chunk)
+    assert out.startswith("data: ")
+    assert out.endswith("\n\n")
+    # Still valid JSON; the opaque value is coerced to a string rather than raising.
+    parsed = json.loads(out.removeprefix("data: ").strip())
+    assert parsed["type"] == "tool-input-available"


### PR DESCRIPTION
## Problem

Production chat returned **"An error occurred while processing your request."** on *every* tool-using turn.

Sentry [`SCOUT-DJANGO-1V`](https://dimagi.sentry.io/issues/?query=SCOUT-DJANGO-1V): `TypeError: Object of type ToolRuntime is not JSON serializable`, culprit `/api/chat/`, logger `apps.chat.stream`, in `_sse`.

## Root cause

- `langchain_mcp_adapters` wraps every MCP tool with a `runtime` parameter; langgraph's `ToolNode` injects a `ToolRuntime` object into it, and it appears in the streamed `on_tool_start` event's `data["input"]`.
- Commit `bb6cc61` ("fix(chat): repair live/reload tool-output rich cards", arch #246) changed the `tool-input-available` SSE event in `apps/chat/stream.py` from `"input": {}` to `"input": _redact_tool_input(raw_input)` — i.e. it started streaming the *real* tool input.
- `_redact_tool_input` only stripped `INJECTED_TOOL_PARAMS = {"workspace_id","user_id","thread_id","tool_call_id"}` — **not** `runtime`. So the `ToolRuntime` object survived into the chunk and `_sse`'s `json.dumps(chunk)` raised on every tool call. The broad `except` then degraded the turn into the generic error text.

## Fix

Two complementary changes:

1. **`_sse` backstop** — `json.dumps(chunk, default=str)`. No single non-serializable value can ever crash the whole stream again; it is coerced to its string form instead of raising. This is the high-leverage safety net.
2. **`_redact_tool_input`** — also drops the injected `runtime` key and any remaining non-JSON-serializable value, so the tool-call card renders the real input without a useless stringified `ToolRuntime`.

## Regression tests

`tests/test_chat_stream_tool_cards.py` (TDD — written first, watched fail on `main`):

- `test_tool_runtime_in_input_does_not_crash_stream` — feeds a real `langgraph.prebuilt.tool_node.ToolRuntime` in the `on_tool_start` input (falls back to a plain opaque object if the internal signature drifts). Asserts the stream does **not** emit the generic error text, the `tool-input-available` card still renders the real `sql` input, and `runtime` does not leak.
- `test_sse_survives_non_serializable_values` — calls `_sse` directly with a non-serializable value and asserts it returns a valid `data: …` line without raising.

Both **fail on `main`** (the first degrades to the "An error occurred" text-delta; the second raises the exact `TypeError`) and **pass with this change**.

```
# before (on origin/main)
FAILED tests/test_chat_stream_tool_cards.py::test_tool_runtime_in_input_does_not_crash_stream
FAILED tests/test_chat_stream_tool_cards.py::test_sse_survives_non_serializable_values
# after
6 passed
```

`uv run ruff check .` / `uv run ruff format .` clean; related chat/stream suites pass.

Regression source: arch #246 / commit `bb6cc61`. Fixes Sentry `SCOUT-DJANGO-1V`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)