### PR TITLE
fix(users): account-merge correctness (arch #259)

### DIFF
--- a/apps/users/management/commands/merge_duplicate_users.py
+++ b/apps/users/management/commands/merge_duplicate_users.py
@@ -102,3 +102,16 @@ class Command(BaseCommand):
             f"workspace(repoint/conflict)={report.workspace_membership_repointed}/"
             f"{report.workspace_membership_conflict_merged}"
         )
+        # 11#4: make any privilege the discarded duplicate held visible at the
+        # y/N prompt. The merge NEVER applies these to the canonical (no silent
+        # escalation); we surface them so the operator knows a privileged dev
+        # artifact is being deleted and can act on it deliberately if needed.
+        if report.discarded_privileges:
+            flags = ", ".join(sorted(report.discarded_privileges))
+            self.stdout.write(
+                self.style.WARNING(
+                    f"  WARNING: duplicate User#{duplicate.pk} holds privilege flags the "
+                    f"canonical lacks: {flags}. These are NOT propagated to the canonical "
+                    f"(no escalation). The privileged duplicate will be deleted."
+                )
+            )

--- a/apps/users/services/merge.py
+++ b/apps/users/services/merge.py
@@ -17,7 +17,7 @@ from allauth.socialaccount.models import SocialAccount
 from django.db import transaction
 
 from apps.users.models import TenantConnection, TenantMembership
-from apps.workspaces.models import WorkspaceMembership, WorkspaceRole
+from apps.workspaces.models import TenantMetadata, WorkspaceMembership, WorkspaceRole
 
 if TYPE_CHECKING:
     from apps.users.models import User
@@ -93,12 +93,17 @@ class MergeReport:
     emailaddress_deleted: int = 0
     tenant_membership_repointed: int = 0
     tenant_membership_conflict_deleted: int = 0
+    tenant_membership_metadata_migrated: int = 0
     tenant_connection_repointed: int = 0
     tenant_connection_conflict_merged: int = 0
     workspace_membership_repointed: int = 0
     workspace_membership_conflict_merged: int = 0
     long_tail_fk_counts: dict[str, int] = field(default_factory=dict)
     duplicate_user_deleted: bool = False
+    # 11#4: privilege flags the discarded duplicate held that the canonical did
+    # NOT — surfaced for the operator/log but never silently applied (no
+    # escalation from the discarded account).
+    discarded_privileges: set[str] = field(default_factory=set)
 
 
 def select_canonical(users: list[User]) -> User:
@@ -152,20 +157,79 @@ def _dedupe_email_addresses(canonical: User, duplicate: User) -> tuple[int, int]
     return repointed, deleted
 
 
-def _merge_tenant_memberships(canonical: User, duplicate: User) -> tuple[int, int]:
-    """Returns (repointed_count, conflict_deleted_count).
+def _migrate_conflicting_membership(canon_m: TenantMembership, dup_m: TenantMembership) -> int:
+    """Carry discovered data from a conflicting duplicate membership onto the
+    canonical's surviving membership, when the canonical lacks it.
 
