### PR TITLE
[arch #256] Truthful failure: stop rendering errors as success

### DIFF
--- a/apps/agents/graph/base.py
+++ b/apps/agents/graph/base.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import copy
 import hashlib
+import json
 import logging
 import time
 from typing import TYPE_CHECKING, Any, Literal
@@ -109,8 +110,58 @@ SCHEMA_CONTEXT_CHAR_BUDGET = 6000
 # messages all carry one of these error codes, the agent has drifted from
 # self-correction into a panic loop — route to the escalation node so the
 # turn ends with an explicit ask instead of consuming the recursion budget.
-ESCALATION_ERROR_CODES = ('"code": "NOT_FOUND"', '"code": "VALIDATION_ERROR"')
+#
+# These are the bare ``error.code`` values from the MCP envelope
+# (mcp_server.envelope), matched against the parsed JSON ``error.code`` field —
+# NOT a substring search. The previous implementation substring-matched
+# ``'"code": "NOT_FOUND"'`` (with a space after the colon), which only worked
+# because FastMCP serialized with ``indent=2``; a switch to compact separators
+# would have silently disabled the breaker (06#1). They are also the single
+# source of truth shared with the base system prompt's "When the Schema is
+# Broken" rule (see apps/agents/prompts/base_system.py).
+ESCALATION_ERROR_CODES = frozenset({"NOT_FOUND", "VALIDATION_ERROR"})
 ESCALATION_TRIGGER_COUNT = 3
+
+
+def _tool_message_error_code(content: Any) -> str | None:
+    """Extract the MCP envelope ``error.code`` from a ToolMessage's content.
+
+    Tool content may be a JSON string, a list of content blocks (the shape
+    langchain_mcp_adapters emits), or already-parsed structures. We parse the
+    JSON and read ``error.code`` so the panic-loop detector keys off the
+    structured field rather than a whitespace-sensitive substring (06#1).
+    Returns None when the content isn't a recognizable error envelope.
+    """
+    if isinstance(content, list):
+        # Content-block list: try each text block until one parses to an error.
+        for block in content:
+            text = None
+            if isinstance(block, dict) and block.get("type") == "text":
+                text = block.get("text")
+            elif isinstance(block, str):
+                text = block
+            if text:
+                code = _tool_message_error_code(text)
+                if code is not None:
+                    return code
+        return None
+    if isinstance(content, dict):
+        envelope = content
+    elif isinstance(content, str):
+        try:
+            envelope = json.loads(content)
+        except (ValueError, TypeError):
+            return None
+    else:
+        return None
+    if not isinstance(envelope, dict) or envelope.get("success") is not False:
+        return None
+    error = envelope.get("error")
+    if isinstance(error, dict):
+        code = error.get("code")
+        return code if isinstance(code, str) else None
+    return None
+
 
 ESCALATION_MESSAGE = (
     "I've encountered repeated schema errors — the tables I expected to "
@@ -123,9 +174,12 @@ def _should_escalate(messages: list) -> bool:
     """Detect a panic loop: last N tool messages all returned an error code.
 
     Looks only at trailing ``ToolMessage``s — a successful tool call in
-    between resets the streak. Substring matches the error envelope's
-    ``"code": "..."`` field rather than parsing JSON, since tool content
-    may be a string, list of content blocks, or other shapes.
+    between resets the streak. Parses each tool message's JSON envelope and
+    matches the structured ``error.code`` value against
+    ``ESCALATION_ERROR_CODES`` (06#1) rather than substring-searching the raw
+    text, so a serialization/whitespace change can't silently disable the
+    breaker and an unrelated row containing the literal "NOT_FOUND" can't
+    falsely trip it.
     """
     streak: list[ToolMessage] = []
     for msg in reversed(messages):
@@ -142,8 +196,8 @@ def _should_escalate(messages: list) -> bool:
         return False
 
     for tm in streak:
-        content = tm.content if isinstance(tm.content, str) else str(tm.content)
-        if not any(code in content for code in ESCALATION_ERROR_CODES):
+        code = _tool_message_error_code(tm.content)
+        if code not in ESCALATION_ERROR_CODES:
             return False
     return True
 

--- a/apps/chat/helpers.py
+++ b/apps/chat/helpers.py
@@ -15,6 +15,16 @@ from apps.workspaces.models import WorkspaceMembership
 logger = logging.getLogger(__name__)
 
 
+class CheckpointerUnavailable(Exception):
+    """Raised when the LangGraph checkpointer can't be reached/read.
+
+    Distinguishes a genuine outage (DB/checkpointer blip) from a thread that is
+    legitimately empty (no checkpoint written yet). Callers that load message
+    history must surface this as an error (non-200) rather than swallowing it
+    into an empty result that reads as "conversation deleted" (arch #256, 07#7).
+    """
+
+
 async def repair_dangling_tool_calls(agent, config) -> list[ToolMessage]:
     """Return synthetic ToolMessages for any tool_use calls that were never answered.
 

--- a/apps/chat/stream.py
+++ b/apps/chat/stream.py
@@ -25,14 +25,16 @@ Chunk types used:
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import logging
+import time
 import uuid
 from collections.abc import AsyncGenerator
 from typing import Any
 
 from anthropic import APIStatusError, InternalServerError, RateLimitError
-from langchain_core.messages import ToolMessage
+from langchain_core.messages import AIMessage, ToolMessage
 
 from apps.agents.graph.base import INJECTED_TOOL_PARAMS
 
@@ -86,6 +88,16 @@ def _sse(chunk: dict) -> str:
     whole stream -- it is coerced to its string form rather than raising.
     """
     return f"data: {json.dumps(chunk, default=str)}\n\n"
+
+
+def _error_ref(exc: BaseException) -> str:
+    """Mint a short correlation ref for a stream failure.
+
+    Matches the hashing used by the non-streaming error paths in
+    ``apps/chat/views.py`` so an operator can cross-reference the user-visible
+    ref against the logged exception.
+    """
+    return hashlib.sha256(f"{time.time()}{exc}".encode()).hexdigest()[:8]
 
 
 def _tool_content_to_str(output: Any) -> str:
@@ -353,10 +365,36 @@ async def langgraph_to_ui_stream(
                     }
                 )
 
-    except TimeoutError:
+            # ── escalation node output ─────────────────────────────────────────
+            elif event_type == "on_chain_end" and event.get("name") == "escalate":
+                # The terminal ``escalate`` node returns a hardcoded AIMessage
+                # rather than calling the LLM, so it emits no on_chat_model_stream
+                # event and its message was never turned into a live text-delta —
+                # the panic-loop recovery affordance only appeared after reload
+                # (06#1). Translate the node's output into a streamed text part so
+                # the user sees it during the turn.
+                output = event.get("data", {}).get("output") or {}
+                esc_messages = output.get("messages", []) if isinstance(output, dict) else []
+                esc_text = "".join(
+                    m.content
+                    for m in esc_messages
+                    if isinstance(m, AIMessage) and isinstance(m.content, str)
+                )
+                if esc_text:
+                    if reasoning_started:
+                        yield _sse({"type": "reasoning-end", "id": reasoning_id})
+                        reasoning_started = False
+                        reasoning_id = f"reasoning-{uuid.uuid4().hex[:8]}"
+                    if not text_started:
+                        yield _sse({"type": "text-start", "id": text_id})
+                        text_started = True
+                    yield _sse({"type": "text-delta", "id": text_id, "delta": esc_text})
+
+    except TimeoutError as exc:
         logger.warning("Agent execution timed out after %ds", AGENT_TIMEOUT_SECONDS)
         if reasoning_started:
             yield _sse({"type": "reasoning-end", "id": reasoning_id})
+            reasoning_started = False
         if not text_started:
             yield _sse({"type": "text-start", "id": text_id})
             text_started = True
@@ -365,6 +403,21 @@ async def langgraph_to_ui_stream(
                 "type": "text-delta",
                 "id": text_id,
                 "delta": "\n\nThe request timed out. Try simplifying your question or breaking it into smaller steps.",
+            }
+        )
+        if text_started:
+            yield _sse({"type": "text-end", "id": text_id})
+            text_started = False
+        # Emit a native AI SDK error chunk so useChat's error state fires — a
+        # timed-out run MUST be distinguishable from a successful one (06#4).
+        # Without this the apology above was just message text followed by a
+        # normal finishReason 'stop', indistinguishable from success.
+        ref = _error_ref(exc)
+        logger.warning("Agent stream timed out [ref=%s]", ref)
+        yield _sse(
+            {
+                "type": "error",
+                "errorText": f"The request timed out. Ref: {ref}",
             }
         )
     except Exception as exc:
@@ -386,9 +439,11 @@ async def langgraph_to_ui_stream(
                 }
             )
         else:
