### PR TITLE
arch #258: close the second (stock-allauth /accounts/) auth perimeter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,9 +39,13 @@ ANTHROPIC_API_KEY=
 # JSON object keyed by allauth provider id ("commcare", "commcare_connect",
 # "ocs"); each value is a list of lowercase domains.
 # A provider absent from the dict (or with an empty list) is unrestricted.
-# A login that returns no email bypasses the check.
-# Defaults to ["dimagi.com"] for each of commcare, commcare_connect, and ocs if unset.
-# SOCIALACCOUNT_ALLOWED_EMAIL_DOMAINS={"commcare": ["dimagi.com"], "commcare_connect": ["dimagi.com"], "ocs": ["dimagi.com"]}
+# For a provider WITH a non-empty list, a login that returns no email is REJECTED
+# (a missing email can't satisfy a configured restriction — arch #258 / 07#2).
+# Coded default (config/settings/base.py) restricts ONLY "commcare" to
+# ["dimagi.com"]. commcare_connect and ocs are deliberately left open (no
+# domain restriction) and must NOT be added here unless you intend to restrict
+# them. Override the whole map at deploy time if needed:
+# SOCIALACCOUNT_ALLOWED_EMAIL_DOMAINS={"commcare": ["dimagi.com"]}
 
 # Langfuse tracing (optional — leave blank to disable)
 LANGFUSE_SECRET_KEY=

--- a/apps/users/adapters.py
+++ b/apps/users/adapters.py
@@ -78,20 +78,25 @@ class EncryptingSocialAccountAdapter(DefaultSocialAccountAdapter):
         is created or login session established. Configured by the
         SOCIALACCOUNT_ALLOWED_EMAIL_DOMAINS setting (provider id -> list of
         allowed email domains). A provider with no entry (or an empty list) is