-    If canonical already has a membership for a given tenant, delete duplicate's
-    row. Otherwise repoint to canonical. (Connections are merged separately by
+    04#1: ``TenantMetadata`` is a OneToOne(CASCADE) on ``TenantMembership`` and
+    ``provider_metadata``/``connection`` ride on the membership row. Deleting the
+    duplicate's conflicting membership cascade-deletes its ``TenantMetadata`` and
+    drops its connection wiring. Before that delete, migrate each of those onto
+    the canonical membership *only when the canonical doesn't already have it* —
+    never clobbering the canonical's own discovered data.
+
+    Returns 1 if any ``TenantMetadata`` row was migrated, else 0.
+    """
+    canon_changed_fields: list[str] = []
+
+    # provider_metadata (JSON on the membership): backfill if canonical's is empty.
+    if not canon_m.provider_metadata and dup_m.provider_metadata:
+        canon_m.provider_metadata = dup_m.provider_metadata
+        canon_changed_fields.append("provider_metadata")
+
+    # connection wiring: adopt the duplicate's connection if the canonical's
+    # membership is unwired. (_merge_tenant_connections repoints the connection
+    # row itself to the canonical user; here we wire the surviving membership to
+    # it so the canonical isn't left connection=None.)
+    if canon_m.connection_id is None and dup_m.connection_id is not None:
+        canon_m.connection_id = dup_m.connection_id
+        canon_changed_fields.append("connection")
+
+    if canon_changed_fields:
+        canon_m.save(update_fields=canon_changed_fields)
+
+    # TenantMetadata (OneToOne, CASCADE): migrate the duplicate's onto the
+    # canonical membership when the canonical has none. Otherwise leave the
+    # duplicate's to cascade away (the canonical's is authoritative).
+    metadata_migrated = 0
+    dup_metadata = TenantMetadata.objects.filter(tenant_membership=dup_m).first()
+    if (
+        dup_metadata is not None
+        and not TenantMetadata.objects.filter(tenant_membership=canon_m).exists()
+    ):
+        dup_metadata.tenant_membership = canon_m
+        dup_metadata.save(update_fields=["tenant_membership"])
+        metadata_migrated = 1
+
+    return metadata_migrated
+
+
+def _merge_tenant_memberships(canonical: User, duplicate: User) -> tuple[int, int, int]:
+    """Returns (repointed_count, conflict_deleted_count, metadata_migrated_count).
+
+    If canonical already has a membership for a given tenant, the duplicate's
+    conflicting row is deleted — but first any discovered data riding on it
+    (TenantMetadata, provider_metadata, connection wiring) is migrated onto the
+    canonical's membership when the canonical lacks it (04#1), so cascade-delete
+    never destroys the only copy. Otherwise the duplicate's membership is
+    repointed to canonical. (Connection *rows* are merged separately by
     _merge_tenant_connections, which the surviving memberships still reference.)
     """
-    canonical_tenant_ids = set(
-        TenantMembership.objects.filter(user=canonical).values_list("tenant_id", flat=True)
-    )
-    dup_qs = TenantMembership.objects.filter(user=duplicate)
-    conflict_deleted, _ = dup_qs.filter(tenant_id__in=canonical_tenant_ids).delete()
-    repointed = dup_qs.exclude(tenant_id__in=canonical_tenant_ids).update(user=canonical)
-    return repointed, conflict_deleted
+    canon_by_tenant = {m.tenant_id: m for m in TenantMembership.objects.filter(user=canonical)}
+    repointed = 0
+    conflict_deleted = 0
+    metadata_migrated = 0
+    for dup_m in TenantMembership.objects.filter(user=duplicate):
+        canon_m = canon_by_tenant.get(dup_m.tenant_id)
+        if canon_m is None:
+            dup_m.user = canonical
+            dup_m.save(update_fields=["user"])
+            repointed += 1
+            continue
+        metadata_migrated += _migrate_conflicting_membership(canon_m, dup_m)
+        dup_m.delete()
+        conflict_deleted += 1
+    return repointed, conflict_deleted, metadata_migrated
 
 
 def _merge_tenant_connections(canonical: User, duplicate: User) -> tuple[int, int]:
@@ -226,18 +290,33 @@ def _merge_workspace_memberships(canonical: User, duplicate: User) -> tuple[int,
     return repointed, conflict_merged
 
 
+def _discarded_privileges(canonical: User, duplicate: User) -> set[str]:
+    """Privilege flags the duplicate holds that the canonical does not.
+
+    11#4: these are NEVER propagated onto the canonical (no silent escalation
+    from a discarded account). They are returned only so the operator command
+    and the merge log can surface that the deleted duplicate was privileged.
+    """
+    discarded: set[str] = set()
+    for flag in ("is_staff", "is_superuser"):
+        if getattr(duplicate, flag) and not getattr(canonical, flag):
+            discarded.add(flag)
+    return discarded
+
+
 def _merge_user_fields(canonical: User, duplicate: User) -> dict[str, str]:
-    """Apply field-level merge rules. Mutates canonical in place; returns changes."""
+    """Apply field-level merge rules. Mutates canonical in place; returns changes.
+
+    NOTE (11#4): ``is_staff``/``is_superuser`` are deliberately NOT merged. The
+    canonical keeps its own privilege flags unchanged so that absorbing a stale
+    ``createsuperuser`` dev artifact (or any privileged duplicate) can never
+    silently promote a normal account to production admin. Use
+    ``_discarded_privileges`` to report what the discarded duplicate held.
+    """
     changes: dict[str, str] = {}
     if not canonical.has_usable_password() and duplicate.has_usable_password():
         canonical.password = duplicate.password
         changes["password"] = "copied from duplicate"  # noqa: S105
-    if duplicate.is_staff and not canonical.is_staff:
-        canonical.is_staff = True
-        changes["is_staff"] = "True (OR with duplicate)"
-    if duplicate.is_superuser and not canonical.is_superuser:
-        canonical.is_superuser = True
-        changes["is_superuser"] = "True (OR with duplicate)"
     if duplicate.last_login and (
         canonical.last_login is None or duplicate.last_login > canonical.last_login
     ):
@@ -263,9 +342,13 @@ def merge_users(
 ) -> MergeReport:
     """Merge ``duplicate`` into ``canonical`` and return a MergeReport.
 
-    Field-level rules are applied to ``canonical`` (password copy, staff/super
-    OR, oldest-last-login, empty-name backfill, timezone backfill). All
-    User-pointing rows are then repointed or merged: SocialAccount,
+    Field-level rules are applied to ``canonical`` (password copy,
+    oldest-last-login, empty-name backfill, timezone backfill).
+    ``is_staff``/``is_superuser`` are intentionally NOT merged (11#4: never
+    escalate the canonical from the discarded duplicate); any privilege the
+    duplicate held that the canonical lacks is reported in
+    ``MergeReport.discarded_privileges``. All User-pointing rows are then
+    repointed or merged: SocialAccount,
     EmailAddress (with dedupe + primary normalization), TenantMembership and
     WorkspaceMembership (with conflict resolution), and every other
     reverse-FK relation discovered via Django's `_meta` (the "long tail"). The
@@ -284,6 +367,7 @@ def merge_users(
     )
     if dry_run:
         # Count-only plan (no writes).
+        report.discarded_privileges = _discarded_privileges(canonical, duplicate)
         report.socialaccount_repointed = SocialAccount.objects.filter(user=duplicate).count()
         canonical_emails = set(
             EmailAddress.objects.filter(user=canonical).values_list("email", flat=True)
@@ -329,14 +413,17 @@ def merge_users(
         return report
 
     with transaction.atomic():
+        report.discarded_privileges = _discarded_privileges(canonical, duplicate)
         report.field_changes = _merge_user_fields(canonical, duplicate)
         report.socialaccount_repointed = _repoint_social_accounts(canonical, duplicate)
         report.emailaddress_repointed, report.emailaddress_deleted = _dedupe_email_addresses(
             canonical, duplicate
         )
-        report.tenant_membership_repointed, report.tenant_membership_conflict_deleted = (
-            _merge_tenant_memberships(canonical, duplicate)
-        )
+        (
+            report.tenant_membership_repointed,
+            report.tenant_membership_conflict_deleted,
+            report.tenant_membership_metadata_migrated,
+        ) = _merge_tenant_memberships(canonical, duplicate)
         report.tenant_connection_repointed, report.tenant_connection_conflict_merged = (
             _merge_tenant_connections(canonical, duplicate)
         )

--- a/apps/users/signals.py
+++ b/apps/users/signals.py
@@ -3,7 +3,9 @@
 import logging
 
 from allauth.account.models import EmailAddress
+from allauth.socialaccount.models import SocialAccount
 from asgiref.sync import async_to_sync
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.db.models.signals import post_save
 from django.dispatch import receiver
@@ -16,6 +18,57 @@ from apps.users.services.tenant_resolution import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _trusted_email_providers() -> set[str]:
+    """allauth provider ids we trust to have verified the email upstream.
+
+    Derived from ``SOCIALACCOUNT_PROVIDERS[<id>]["VERIFIED_EMAIL"] is True``.
+    These are the Dimagi-operated IdPs (CommCare HQ, CommCare Connect, OCS) whose
+    ``extract_email_addresses`` returns a verified ``EmailAddress`` on login.
+    """
+    providers = getattr(settings, "SOCIALACCOUNT_PROVIDERS", {}) or {}
+    return {pid for pid, cfg in providers.items() if (cfg or {}).get("VERIFIED_EMAIL") is True}
+
+
+def _canonical_provably_owns_email(canonical, email: str) -> bool:
+    """Whether ``canonical`` has *proven* it owns ``email`` (01#8).
+
+    Auto-merge folds the incoming OAuth identity INTO ``canonical``, so we must
+    be sure ``canonical`` is the legitimate owner of the email — otherwise an
+    attacker who ``/signup``'d with a victim's email (signup_view bypasses
+    allauth, creating no ``EmailAddress``) could absorb the victim's OAuth
+    account on the victim's next login (closed by commit 1dc1d58).
+
+    Ownership is proven by EITHER:
+
+    1. a verified allauth ``EmailAddress`` for that email (the OAuth->OAuth case:
+       a prior trusted-provider login persisted one), OR
+    2. a ``SocialAccount`` on ``canonical`` from a trusted provider whose login
+       asserted this email — same upstream-verified signal, robust to the case
+       where the verified ``EmailAddress`` row was never persisted/got out of
+       sync.
+
+    SEAM (01#8 / #258): a canonical that owns the email ONLY via a password
+    ``/signup`` satisfies NEITHER and is (correctly) refused here. Making the
+    password->OAuth path auto-link safely needs allauth-side email verification
+    at signup — that perimeter is owned by issue #258. See the PR body.
+    """
+    if EmailAddress.objects.filter(
+        user=canonical,
+        email__iexact=email,
+        verified=True,
+    ).exists():
+        return True
+
+    trusted = _trusted_email_providers()
+    if not trusted:
+        return False
+    for account in SocialAccount.objects.filter(user=canonical, provider__in=trusted):
+        account_email = (account.extra_data or {}).get("email") or ""
+        if account_email.strip().lower() == email.strip().lower():
+            return True
+    return False
 
 
 @receiver(post_save, sender="users.TenantMembership")
@@ -101,14 +154,10 @@ def reconcile_existing_user_on_login(sender, request, sociallogin, **kwargs):
         user.save(update_fields=["email"])
         return
 
-    canonical_owns_email = EmailAddress.objects.filter(
-        user=canonical,
-        email__iexact=new_email,
-        verified=True,
-    ).exists()
-    if not canonical_owns_email:
+    if not _canonical_provably_owns_email(canonical, new_email):
         logger.warning(
-            "Refusing auto-merge: canonical user=%s lacks verified EmailAddress for %s",
+            "Refusing auto-merge: canonical user=%s has not proven ownership of %s "
+            "(no verified EmailAddress and no trusted-provider SocialAccount)",
             canonical.pk,
             new_email,
         )

--- a/tests/test_merge_duplicate_users_command.py
+++ b/tests/test_merge_duplicate_users_command.py
@@ -131,6 +131,47 @@ def test_prompt_rejection_aborts_without_changes():
 
 
 @pytest.mark.django_db
+def test_dry_run_surfaces_discarded_privilege_at_prompt():
+    """11#4: when the duplicate carries privilege flags the canonical lacks, the
+    printed plan must WARN that a privileged duplicate is being discarded (and
+    that the flags are not propagated) — making the escalation risk visible
+    before the y/N confirmation."""
+    # Canonical is the older, password-holding row (selected as canonical).
+    older = User.objects.create(email="x@y.com", username="x1")
+    older.set_password("pw")
+    older.save()
+    # Duplicate is a stale createsuperuser-style artifact.
+    User.objects.create(email="X@y.com", username="x2", is_staff=True, is_superuser=True)
+    out = StringIO()
+
+    call_command("merge_duplicate_users", "--dry-run", stdout=out)
+
+    output = out.getvalue()
+    assert "WARNING" in output
+    assert "is_staff" in output
+    assert "is_superuser" in output
+    assert "not propagated" in output.lower()
+
+
+@pytest.mark.django_db
+def test_yes_flag_merge_does_not_escalate_canonical_privileges():
+    """11#4 end-to-end: merging a privileged duplicate via the command must not
+    promote the canonical to staff/superuser."""
+    older = User.objects.create(email="x@y.com", username="x1")
+    older.set_password("pw")
+    older.save()
+    newer = User.objects.create(email="X@y.com", username="x2", is_staff=True, is_superuser=True)
+    out = StringIO()
+
+    call_command("merge_duplicate_users", "--yes", stdout=out)
+
+    older.refresh_from_db()
+    assert older.is_staff is False
+    assert older.is_superuser is False
+    assert not User.objects.filter(pk=newer.pk).exists()
+
+
+@pytest.mark.django_db
 def test_failure_in_one_group_does_not_block_others():
     # Group A — will fail
     User.objects.create(email="a@y.com", username="a1")

--- a/tests/test_merge_users_service.py
+++ b/tests/test_merge_users_service.py
@@ -63,8 +63,14 @@ def test_field_level_merge_copies_password_from_duplicate():
 
 
 @pytest.mark.django_db
-def test_field_level_merge_ors_staff_and_superuser_flags():
+def test_field_level_merge_never_escalates_staff_or_superuser_from_duplicate():
+    """SECURITY (11#4): merging a privileged duplicate (e.g. a stale
+    createsuperuser dev artifact) into a normal canonical must NOT silently
+    promote the canonical. The canonical's own flags are kept; the discarded
+    duplicate's flags are never OR-propagated."""
     canonical = User.objects.create(email="canon@y.com", username="canon")
+    assert canonical.is_staff is False
+    assert canonical.is_superuser is False
     duplicate = User.objects.create(
         email="dup@y.com",
         username="dup",
@@ -72,11 +78,34 @@ def test_field_level_merge_ors_staff_and_superuser_flags():
         is_superuser=True,
     )
 
-    merge_users(canonical=canonical, duplicate=duplicate)
+    report = merge_users(canonical=canonical, duplicate=duplicate)
+
+    canonical.refresh_from_db()
+    # No escalation: canonical stays exactly as privileged as it was.
+    assert canonical.is_staff is False
+    assert canonical.is_superuser is False
+    assert "is_staff" not in report.field_changes
+    assert "is_superuser" not in report.field_changes
+    # The discarded privilege is surfaced (so the operator/log can see it) but
+    # NOT applied.
+    assert report.discarded_privileges == {"is_staff", "is_superuser"}
+
+
+@pytest.mark.django_db
+def test_field_level_merge_keeps_canonical_existing_privileges():
+    """A canonical that is already staff/superuser stays so regardless of the
+    duplicate; no privilege is dropped or surfaced as discarded."""
+    canonical = User.objects.create(
+        email="canon@y.com", username="canon", is_staff=True, is_superuser=True
+    )
+    duplicate = User.objects.create(email="dup@y.com", username="dup")
+
+    report = merge_users(canonical=canonical, duplicate=duplicate)
 
     canonical.refresh_from_db()
     assert canonical.is_staff is True
     assert canonical.is_superuser is True
+    assert report.discarded_privileges == set()
 
 
 @pytest.mark.django_db
@@ -527,3 +556,115 @@ def test_merge_conflict_delete_keeps_canonical_tenant_metadata():
     # dangling rows pointing at the deleted membership remain.
     assert TenantMetadata.objects.count() == 1
     assert TenantMetadata.objects.filter(tenant_membership=dup_tm.id).count() == 0
+
+
+@pytest.mark.django_db
+def test_merge_conflict_migrates_duplicate_metadata_when_canonical_has_none():
+    """04#1: both users belong to the same tenant, but only the DUPLICATE's
+    membership carries discovered TenantMetadata. The conflict path must migrate
+    that metadata onto the canonical's bare membership BEFORE deleting the
+    duplicate's row — otherwise the only copy of the discovered metadata is
+    cascade-deleted."""
+    canonical = User.objects.create(email="canon@y.com", username="canon")
+    duplicate = User.objects.create(email="dup@y.com", username="dup")
+    shared = Tenant.objects.create(provider="ocs", external_id="shared1", canonical_name="Shared")
+
+    # Canonical membership has NO metadata.
+    canon_tm = TenantMembership.objects.create(user=canonical, tenant=shared)
+    # Duplicate membership carries the only discovered metadata.
+    dup_tm = TenantMembership.objects.create(user=duplicate, tenant=shared)
+    TenantMetadata.objects.create(
+        tenant_membership=dup_tm,
+        metadata={"team_slug": "alpha", "discovered": True},
+        discovered_at=None,
+    )
+
+    merge_users(canonical=canonical, duplicate=duplicate)
+
+    # The duplicate's membership is gone (conflict-deleted) but its metadata was
+    # migrated onto the canonical's surviving membership — not cascade-deleted.
+    surviving = TenantMembership.objects.get(user=canonical, tenant=shared)
+    assert surviving.id == canon_tm.id
+    md = TenantMetadata.objects.get(tenant_membership=surviving)
+    assert md.metadata == {"team_slug": "alpha", "discovered": True}
+    assert TenantMetadata.objects.count() == 1
+    assert not TenantMembership.objects.filter(pk=dup_tm.pk).exists()
+
+
+@pytest.mark.django_db
+def test_merge_conflict_migrates_duplicate_connection_when_canonical_unwired():
+    """04#1: on a tenant both users share, only the DUPLICATE's membership is
+    wired to a connection. The conflict path must carry that connection wiring
+    onto the canonical's unwired membership so it is not left connection=None."""
+    canonical = User.objects.create(email="canon@y.com", username="canon")
+    duplicate = User.objects.create(email="dup@y.com", username="dup")
+    shared = Tenant.objects.create(provider="ocs", external_id="shared2", canonical_name="Shared2")
+
+    # Canonical's membership is unwired (connection=None).
+    canon_tm = TenantMembership.objects.create(user=canonical, tenant=shared, connection=None)
+    # Duplicate's membership is wired to its OAuth connection.
+    dup_conn = TenantConnection.objects.create(
+        user=duplicate,
+        provider="ocs",
+        credential_type=TenantConnection.OAUTH,
+    )
+    TenantMembership.objects.create(user=duplicate, tenant=shared, connection=dup_conn)
+
+    merge_users(canonical=canonical, duplicate=duplicate)
+
+    surviving = TenantMembership.objects.get(user=canonical, tenant=shared)
+    assert surviving.id == canon_tm.id
+    # The connection moved to canonical (via _merge_tenant_connections) AND the
+    # surviving membership is now wired to it — not left connection=None.
+    surviving.refresh_from_db()
+    assert surviving.connection_id is not None
+    assert surviving.connection.user_id == canonical.pk
+
+
+@pytest.mark.django_db
+def test_merge_conflict_migrates_provider_metadata_when_canonical_empty():
+    """04#1: the JSON provider_metadata (team_slug/team_name) on the duplicate's
+    membership is preserved onto the canonical's membership when the canonical's
+    is empty."""
+    canonical = User.objects.create(email="canon@y.com", username="canon")
+    duplicate = User.objects.create(email="dup@y.com", username="dup")
+    shared = Tenant.objects.create(provider="ocs", external_id="shared3", canonical_name="Shared3")
+
+    TenantMembership.objects.create(user=canonical, tenant=shared, provider_metadata={})
+    TenantMembership.objects.create(
+        user=duplicate,
+        tenant=shared,
+        provider_metadata={"team_slug": "beta", "team_name": "Beta Team"},
+    )
+
+    merge_users(canonical=canonical, duplicate=duplicate)
+
+    surviving = TenantMembership.objects.get(user=canonical, tenant=shared)
+    assert surviving.provider_metadata == {"team_slug": "beta", "team_name": "Beta Team"}
+
+
+@pytest.mark.django_db
+def test_merge_conflict_does_not_clobber_canonical_metadata():
+    """04#1 guardrail: when the canonical membership ALREADY has metadata, the
+    duplicate's conflicting metadata is discarded (cascade) — the canonical's is
+    never overwritten."""
+    canonical = User.objects.create(email="canon@y.com", username="canon")
+    duplicate = User.objects.create(email="dup@y.com", username="dup")
+    shared = Tenant.objects.create(provider="ocs", external_id="shared4", canonical_name="Shared4")
+
+    canon_tm = TenantMembership.objects.create(
+        user=canonical, tenant=shared, provider_metadata={"team_slug": "canon"}
+    )
+    TenantMetadata.objects.create(tenant_membership=canon_tm, metadata={"owner": "canonical"})
+    dup_tm = TenantMembership.objects.create(
+        user=duplicate, tenant=shared, provider_metadata={"team_slug": "dup"}
+    )
+    TenantMetadata.objects.create(tenant_membership=dup_tm, metadata={"owner": "duplicate"})
+
+    merge_users(canonical=canonical, duplicate=duplicate)
+
+    surviving = TenantMembership.objects.get(user=canonical, tenant=shared)
+    assert surviving.provider_metadata == {"team_slug": "canon"}
+    md = TenantMetadata.objects.get(tenant_membership=surviving)
+    assert md.metadata == {"owner": "canonical"}
+    assert TenantMetadata.objects.count() == 1

--- a/tests/test_social_login_reconciliation.py
+++ b/tests/test_social_login_reconciliation.py
@@ -207,6 +207,98 @@ def test_collision_allows_merge_when_canonical_email_verified(caplog):
     assert sl.user == canonical
 
 
+@pytest.mark.django_db
+def test_collision_allows_merge_when_canonical_owns_email_via_trusted_social(caplog):
+    """01#8: the canonical proves ownership of the email through a trusted
+    provider login (a SocialAccount from a VERIFIED_EMAIL provider asserting this
+    email) even when NO standalone verified EmailAddress row exists. The
+    OAuth->OAuth merge proceeds because the canonical legitimately owns the
+    email — robust to allauth not having persisted the EmailAddress row."""
+    canonical = User.objects.create(email="brian@y.com", username="canon")
+    # NO EmailAddress row at all — ownership is proven solely by a prior trusted
+    # OAuth login (commcare is a VERIFIED_EMAIL provider).
+    SocialAccount.objects.create(
+        user=canonical,
+        provider="commcare",
+        uid="111",
+        extra_data={"email": "brian@y.com"},
+    )
+    assert not EmailAddress.objects.filter(user=canonical).exists()
+    duplicate = User.objects.create(email=None, username="connect-user")
+    dup_account = SocialAccount.objects.create(
+        user=duplicate,
+        provider="commcare_connect",
+        uid="999",
+        extra_data={"email": "brian@y.com"},
+    )
+    sl = SimpleNamespace(user=duplicate, account=dup_account)
+
+    reconcile_existing_user_on_login(sender=None, request=None, sociallogin=sl)
+
+    assert not User.objects.filter(pk=duplicate.pk).exists()
+    assert sl.user == canonical
+
+
+@pytest.mark.django_db
+def test_collision_refuses_merge_for_untrusted_social_account(caplog):
+    """01#8 guardrail: a SocialAccount on the canonical from an UNtrusted
+    provider (not in the VERIFIED_EMAIL set) does NOT prove ownership — the merge
+    is still refused so an unverified provider can't be used to absorb an
+    account."""
+    canonical = User.objects.create(email="brian@y.com", username="canon")
+    SocialAccount.objects.create(
+        user=canonical,
+        provider="github",  # not a VERIFIED_EMAIL provider in our settings
+        uid="222",
+        extra_data={"email": "brian@y.com"},
+    )
+    duplicate = User.objects.create(email=None, username="connect-user")
+    dup_account = SocialAccount.objects.create(
+        user=duplicate,
+        provider="commcare_connect",
+        uid="999",
+        extra_data={"email": "brian@y.com"},
+    )
+    sl = SimpleNamespace(user=duplicate, account=dup_account)
+
+    reconcile_existing_user_on_login(sender=None, request=None, sociallogin=sl)
+
+    assert User.objects.filter(pk=duplicate.pk).exists()
+    assert sl.user == duplicate
+
+
+@pytest.mark.django_db
+def test_collision_refuses_merge_for_password_only_canonical(caplog):
+    """01#8 / security seam: a canonical that owns the email ONLY via a password
+    /signup (no verified EmailAddress, no trusted SocialAccount) is still
+    refused — auto-merging an incoming OAuth identity into it would let an
+    attacker who /signup'd with a victim's email absorb the victim's OAuth
+    account. Resolving the password->OAuth path safely needs the #258 allauth
+    email-verification work and a product decision; see PR body."""
+    canonical = User.objects.create(email="brian@y.com", username="canon")
+    canonical.set_password("attacker-chosen")
+    canonical.save()
+    # No EmailAddress row, no SocialAccount — exactly the /signup-bypasses-allauth
+    # state.
+    duplicate = User.objects.create(email=None, username="connect-user")
+    dup_account = SocialAccount.objects.create(
+        user=duplicate,
+        provider="commcare_connect",
+        uid="999",
+        extra_data={"email": "brian@y.com"},
+    )
+    sl = SimpleNamespace(user=duplicate, account=dup_account)
+
+    reconcile_existing_user_on_login(sender=None, request=None, sociallogin=sl)
+
+    assert User.objects.filter(pk=duplicate.pk).exists()
+    assert User.objects.filter(pk=canonical.pk).exists()
+    assert sl.user == duplicate
+    assert any(
+        r.levelname == "WARNING" and "Refusing auto-merge" in r.message for r in caplog.records
+    )
+
+
 def test_signal_is_wired_in_app_ready():
     receivers = [entry[1]() for entry in pre_social_login.receivers if entry[1]() is not None]
     receiver_names = [getattr(r, "__name__", "") for r in receivers]


### PR DESCRIPTION
## What & why

Closes #259. Fixes the four findings in the `account-merge-correctness` cluster.

### `11#4` (security) — privilege escalation through merge
`merge_users` OR-propagated `is_staff`/`is_superuser` from the deleted duplicate onto the canonical, invisible at the y/N confirmation prompt. Merging a stale `createsuperuser` dev artifact into a normal OAuth user silently promoted that user to production superuser.

- `_merge_user_fields` no longer touches `is_staff`/`is_superuser`. The canonical keeps its own privilege flags unchanged — **never escalates from the discarded duplicate** (safest default per the issue).
- New `_discarded_privileges` helper reports which privilege flags the duplicate held that the canonical lacked, on `MergeReport.discarded_privileges` (set, also populated in the dry-run plan).
- `merge_duplicate_users._print_plan` now prints a `WARNING` line when the discarded duplicate is privileged, so the escalation/teardown is **visible at the y/N prompt** — but the privilege is still never applied.

### `04#1` (correctness) — conflict path cascade-deletes TenantMetadata / orphans connection
`_merge_tenant_memberships` deleted the duplicate's conflicting `TenantMembership` when the canonical already had that tenant. `TenantMetadata` is a `OneToOne(CASCADE)` on `TenantMembership`, so discovered provider/team metadata riding on the duplicate's membership was destroyed even when the canonical's had none; the survivor could also be left `connection=None` when only the duplicate's was wired.

- New `_migrate_conflicting_membership`: before deleting the conflicting duplicate row, it migrates the duplicate's `TenantMetadata`, `provider_metadata`, and `connection` wiring onto the canonical's surviving membership **only when the canonical lacks each** — never clobbering the canonical's own discovered data.
- `_merge_tenant_memberships` rewritten from a bulk `.delete()`/`.update()` into a per-row loop so the migration can run before each conflict-delete; returns a new `metadata_migrated` count (`MergeReport.tenant_membership_metadata_migrated`).
- Ordering note: this runs before `_merge_tenant_connections`, which repoints the connection *row* to the canonical user; wiring the surviving membership to `dup_m.connection_id` here keeps it consistent after that repoint (and remains correct if the connection is later OAuth-conflict-merged).

### `01#8` (correctness, subtle — coordinated with #258) — verified-email merge gate
`reconcile_existing_user_on_login` refused auto-merge unless the canonical had a verified `EmailAddress`. At the arch-review snapshot the system produced none, so the gate was effectively dead. Since then the three providers' `extract_email_addresses` overrides (incl. OCS's `email_verified` claim) **do** create verified `EmailAddress` rows on OAuth login, so the OAuth→OAuth case already works. The residual incoherence is the **password→OAuth** path.

- Extracted the gate into `_canonical_provably_owns_email`, which accepts ownership proven by **either** a verified `EmailAddress` **or** a trusted-provider (`VERIFIED_EMAIL: True`) `SocialAccount` asserting the same email. This makes the trust model explicit and the OAuth→OAuth path robust even if allauth didn't persist the `EmailAddress` row, without weakening any refusal.
- Trusted providers are derived from `SOCIALACCOUNT_PROVIDERS[*]["VERIFIED_EMAIL"] is True` (read-only — no allauth config changed).

**#258 seam (left intentionally):** a canonical that owns the email *only* via a password `/signup` (no verified `EmailAddress`, no trusted `SocialAccount`) is still **refused**. Auto-linking it would re-open the takeover vector closed by commit `1dc1d58` (attacker `/signup`s a victim's email, victim's next OAuth login gets absorbed). Closing that path safely needs allauth-side email verification at signup, which is the **#258** (allauth perimeter) lane. I did **not** touch the allauth email backend, `ACCOUNT_EMAIL_VERIFICATION`, or the rate-limiter. The decision-logic half I own is coherent; the password→OAuth resolution depends on #258.

### `11#9` (historical — no code change)
Migration `0004_deduplicate_tenant_memberships` is already applied and is **not** rewritten. It shares the earliest-row-kept / CASCADE-`TenantMetadata` pattern with the live merge path; that live pattern is now fixed by `04#1`. No forward data migration is added: at `0004`'s execution time (2026-04-22) provider-metadata discovery and the OCS team-metadata loaders did not yet exist, so there is no recoverable lost row to repair, and a corrective migration would be guesswork over an already-executed dedup. Ticked off as historical/no-action.

## Sibling sweep (required on bug/incident fixes)

- **Grep used:**
  - Privilege OR-propagation: `grep -rn 'is_staff|is_superuser' apps --include=*.py` + `grep -rn '|=' apps`
  - CASCADE OneToOne metadata a merge/dedup could destroy: `grep -rn 'OneToOneField' apps --include=*.py`
  - Reconcile gates on never-produced verified state: `grep -rn 'EmailAddress|verified' apps/users/signals.py apps/users/services/merge.py`
- **Sibling sites found & disposition:**
  - [x] `apps/users/services/merge.py` `_merge_user_fields` — **fixed** (the only privilege OR-propagation site).
  - [x] `apps/knowledge/api/views.py:88` `search_q |= Q(...)` — not applicable (search-filter Q-object OR, not a privilege flag).
  - [x] `apps/workspaces/models.py:266` `TenantMetadata.tenant_membership` CASCADE OneToOne — **fixed** (the `04#1` site).
  - [x] `apps/workspaces/models.py:222` `WorkspaceViewSchema.workspace` CASCADE OneToOne — not applicable: it cascades off `Workspace`, and the user-merge path never deletes a `Workspace` (only repoints/merges memberships), so no merge/dedup path can destroy it.
  - [x] `reconcile_existing_user_on_login` gate — **fixed** (the only reconcile gate; made coherent via `_canonical_provably_owns_email`).

## Testing

`uv run pytest tests/test_merge_users_service.py tests/test_social_login_reconciliation.py tests/test_merge_duplicate_users_command.py tests/test_provider_email_verification.py tests/test_auth.py tests/test_oauth_domain_restriction.py tests/test_async_conventions.py` — all green. New/updated tests (TDD, red→green):

- `11#4`: `test_field_level_merge_never_escalates_staff_or_superuser_from_duplicate`, `test_field_level_merge_keeps_canonical_existing_privileges`, command `test_dry_run_surfaces_discarded_privilege_at_prompt`, `test_yes_flag_merge_does_not_escalate_canonical_privileges` (replaces the old `..._ors_staff_and_superuser_flags` test that pinned the vulnerable behavior).
- `04#1`: `test_merge_conflict_migrates_duplicate_metadata_when_canonical_has_none`, `..._migrates_duplicate_connection_when_canonical_unwired`, `..._migrates_provider_metadata_when_canonical_empty`, `..._does_not_clobber_canonical_metadata`.
- `01#8`: `test_collision_allows_merge_when_canonical_owns_email_via_trusted_social`, `test_collision_refuses_merge_for_untrusted_social_account`, `test_collision_refuses_merge_for_password_only_canonical`.

`ruff check` / `ruff format` clean; `makemigrations --check` reports no model changes (no migration needed).

## Notes for reviewers

- **#258 dependency:** the password→OAuth auto-link gap (`01#8`) is deliberately left refused; it needs #258's allauth email-verification work + a product decision on trusting password-signup emails. See the `01#8` section above.
- No DB migration: all changes are behavioral in the merge service / signal / command.
- `_merge_tenant_memberships` changed from set-based bulk ops to a per-row loop; merge groups are small (duplicate accounts for one human), so the cost is negligible and it stays inside the existing `transaction.atomic()` block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HpAA218jN8dR5SMJTM3Ur4