### PR TITLE
fix(ocs): request participants:read scope so participant sync stops 403ing (SCOUT-DJANGO-1X)

### DIFF
--- a/apps/users/providers/ocs/provider.py
+++ b/apps/users/providers/ocs/provider.py
@@ -24,7 +24,7 @@ class OCSProvider(OAuth2Provider):
     oauth2_adapter_class = OCSOAuth2Adapter
 
     def get_default_scope(self) -> list[str]:
-        return ["chatbots:read", "sessions:read", "files:read", "openid"]
+        return ["chatbots:read", "sessions:read", "files:read", "participants:read", "openid"]
 
     def extract_uid(self, data: dict) -> str:
         sub = data.get("sub")

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -13,6 +13,7 @@ from django.contrib.sites.models import Site
 from django.db import IntegrityError
 
 from apps.users.models import TenantConnection, TenantMembership
+from apps.users.providers.ocs.provider import OCSProvider
 
 User = get_user_model()
 
@@ -645,6 +646,36 @@ class TestCustomCommCareProvider:
 
         account = CommCareAccount(mock_account)
         assert account.get_avatar_url() is None
+
+
+# ============================================================================
+# 7b. TestOCSProviderScopes
+# ============================================================================
+
+
+class TestOCSProviderScopes:
+    """The OCS OAuth scopes Scout requests must cover every data source it loads."""
+
+    def _provider(self) -> OCSProvider:
+        # get_default_scope only needs an ``app`` on the provider; an unsaved
+        # SocialApp keeps this a pure unit test (no DB), matching the pattern in
+        # tests/test_provider_email_verification.py.
+        app = SocialApp(provider=OCSProvider.id, name="OCS", client_id="x", secret="x")
+        return OCSProvider(request=None, app=app)
+
+    def test_default_scope_includes_participants_read(self):
+        """Participant sync hits OCS GET /api/participants, which requires
+        the participants:read scope. Its omission 403s the load (SCOUT-DJANGO-1X)."""
+        assert "participants:read" in self._provider().get_default_scope()
+
+    def test_default_scope_covers_all_loaded_sources(self):
+        """Each OCS source Scout materializes maps to a read scope; all must be requested."""
+        scope = self._provider().get_default_scope()
+        # experiments -> chatbots:read, sessions/messages -> sessions:read,
+        # files -> files:read, participants -> participants:read
+        for required in ("chatbots:read", "sessions:read", "files:read", "participants:read"):
+            assert required in scope, f"missing OCS scope: {required}"
+        assert "openid" in scope
 
 
 # ============================================================================


### PR DESCRIPTION
## Problem

Scout's OCS data refresh fails to load **participants** with HTTP 403 (Sentry **SCOUT-DJANGO-1X**).

## Root cause

Scout's OCS OAuth integration never requested the `participants:read` scope. OCS's `GET /api/participants` endpoint requires it. The other three OCS sources Scout loads succeed because each maps to a scope that *was* already requested — only participants was missing:

| OCS source Scout loads | Required OAuth scope | Requested before this PR? |
|------------------------|----------------------|---------------------------|
| experiments            | `chatbots:read`      | yes                       |
| sessions / messages    | `sessions:read`      | yes                       |
| files                  | `files:read`         | yes                       |
| **participants**       | **`participants:read`** | **no → 403**           |

OCS already defines `participants:read` as an available scope, so this was purely a Scout-side omission.

## Fix

Add `participants:read` to `OCSProvider.get_default_scope()` in `apps/users/providers/ocs/provider.py`.

`get_default_scope()` is the single source of truth for the authorize request:
- No `SCOPE` is pinned in `SOCIALACCOUNT_PROVIDERS["ocs"]` (`config/settings/base.py`) — only `OAUTH_PKCE_ENABLED` / `VERIFIED_EMAIL`.
- `apps/users/management/commands/setup_oauth_apps.py` seeds only `client_id`/`secret` on the `SocialApp`, no scopes.

So allauth derives the requested scopes from this method; the one-line change is sufficient for **new** authorizations to request it. No other config needed updating.

## ⚠️ Required follow-up: existing users must re-authorize

OAuth scopes are fixed at **grant time**. This fix only takes effect for **new authorizations**. Existing OCS users will keep 403ing on participants until they **RE-AUTHORIZE (re-consent)** their OCS connection — a silent refresh-token refresh will **NOT** pick up the new scope.

The deploy will need a forced reconnect or a re-auth prompt. That decision is being handled separately and is intentionally **not** implemented here.

## Tests

Added `TestOCSProviderScopes` in `tests/test_auth.py` (pure unit test, no DB):
- `test_default_scope_includes_participants_read` — asserts `participants:read` is requested.
- `test_default_scope_covers_all_loaded_sources` — asserts every loaded-source scope is requested.

Both fail before the fix and pass after. Full `uv run pytest -k ocs` suite: 65 passed. `ruff check` / `ruff format` clean.

Sentry: SCOUT-DJANGO-1X

🤖 Generated with [Claude Code](https://claude.com/claude-code)