-        unrestricted; a login that returns no email is allowed regardless.
+        unrestricted.
+
+        For a provider WITH a non-empty allow-list, a login that returns no email
+        is rejected (arch #258, finding 07#2): a missing email must not silently
+        bypass a configured domain restriction. Providers Scout deliberately
+        leaves open (Connect, OCS) carry no allow-list, so their no-email logins
+        are unaffected by this gate.
         """
         provider = sociallogin.account.provider
         allowed = settings.SOCIALACCOUNT_ALLOWED_EMAIL_DOMAINS.get(provider) or []
         if not allowed:
             return
 
-        email = (sociallogin.user.email or "").strip().lower()
-        if not email:
-            return
-
-        domain = email.rpartition("@")[2]
         allowed_lower = [d.lower() for d in allowed]
-        if domain in allowed_lower:
+        email = (sociallogin.user.email or "").strip().lower()
+        # A configured allow-list means this provider is restricted; a no-email
+        # login can't be confirmed to satisfy it, so reject rather than bypass.
+        domain = email.rpartition("@")[2] if email else ""
+        if domain and domain in allowed_lower:
             return
 
         provider_class = providers_registry.get_class(provider)

--- a/apps/users/allauth_urls.py
+++ b/apps/users/allauth_urls.py
@@ -1,0 +1,42 @@
+"""Narrowed allauth URL surface (arch #258, finding 13#9).
+
+Scout's SPA owns the human-facing auth UI: email/password login + signup live at
+``/api/auth/`` (rate-limited, CSRF-protected) and social login is initiated from
+React via the provider login URLs returned by ``/api/auth/providers/``.
+
+Stock allauth (``include('allauth.urls')``) additionally mounts a *second*,
+ungoverned HTML auth perimeter parallel to the SPA: open self-registration
+(``/accounts/signup/``), an HTML login form, password reset, email management,
+and the ``3rdparty/`` HTML connection views. None of those are surfaced by the
+SPA, none are covered by Scout's per-email rate limiter, and password
+reset/email verification can't deliver in production (no MTA — see 14#0). They
+are pure attack surface.
+
+This module mounts ONLY the routes the SPA / OAuth round-trip actually needs:
+
+* per-provider ``<provider>/login/`` and ``<provider>/login/callback/`` routes
+  (built by ``build_provider_urlpatterns``) — the SPA links to these,
+* the OAuth ``login/cancelled/`` and ``login/error/`` landing pages,
+* an ``account_login`` *name* that redirects to the SPA root, so allauth's
+  ``LOGIN_URL`` default and the adapter's allowlist-rejection redirect
+  (``redirect("account_login")``) still resolve without rendering an HTML form.
+
+It deliberately does NOT include ``allauth.account.urls`` or the
+``allauth.socialaccount.urls`` (``3rdparty/``) HTML views.
+"""
+
+from allauth.socialaccount.views import login_cancelled, login_error
+from allauth.urls import build_provider_urlpatterns
+from django.urls import path
+from django.views.generic.base import RedirectView
+
+# Note: allauth's LOGIN_REDIRECT_URL/LOGIN_URL and our adapter both reference the
+# "account_login" view name. We keep the *name* resolvable but point it at the
+# SPA root rather than the stock HTML login form. The SPA renders its own login
+# UI and surfaces any queued allauth messages on the next page load.
+urlpatterns = [
+    path("login/", RedirectView.as_view(url="/", query_string=True), name="account_login"),
+    path("login/cancelled/", login_cancelled, name="socialaccount_login_cancelled"),
+    path("login/error/", login_error, name="socialaccount_login_error"),
+    *build_provider_urlpatterns(),
+]

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -218,8 +218,12 @@ ACCOUNT_EMAIL_VERIFICATION = "optional"
 ACCOUNT_DEFAULT_HTTP_PROTOCOL = env("ACCOUNT_DEFAULT_HTTP_PROTOCOL", default="http")
 
 # Social account settings
+# Require POST (not GET) to initiate OAuth, so /accounts/<provider>/login/ can't
+# be triggered by a forged GET (login CSRF). allauth renders a short CSRF-token
+# "Continue with <provider>" interstitial on GET that POSTs to the same URL.
+# (arch #258, finding 14#2.)
+SOCIALACCOUNT_LOGIN_ON_GET = False
 # Auto-create Django user on first OAuth login
-SOCIALACCOUNT_LOGIN_ON_GET = True
 SOCIALACCOUNT_AUTO_SIGNUP = True
 # Don't require email for OAuth signups (Connect doesn't provide one)
 SOCIALACCOUNT_EMAIL_REQUIRED = False
@@ -237,6 +241,17 @@ SOCIALACCOUNT_ADAPTER = "apps.users.adapters.EncryptingSocialAccountAdapter"
 # Redirect URLs after login/logout
 LOGIN_REDIRECT_URL = "/"
 LOGOUT_REDIRECT_URL = "/"
+
+# Email backend (arch #258, finding 14#0).
+# Django's default is the SMTP backend pointed at localhost:25; a container with
+# no local MTA would silently fail (or 500) on any send. Scout's HTML
+# password-reset / email-verification surface is no longer mounted (13#9), so no
+# email-dependent flow is reachable by default and the safe default is the
+# console backend. Override at deploy time with EMAIL_BACKEND (and the standard
+# EMAIL_HOST/EMAIL_PORT/... vars) to stand up real transactional email — see the
+# DEFAULT_FROM_EMAIL note below.
+EMAIL_BACKEND = env("EMAIL_BACKEND", default="django.core.mail.backends.console.EmailBackend")
+DEFAULT_FROM_EMAIL = env("DEFAULT_FROM_EMAIL", default="webmaster@localhost")
 
 # Provider-specific settings (credentials stored in DB via Django admin SocialApp model)
 # Configure client IDs and secrets via Django admin at /admin/socialaccount/socialapp/

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -274,8 +274,10 @@ SOCIALACCOUNT_PROVIDERS = {
 # Map of allauth provider id -> list of allowed email domains (lowercase, exact match).
 # A provider absent from the dict (or mapped to an empty list) is unrestricted.
 # A provider with a non-empty list rejects OAuth logins whose email domain isn't in the list.
-# A login that returns no email is allowed regardless (best-effort: covers providers like
-# Connect that don't return an email).
+# For a provider WITH a non-empty list, a login that returns no email is REJECTED
+# (a missing email can't satisfy a configured restriction — arch #258, finding 07#2).
+# Unrestricted providers (no/empty list — e.g. the deliberately-open Connect/OCS)
+# still allow no-email logins.
 # Override at deploy time with the SOCIALACCOUNT_ALLOWED_EMAIL_DOMAINS env var (JSON).
 SOCIALACCOUNT_ALLOWED_EMAIL_DOMAINS: dict[str, list[str]] = env.json(
     "SOCIALACCOUNT_ALLOWED_EMAIL_DOMAINS",

--- a/config/urls.py
+++ b/config/urls.py
@@ -80,7 +80,11 @@ urlpatterns = [
     path("widget.js", widget_js_view, name="widget-js"),
     path("health/", health_check, name="health_check"),
     path("admin/", admin.site.urls),
-    path("accounts/", include("allauth.urls")),
+    # Narrowed allauth surface: only the OAuth provider login/callback routes the
+    # SPA needs. The stock allauth HTML auth perimeter (open self-registration,
+    # password reset, email management) is deliberately NOT mounted — see
+    # apps/users/allauth_urls.py (arch #258, finding 13#9).
+    path("accounts/", include("apps.users.allauth_urls")),
     # Workspace-scoped content APIs
     path("api/workspaces/", WorkspaceListView.as_view(), name="workspace_list"),
     path(

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -135,10 +135,11 @@ class TestDjangoAllauthConfiguration:
         assert settings.SOCIALACCOUNT_EMAIL_AUTHENTICATION_AUTO_CONNECT is True
         assert settings.SOCIALACCOUNT_EMAIL_VERIFICATION == "none"
 
-    def test_socialaccount_login_on_get_enabled(self, settings):
-        """SOCIALACCOUNT_LOGIN_ON_GET=True skips the unnecessary allauth confirmation
-        page. Login CSRF risk is mitigated by the OAuth provider's own authorize screen."""
-        assert settings.SOCIALACCOUNT_LOGIN_ON_GET is True
+    def test_socialaccount_login_on_get_disabled(self, settings):
+        """SOCIALACCOUNT_LOGIN_ON_GET=False requires a POST (with CSRF token) to
+        initiate OAuth, closing login-CSRF on GET (arch #258, finding 14#2).
+        allauth renders a short "Continue with <provider>" interstitial on GET."""
+        assert settings.SOCIALACCOUNT_LOGIN_ON_GET is False
 
     def test_site_id_configured(self, settings):
         """Test that SITE_ID is set for django.contrib.sites."""

--- a/tests/test_auth_perimeter.py
+++ b/tests/test_auth_perimeter.py
@@ -1,0 +1,128 @@
+"""Tests for closing the second (stock-allauth /accounts/) auth perimeter (arch #258).
+
+Covers:
+- 13#9 — the dangerous allauth HTML surface (open self-registration, HTML login,
+  password reset, email management) is no longer mounted, while the SPA-required
+  OAuth provider login/callback routes STILL resolve.
+- 14#2 — SOCIALACCOUNT_LOGIN_ON_GET is False (require POST to initiate OAuth;
+  closes login-CSRF on GET).
+- 14#1 — no allauth HTML login/signup form remains reachable, so the brute-force
+  budget can't be split across a second un-rate-limited surface.
+- 14#0 — an explicit EMAIL_BACKEND is configured so prod never silently falls
+  back to SMTP localhost:25.
+- 07#2 — a provider WITH a configured allowlist can't be bypassed by a no-email
+  login; the .env.example default matches the coded default.
+"""
+
+import pytest
+from django.conf import settings
+from django.test import Client
+from django.urls import NoReverseMatch, Resolver404, resolve, reverse
+
+# --- 13#9: dangerous allauth HTML routes are no longer mounted ------------- #
+
+# Stock-allauth HTML views that constitute the second registration/auth
+# perimeter. None of these should be reachable once the narrowed include lands.
+DANGEROUS_ALLAUTH_ROUTE_NAMES = [
+    "account_signup",  # open self-registration
+    "account_email",  # email management
+    "account_reset_password",  # password reset (broken email backend)
+    "account_change_password",
+    "account_set_password",
+    "account_reauthenticate",
+    "socialaccount_signup",  # 3rdparty HTML signup
+    "socialaccount_connections",  # 3rdparty HTML connection management
+]
+
+# allauth route names the SPA / OAuth flow depend on. These MUST keep resolving.
+SPA_REQUIRED_PROVIDER_ROUTE_NAMES = [
+    "google_login",
+    "github_login",
+    "commcare_login",
+    "commcare_connect_login",
+    "ocs_login",
+    "google_callback",
+    "commcare_callback",
+    "commcare_connect_callback",
+    "ocs_callback",
+]
+
+
+class TestDangerousHtmlSurfaceRemoved:
+    @pytest.mark.parametrize("name", DANGEROUS_ALLAUTH_ROUTE_NAMES)
+    def test_route_name_does_not_resolve(self, name):
+        """The dangerous HTML view names must not be registered at all."""
+        with pytest.raises(NoReverseMatch):
+            reverse(name)
+
+    def test_signup_path_returns_404(self):
+        """The open self-registration form must be unreachable by path."""
+        with pytest.raises(Resolver404):
+            resolve("/accounts/signup/")
+
+    def test_password_reset_path_returns_404(self):
+        with pytest.raises(Resolver404):
+            resolve("/accounts/password/reset/")
+
+    def test_email_management_path_returns_404(self):
+        with pytest.raises(Resolver404):
+            resolve("/accounts/email/")
+
+    @pytest.mark.django_db
+    def test_signup_http_request_is_404(self):
+        """A live GET to the open-signup form must 404, not render a form."""
+        resp = Client().get("/accounts/signup/")
+        assert resp.status_code == 404
+
+    @pytest.mark.django_db
+    def test_password_reset_http_request_is_404(self):
+        resp = Client().get("/accounts/password/reset/")
+        assert resp.status_code == 404
+
+
+# --- 13#9: SPA-required OAuth routes still resolve -------------------------- #
+
+
+class TestSpaOauthRoutesPreserved:
+    @pytest.mark.parametrize("name", SPA_REQUIRED_PROVIDER_ROUTE_NAMES)
+    def test_provider_route_still_resolves(self, name):
+        """Provider login/callback routes the SPA links to must keep resolving."""
+        # Should not raise NoReverseMatch.
+        url = reverse(name)
+        assert url.startswith("/accounts/")
+
+    def test_commcare_login_path_resolves(self):
+        """The exact path the SPA anchors to (commcare/login/) must resolve."""
+        match = resolve("/accounts/commcare/login/")
+        assert match is not None
+
+    def test_account_login_name_still_reverses(self):
+        """The adapter redirects to account_login on allowlist rejection;
+        the name must remain resolvable (even if it no longer renders a form)."""
+        url = reverse("account_login")
+        assert url  # resolves to something
+
+    def test_oauth_error_landing_routes_resolve(self):
+        """OAuth cancel/error landing pages are part of the provider flow."""
+        assert reverse("socialaccount_login_cancelled")
+        assert reverse("socialaccount_login_error")
+
+
+# --- 14#2: LOGIN_ON_GET requires POST -------------------------------------- #
+
+
+class TestLoginOnGetDisabled:
+    def test_socialaccount_login_on_get_is_false(self):
+        assert settings.SOCIALACCOUNT_LOGIN_ON_GET is False
+
+
+# --- 14#0: explicit email backend ------------------------------------------ #
+
+
+class TestEmailBackendConfigured:
+    def test_email_backend_is_set_explicitly(self):
+        """base.py must set EMAIL_BACKEND so prod never silently uses SMTP
+        localhost:25 (which has no MTA in the container)."""
+        assert settings.EMAIL_BACKEND
+        # Must not be the Django SMTP default that points at localhost:25.
+        assert settings.EMAIL_BACKEND != "django.core.mail.backends.smtp.EmailBackend"

--- a/tests/test_oauth_domain_restriction.py
+++ b/tests/test_oauth_domain_restriction.py
@@ -71,9 +71,21 @@ class TestPreSocialLoginEnforcement:
         assert "@dimagi.com" in messages[0].message
 
     @override_settings(SOCIALACCOUNT_ALLOWED_EMAIL_DOMAINS={"commcare": ["dimagi.com"]})
-    def test_empty_email_allowed(self, adapter):
+    def test_empty_email_blocked_for_restricted_provider(self, adapter):
+        """07#2: a provider WITH a configured allow-list must not be bypassed by
+        a login that returns no email — a missing email can't satisfy the gate."""
         request = _make_request()
         sociallogin = _make_sociallogin("commcare", "")
+        with pytest.raises(ImmediateHttpResponse):
+            adapter.pre_social_login(request, sociallogin)
+
+    @override_settings(SOCIALACCOUNT_ALLOWED_EMAIL_DOMAINS={"commcare": ["dimagi.com"]})
+    def test_empty_email_allowed_for_unrestricted_provider(self, adapter):
+        """A provider with no allow-list (Connect/OCS) is deliberately open, so a
+        no-email login there is still allowed — the 07#2 fix must not impose a
+        new restriction on the intentionally-open providers."""
+        request = _make_request()
+        sociallogin = _make_sociallogin("commcare_connect", "")
         assert adapter.pre_social_login(request, sociallogin) is None
 
     @override_settings(SOCIALACCOUNT_ALLOWED_EMAIL_DOMAINS={})


### PR DESCRIPTION
## What & why

Closes #258.

Stock allauth was mounted via `include('allauth.urls')` at `/accounts/`, exposing a **second, ungoverned HTML auth perimeter** parallel to the SPA's `/api/auth/` paths: open self-registration, an HTML login form, password reset, email management, and the `3rdparty/` HTML connection views. The SPA never surfaces those, none are covered by Scout's per-email rate limiter, and password-reset/verification can't deliver in production. This PR closes that surface while **preserving the OAuth provider login/callback routes the SPA actually depends on**.

### Finding-by-finding

**`13#9` — second HTML auth perimeter (security).** Replaced `include('allauth.urls')` with a narrowed include (`apps/users/allauth_urls.py`) that mounts ONLY:
- per-provider `<provider>/login/` + `<provider>/login/callback/` routes (`build_provider_urlpatterns()`) — the SPA links to these,
- the OAuth `login/cancelled/` + `login/error/` landing pages,
- an `account_login` **name** that redirects to the SPA root (so allauth's `LOGIN_URL` default and the adapter's allowlist-rejection `redirect("account_login")` still resolve without rendering an HTML form).

It deliberately drops `allauth.account.urls` (signup/login/password/email) and the `3rdparty/` socialaccount HTML views. New test `tests/test_auth_perimeter.py` asserts the dangerous routes 404 and the SPA provider routes still resolve.

**`14#2` — LOGIN_ON_GET + AUTO_CONNECT (security).** Set `SOCIALACCOUNT_LOGIN_ON_GET=False` so OAuth can't be initiated by a forged GET (login CSRF). **Left `SOCIALACCOUNT_EMAIL_AUTHENTICATION_AUTO_CONNECT=True`** — #259's account-merge gate deliberately relies on trusted-provider auto-connect, and `test_auth_settings.py` pins it; with GET-initiation closed the residual forced-link vector is much reduced. See fork note below.

**`14#1` — rate-limiter split (security).** Mooted by 13#9: no allauth HTML login/signup form remains reachable, so the only remaining auth surfaces are the SPA's `/api/auth/` paths (already rate-limited via `apps/users/rate_limiting.py`) and admin login (throttled by #260). The brute-force budget can no longer be split across a second un-limited surface.

**`14#0` — no working email backend (correctness).** Added an explicit `EMAIL_BACKEND` (and `DEFAULT_FROM_EMAIL`) to `base.py`, defaulting to the **console backend** and overridable via the `EMAIL_BACKEND` env var, so prod never silently falls back to Django's SMTP-`localhost:25` default. Since the HTML password-reset/verification surface is now unmounted (13#9), no email-dependent flow is reachable-but-broken. See fork note below.

**`07#2` — OCS allowlist open-by-default + no-email bypass (security).** Per the deliberate product decision that **Connect and OCS are NOT domain-limited**, I did **not** add any new domain restriction to those providers. The legitimate fixes:
- (a) **Reconciled `.env.example`** with the coded default — the comment claimed the default restricted commcare, commcare_connect, AND ocs; the code restricts only commcare. The comment now matches and documents Connect/OCS as intentionally open.
- (b) **Closed the no-email bypass** in `adapters.py`: a provider WITH a non-empty allow-list now rejects a no-email login (a missing email can't satisfy a configured restriction). Providers with no/empty allow-list (Connect, OCS) are unchanged — their no-email logins are still allowed.

## Sibling sweep (required on bug/incident fixes)

- **Greps used:**
  - `grep -rn "allauth.urls\|allauth.account.urls\|allauth.socialaccount.urls\|allauth.headless" apps/ config/` — only the one mount existed; no headless mount.
  - `grep -rn "LOGIN_ON_GET\|AUTO_CONNECT\|AUTO_SIGNUP\|is_open_for_signup\|ACCOUNT_ADAPTER" apps/ config/` — no other LOGIN_ON_GET/auto-connect sites.
  - `grep -rn "create_user\|register\b\|signup" apps/ config/` — `create_user` only in `auth_views.py:165` (SPA signup, already rate-limited); no other registration surface.
  - `grep -rn "send_mail\|EmailMessage\|send_email\|get_connection\|mail_admins" apps/ config/ mcp_server/` — no app-level email-sending code; the only email-dependent surface was allauth's (now unmounted).
- **Sibling sites found & disposition:**
  - [x] `config/urls.py` allauth mount — fixed (narrowed include).
  - [x] `apps/users/adapters.py` no-email bypass — fixed.
  - [x] `.env.example` allowlist doc — fixed (reconciled).
  - [x] `apps/users/auth_views.py:165` SPA signup — N/A: already rate-limited + email-uniqueness guarded; this is the intended SPA registration path, not a second perimeter.
  - [x] no other allauth.urls includes / LOGIN_ON_GET / app-level email senders — none found.

## Testing

- New `tests/test_auth_perimeter.py` (27 tests): dangerous HTML routes 404 (by name, by path resolution, and via live HTTP request); SPA provider login/callback routes still resolve; `account_login` still reverses; OAuth error landings resolve; `LOGIN_ON_GET=False`; `EMAIL_BACKEND` set and not the SMTP default.
- Updated `tests/test_oauth_domain_restriction.py`: flipped the old no-email-allowed assertion to assert rejection for a restricted provider; added a test that a no-allowlist (open) provider still allows no-email logins.
- Updated `tests/test_auth.py::test_socialaccount_login_on_get_disabled`.
- `uv run pytest` on the full auth surface (214 tests) passes; `ruff check`, `ruff format --check`, `manage.py makemigrations --check`, `manage.py check --settings=config.settings.production`, and `test_async_conventions.py` all clean. No frontend changes (backend-only).

## Notes for reviewers — forks I'm surfacing (Brian to decide)

1. **SPA OAuth UX impact of `LOGIN_ON_GET=False` (verified safe, not breaking):** the SPA initiates social login via GET anchor links (`LoginForm.tsx`, `ConnectionsPage.tsx` `?process=connect`, `OnboardingWizard.tsx`). With `LOGIN_ON_GET=False`, a GET to `/accounts/<provider>/login/` now renders allauth's short "Continue with <provider>" interstitial (a CSRF-token POST form) instead of redirecting straight to the provider — login still completes, just with one extra click. Verified by reading `allauth/socialaccount/providers/base/utils.py::respond_to_login_on_get` and route resolution. **If you'd rather avoid the extra click, the follow-up is a small SPA change to POST to the login URL (with the CSRF token) instead of using a GET anchor** — flag if you want that.

2. **`EMAIL_BACKEND` / transactional email (14#0 + #259 merge-gate seam):** I set a safe console default so prod doesn't silently hit `localhost:25`. The HTML email surface is now closed, so nothing is reachable-but-broken. **Decision for you:** does Scout want a *real* transactional email backend? Standing one up would (a) re-enable a governed verification path and (b) unlock the #259 account-merge gate's "verified email" requirement for the password→OAuth case (the `_canonical_provably_owns_email` SEAM in `signals.py`). I did NOT stand up SMTP myself per the guardrail.

3. **`AUTO_CONNECT` left enabled (14#2):** I kept `SOCIALACCOUNT_EMAIL_AUTHENTICATION_AUTO_CONNECT=True` because #259 relies on it and `test_auth_settings.py` pins it. With GET-initiation closed the forced-link vector is reduced. Tell me if you want it disabled (would need coordination with #259's merge logic).

I stayed out of `apps/users/signals.py` entirely (Cluster C's #256 lane + #259's reconcile gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HpAA218jN8dR5SMJTM3Ur4