-            logger.exception("Error during agent streaming")
+            ref = _error_ref(exc)
+            logger.exception("Error during agent streaming [ref=%s]", ref)
             if reasoning_started:
                 yield _sse({"type": "reasoning-end", "id": reasoning_id})
+                reasoning_started = False
             if not text_started:
                 yield _sse({"type": "text-start", "id": text_id})
                 text_started = True
@@ -397,6 +452,19 @@ async def langgraph_to_ui_stream(
                     "type": "text-delta",
                     "id": text_id,
                     "delta": "\n\nAn error occurred while processing your request.",
+                }
+            )
+            if text_started:
+                yield _sse({"type": "text-end", "id": text_id})
+                text_started = False
+            # Emit a native AI SDK error chunk so useChat's error state fires —
+            # a failed agent run MUST be distinguishable from a successful one
+            # (06#4). The apology text above is informational; this is what makes
+            # the frontend show an error state instead of a clean finish.
+            yield _sse(
+                {
+                    "type": "error",
+                    "errorText": f"An error occurred while processing your request. Ref: {ref}",
                 }
             )
 

--- a/apps/chat/stream.py
+++ b/apps/chat/stream.py
@@ -391,7 +391,10 @@ async def langgraph_to_ui_stream(
                     yield _sse({"type": "text-delta", "id": text_id, "delta": esc_text})
 
     except TimeoutError as exc:
-        logger.warning("Agent execution timed out after %ds", AGENT_TIMEOUT_SECONDS)
+        ref = _error_ref(exc)
+        logger.warning(
+            "Agent execution timed out after %ds [ref=%s]", AGENT_TIMEOUT_SECONDS, ref
+        )
         if reasoning_started:
             yield _sse({"type": "reasoning-end", "id": reasoning_id})
             reasoning_started = False
@@ -412,8 +415,6 @@ async def langgraph_to_ui_stream(
         # timed-out run MUST be distinguishable from a successful one (06#4).
         # Without this the apology above was just message text followed by a
         # normal finishReason 'stop', indistinguishable from success.
-        ref = _error_ref(exc)
-        logger.warning("Agent stream timed out [ref=%s]", ref)
         yield _sse(
             {
                 "type": "error",

--- a/apps/chat/thread_views.py
+++ b/apps/chat/thread_views.py
@@ -8,6 +8,7 @@ from django.http import JsonResponse
 
 from apps.chat.checkpointer import ensure_checkpointer
 from apps.chat.helpers import (
+    CheckpointerUnavailable,
     _resolve_workspace_and_membership,
     async_login_required,
 )
@@ -103,14 +104,20 @@ async def _list_threads(user, *, workspace_id):
 
 
 async def _load_thread_messages(thread_id) -> list[dict]:
-    """Load messages from checkpointer and convert to UI format."""
+    """Load messages from checkpointer and convert to UI format.
+
+    Raises ``CheckpointerUnavailable`` on a checkpointer/DB error so the caller
+    can return a non-200 error: an empty list is reserved for a thread that is
+    genuinely empty (no checkpoint written yet). Swallowing the error into []
+    made a transient outage look like "the conversation was deleted" (07#7).
+    """
     try:
         checkpointer = await ensure_checkpointer()
         config = {"configurable": {"thread_id": str(thread_id)}}
         checkpoint_tuple = await checkpointer.aget_tuple(config)
-    except Exception:
+    except Exception as exc:
         logger.warning("Failed to load checkpoint for thread %s", thread_id, exc_info=True)
-        return []
+        raise CheckpointerUnavailable(str(exc)) from exc
 
     if checkpoint_tuple is None:
         return []
@@ -166,7 +173,15 @@ async def thread_messages_view(request, workspace_id, thread_id):
             return JsonResponse({"error": "Thread not found"}, status=404)
         return JsonResponse([], safe=False)
 
-    ui_messages = await _load_thread_messages(thread_id)
+    try:
+        ui_messages = await _load_thread_messages(thread_id)
+    except CheckpointerUnavailable:
+        # A checkpointer/DB blip — surface it as a retryable error instead of an
+        # empty list that reads as "conversation deleted" (07#7).
+        return JsonResponse(
+            {"error": "Conversation history is temporarily unavailable. Please try again."},
+            status=503,
+        )
     return JsonResponse(ui_messages, safe=False)
 
 
@@ -250,7 +265,13 @@ async def public_thread_view(request, share_token):
         return JsonResponse({"error": "Thread not found"}, status=404)
 
     # Load messages from checkpointer
-    messages = await _load_thread_messages(thread.id)
+    try:
+        messages = await _load_thread_messages(thread.id)
+    except CheckpointerUnavailable:
+        return JsonResponse(
+            {"error": "Conversation history is temporarily unavailable. Please try again."},
+            status=503,
+        )
 
     # Load associated artifacts
     artifacts = await _get_thread_artifacts(thread.id)

--- a/apps/users/signals.py
+++ b/apps/users/signals.py
@@ -61,21 +61,26 @@ def resolve_tenant_on_social_login(request, sociallogin, **kwargs):
         logger.warning("No access token available after OAuth for %s", sociallogin.user)
         return
 
+    # A resolution failure must NOT break login (we can't 500 the OAuth
+    # callback), but it must be surfaced loudly: log at ERROR via
+    # logger.exception so Sentry pages. Logging at WARNING left the user with
+    # zero TenantMembership rows and an empty data-sources page that looked
+    # identical to "account has no opportunities", with nobody told (07#6).
     if provider == "commcare_connect":
         try:
             async_to_sync(resolve_connect_opportunities)(sociallogin.user, token.token)
         except Exception:
-            logger.warning("Failed to resolve Connect opportunities after OAuth", exc_info=True)
+            logger.exception("Failed to resolve Connect opportunities after OAuth")
     elif provider == "ocs":
         try:
             async_to_sync(resolve_ocs_chatbots)(sociallogin.user, token.token)
         except Exception:
-            logger.warning("Failed to resolve OCS chatbots after OAuth", exc_info=True)
+            logger.exception("Failed to resolve OCS chatbots after OAuth")
     elif provider.startswith("commcare"):
         try:
             async_to_sync(resolve_commcare_domains)(sociallogin.user, token.token)
         except Exception:
-            logger.warning("Failed to resolve CommCare domains after OAuth", exc_info=True)
+            logger.exception("Failed to resolve CommCare domains after OAuth")
 
 
 def reconcile_existing_user_on_login(sender, request, sociallogin, **kwargs):

--- a/apps/workspaces/models.py
+++ b/apps/workspaces/models.py
@@ -211,6 +211,23 @@ class WorkspaceMembership(models.Model):
         return f"{self.user.email} in {self.workspace.name} ({self.role})"
 
 
+# Sentinel prefix written to WorkspaceViewSchema.last_error when a view schema
+# is flipped to FAILED because a tenant schema it depends on was torn down (TTL
+# expiry / teardown cascade) — NOT because build_view_schema itself failed. The
+# distinction drives recovery advice: a genuine build failure can't be fixed by
+# re-running materialization, but a teardown cascade IS fixed by re-materializing
+# the torn-down tenant. Resume-prompt logic keys off this marker (arch #256,
+# 07#9). It is part of the human-readable message so get_schema_status surfaces a
+# truthful cause to the agent.
+VIEW_SCHEMA_CASCADE_TEARDOWN_MARKER = "[cascade-teardown]"
+VIEW_SCHEMA_CASCADE_TEARDOWN_ERROR = (
+    f"{VIEW_SCHEMA_CASCADE_TEARDOWN_MARKER} A tenant schema this workspace's "
+    "combined view depends on was torn down (inactivity TTL or teardown), so the "
+    "namespaced views were cascade-dropped. Re-running materialization rebuilds "
+    "the tenant data and the view schema."
+)
+
+
 class WorkspaceViewSchema(models.Model):
     """Tracks the PostgreSQL view schema for a multi-tenant workspace.
 

--- a/apps/workspaces/tasks.py
+++ b/apps/workspaces/tasks.py
@@ -26,6 +26,8 @@ from apps.users.services.credential_resolver import (
     aresolve_credential,
 )
 from apps.workspaces.models import (
+    VIEW_SCHEMA_CASCADE_TEARDOWN_ERROR,
+    VIEW_SCHEMA_CASCADE_TEARDOWN_MARKER,
     MaterializationRun,
     SchemaState,
     TenantSchema,
@@ -63,6 +65,26 @@ MATERIALIZATION_FAILED_MESSAGE = (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _no_pipeline_error(registry, provider: str) -> str:
+    """Build the 'no pipeline for provider' error, distinguishing cause (07#7).
+
+    A genuinely-unconfigured provider and a provider whose pipeline YAML failed
+    to parse both surfaced as the same "No pipeline for provider X" message,
+    which pointed at workspace config when the real cause was a broken deploy.
+    When the registry recorded load errors, say so explicitly so the failure
+    points at the deploy, not the workspace.
+    """
+    load_errors = registry.load_errors
+    if load_errors:
+        return (
+            f"No pipeline available for provider '{provider}': "
+            f"{len(load_errors)} pipeline definition(s) failed to load "
+            f"({', '.join(sorted(load_errors))}). This is a deploy/config error, "
+            "not a workspace setting — check the pipeline YAML files."
+        )
+    return f"No pipeline configured for provider '{provider}'"
 
 
 def _compose_failure_summary(runs: list[MaterializationRun]) -> str:
@@ -180,7 +202,9 @@ async def refresh_tenant_schema(schema_id: str, membership_id: str) -> dict:
         pipeline_name = provider_pipeline_map.get(membership.tenant.provider)
         if pipeline_name is None:
             await _drop_schema_and_fail(new_schema)
-            return {"error": f"No pipeline configured for provider '{membership.tenant.provider}'"}
+            return {
+                "error": _no_pipeline_error(registry, membership.tenant.provider),
+            }
         pipeline_config = registry.get(pipeline_name)
         # Load into the new "_r" schema this task created — NOT the tenant's
         # base schema. Without target_schema, run_pipeline re-resolves the base
@@ -283,7 +307,7 @@ async def materialize_workspace_core(
                 {
                     "tenant": tenant_id,
                     "success": False,
-                    "error": f"No pipeline for provider '{tm.tenant.provider}'",
+                    "error": _no_pipeline_error(registry, tm.tenant.provider),
                 }
             )
             continue
@@ -906,10 +930,19 @@ async def _fail_dependent_view_schemas(tenant_id) -> int:
         .filter(num_tenants__gte=2)
         .values("id")
     )
+    # Write a truthful last_error describing the teardown cascade (07#9). Without
+    # it, get_schema_status returns the generic fallback "View schema build
+    # failed." and the resume prompt tells the agent "do NOT re-run
+    # materialization; a system-side fix is required" — wrong advice, since
+    # re-materializing the torn-down tenant IS the fix. The marker lets the
+    # resume logic give correct, cause-specific recovery advice.
     return await WorkspaceViewSchema.objects.filter(
         workspace_id__in=dependent_workspace_ids,
         state=SchemaState.ACTIVE,
-    ).aupdate(state=SchemaState.FAILED)
+    ).aupdate(
+        state=SchemaState.FAILED,
+        last_error=VIEW_SCHEMA_CASCADE_TEARDOWN_ERROR,
+    )
 
 
 STALE_JOB_THRESHOLD = timedelta(minutes=10)
@@ -1377,16 +1410,34 @@ async def resume_thread_after_materialization(context, thread_job_id: str) -> di
                 )
 
     if view_schema_failed:
-        body = (
-            f"{SYSTEM_RESUME_MARKER} Per-tenant data loaded successfully, BUT the "
-            f"workspace query layer (the combined view schema that UNION ALLs the "
-            f"tenant tables) FAILED to build, so there is currently NO queryable "
-            f"surface for this workspace. Error: {view_schema_error}. Do NOT re-run "
-            f"materialization — it cannot fix this; the per-tenant data is already "
-            f"loaded and re-running will hit the same build failure. Tell the user "
-            f"plainly that a system-side fix is required and quote the error summary "
-            f"above. Per-tenant: {summary}"
-        )
+        if VIEW_SCHEMA_CASCADE_TEARDOWN_MARKER in view_schema_error:
+            # 07#9: the view schema is FAILED because a tenant schema it depends
+            # on was torn down (TTL/teardown), cascade-dropping the namespaced
+            # views — NOT because build_view_schema itself failed. Re-running
+            # materialization IS the fix here (it rebuilds the tenant data and the
+            # view schema), so the advice must invite a re-run, not forbid it.
+            body = (
+                f"{SYSTEM_RESUME_MARKER} The per-tenant runs reported success, but "
+                f"the workspace query layer (the combined view schema that UNION "
+                f"ALLs the tenant tables) is currently unavailable because a tenant "
+                f"schema it depends on was torn down (inactivity TTL or teardown), "
+                f"so the namespaced views were cascade-dropped. There is currently "
+                f"NO queryable surface for this workspace. Re-running materialization "
+                f"WILL fix this: it rebuilds the tenant data and the view schema. "
+                f"Tell the user the data needs to be reloaded and offer to re-run "
+                f"materialization. Error: {view_schema_error}. Per-tenant: {summary}"
+            )
+        else:
+            body = (
+                f"{SYSTEM_RESUME_MARKER} Per-tenant data loaded successfully, BUT the "
+                f"workspace query layer (the combined view schema that UNION ALLs the "
+                f"tenant tables) FAILED to build, so there is currently NO queryable "
+                f"surface for this workspace. Error: {view_schema_error}. Do NOT re-run "
+                f"materialization — it cannot fix this; the per-tenant data is already "
+                f"loaded and re-running will hit the same build failure. Tell the user "
+                f"plainly that a system-side fix is required and quote the error summary "
+                f"above. Per-tenant: {summary}"
+            )
     elif status == "no_runs":
         logger.warning(
             "resume: no MaterializationRun rows for ThreadJob %s job_id=%s; "
@@ -1555,7 +1606,15 @@ async def resume_thread_after_materialization(context, thread_job_id: str) -> di
     )
     error_summary = ""
     if terminal == ThreadJob.State.FAILED:
-        if view_schema_failed:
+        if view_schema_failed and VIEW_SCHEMA_CASCADE_TEARDOWN_MARKER in view_schema_error:
+            # 07#9: cascade teardown, not a build defect — re-running
+            # materialization IS the fix, so the summary must say so.
+            error_summary = (
+                "The workspace query layer (view schema) is unavailable because a "
+                f"tenant schema it depends on was torn down: {view_schema_error}. "
+                "Re-running materialization will rebuild it."
+            )
+        elif view_schema_failed:
             error_summary = (
                 "Per-tenant data loaded, but the workspace query layer (view "
                 f"schema) failed to build: {view_schema_error}. A system-side "

--- a/frontend/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/Sidebar/Sidebar.tsx
@@ -27,6 +27,7 @@ export function Sidebar() {
   const logout = useAppStore((s) => s.authActions.logout)
   const threadId = useAppStore((s) => s.threadId)
   const threads = useAppStore((s) => s.threads)
+  const threadsStatus = useAppStore((s) => s.threadsStatus)
   const fetchThreads = useAppStore((s) => s.uiActions.fetchThreads)
   const newThread = useAppStore((s) => s.uiActions.newThread)
   const selectThread = useAppStore((s) => s.uiActions.selectThread)
@@ -115,6 +116,26 @@ export function Sidebar() {
           </Button>
         </div>
         <div className="flex-1 overflow-y-auto px-2 pb-2">
+          {threadsStatus === "error" && (
+            // 07#7: a load failure must not look like "no conversations". Show a
+            // distinct error + retry so an outage is recoverable, not silent.
+            <div
+              className="px-3 py-2 text-xs text-muted-foreground"
+              data-testid="sidebar-threads-error"
+            >
+              <p>Couldn&apos;t load conversations.</p>
+              <button
+                type="button"
+                onClick={() => {
+                  if (activeDomainId) void fetchThreads(activeDomainId)
+                }}
+                className="mt-1 text-primary underline-offset-2 hover:underline"
+                data-testid="sidebar-threads-retry"
+              >
+                Retry
+              </button>
+            </div>
+          )}
           {threads.map((thread) => {
             const job = jobsByThreadId[thread.id]
             const lastUpdated = new Date(thread.updated_at)

--- a/frontend/src/store/domainSlice.test.ts
+++ b/frontend/src/store/domainSlice.test.ts
@@ -1,5 +1,6 @@
-import { beforeEach, describe, expect, it } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { useAppStore } from "@/store/store"
+import { api } from "@/api/client"
 
 describe("domainSlice.setActiveDomain — threadId leak guard (00c423d)", () => {
   beforeEach(() => {
@@ -21,5 +22,38 @@ describe("domainSlice.setActiveDomain — threadId leak guard (00c423d)", () => 
     useAppStore.getState().domainActions.setActiveDomain("ws-a")
     expect(useAppStore.getState().activeDomainId).toBe("ws-a")
     expect(useAppStore.getState().threadId).toBe("thread-a")
+  })
+})
+
+describe("domainSlice.ensureTenant — surfaces failure, not empty (07#6)", () => {
+  beforeEach(() => {
+    useAppStore.setState({ domainsStatus: "idle", domainsError: null, domains: [] })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("sets an error state when ensure-tenant fails (vs silent empty)", async () => {
+    vi.spyOn(api, "post").mockRejectedValue(new Error("ensure 503"))
+
+    await useAppStore.getState().domainActions.ensureTenant("ocs", "team-1")
+
+    // A failed resolution must be distinguishable from "account has no
+    // opportunities" — the user/operator can tell the two apart.
+    expect(useAppStore.getState().domainsStatus).toBe("error")
+    expect(useAppStore.getState().domainsError).toBeTruthy()
+  })
+
+  it("does not flag an error on success", async () => {
+    vi.spyOn(api, "post").mockResolvedValue({ workspace_id: "ws-x" } as never)
+    // fetchDomains runs after a successful ensure — stub the list call too.
+    const { workspaceApi } = await import("@/api/workspaces")
+    vi.spyOn(workspaceApi, "list").mockResolvedValue([] as never)
+
+    await useAppStore.getState().domainActions.ensureTenant("ocs", "team-1")
+
+    expect(useAppStore.getState().domainsStatus).not.toBe("error")
+    expect(useAppStore.getState().domainsError).toBeNull()
   })
 })

--- a/frontend/src/store/domainSlice.ts
+++ b/frontend/src/store/domainSlice.ts
@@ -86,7 +86,16 @@ export const createDomainSlice: StateCreator<DomainSlice, [], [], DomainSlice> =
         }
         await get().domainActions.fetchDomains()
       } catch (error) {
+        // A failed ensure-tenant must surface an error state, not silently
+        // console.error and leave the user on an empty data-sources page that
+        // reads as "no opportunities" (07#6). Flag it so the UI can show a
+        // distinct "couldn't load your workspace" message + retry.
         console.error("[Scout] Failed to ensure tenant:", error)
+        set({
+          domainsStatus: "error",
+          domainsError:
+            error instanceof Error ? error.message : "Failed to set up your workspace",
+        })
       }
     },
   },

--- a/frontend/src/store/uiSlice.test.ts
+++ b/frontend/src/store/uiSlice.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { useAppStore } from "@/store/store"
+import { api } from "@/api/client"
+import type { Thread } from "@/store/uiSlice"
+
+function thread(id: string, title: string): Thread {
+  return {
+    id,
+    title,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    is_shared: false,
+    is_public: false,
+    share_token: null,
+    last_viewed_at: null,
+  }
+}
+
+describe("uiSlice.fetchThreads — outage vs empty (07#7)", () => {
+  beforeEach(() => {
+    useAppStore.setState({ threads: [], threadsStatus: "idle" })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("marks threadsStatus 'error' on load failure instead of 'loaded' with []", async () => {
+    vi.spyOn(api, "get").mockRejectedValue(new Error("503 Service Unavailable"))
+
+    await useAppStore.getState().uiActions.fetchThreads("ws-1")
+
+    // The failure must be distinguishable from a genuinely-empty history: a
+    // silent {threads:[], status:'loaded'} read as "all conversations deleted".
+    expect(useAppStore.getState().threadsStatus).toBe("error")
+  })
+
+  it("keeps previously-loaded threads visible when a refetch fails", async () => {
+    const existing = [thread("t1", "Existing chat")]
+    useAppStore.setState({ threads: existing, threadsStatus: "loaded" })
+
+    vi.spyOn(api, "get").mockRejectedValue(new Error("network blip"))
+    await useAppStore.getState().uiActions.fetchThreads("ws-1")
+
+    expect(useAppStore.getState().threadsStatus).toBe("error")
+    // The list is not wiped to empty during a transient blip.
+    expect(useAppStore.getState().threads).toEqual(existing)
+  })
+
+  it("loads threads and marks 'loaded' on success", async () => {
+    const fetched = [thread("t2", "Loaded chat")]
+    vi.spyOn(api, "get").mockResolvedValue(fetched as never)
+
+    await useAppStore.getState().uiActions.fetchThreads("ws-1")
+
+    expect(useAppStore.getState().threadsStatus).toBe("loaded")
+    expect(useAppStore.getState().threads).toEqual(fetched)
+  })
+})

--- a/frontend/src/store/uiSlice.ts
+++ b/frontend/src/store/uiSlice.ts
@@ -20,7 +20,7 @@ export interface ThreadShareState {
   share_token: string | null
 }
 
-export type ThreadsStatus = "idle" | "loading" | "loaded"
+export type ThreadsStatus = "idle" | "loading" | "loaded" | "error"
 
 export interface UiSlice {
   threadId: string
@@ -69,8 +69,14 @@ export const createUiSlice: StateCreator<UiSlice, [], [], UiSlice> = (set, get) 
       try {
         const threads = await api.get<Thread[]>(`/api/workspaces/${workspaceId}/threads/`)
         set({ threads, threadsStatus: "loaded" })
-      } catch {
-        set({ threads: [], threadsStatus: "loaded" })
+      } catch (error) {
+        // Distinguish an outage from a genuinely empty history (07#7): a failed
+        // load must NOT report "loaded" with an empty array — that rendered as
+        // "no conversations" during a DB/checkpointer blip, as if every
+        // conversation had been deleted. Keep any threads already shown and flag
+        // the error so the sidebar can surface a retry affordance instead.
+        console.error("[Scout] Failed to load threads:", error)
+        set({ threadsStatus: "error" })
       }
     },
     updateThreadSharing: async (

--- a/mcp_server/pipeline_registry.py
+++ b/mcp_server/pipeline_registry.py
@@ -80,11 +80,18 @@ class PipelineRegistry:
     def __init__(self, pipelines_dir: str | None = None) -> None:
         self._dir = pathlib.Path(pipelines_dir) if pipelines_dir else _DEFAULT_PIPELINES_DIR
         self._cache: dict[str, PipelineConfig] | None = None
+        # Filenames that failed to parse on the last load. A YAML parse failure
+        # silently dropped the provider from the registry, later surfacing as a
+        # misleading "No pipeline for provider X" that pointed at workspace
+        # config rather than the real cause (a broken deploy). Tracking the
+        # failures lets callers tell the two apart (arch #256, 07#7).
+        self._load_errors: list[str] = []
 
     def _load_all(self) -> dict[str, PipelineConfig]:
         if self._cache is not None:
             return self._cache
         configs: dict[str, PipelineConfig] = {}
+        load_errors: list[str] = []
         for path in self._dir.glob("*.yml"):
             try:
                 with path.open() as f:
@@ -93,8 +100,21 @@ class PipelineRegistry:
                 configs[config.name] = config
             except Exception:
                 logger.exception("Failed to load pipeline from %s", path)
+                load_errors.append(path.name)
         self._cache = configs
+        self._load_errors = load_errors
         return configs
+
+    @property
+    def load_errors(self) -> list[str]:
+        """Pipeline files that failed to parse on the most recent load.
+
+        Non-empty means a broken deploy (malformed pipeline YAML), NOT a
+        workspace misconfiguration — callers reporting "No pipeline for provider"
+        should consult this to give a truthful cause (07#7).
+        """
+        self._load_all()
+        return list(self._load_errors)
 
     def get(self, name: str) -> PipelineConfig | None:
         return self._load_all().get(name)

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -472,9 +472,9 @@ async def get_materialization_status(run_id: str) -> dict:
 async def cancel_materialization(run_id: str) -> dict:
     """Cancel a running materialization pipeline.
 
-    Marks the run as failed in the database. This is a best-effort cancellation —
-    in-flight loader operations may not terminate immediately. Full subprocess
-    cancellation is a future feature.
+    Marks the run as CANCELLED in the database. This is a best-effort
+    cancellation — in-flight loader operations may not terminate immediately.
+    Full subprocess cancellation is a future feature.
 
     Args:
         run_id: UUID of the MaterializationRun to cancel.
@@ -502,7 +502,12 @@ async def cancel_materialization(run_id: str) -> dict:
             return tc["result"]
 
         previous_state = run.state
-        run.state = MaterializationRun.RunState.FAILED
+        # Write the dedicated CANCELLED state (not FAILED) so a deliberately
+        # cancelled run is distinguishable from a genuine failure in any
+        # state-based reporting — matching the user-facing cancel path
+        # (apps/workspaces/api/jobs_cancel.py::cancel_thread_job). The
+        # result.cancelled flag is retained for back-compat (#290).
+        run.state = MaterializationRun.RunState.CANCELLED
         run.completed_at = datetime.now(UTC)
         run.result = {**(run.result or {}), "cancelled": True}
         await run.asave(update_fields=["state", "completed_at", "result"])
@@ -723,7 +728,11 @@ async def get_schema_status(workspace_id: str = "", user_id: str = "", thread_id
         try:
             workspace = await Workspace.objects.aget(id=workspace_id)
         except Workspace.DoesNotExist:
-            tc["result"] = not_provisioned
+            # A genuinely missing workspace is NOT the same as an existing-but-
+            # unprovisioned one. Returning the empty 'not_provisioned' success
+            # envelope here invited the agent to materialize against a phantom
+            # workspace (07#7); surface a NOT_FOUND error so it stops instead.
+            tc["result"] = error_response(NOT_FOUND, f"Workspace '{workspace_id}' not found")
             return tc["result"]
 
         tenant_count = await workspace.tenants.acount()

--- a/tests/agents/test_panic_loop_graph.py
+++ b/tests/agents/test_panic_loop_graph.py
@@ -136,3 +136,48 @@ class TestShouldEscalate:
 
     def test_empty_message_list_does_not_trigger_escalation(self):
         assert _should_escalate([]) is False
+
+    def test_compact_json_envelope_still_triggers_escalation(self):
+        # 06#1: the detector must not couple to FastMCP's indent=2 spacing.
+        # A compact ``{"code":"NOT_FOUND"}`` (no space after the colon) — what a
+        # serialization change to compact separators would produce — must still
+        # trip the circuit breaker. The old substring match keyed on
+        # ``'"code": "NOT_FOUND"'`` (with a space) and silently failed here.
+        def _compact_err(code: str, tc: str) -> ToolMessage:
+            body = json.dumps(
+                {"success": False, "error": {"code": code, "message": "x"}},
+                separators=(",", ":"),
+            )
+            return ToolMessage(content=body, tool_call_id=tc, name="query")
+
+        messages = [
+            HumanMessage(content="how many users?"),
+            _ai_with_tool_call("a"),
+            _compact_err("NOT_FOUND", "a"),
+            _ai_with_tool_call("b"),
+            _compact_err("VALIDATION_ERROR", "b"),
+            _ai_with_tool_call("c"),
+            _compact_err("NOT_FOUND", "c"),
+        ]
+        assert _should_escalate(messages) is True
+
+    def test_code_substring_in_unrelated_field_does_not_trigger(self):
+        # A robust check matches the ``error.code`` value, not any occurrence of
+        # the string "NOT_FOUND" anywhere in the payload (e.g. a row that happens
+        # to contain the text). A successful envelope must never escalate.
+        def _ok_with_text(tc: str) -> ToolMessage:
+            body = json.dumps(
+                {"success": True, "data": {"rows": [["NOT_FOUND was mentioned here"]]}}
+            )
+            return ToolMessage(content=body, tool_call_id=tc, name="query")
+
+        messages = [
+            HumanMessage(content="show me the log"),
+            _ai_with_tool_call("a"),
+            _ok_with_text("a"),
+            _ai_with_tool_call("b"),
+            _ok_with_text("b"),
+            _ai_with_tool_call("c"),
+            _ok_with_text("c"),
+        ]
+        assert _should_escalate(messages) is False

--- a/tests/test_chat_stream_escalation.py
+++ b/tests/test_chat_stream_escalation.py
@@ -1,0 +1,178 @@
+"""Tests for two truthful-failure fixes in the chat SSE stream (arch #256).
+
+06#1 — the panic-loop escalation node returns a fixed ``AIMessage`` (no
+``on_chat_model_stream`` event), so the escalation message was never turned
+into a live text-delta and only appeared on reload. ``langgraph_to_ui_stream``
+must translate the escalate node's output into a streamed text-delta.
+
+06#4 — on TimeoutError / any non-transient exception the stream emitted an
+apology as plain message text plus a normal ``finish`` with
+``finishReason 'stop'`` and NO error chunk, so the frontend ``useChat`` error
+state never fired and a failed run was indistinguishable from success. The
+stream must emit a native AI SDK ``{"type":"error"}`` chunk so the failure
+surfaces.
+"""
+
+import json
+
+import pytest
+from langchain_core.messages import AIMessage
+
+from apps.agents.graph.base import ESCALATION_MESSAGE
+from apps.chat import stream
+
+
+def _parse_sse(chunks: list[str]) -> list[dict]:
+    out = []
+    for c in chunks:
+        line = c.removeprefix("data: ").strip()
+        out.append(json.loads(line))
+    return out
+
+
+class _EventAgent:
+    """Replays a fixed event sequence as the LangGraph agent would."""
+
+    def __init__(self, events: list[dict]):
+        self._events = events
+
+    def astream_events(self, input_state, *, config, version):
+        events = self._events
+
+        async def _gen():
+            for ev in events:
+                yield ev
+
+        return _gen()
+
+
+class _RaisingAgent:
+    """Its event stream raises immediately (mirrors a mid-run failure)."""
+
+    def __init__(self, exc: BaseException):
+        self._exc = exc
+
+    def astream_events(self, input_state, *, config, version):
+        exc = self._exc
+
+        async def _gen():
+            if False:  # async generator that yields nothing, then raises
+                yield
+            raise exc
+
+        return _gen()
+
+
+async def _run_events(events: list[dict]) -> list[dict]:
+    agent = _EventAgent(events)
+    return _parse_sse(
+        [
+            c
+            async for c in stream.langgraph_to_ui_stream(
+                agent, {}, {"configurable": {"thread_id": "t1"}}
+            )
+        ]
+    )
+
+
+async def _run_raising(exc: BaseException) -> list[dict]:
+    agent = _RaisingAgent(exc)
+    return _parse_sse(
+        [
+            c
+            async for c in stream.langgraph_to_ui_stream(
+                agent, {}, {"configurable": {"thread_id": "t1"}}
+            )
+        ]
+    )
+
+
+# --- 06#1: escalation message is streamed live -----------------------------
+
+
+@pytest.mark.asyncio
+async def test_escalation_node_output_is_streamed_as_text_delta():
+    """The terminal ``escalate`` node returns a hardcoded AIMessage. The stream
+    must surface its content as a live text-delta so the user sees the recovery
+    affordance during the turn, not only after reload."""
+    events = [
+        {
+            "event": "on_chain_end",
+            "name": "escalate",
+            "data": {"output": {"messages": [AIMessage(content=ESCALATION_MESSAGE)]}},
+        }
+    ]
+    chunks = await _run_events(events)
+
+    deltas = [c for c in chunks if c.get("type") == "text-delta"]
+    assert deltas, "escalation produced no text-delta — user sees nothing live"
+    streamed = "".join(c["delta"] for c in deltas)
+    assert ESCALATION_MESSAGE in streamed
+
+    # The text part is opened and closed so the AI SDK renders it cleanly.
+    types = [c["type"] for c in chunks]
+    assert "text-start" in types
+    assert "text-end" in types
+    # Stream still finishes normally (the escalation is a clean end-of-turn).
+    assert any(c["type"] == "finish" for c in chunks)
+
+
+@pytest.mark.asyncio
+async def test_non_escalate_chain_end_is_ignored():
+    """Only the ``escalate`` node's output is surfaced — a normal node's
+    on_chain_end carrying messages must NOT be double-emitted as text (the LLM
+    text already arrived via on_chat_model_stream)."""
+    events = [
+        {
+            "event": "on_chain_end",
+            "name": "agent",
+            "data": {"output": {"messages": [AIMessage(content="regular answer")]}},
+        }
+    ]
+    chunks = await _run_events(events)
+    deltas = [c for c in chunks if c.get("type") == "text-delta"]
+    assert not deltas
+
+
+# --- 06#4: failures emit an error chunk, not a silent successful finish -----
+
+
+@pytest.mark.asyncio
+async def test_timeout_emits_error_chunk():
+    """A TimeoutError must emit a native AI SDK error chunk so useChat.error
+    fires — a timed-out run must be distinguishable from a successful one."""
+    chunks = await _run_raising(TimeoutError("agent exceeded timeout"))
+
+    errors = [c for c in chunks if c.get("type") == "error"]
+    assert errors, "timeout emitted no error chunk — failure looks like success"
+    assert "errorText" in errors[0]
+    # The error text carries a correlation ref the user can quote.
+    assert "Ref:" in errors[0]["errorText"]
+
+
+@pytest.mark.asyncio
+async def test_generic_exception_emits_error_chunk():
+    chunks = await _run_raising(ValueError("boom"))
+    errors = [c for c in chunks if c.get("type") == "error"]
+    assert errors, "generic exception emitted no error chunk"
+    assert "Ref:" in errors[0]["errorText"]
+
+
+@pytest.mark.asyncio
+async def test_transient_overload_does_not_emit_error_chunk():
+    """The transient-overload path is auto-retried by the frontend and must NOT
+    emit a hard error chunk (which would surface a dead-end error state)."""
+    import httpx
+    from anthropic import APIStatusError
+
+    body = {
+        "type": "error",
+        "error": {"type": "overloaded_error", "message": "Overloaded"},
+    }
+    request = httpx.Request("POST", "https://api.anthropic.com/v1/messages")
+    exc = APIStatusError(f"{body}", response=httpx.Response(200, request=request), body=body)
+
+    chunks = await _run_raising(exc)
+    assert not [c for c in chunks if c.get("type") == "error"]
+    # Still signals the retryable condition the frontend keys auto-retry off of.
+    assert any(c.get("type") == "data-chat-status" for c in chunks)

--- a/tests/test_mcp_tenant_tools.py
+++ b/tests/test_mcp_tenant_tools.py
@@ -643,10 +643,31 @@ class TestGetSchemaStatusTool:
         assert result["error"]["code"] == VALIDATION_ERROR
 
     @pytest.mark.django_db
-    async def test_returns_not_provisioned_when_workspace_not_found(self):
+    async def test_returns_not_found_when_workspace_missing(self):
+        # 07#7: a non-existent workspace is NOT the same as an existing-but-
+        # unprovisioned one. Returning the empty 'not_provisioned' success
+        # envelope for a phantom workspace invited the agent to materialize
+        # against a workspace that doesn't exist. Surface a NOT_FOUND error so
+        # the agent stops instead of looping on a non-existent target.
         from mcp_server.server import get_schema_status
 
         result = await get_schema_status(workspace_id="00000000-0000-0000-0000-000000000000")
+
+        assert result["success"] is False
+        assert result["error"]["code"] == NOT_FOUND
+
+    @pytest.mark.django_db
+    async def test_returns_not_provisioned_when_workspace_exists_without_schema(self):
+        # An existing workspace with no tenants/schema is genuinely
+        # unprovisioned — that path must still report not_provisioned so the
+        # agent can offer to materialize.
+        from mcp_server.server import get_schema_status
+
+        User = get_user_model()
+        user = await User.objects.acreate_user(email="noschema@b.c", password="x")
+        ws = await Workspace.objects.acreate(name="empty-ws", created_by=user)
+
+        result = await get_schema_status(workspace_id=str(ws.id))
 
         assert result["success"] is True
         assert result["data"]["exists"] is False
@@ -837,6 +858,7 @@ class TestCancelMaterialization:
             mock_cls.RunState.LOADING = "loading"
             mock_cls.RunState.TRANSFORMING = "transforming"
             mock_cls.RunState.FAILED = "failed"
+            mock_cls.RunState.CANCELLED = "cancelled"
             from mcp_server.server import cancel_materialization
 
             result = asyncio.run(cancel_materialization(run_id=run_id))
@@ -845,12 +867,12 @@ class TestCancelMaterialization:
         assert result["data"]["cancelled"] is True
         assert result["data"]["run_id"] == run_id
         assert result["data"]["previous_state"] == "loading"
-        # 12#0 item 6: assert the PERSISTED state, not just the response flag.
-        # cancel_materialization currently writes RunState.FAILED (NOT CANCELLED)
-        # and stamps result["cancelled"]=True. Pinning the written state makes the
-        # FAILED-vs-CANCELLED inconsistency vs cancel_thread_job visible; the
-        # reconciliation is tracked in #290.
-        assert mock_run.state == "failed"
+        # #290: cancel_materialization now writes the dedicated RunState.CANCELLED
+        # (matching the user-facing cancel_thread_job endpoint) instead of FAILED,
+        # so a deliberately-cancelled run no longer masquerades as a failure in
+        # state-based reporting. The response still carries result.cancelled=True
+        # for back-compat.
+        assert mock_run.state == "cancelled"
         assert mock_run.result == {"cancelled": True}
         mock_run.asave.assert_awaited_once_with(update_fields=["state", "completed_at", "result"])
 

--- a/tests/test_mcp_tenant_tools.py
+++ b/tests/test_mcp_tenant_tools.py
@@ -656,7 +656,7 @@ class TestGetSchemaStatusTool:
         assert result["success"] is False
         assert result["error"]["code"] == NOT_FOUND
 
-    @pytest.mark.django_db
+    @pytest.mark.django_db(transaction=True)
     async def test_returns_not_provisioned_when_workspace_exists_without_schema(self):
         # An existing workspace with no tenants/schema is genuinely
         # unprovisioned — that path must still report not_provisioned so the

--- a/tests/test_pipeline_registry.py
+++ b/tests/test_pipeline_registry.py
@@ -86,11 +86,57 @@ relationships:
         assert r.to_column == "case_id"
         assert r.description == "Forms reference cases"
 
+    def test_load_errors_empty_when_all_pipelines_parse(self, tmp_path):
+        (tmp_path / "a.yml").write_text(
+            "pipeline: a\ndescription: A\nversion: '1.0'\nprovider: commcare\nsources: []\n"
+        )
+        registry = PipelineRegistry(pipelines_dir=str(tmp_path))
+        assert registry.load_errors == []
+
+    def test_load_errors_records_unparseable_pipeline(self, tmp_path):
+        # 07#7: a malformed pipeline YAML must be tracked (a broken deploy), not
+        # silently dropped — otherwise the provider just vanishes from the
+        # registry and surfaces later as a misleading "No pipeline for provider".
+        (tmp_path / "good.yml").write_text(
+            "pipeline: good\ndescription: G\nversion: '1.0'\nprovider: ocs\nsources: []\n"
+        )
+        (tmp_path / "broken.yml").write_text("pipeline: broken\nsources: [: : :\n")  # bad YAML
+        registry = PipelineRegistry(pipelines_dir=str(tmp_path))
+
+        # The good pipeline still loads; the broken one is recorded as an error.
+        assert registry.get("good") is not None
+        assert "broken.yml" in registry.load_errors
+
     def test_source_config_physical_table_name_defaults_to_raw_prefix(self):
         from mcp_server.pipeline_registry import SourceConfig
 
         s = SourceConfig(name="cases")
         assert s.physical_table_name == "raw_cases"
+
+
+class TestNoPipelineErrorMessage:
+    """07#7: the 'no pipeline' error must distinguish a misconfigured workspace
+    from a broken deploy (pipeline YAML failed to load)."""
+
+    def test_plain_message_when_no_load_errors(self):
+        from types import SimpleNamespace
+
+        from apps.workspaces.tasks import _no_pipeline_error
+
+        registry = SimpleNamespace(load_errors=[])
+        msg = _no_pipeline_error(registry, "weird_provider")
+        assert "weird_provider" in msg
+        assert "deploy" not in msg.lower()
+
+    def test_deploy_hint_when_pipeline_yaml_failed_to_load(self):
+        from types import SimpleNamespace
+
+        from apps.workspaces.tasks import _no_pipeline_error
+
+        registry = SimpleNamespace(load_errors=["ocs_sync.yml"])
+        msg = _no_pipeline_error(registry, "ocs")
+        assert "ocs_sync.yml" in msg
+        assert "deploy" in msg.lower()
 
     def test_source_config_physical_table_name_explicit_override(self):
         from mcp_server.pipeline_registry import SourceConfig

--- a/tests/test_resume_thread_task.py
+++ b/tests/test_resume_thread_task.py
@@ -1122,6 +1122,45 @@ async def test_resume_surfaces_view_schema_failure_for_multi_tenant():
 
 @pytest.mark.asyncio
 @pytest.mark.django_db(transaction=True)
+async def test_resume_cascade_teardown_view_schema_advises_rerun():
+    """07#9: when the view schema is FAILED because a tenant schema it depends on
+    was torn down (cascade), re-running materialization IS the fix. The resume
+    prompt must invite a re-run, NOT forbid it / claim a system-side fix."""
+    from apps.workspaces.models import VIEW_SCHEMA_CASCADE_TEARDOWN_ERROR
+
+    tj = await _make_multi_tenant_job(
+        email="vsc@b.c",
+        ws_name="W-vsc",
+        pj_id=20003,
+        view_schema_state=SchemaState.FAILED,
+        last_error=VIEW_SCHEMA_CASCADE_TEARDOWN_ERROR,
+    )
+
+    mock_agent = MagicMock()
+    mock_agent.ainvoke = AsyncMock(return_value={"messages": []})
+    with patch(
+        "apps.workspaces.tasks._build_agent_for_resume",
+        AsyncMock(return_value=(mock_agent, {})),
+    ):
+        result = await resume_thread_after_materialization(None, thread_job_id=str(tj.id))
+
+    mock_agent.ainvoke.assert_awaited_once()
+    body = mock_agent.ainvoke.await_args.args[0]["messages"][0].content
+    lower = body.lower()
+    # Correct, cause-specific advice: re-running materialization WILL fix it.
+    assert "re-running materialization will fix this" in lower
+    # The WRONG advice from the generic-build-failure branch must NOT appear.
+    assert "do not re-run materialization" not in lower
+    assert "a system-side fix is required" not in lower
+    # Terminal state is FAILED (no queryable surface right now) but the
+    # error_summary tells the truthful, recoverable story.
+    assert result["terminal_state"] == ThreadJob.State.FAILED
+    await tj.arefresh_from_db()
+    assert "re-running materialization will rebuild it" in tj.error_summary.lower()
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
 async def test_resume_plain_completed_for_multi_tenant_active_view_schema():
     """Regression: when the WorkspaceViewSchema is ACTIVE, the multi-tenant
     resume uses the normal 'just completed' copy, not the failure branch."""

--- a/tests/test_schema_ttl_task.py
+++ b/tests/test_schema_ttl_task.py
@@ -362,6 +362,13 @@ async def test_teardown_schema_fails_dependent_multitenant_view_schemas(
     assert active_schema.state == SchemaState.EXPIRED
     # B's namespaced views were cascade-dropped; ACTIVE was a lie → now FAILED.
     assert vs_b.state == SchemaState.FAILED
+    # 07#9: the FAILED row must carry a TRUTHFUL last_error explaining the
+    # teardown cascade (marked) — not the empty fallback that get_schema_status
+    # would render as the generic "View schema build failed." and that the resume
+    # prompt would misread as "a system-side fix is required, do NOT re-run".
+    from apps.workspaces.models import VIEW_SCHEMA_CASCADE_TEARDOWN_MARKER
+
+    assert VIEW_SCHEMA_CASCADE_TEARDOWN_MARKER in vs_b.last_error
     # C is single-tenant — its view schema must not be clobbered.
     assert vs_c.state == SchemaState.ACTIVE
 

--- a/tests/test_tenant_resolution_signal_failure.py
+++ b/tests/test_tenant_resolution_signal_failure.py
@@ -1,0 +1,67 @@
+"""Truthful-failure test for login-time tenant resolution (arch #256, 07#6).
+
+Post-OAuth tenant resolution for all three providers was wrapped in
+``except Exception: logger.warning(...)``. A provider-API blip at login then
+yielded a logged-in user with NO TenantMembership rows and an empty data-sources
+page — indistinguishable from "account has no opportunities" — and the WARNING
+was suppressed by Sentry's ERROR event-level default, so nobody was told.
+
+The handler must still not break login (a resolution failure can't 500 the OAuth
+callback), but it must surface the failure at ERROR level so Sentry pages and an
+operator can tell "resolution failed" from "no opportunities."
+"""
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from apps.users import signals
+
+SIGNALS_LOGGER = "apps.users.signals"
+
+
+def _sociallogin(provider: str, token: str = "tok"):
+    return SimpleNamespace(
+        account=SimpleNamespace(provider=provider),
+        token=SimpleNamespace(token=token),
+        user=SimpleNamespace(pk=1, email="u@b.c"),
+    )
+
+
+@pytest.mark.parametrize(
+    ("provider", "resolver_name"),
+    [
+        ("commcare_connect", "resolve_connect_opportunities"),
+        ("ocs", "resolve_ocs_chatbots"),
+        ("commcare", "resolve_commcare_domains"),
+    ],
+)
+def test_resolution_failure_logs_at_error_not_warning(provider, resolver_name, caplog):
+    """A provider-API failure must be logged at ERROR (Sentry pages) and must not
+    propagate out of the handler (login still succeeds)."""
+    sl = _sociallogin(provider)
+
+    failing = AsyncMock(side_effect=RuntimeError("provider 503"))
+    with patch.object(signals, resolver_name, failing):
+        with caplog.at_level(logging.WARNING, logger=SIGNALS_LOGGER):
+            # Must not raise — login must not break.
+            signals.resolve_tenant_on_social_login(request=None, sociallogin=sl)
+
+    records = [r for r in caplog.records if r.name == SIGNALS_LOGGER]
+    levels = {r.levelno for r in records}
+    assert logging.ERROR in levels, "resolution failure must page (ERROR), not be a quiet WARNING"
+
+
+def test_missing_token_still_warns_and_returns():
+    """No token at all is a benign 'nothing to resolve' — stays a WARNING and the
+    handler returns without attempting resolution."""
+    sl = SimpleNamespace(
+        account=SimpleNamespace(provider="ocs"),
+        token=SimpleNamespace(token=""),
+        user=SimpleNamespace(pk=1, email="u@b.c"),
+    )
+    with patch.object(signals, "resolve_ocs_chatbots", AsyncMock()) as resolver:
+        signals.resolve_tenant_on_social_login(request=None, sociallogin=sl)
+    resolver.assert_not_called()

--- a/tests/test_thread_messages_checkpointer_outage.py
+++ b/tests/test_thread_messages_checkpointer_outage.py
@@ -1,0 +1,90 @@
+"""Truthful-failure tests for thread-message loading during a checkpointer
+outage (arch #256, finding 07#7).
+
+``_load_thread_messages`` used to swallow ANY checkpointer error and return an
+empty list with HTTP 200, so during a DB/checkpointer blip a user saw their
+conversation apparently deleted with no error. The load must distinguish a
+genuinely-empty thread (no checkpoint yet → 200 []) from a checkpointer failure
+(→ a non-200 error the UI can surface as an error state).
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import AsyncClient
+
+from apps.chat.helpers import CheckpointerUnavailable
+from apps.chat.models import Thread
+from apps.chat.thread_views import _load_thread_messages
+from apps.users.models import Tenant, TenantMembership
+from apps.workspaces.models import (
+    Workspace,
+    WorkspaceMembership,
+    WorkspaceRole,
+    WorkspaceTenant,
+)
+
+User = get_user_model()
+
+
+async def _make_owned_thread():
+    user = await User.objects.acreate_user(email="ckpt-owner@b.c", password="x")
+    ws = await Workspace.objects.acreate(name="W-ckpt", created_by=user)
+    tenant = await Tenant.objects.acreate(
+        external_id="t-ckpt", provider="commcare", canonical_name="Ckpt Tenant"
+    )
+    await WorkspaceTenant.objects.acreate(workspace=ws, tenant=tenant)
+    tm = await TenantMembership.objects.acreate(user=user, tenant=tenant)  # noqa: F841
+    await WorkspaceMembership.objects.acreate(
+        workspace=ws, user=user, role=WorkspaceRole.READ_WRITE
+    )
+    thread = await Thread.objects.acreate(user=user, workspace=ws, title="t")
+    return user, ws, thread
+
+
+@pytest.mark.asyncio
+async def test_load_thread_messages_raises_on_checkpointer_error():
+    """A checkpointer failure must propagate as CheckpointerUnavailable, not be
+    silently converted to []."""
+    boom = AsyncMock(side_effect=RuntimeError("connection reset"))
+    fake_ckpt = AsyncMock()
+    fake_ckpt.aget_tuple = boom
+    with patch(
+        "apps.chat.thread_views.ensure_checkpointer",
+        AsyncMock(return_value=fake_ckpt),
+    ):
+        with pytest.raises(CheckpointerUnavailable):
+            await _load_thread_messages("11111111-1111-1111-1111-111111111111")
+
+
+@pytest.mark.asyncio
+async def test_load_thread_messages_returns_empty_when_no_checkpoint():
+    """A brand-new thread with no checkpoint yet is genuinely empty → []."""
+    fake_ckpt = AsyncMock()
+    fake_ckpt.aget_tuple = AsyncMock(return_value=None)
+    with patch(
+        "apps.chat.thread_views.ensure_checkpointer",
+        AsyncMock(return_value=fake_ckpt),
+    ):
+        result = await _load_thread_messages("22222222-2222-2222-2222-222222222222")
+    assert result == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_thread_messages_view_returns_503_on_checkpointer_outage():
+    """The view must surface a non-200 status during a checkpointer blip so the
+    frontend can show an error state instead of 'conversation deleted'."""
+    user, ws, thread = await _make_owned_thread()
+
+    client = AsyncClient()
+    await client.alogin(email=user.email, password="x")
+
+    with patch(
+        "apps.chat.thread_views._load_thread_messages",
+        AsyncMock(side_effect=CheckpointerUnavailable("blip")),
+    ):
+        resp = await client.get(f"/api/workspaces/{ws.id}/threads/{thread.id}/messages/")
+
+    assert resp.status_code == 503


### PR DESCRIPTION
## What & why

Closes #256. Closes #290.

The truthful-failure cluster: five places where a failure was rendered as success (or with a fabricated cause), making a broken run indistinguishable from a good one — the SSE flavor of the 2026-06-10 "failures swallowed, caller told completed" incident. Built on top of #257's audit logging and #313's ToolRuntime SSE-crash fix (both preserved).

Finding-by-finding:

- **`06#4`** — Chat SSE stream swallowed errors: on `TimeoutError` / any non-transient exception it emitted an apology as message text then a normal `finish` with `finishReason 'stop'` and **no** error chunk, so `useChat`'s `error` never fired and thread-list refresh treated the failure as success. Now the stream emits a native AI SDK `{"type":"error","errorText":"… Ref: <hash>"}` chunk (closing any open text part first), minting a hashed correlation ref consistent with `views.py`. The transient-overload auto-retry path is untouched (still emits `data-chat-status`, no hard error). `apps/chat/stream.py`.
- **`06#1`** — Panic-loop escalation never streamed live + brittle detector. The terminal `escalate` node returns a hardcoded `AIMessage` (no `on_chat_model_stream`), so its message only appeared after reload. The stream now translates the escalate node's `on_chain_end` output into a live text-delta. Separately, `_should_escalate` now parses the JSON envelope's `error.code` (via `_tool_message_error_code`) instead of substring-matching `'"code": "NOT_FOUND"'` (a whitespace-dependent match that only worked because FastMCP serialized with `indent=2`). `ESCALATION_ERROR_CODES` is now a shared `frozenset({"NOT_FOUND","VALIDATION_ERROR"})` of bare codes. `apps/agents/graph/base.py`, `apps/chat/stream.py`.
- **`07#7`** — Outage rendered as empty-but-successful UI. `_load_thread_messages` now raises `CheckpointerUnavailable` on a checkpointer/DB error (reserving `[]` for a genuinely-empty thread); `thread_messages_view` and `public_thread_view` return **503** instead of `[]`-with-200. `get_schema_status` returns `NOT_FOUND` for a phantom (`Workspace.DoesNotExist`) workspace instead of the `not_provisioned` success envelope. The pipeline registry now tracks `load_errors`, and `materialize_workspace`'s "No pipeline for provider X" message names a broken deploy when a pipeline YAML failed to parse (vs blaming workspace config). Frontend: `uiSlice.fetchThreads` sets `threadsStatus: 'error'` (keeping any already-loaded threads) and the Sidebar shows a retry affordance. `apps/chat/thread_views.py`, `apps/chat/helpers.py`, `mcp_server/server.py`, `mcp_server/pipeline_registry.py`, `apps/workspaces/tasks.py`, `frontend/src/store/uiSlice.ts`, `frontend/src/components/Sidebar/Sidebar.tsx`.
- **`07#9`** — Cascade-FAILED view schemas reported a fabricated cause + wrong recovery advice. `_fail_dependent_view_schemas` now writes a truthful `last_error` (marked `[cascade-teardown]`) describing the tenant-teardown cascade. The resume prompt and `ThreadJob.error_summary` now advise **re-materializing** for that cause (which IS the fix) instead of "do NOT re-run; a system-side fix is required". A genuine `build_view_schema` failure still gets the original "don't re-run" advice. `get_schema_status` already surfaces `last_error`, so it now reports the truthful cause too. `apps/workspaces/tasks.py`, `apps/workspaces/models.py` (shared marker constant).
- **`07#6`** — Login-time tenant resolution failures swallowed. The three-provider resolution try/excepts in `resolve_tenant_on_social_login` now log at ERROR via `logger.exception` (so Sentry pages) instead of `logger.warning` — change kept minimal/localized to the resolution blocks (~lines 64-83) so a rebase against #259's merge/reconcile work (a different function) is trivial. Login still never breaks. Frontend `ensureTenant` now flags `domainsStatus: 'error'` + `domainsError` instead of only `console.error`. `apps/users/signals.py`, `frontend/src/store/domainSlice.ts`.
- **`#290`** — `cancel_materialization` now writes `RunState.CANCELLED` (matching the user-facing `cancel_thread_job` endpoint) instead of `FAILED`, so a deliberately-cancelled run no longer masquerades as a failure. The response keeps `result.cancelled=True` for back-compat. The pinned test from #289 was updated to assert `CANCELLED`. `mcp_server/server.py`, `tests/test_mcp_tenant_tools.py`.

## Sibling sweep (required on bug/incident fixes)

- **Grep used:** `grep -rn "return \[\]" apps/chat/ apps/workspaces/api/`; `grep -rn "RunState.FAILED\|State.FAILED" apps/workspaces/ mcp_server/`; `grep -rn '"code": "' apps/`; `grep -rn "AIMessage(content=" apps/agents/graph/`; frontend `catch` in `frontend/src/store/*.ts`.
- **Sibling sites found & disposition:**
  - [x] `apps/chat/stream.py` timeout + generic-exception handlers — **fixed** (both now emit an error chunk). The overload branch is intentionally not an error (auto-retried).
  - [x] `apps/chat/thread_views.py::_load_thread_messages` (used by both `thread_messages_view` and `public_thread_view`) — **fixed**, both callers now 503.
  - [x] `frontend/src/store/uiSlice.ts::fetchThreads` and `domainSlice.ts::ensureTenant` — **fixed** (error states). `fetchDomains` already had an error state.
  - [x] `mcp_server/server.py::get_schema_status` `Workspace.DoesNotExist` — **fixed** (NOT_FOUND). The multi-tenant FAILED path already returned a top-level error envelope (arch #246).
  - [x] `mcp_server/pipeline_registry.py::_load_all` silent provider drop — **fixed** (tracked via `load_errors`, surfaced in the "No pipeline" message). Both "No pipeline" sites in `tasks.py` route through one `_no_pipeline_error` helper.
  - [x] FAILED-vs-CANCELLED writes — `mcp_server/server.py:505` was the only spurious one (#290, fixed). The other `RunState.FAILED` / `State.FAILED` writes in `tasks.py`/`materializer.py` are genuine failures.
  - [x] Hardcoded non-LLM graph nodes that won't stream — `escalation_node` was the only one (fixed). `agent_node` streams via the LLM.
  - [x] Brittle serialization-dependent substring matches on the error envelope — `ESCALATION_ERROR_CODES` was the only one (fixed); the prompt eval pins the code *names* in `base_system.py` (intentional, human-readable rule text).
  - [x] `apps/chat/helpers.py::repair_dangling_tool_calls` returns `[]` on checkpoint-load error — **left as-is by design**: it's best-effort and `agent_node` has its own dangling-tool-call repair guard, so a skipped repair here doesn't produce a wrong "success" surface. Noted for reviewers.

## Testing

`uv run pytest` (full backend suite): **1482 passed, 5 skipped, 1 xpassed**. `uv run ruff check/format` clean; `manage.py makemigrations --check` reports no changes (the new model constant is module-level, not a field). Frontend: `bun run test` **61 passed (13 files)**, `bun run lint` clean, `bun run build` (tsc + vite) clean.

New/updated tests:
- `tests/test_chat_stream_escalation.py` — escalation node → text-delta; timeout/exception → error chunk; overload → no error chunk (06#1, 06#4).
- `tests/agents/test_panic_loop_graph.py` — compact-JSON (no space) still trips the breaker; unrelated `NOT_FOUND` text in a data row doesn't (06#1).
- `tests/test_thread_messages_checkpointer_outage.py` — `_load_thread_messages` raises on error / returns [] when empty; view returns 503 (07#7).
- `tests/test_mcp_tenant_tools.py` — `get_schema_status` NOT_FOUND for missing ws vs not_provisioned for empty ws; cancel writes CANCELLED (07#7, #290).
- `tests/test_pipeline_registry.py` — `load_errors` tracks unparseable YAML; `_no_pipeline_error` deploy-hint (07#7).
- `tests/test_schema_ttl_task.py` + `tests/test_resume_thread_task.py` — cascade `last_error` written; resume advises re-materialize for cascade vs "don't re-run" for build failure (07#9).
- `tests/test_tenant_resolution_signal_failure.py` — resolution failure logs at ERROR, login doesn't break (07#6).
- `frontend/src/store/uiSlice.test.ts`, `domainSlice.test.ts` — thread-list + ensure-tenant error states (07#7, 07#6).

## Notes for reviewers

- **Design decision (06#4 error-event schema):** I used the AI SDK v6 native `{"type":"error","errorText":…}` UI-message-stream chunk, which `useChat`'s transport maps to `onError(new Error(errorText))` → the hook's `error` state, rendered by the existing `ChatError` component. No new frontend wiring was needed; the bug lived entirely in the stream never emitting the error type. Flagging in case you'd prefer a custom `data-*` error part instead.
- **`signals.py` / #259 coordination:** my change is localized to the tenant-resolution try/except blocks; #259 edits a different function (`reconcile_existing_user_on_login`). If #259 merges first I'll rebase — should be conflict-free.
- **Deferred / out of scope:** `repair_dangling_tool_calls`'s best-effort `[]` (see sibling sweep). No DB migration in this PR (the new `VIEW_SCHEMA_CASCADE_TEARDOWN_*` constants are module-level; `last_error` already exists on `WorkspaceViewSchema`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HpAA218jN8dR5SMJTM3Ur4