### PR TITLE
[arch] MCP server hardening: caller auth, connection hygiene, pooling, dead-code (#253)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,13 @@ ANTHROPIC_API_KEY=
 # MCP server URL (data access layer for the agent)
 # MCP_SERVER_URL=http://localhost:8100/mcp
 
+# Shared secret authenticating callers of the internal MCP server (defense in
+# depth — the MCP server is internal/IP-filtered). Sent by the API/worker in the
+# X-Scout-MCP-Secret header. Leave UNSET in local dev (loopback only) to disable
+# the check; set the SAME value on the MCP server and its clients in production.
+# Generate with: python -c "import secrets; print(secrets.token_urlsafe(32))"
+# MCP_SHARED_SECRET=
+
 # CommCare Connect API URL
 # CONNECT_API_URL=https://connect.dimagi.com
 

--- a/apps/agents/graph/base.py
+++ b/apps/agents/graph/base.py
@@ -73,6 +73,10 @@ MCP_TOOL_NAMES = frozenset(
         "run_materialization",
         "get_schema_status",
         "get_lineage",
+        # workspace_id is injected into these so an LLM-supplied run_id is scoped
+        # to the calling workspace (arch #253, 01#6).
+        "get_materialization_status",
+        "cancel_materialization",
     }
 )
 
@@ -603,7 +607,6 @@ async def build_agent_graph(
     user: User | None = None,
     checkpointer: BaseCheckpointSaver | None = None,
     mcp_tools: list | None = None,
-    oauth_tokens: dict | None = None,
     conversation_id: str | None = None,
     *,
     interactive: bool = True,
@@ -617,7 +620,6 @@ async def build_agent_graph(
         user: Optional User model instance.
         checkpointer: Optional LangGraph checkpointer for conversation persistence.
         mcp_tools: List of MCP tools to include.
-        oauth_tokens: Optional OAuth tokens for tool authentication.
         conversation_id: Optional thread/conversation id. Threaded through to the
             artifact tools so chat-created artifacts record their originating
             conversation (so shared/public thread pages can find them).

--- a/apps/agents/mcp_client.py
+++ b/apps/agents/mcp_client.py
@@ -1,9 +1,15 @@
 """
 MCP client for connecting the Scout agent to the MCP data server.
 
-Creates a fresh MultiServerMCPClient per call so per-request progress
-callbacks can be attached. Circuit breaker logic prevents hammering an
-unavailable server.
+The MCP tool *schemas* are static, so the tool list is loaded once and cached
+across chat turns instead of doing a ``tools/list`` HTTP round trip on every
+message (arch #253, finding 10#1). Each cached tool still opens its own MCP
+session at invocation time (langchain-mcp-adapters starts a new session per
+tool call), so caching the list does not pin a long-lived connection.
+
+Every call carries the shared secret in the ``X-Scout-MCP-Secret`` header so the
+MCP server's ``SharedSecretMiddleware`` accepts it (arch #253, finding 01#6).
+A circuit breaker prevents hammering an unavailable server.
 """
 
 from __future__ import annotations
@@ -11,9 +17,10 @@ from __future__ import annotations
 import logging
 import time
 
-from allauth.socialaccount.models import SocialToken
 from django.conf import settings
 from langchain_mcp_adapters.client import MultiServerMCPClient
+
+from mcp_server.auth import SHARED_SECRET_HEADER
 
 logger = logging.getLogger(__name__)
 
@@ -23,19 +30,35 @@ _last_failure_time: float = 0.0
 _CIRCUIT_BREAKER_THRESHOLD = 5
 _CIRCUIT_BREAKER_COOLDOWN = 30.0
 
+# Cached tool list (schemas are static; reset via reset_tools_cache()).
+_cached_tools: list | None = None
+
 
 class MCPServerUnavailable(Exception):
     """Raised when the circuit breaker is open."""
 
 
+def _build_connection() -> dict:
+    """Build the streamable-HTTP connection config, attaching the shared secret."""
+    conn: dict = {"transport": "streamable_http", "url": settings.MCP_SERVER_URL}
+    secret = getattr(settings, "MCP_SHARED_SECRET", "")
+    if secret:
+        conn["headers"] = {SHARED_SECRET_HEADER: secret}
+    return conn
+
+
 async def get_mcp_tools() -> list:
     """Load MCP tools as LangChain tools.
 
-    Creates a fresh MultiServerMCPClient on each call.
+    Returns a cached tool list when available (the schemas are static); only the
+    first call per process performs the ``tools/list`` round trip.
 
     Raises MCPServerUnavailable when the circuit breaker is open.
     """
-    global _consecutive_failures, _last_failure_time
+    global _consecutive_failures, _last_failure_time, _cached_tools
+
+    if _cached_tools is not None:
+        return _cached_tools
 
     if _consecutive_failures >= _CIRCUIT_BREAKER_THRESHOLD:
         elapsed = time.monotonic() - _last_failure_time
@@ -46,14 +69,12 @@ async def get_mcp_tools() -> list:
             )
         logger.info("Circuit breaker cooldown elapsed, allowing retry")
 
-    url = settings.MCP_SERVER_URL
     try:
-        client = MultiServerMCPClient(
-            {"scout-data": {"transport": "streamable_http", "url": url}},
-        )
+        client = MultiServerMCPClient({"scout-data": _build_connection()})
         tools = await client.get_tools()
         logger.info("Loaded %d MCP tools: %s", len(tools), [t.name for t in tools])
         _consecutive_failures = 0
+        _cached_tools = tools
         return tools
     except MCPServerUnavailable:
         raise
@@ -71,20 +92,8 @@ def reset_circuit_breaker() -> None:
     _last_failure_time = 0.0
 
 
-# --- OAuth token retrieval ---
-
-COMMCARE_PROVIDERS = frozenset({"commcare", "commcare_connect"})
-
-
-async def get_user_oauth_tokens(user) -> dict[str, str]:
-    """Retrieve OAuth tokens for a user's CommCare providers."""
-    if user is None or not getattr(user, "pk", None):
-        return {}
-    return {
-        st.account.provider: st.token
-        async for st in SocialToken.objects.filter(
-            account__user=user,
-            account__provider__in=COMMCARE_PROVIDERS,
-        ).select_related("account")
-        if st.account.provider in COMMCARE_PROVIDERS
-    }
+def reset_tools_cache() -> None:
+    """Clear the cached MCP tool list. Used in tests; also lets a process drop a
+    stale schema cache if the server's tool surface ever changes."""
+    global _cached_tools
+    _cached_tools = None

--- a/apps/chat/views.py
+++ b/apps/chat/views.py
@@ -19,7 +19,7 @@ from django.utils import timezone
 from django.views.decorators.csrf import csrf_protect
 
 from apps.agents.graph.base import build_agent_graph
-from apps.agents.mcp_client import get_mcp_tools, get_user_oauth_tokens
+from apps.agents.mcp_client import get_mcp_tools
 from apps.chat.checkpointer import ensure_checkpointer
 from apps.chat.helpers import (
     _resolve_workspace_and_membership,
@@ -169,9 +169,6 @@ async def chat_view(request):
         logger.exception("Failed to load MCP tools [ref=%s]", error_ref)
         return JsonResponse({"error": f"Agent initialization failed. Ref: {error_ref}"}, status=500)
 
-    # Retrieve user's OAuth tokens for materialization
-    oauth_tokens = await get_user_oauth_tokens(user)
-
     # Build agent (retry once with fresh checkpointer on connection errors)
     try:
         checkpointer = await ensure_checkpointer()
@@ -180,7 +177,6 @@ async def chat_view(request):
             user=user,
             checkpointer=checkpointer,
             mcp_tools=mcp_tools,
-            oauth_tokens=oauth_tokens,
             conversation_id=str(thread_id),
         )
     except Exception:
@@ -193,7 +189,6 @@ async def chat_view(request):
                 user=user,
                 checkpointer=checkpointer,
                 mcp_tools=mcp_tools,
-                oauth_tokens=oauth_tokens,
                 conversation_id=str(thread_id),
             )
         except Exception as e:
@@ -206,7 +201,6 @@ async def chat_view(request):
     config = {
         "configurable": {"thread_id": thread_id},
         "recursion_limit": 50,
-        "oauth_tokens": oauth_tokens,
     }
 
     # Repair any dangling tool_use calls from a previous interrupted turn.

--- a/apps/recipes/services/runner.py
+++ b/apps/recipes/services/runner.py
@@ -15,7 +15,7 @@ from django.utils import timezone
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 
 from apps.agents.graph.base import build_agent_graph
-from apps.agents.mcp_client import get_mcp_tools, get_user_oauth_tokens
+from apps.agents.mcp_client import get_mcp_tools
 from apps.recipes.models import Recipe, RecipeRun, RecipeRunStatus
 from apps.workspaces.models import Workspace
 
@@ -76,7 +76,6 @@ class RecipeRunner:
         # materialization tool for MaterializationRun traceability.
         self._job_id: int | None = job_id
         self._thread_id: str = ""
-        self._oauth_tokens: dict = {}
 
     @staticmethod
     def validate_and_default(recipe: Recipe, variable_values: dict[str, Any]) -> dict[str, Any]:
@@ -116,13 +115,11 @@ class RecipeRunner:
             # SynchronousOnlyOperation under async (root of Sentry #276).
             workspace = await Workspace.objects.aget(id=self.recipe.workspace_id)
             mcp_tools = await get_mcp_tools()
-            self._oauth_tokens = await get_user_oauth_tokens(self.user)
             self._graph = await build_agent_graph(
                 workspace=workspace,
                 user=self.user,
                 checkpointer=None,
                 mcp_tools=mcp_tools,
-                oauth_tokens=self._oauth_tokens,
                 conversation_id=self._thread_id or None,
                 # A recipe is a HEADLESS run: no chat Thread, no checkpointer, no
                 # async-resume path. interactive=False gives the agent the
@@ -191,7 +188,6 @@ class RecipeRunner:
         config = {
             "configurable": {"thread_id": self._thread_id},
             "recursion_limit": 50,
-            "oauth_tokens": self._oauth_tokens,
         }
 
         prompt = self.recipe.render_prompt(self.variable_values)

--- a/apps/workspaces/tasks.py
+++ b/apps/workspaces/tasks.py
@@ -15,7 +15,7 @@ from langchain_core.messages import AIMessage, HumanMessage
 from procrastinate.contrib.django.models import ProcrastinateJob
 
 from apps.agents.graph.base import build_agent_graph
-from apps.agents.mcp_client import get_mcp_tools, get_user_oauth_tokens
+from apps.agents.mcp_client import get_mcp_tools
 from apps.chat.checkpointer import ensure_checkpointer
 from apps.chat.constants import SYSTEM_RESUME_MARKER
 from apps.chat.models import Thread, ThreadJob
@@ -210,7 +210,7 @@ async def refresh_tenant_schema(schema_id: str, membership_id: str) -> dict:
         # base schema. Without target_schema, run_pipeline re-resolves the base
         # (old active) schema via provision() and the data lands there; we then
         # activate this empty new schema and tear down the data-bearing old one.
-        await asyncio.to_thread(
+        await _to_thread_fresh_db(
             run_pipeline, membership, credential, pipeline_config, target_schema=new_schema
         )
     except Exception:
@@ -387,7 +387,7 @@ async def materialize_workspace_core(
     workspace_tenant_count = await workspace.workspace_tenants.acount()
     if workspace_tenant_count > 1 and all_succeeded:
         try:
-            await asyncio.to_thread(SchemaManager().build_view_schema, workspace)
+            await _to_thread_fresh_db(SchemaManager().build_view_schema, workspace)
             view_schema_outcome = {"ok": True, "error": None}
         except Exception as exc:
             # Don't re-raise — the resume task should still fire so the
@@ -599,6 +599,31 @@ async def _rebuild_dependent_view_schemas(tenant_ids, *, exclude_workspace_id=No
             )
 
 
+async def _to_thread_fresh_db(func, /, *args, **kwargs):
+    """Run a sync ORM-touching callable on a to_thread pool thread that first
+    closes stale/dead DB connections (arch #253, 08#0).
+
+    ORM run via ``asyncio.to_thread`` executes on a default-executor pool thread
+    whose thread-local Django connection the worker ``task`` decorator's cleanup
+    (which only reaches the async-ORM thread) cannot touch. Pool threads are
+    reused across jobs, so a connection that died since this thread's last run
+    would otherwise poison the call (view-schema rebuilds surfacing as
+    "system-side fix required"; refreshes leaving the row stuck PROVISIONING).
+    Running ``close_old_connections`` on the SAME pool thread, immediately before
+    the body, replaces such a connection so the first ORM use re-opens it.
+
+    The cleanup is wrapped into the threaded callable (not run on the caller's
+    thread) so it never closes the connection a synchronous unit test or request
+    is using — only the pool thread's own connection.
+    """
+
+    def _guarded():
+        close_old_connections()
+        return func(*args, **kwargs)
+
+    return await asyncio.to_thread(_guarded)
+
+
 def _run_pipeline_with_progress(
     tenant_membership,
     credential: dict,
@@ -725,7 +750,7 @@ async def rebuild_workspace_view_schema(workspace_id: str) -> dict:
 
     manager = SchemaManager()
     try:
-        vs = await asyncio.to_thread(manager.build_view_schema, workspace)
+        vs = await _to_thread_fresh_db(manager.build_view_schema, workspace)
     except Exception:
         # build_view_schema already saves state=FAILED before re-raising;
         # no need to write it again here (doing so risks overwriting a
@@ -1155,22 +1180,16 @@ async def _build_failure_summary_for_job(procrastinate_job_id: int) -> str:
 
 
 async def _build_agent_for_resume(workspace, user, conversation_id=None):
-    """Build the LangGraph agent + load oauth_tokens for runtime config.
-
-    Returns (agent, oauth_tokens).
-    """
+    """Build the LangGraph agent for the resume task."""
     mcp_tools = await get_mcp_tools()
-    oauth_tokens = await get_user_oauth_tokens(user)
     checkpointer = await ensure_checkpointer()
-    agent = await build_agent_graph(
+    return await build_agent_graph(
         workspace=workspace,
         user=user,
         checkpointer=checkpointer,
         mcp_tools=mcp_tools,
-        oauth_tokens=oauth_tokens,
         conversation_id=conversation_id,
     )
-    return agent, oauth_tokens
 
 
 def _resume_langfuse_span(*, thread_job_id: str, thread_id: str, status: str):
@@ -1214,7 +1233,7 @@ async def _persist_synthetic_failure_message(thread_job, text: str) -> None:
     not a correctness invariant.
     """
     try:
-        agent, _ = await _build_agent_for_resume(
+        agent = await _build_agent_for_resume(
             thread_job.thread.workspace,
             thread_job.thread.user,
             conversation_id=str(thread_job.thread.id),
@@ -1504,9 +1523,7 @@ async def resume_thread_after_materialization(context, thread_job_id: str) -> di
     )
     start = time.monotonic()
     try:
-        agent, oauth_tokens = await _build_agent_for_resume(
-            workspace, user, conversation_id=str(tj.thread.id)
-        )
+        agent = await _build_agent_for_resume(workspace, user, conversation_id=str(tj.thread.id))
         input_state = {
             "messages": [HumanMessage(content=body)],
             "workspace_id": str(workspace.id),
@@ -1517,7 +1534,6 @@ async def resume_thread_after_materialization(context, thread_job_id: str) -> di
         config = {
             "configurable": {"thread_id": str(tj.thread.id)},
             "recursion_limit": settings.AGENT_RESUME_RECURSION_LIMIT,
-            "oauth_tokens": oauth_tokens,
         }
         with _resume_langfuse_span(
             thread_job_id=thread_job_id,

--- a/config/deploy-mcp.yml
+++ b/config/deploy-mcp.yml
@@ -34,6 +34,9 @@ env:
     - DB_CREDENTIAL_KEY
     - DJANGO_SECRET_KEY
     - SENTRY_DSN
+    # Shared-secret caller auth (arch #253, 01#6). MUST match the value the API
+    # (deploy.yml) and worker (deploy-worker.yml) send in X-Scout-MCP-Secret.
+    - MCP_SHARED_SECRET
 
 ssh:
   user: scout

--- a/config/deploy-worker.yml
+++ b/config/deploy-worker.yml
@@ -48,6 +48,9 @@ env:
     # Worker executes tasks and updates their Task Badger status; it also chains
     # the resume task, so it defers (creates) Task Badger records too.
     - TASKBADGER_API_KEY
+    # The resume task's get_mcp_tools call authenticates to the MCP server with
+    # this shared secret (arch #253, 01#6). MUST match deploy-mcp.yml.
+    - MCP_SHARED_SECRET
 
 ssh:
   user: scout

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -59,6 +59,9 @@ env:
     - OCS_OAUTH_CLIENT_SECRET
     - SENTRY_DSN
     - TASKBADGER_API_KEY
+    # Sent in X-Scout-MCP-Secret to authenticate to the MCP server (arch #253,
+    # 01#6). MUST match deploy-mcp.yml's MCP_SHARED_SECRET.
+    - MCP_SHARED_SECRET
 
 ssh:
   user: scout

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -344,6 +344,12 @@ TASKBADGER_ENVIRONMENT = env("TASKBADGER_ENVIRONMENT", default=DEPLOY_ENVIRONMEN
 # MCP server URL (Scout data access layer)
 MCP_SERVER_URL = env("MCP_SERVER_URL", default="http://localhost:8100/mcp")
 
+# Shared secret authenticating callers of the internal MCP HTTP server (arch
+# #253, finding 01#6). Sent by the API/worker in the X-Scout-MCP-Secret header
+# and verified by mcp_server.auth.SharedSecretMiddleware. Empty in local dev
+# (loopback only) disables the check; production deploy configs set it.
+MCP_SHARED_SECRET = env("MCP_SHARED_SECRET", default="")
+
 # CommCare Connect API
 CONNECT_API_URL = env("CONNECT_API_URL", default="https://connect.dimagi.com")
 OCS_URL = env("OCS_URL", default="https://www.openchatstudio.com")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,9 @@ services:
       - DJANGO_SETTINGS_MODULE=config.settings.development
       - DB_CREDENTIAL_KEY=${DB_CREDENTIAL_KEY}
       - DJANGO_SECRET_KEY=${DJANGO_SECRET_KEY:-dev-secret-key-change-in-production}
+      # Shared-secret caller auth (must match the API's value below). Unset =
+      # check disabled (dev default).
+      - MCP_SHARED_SECRET=${MCP_SHARED_SECRET:-}
     expose:
       - "8100"
     depends_on:
@@ -51,6 +54,8 @@ services:
       - DEFAULT_LLM_MODEL=${DEFAULT_LLM_MODEL:-claude-opus-4-8}
       - DJANGO_SECRET_KEY=${DJANGO_SECRET_KEY:-dev-secret-key-change-in-production}
       - MCP_SERVER_URL=http://mcp-server:8100/mcp
+      # Must match the mcp-server's value above so the API can authenticate.
+      - MCP_SHARED_SECRET=${MCP_SHARED_SECRET:-}
       - MAX_CONNECTIONS_PER_PROJECT=5
     volumes:
       - ./apps:/app/apps

--- a/mcp_server/auth.py
+++ b/mcp_server/auth.py
@@ -1,25 +1,65 @@
-"""Authentication helpers for the MCP server.
+"""Caller authentication for the MCP HTTP server (arch #253, finding 01#6).
 
-Extracts OAuth tokens from MCP request metadata. Tokens are injected
-by the Django chat view at the transport layer and are never visible
-to the LLM.
+The streamable-HTTP MCP server runs on an internal, IP-filtered network and is
+reached only by the Django API and the Procrastinate worker over the Docker
+network. Previously it had *no* caller authentication at all: every tenant-scoped
+tool resolved context purely from the ``workspace_id`` argument, so any
+co-located process, SSRF, or dev port-forward could call destructive tools
+(``teardown_schema``) against any workspace. Isolation was network topology only.
+
+We add a lightweight shared-secret check as defense-in-depth (not a perimeter):
+every request must carry ``X-Scout-MCP-Secret`` matching ``MCP_SHARED_SECRET``.
+The check is a Starlette middleware so it fires before any tool dispatch,
+including the MCP session/initialize handshake.
+
+Fail-open when unset: if ``MCP_SHARED_SECRET`` is empty (local dev, where the
+server is loopback-only) the check is disabled and a warning is logged once, so
+developers are not forced to set a secret. Production deploy configs set it and
+the matching clients send it (``apps/agents/mcp_client.py``).
 """
 
 from __future__ import annotations
 
-from typing import Any
+import hmac
+import logging
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+logger = logging.getLogger(__name__)
+
+# Header the MCP clients (Django API, worker) send the shared secret in.
+SHARED_SECRET_HEADER = "X-Scout-MCP-Secret"  # noqa: S105 — header name, not a credential
 
 
-def extract_oauth_tokens(meta: dict[str, Any] | None) -> dict[str, str]:
-    """Extract OAuth tokens from MCP request _meta field.
+class SharedSecretMiddleware(BaseHTTPMiddleware):
+    """Reject requests that do not carry the configured shared secret.
 
-    Args:
-        meta: The _meta dict from an MCP tool call. May be None.
-
-    Returns:
-        Dict mapping provider ID to access token string.
-        Empty dict if no tokens present.
+    A constant-time comparison guards against timing oracles. When ``secret`` is
+    empty the middleware is a no-op (fail-open) and logs a one-time warning.
     """
-    if not meta:
-        return {}
-    return meta.get("oauth_tokens", {})
+
+    def __init__(self, app, *, secret: str) -> None:
+        super().__init__(app)
+        self._secret = secret or ""
+        if not self._secret:
+            logger.warning(
+                "MCP_SHARED_SECRET is not set — MCP caller authentication is DISABLED. "
+                "Set MCP_SHARED_SECRET in production so only the Scout API/worker can "
+                "reach the MCP server."
+            )
+
+    async def dispatch(self, request: Request, call_next):
+        if self._secret:
+            provided = request.headers.get(SHARED_SECRET_HEADER, "")
+            if not hmac.compare_digest(provided, self._secret):
+                logger.warning(
+                    "Rejected MCP request without a valid shared secret (path=%s)",
+                    request.url.path,
+                )
+                return JSONResponse(
+                    {"error": "Unauthorized: missing or invalid MCP shared secret"},
+                    status_code=401,
+                )
+        return await call_next(request)

--- a/mcp_server/context.py
+++ b/mcp_server/context.py
@@ -44,7 +44,6 @@ class TenantContext:
     user_id: str
     provider: str
     schema_name: str
-    oauth_tokens: dict[str, str] = None  # type: ignore[assignment]
     max_rows_per_query: int = 500
     max_query_timeout_seconds: int = 30
 

--- a/mcp_server/envelope.py
+++ b/mcp_server/envelope.py
@@ -16,7 +16,21 @@ import time
 from contextlib import asynccontextmanager
 from typing import Any
 
+from asgiref.sync import sync_to_async
+from django.db import close_old_connections
+
 logger = logging.getLogger(__name__)
+
+# Dead-DB-connection hygiene for the long-lived MCP server process (arch #253,
+# finding 08#0). The MCP server is a Django-ORM process with no HTTP
+# request_started/request_finished cycle, so a connection that dies underneath
+# it (RDS restart/upgrade, idle TCP timeout) is reused — closed — forever, and
+# every ORM-touching tool call fails until the process restarts. Mirroring the
+# procrastinate worker's fix (config/procrastinate.py), we close stale/dead
+# connections around every tool call so the next ORM use re-opens them. The
+# cleanup must run on the asgiref thread-sensitive executor — the same thread
+# the async ORM routes queries through — so it reaches the right connection.
+_aclose_old_connections = sync_to_async(close_old_connections, thread_sensitive=True)
 
 # Audit logger — separate from the module logger so it can be filtered/routed
 audit_logger = logging.getLogger("mcp_server.audit")
@@ -79,8 +93,11 @@ class Timer:
         return int((time.monotonic() - self._start) * 1000)
 
 
-# Fields that must never appear in audit logs
-_SCRUB_KEYS = frozenset({"oauth_tokens"})
+# Fields that must never appear in audit logs. Currently empty: the only entry
+# was ``oauth_tokens``, removed with the dead OAuth-into-MCP transport (arch
+# #253, finding 01#0). Kept as the single hook to scrub any sensitive extra
+# field a future tool might pass into ``tool_context``.
+_SCRUB_KEYS: frozenset[str] = frozenset()
 
 
 def scrub_extra_fields(extra: dict[str, Any]) -> dict[str, Any]:
@@ -106,9 +123,13 @@ async def tool_context(tool_name: str, context_id: str, **extra_fields: Any):
     """
     timer = Timer()
     tc: dict[str, Any] = {"timer": timer}
+    # Replace a connection that died between tool calls before the body runs (so
+    # ORM use re-opens it), and close after so nothing leaks between calls.
+    await _aclose_old_connections()
     try:
         yield tc
     finally:
+        await _aclose_old_connections()
         status = "success" if tc.get("result", {}).get("success") else "error"
         # Drop empty actor/context fields so they don't add noise (e.g. operator
         # or context-free tools that carry no user/thread).

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -431,7 +431,7 @@ async def list_pipelines() -> dict:
 
 
 @mcp.tool()
-async def get_materialization_status(run_id: str) -> dict:
+async def get_materialization_status(run_id: str, workspace_id: str = "") -> dict:
     """Retrieve the status of a materialization run by ID.
 
     Primarily a fallback for reconnection scenarios — live progress is delivered
@@ -439,13 +439,22 @@ async def get_materialization_status(run_id: str) -> dict:
 
     Args:
         run_id: UUID of the MaterializationRun to look up.
+        workspace_id: Workspace UUID (injected server-side by the agent graph).
+            The run is scoped to this workspace (arch #253, 01#6) so a run in
+            another workspace cannot be inspected from here.
     """
-    async with tool_context("get_materialization_status", run_id) as tc:
+    async with tool_context("get_materialization_status", run_id, workspace_id=workspace_id) as tc:
         try:
             run = await MaterializationRun.objects.select_related("tenant_schema__tenant").aget(
                 id=run_id
             )
         except (MaterializationRun.DoesNotExist, ValueError, _ValidationError):
+            tc["result"] = error_response(NOT_FOUND, f"Materialization run '{run_id}' not found")
+            return tc["result"]
+
+        if not await _run_belongs_to_workspace(run, workspace_id):
+            # Same NOT_FOUND as a genuinely missing run so a caller can't probe
+            # the existence of runs in other workspaces.
             tc["result"] = error_response(NOT_FOUND, f"Materialization run '{run_id}' not found")
             return tc["result"]
 
@@ -469,7 +478,7 @@ async def get_materialization_status(run_id: str) -> dict:
 
 
 @mcp.tool()
-async def cancel_materialization(run_id: str) -> dict:
+async def cancel_materialization(run_id: str, workspace_id: str = "") -> dict:
     """Cancel a running materialization pipeline.
 
     Marks the run as CANCELLED in the database. This is a best-effort
@@ -478,13 +487,20 @@ async def cancel_materialization(run_id: str) -> dict:
 
     Args:
         run_id: UUID of the MaterializationRun to cancel.
+        workspace_id: Workspace UUID (injected server-side by the agent graph).
+            The run is scoped to this workspace (arch #253, 01#6) so a run in
+            another workspace cannot be cancelled from here.
     """
-    async with tool_context("cancel_materialization", run_id) as tc:
+    async with tool_context("cancel_materialization", run_id, workspace_id=workspace_id) as tc:
         try:
             run = await MaterializationRun.objects.select_related("tenant_schema__tenant").aget(
                 id=run_id
             )
         except (MaterializationRun.DoesNotExist, ValueError, _ValidationError):
+            tc["result"] = error_response(NOT_FOUND, f"Materialization run '{run_id}' not found")
+            return tc["result"]
+
+        if not await _run_belongs_to_workspace(run, workspace_id):
             tc["result"] = error_response(NOT_FOUND, f"Materialization run '{run_id}' not found")
             return tc["result"]
 
@@ -525,7 +541,17 @@ async def cancel_materialization(run_id: str) -> dict:
 
 
 async def _resolve_workspace_memberships(workspace_id, user_id):
-    """Resolve TenantMemberships for all tenants in a workspace."""
+    """Resolve a user's TenantMemberships within a workspace.
+
+    Entitlement guard (arch #253, 01#6): ``user_id`` is REQUIRED. An empty
+    ``user_id`` previously skipped the user filter and returned every membership
+    in the workspace, so the membership guard passed for any/no user. We now
+    reject an empty ``user_id`` outright — a server-injected acting user is the
+    whole point of the check.
+    """
+    if not user_id:
+        return None, "user_id is required"
+
     workspace = await Workspace.objects.filter(id=workspace_id).afirst()
     if workspace is None:
         return None, f"Workspace '{workspace_id}' not found"
@@ -537,15 +563,31 @@ async def _resolve_workspace_memberships(workspace_id, user_id):
     if not tenant_ids:
         return None, "Workspace has no tenants configured"
 
-    qs = TenantMembership.objects.select_related("user", "tenant").filter(tenant_id__in=tenant_ids)
-    if user_id:
-        qs = qs.filter(user_id=user_id)
-
-    memberships = [tm async for tm in qs]
+    memberships = [
+        tm
+        async for tm in TenantMembership.objects.select_related("user", "tenant").filter(
+            tenant_id__in=tenant_ids, user_id=user_id
+        )
+    ]
     if not memberships:
         return None, "No tenant memberships found for this user in this workspace"
 
     return memberships, None
+
+
+async def _run_belongs_to_workspace(run, workspace_id) -> bool:
+    """Return True if a MaterializationRun's tenant is part of ``workspace_id``.
+
+    Scopes LLM-supplied ``run_id``s to the calling workspace (arch #253, 01#6)
+    so a run in another workspace cannot be inspected or cancelled from a chat
+    scoped elsewhere.
+    """
+    if not workspace_id:
+        return False
+    return await WorkspaceTenant.objects.filter(
+        workspace_id=workspace_id,
+        tenant_id=run.tenant_schema.tenant_id,
+    ).aexists()
 
 
 @mcp.tool()
@@ -966,16 +1008,44 @@ def _run_server(args: argparse.Namespace) -> None:
     logger.info("Starting Scout MCP server (transport=%s)", args.transport)
 
     if args.transport == "streamable-http":
-        mcp.settings.host = args.host
-        mcp.settings.port = args.port
-        # Allow internal Docker network hostname in addition to loopback defaults.
-        # The MCP server is internal-only; DNS rebinding protection is still on.
-        mcp.settings.transport_security = TransportSecuritySettings(
-            enable_dns_rebinding_protection=True,
-            allowed_hosts=["127.0.0.1:*", "localhost:*", "[::1]:*", "scout-mcp-web:*"],
-        )
+        _run_streamable_http(args)
+        return
 
     mcp.run(transport=args.transport)
+
+
+def _run_streamable_http(args: argparse.Namespace) -> None:
+    """Serve the streamable-HTTP transport with shared-secret caller auth.
+
+    We build the Starlette app ourselves (rather than calling ``mcp.run``) so we
+    can wrap it in ``SharedSecretMiddleware`` (arch #253, 01#6) — the secret
+    check then fires ahead of any MCP session/tool dispatch. DNS-rebinding Host
+    protection stays on as a second layer.
+    """
+    import uvicorn
+    from django.conf import settings
+
+    from mcp_server.auth import SharedSecretMiddleware
+
+    mcp.settings.host = args.host
+    mcp.settings.port = args.port
+    # Allow internal Docker network hostname in addition to loopback defaults.
+    # The MCP server is internal-only; DNS rebinding protection is still on.
+    mcp.settings.transport_security = TransportSecuritySettings(
+        enable_dns_rebinding_protection=True,
+        allowed_hosts=["127.0.0.1:*", "localhost:*", "[::1]:*", "scout-mcp-web:*"],
+    )
+
+    app = mcp.streamable_http_app()
+    app.add_middleware(SharedSecretMiddleware, secret=settings.MCP_SHARED_SECRET)
+
+    config = uvicorn.Config(
+        app,
+        host=args.host,
+        port=args.port,
+        log_level=("debug" if args.verbose else "info"),
+    )
+    uvicorn.Server(config).run()
 
 
 def _run_with_reload(args: argparse.Namespace) -> None:

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -27,6 +27,8 @@ import sys
 import uuid
 from datetime import UTC, datetime
 
+import uvicorn
+from django.conf import settings
 from django.core.exceptions import ValidationError as _ValidationError
 from mcp.server.fastmcp import Context, FastMCP
 from mcp.server.transport_security import TransportSecuritySettings
@@ -46,6 +48,7 @@ from apps.workspaces.models import (
 )
 from apps.workspaces.services.schema_manager import SchemaManager
 from apps.workspaces.tasks import materialize_workspace
+from mcp_server.auth import SharedSecretMiddleware
 from mcp_server.context import load_workspace_context
 from mcp_server.envelope import (
     INTERNAL_ERROR,
@@ -1022,11 +1025,6 @@ def _run_streamable_http(args: argparse.Namespace) -> None:
     check then fires ahead of any MCP session/tool dispatch. DNS-rebinding Host
     protection stays on as a second layer.
     """
-    import uvicorn
-    from django.conf import settings
-
-    from mcp_server.auth import SharedSecretMiddleware
-
     mcp.settings.host = args.host
     mcp.settings.port = args.port
     # Allow internal Docker network hostname in addition to loopback defaults.

--- a/mcp_server/services/pool.py
+++ b/mcp_server/services/pool.py
@@ -1,0 +1,95 @@
+"""Managed-DB connection pool for the MCP server (arch #253, finding 10#1).
+
+Every MCP ``query``/``describe_table``/``list_tables`` and every artifact source
+query previously opened a *fresh* psycopg TLS connection (``sslmode=require``),
+so one agent turn against a 15-table schema could open 20+ serial TLS
+connections. We pool the managed-DB connections per base DSN and reuse them
+across queries, consistent with how the LangGraph checkpointer pools
+(``apps/chat/checkpointer.py``).
+
+The pool is keyed by the *base* connection identity (host/port/dbname/user) —
+NOT the per-schema search_path — because every tenant/view schema lives in the
+same managed database and differs only by ``search_path``/role, which callers
+set per checkout. Pools are lazily created and cached per key for the lifetime
+of the process.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from psycopg_pool import AsyncConnectionPool
+
+logger = logging.getLogger(__name__)
+
+# Connection-param keys that identify the base DB (NOT the per-schema options).
+_BASE_KEYS = ("host", "port", "dbname", "user", "password", "sslmode")
+
+# Cached pools keyed by base DSN tuple. One pool per managed DB per process.
+_pools: dict[tuple, AsyncConnectionPool] = {}
+_lock = asyncio.Lock()
+
+# Bound the pool so a burst of concurrent queries can't exhaust managed-DB
+# connection slots. Matches the checkpointer's sizing.
+_POOL_MAX_SIZE = 10
+
+
+def _base_conninfo(params: dict[str, Any]) -> str:
+    """Build a libpq conninfo string from the base (schema-independent) params."""
+    parts = []
+    for key in _BASE_KEYS:
+        val = params.get(key)
+        if val in (None, ""):
+            continue
+        # Escape single quotes and backslashes per libpq conninfo rules.
+        sval = str(val).replace("\\", "\\\\").replace("'", "\\'")
+        parts.append(f"{key}='{sval}'")
+    return " ".join(parts)
+
+
+def _pool_key(params: dict[str, Any]) -> tuple:
+    return tuple(params.get(k) for k in _BASE_KEYS)
+
+
+async def get_pool(params: dict[str, Any]) -> AsyncConnectionPool:
+    """Return a lazily-created, cached AsyncConnectionPool for these base params.
+
+    The returned pool's connections carry NO per-schema search_path — callers
+    set ``SET search_path``/``SET ROLE`` per checkout. Connections are opened
+    with ``autocommit=True`` (the read path runs single statements) and
+    ``prepare_threshold=0`` (PgBouncer-safe, matching the checkpointer pool).
+    """
+    key = _pool_key(params)
+    pool = _pools.get(key)
+    if pool is not None:
+        return pool
+
+    async with _lock:
+        pool = _pools.get(key)
+        if pool is not None:
+            return pool
+        conninfo = _base_conninfo(params)
+        pool = AsyncConnectionPool(
+            conninfo=conninfo,
+            max_size=_POOL_MAX_SIZE,
+            open=False,
+            # check keeps the pool from handing out a connection that died
+            # underneath it (RDS restart / idle timeout) — the long-lived-process
+            # analogue of the worker's connection hygiene (arch #253, 08#0).
+            check=AsyncConnectionPool.check_connection,
+            kwargs={"autocommit": True, "prepare_threshold": 0},
+        )
+        await pool.open(wait=True, timeout=10)
+        _pools[key] = pool
+        logger.info("Opened managed-DB connection pool (max_size=%d)", _POOL_MAX_SIZE)
+        return pool
+
+
+async def close_all_pools() -> None:
+    """Close and drop all cached pools. Used in tests and on shutdown."""
+    async with _lock:
+        for pool in _pools.values():
+            await pool.close()
+        _pools.clear()

--- a/mcp_server/services/query.py
+++ b/mcp_server/services/query.py
@@ -21,6 +21,7 @@ from mcp_server.envelope import (
     VALIDATION_ERROR,
     error_response,
 )
+from mcp_server.services.pool import get_pool
 from mcp_server.services.sql_validator import SQLValidationError, SQLValidator
 
 logger = logging.getLogger(__name__)
@@ -36,11 +37,15 @@ def _build_validator(ctx: QueryContext) -> SQLValidator:
 
 
 async def _execute_async(ctx: QueryContext, sql: str, timeout_seconds: int) -> dict[str, Any]:
-    """Run a SQL query asynchronously under the tenant's read-only role."""
-    async with (
-        await psycopg.AsyncConnection.connect(**ctx.connection_params, autocommit=True) as conn,
-        conn.cursor() as cursor,
-    ):
+    """Run a SQL query asynchronously under the tenant's read-only role.
+
+    Acquires a connection from the shared managed-DB pool (arch #253, 10#1)
+    instead of opening a fresh TLS connection per call. The pool's connections
+    carry no schema-specific search_path/role, so each checkout sets them
+    explicitly and RESETs the role before the connection returns to the pool.
+    """
+    pool = await get_pool(ctx.connection_params)
+    async with pool.connection() as conn, conn.cursor() as cursor:
         await cursor.execute(psql.SQL("SET ROLE {}").format(psql.Identifier(ctx.readonly_role)))
         try:
             await cursor.execute(
@@ -62,35 +67,44 @@ async def _execute_async(ctx: QueryContext, sql: str, timeout_seconds: int) -> d
                 "row_count": len(rows),
             }
         finally:
+            # Return the connection to the pool with no lingering role or
+            # per-query timeout. RESET ALL clears search_path + statement_timeout
+            # too, so a reused connection never inherits another schema's state.
             await cursor.execute("RESET ROLE")
+            await cursor.execute("RESET ALL")
 
 
 async def _execute_async_parameterized(
     ctx: QueryContext, sql: str, params: tuple, timeout_seconds: int
 ) -> dict[str, Any]:
-    """Run a parameterized SQL query asynchronously. No validation or LIMIT injection."""
-    async with (
-        await psycopg.AsyncConnection.connect(**ctx.connection_params, autocommit=True) as conn,
-        conn.cursor() as cursor,
-    ):
-        await cursor.execute(
-            psql.SQL("SET search_path TO {}").format(psql.Identifier(ctx.schema_name))
-        )
-        await cursor.execute(f"SET statement_timeout TO '{timeout_seconds}s'")
-        await cursor.execute(sql, params)
+    """Run a parameterized SQL query asynchronously. No validation or LIMIT injection.
 
-        columns: list[str] = []
-        rows: list[list[Any]] = []
+    Uses the shared managed-DB pool (arch #253, 10#1). RESETs the connection's
+    per-query state before returning it to the pool.
+    """
+    pool = await get_pool(ctx.connection_params)
+    async with pool.connection() as conn, conn.cursor() as cursor:
+        try:
+            await cursor.execute(
+                psql.SQL("SET search_path TO {}").format(psql.Identifier(ctx.schema_name))
+            )
+            await cursor.execute(f"SET statement_timeout TO '{timeout_seconds}s'")
+            await cursor.execute(sql, params)
 
-        if cursor.description:
-            columns = [desc[0] for desc in cursor.description]
-            rows = [list(row) for row in await cursor.fetchall()]
+            columns: list[str] = []
+            rows: list[list[Any]] = []
 
-        return {
-            "columns": columns,
-            "rows": rows,
-            "row_count": len(rows),
-        }
+            if cursor.description:
+                columns = [desc[0] for desc in cursor.description]
+                rows = [list(row) for row in await cursor.fetchall()]
+
+            return {
+                "columns": columns,
+                "rows": rows,
+                "row_count": len(rows),
+            }
+        finally:
+            await cursor.execute("RESET ALL")
 
 
 async def execute_internal_query(ctx: QueryContext, sql: str, params: tuple = ()) -> dict[str, Any]:

--- a/tests/test_chat_mcp_contract.py
+++ b/tests/test_chat_mcp_contract.py
@@ -63,11 +63,13 @@ pytestmark = pytest.mark.asyncio(loop_scope="function")
 
 # Tools the server exposes that do NOT take a server-injected context id. Kept
 # explicit so adding a context-free tool is a deliberate edit, not silent drift.
+# ``get_materialization_status``/``cancel_materialization`` were moved OUT of this
+# set (arch #253, 01#6): they now take an injected ``workspace_id`` that scopes
+# the LLM-supplied ``run_id`` to the calling workspace, so they belong in
+# ``MCP_TOOL_NAMES`` instead.
 CONTEXT_FREE_TOOLS = frozenset(
     {
         "list_pipelines",
-        "get_materialization_status",
-        "cancel_materialization",
     }
 )
 
@@ -243,6 +245,7 @@ async def test_prompt_does_not_reference_params_absent_from_tool_schema(db):
 # --------------------------------------------------------------------------- #
 
 
+@pytest.mark.django_db(transaction=True)
 async def test_list_pipelines_round_trip_shape():
     """list_pipelines round-trips and returns the documented success envelope.
 
@@ -294,6 +297,7 @@ async def test_get_schema_status_round_trip_not_provisioned(db):
 # --------------------------------------------------------------------------- #
 
 
+@pytest.mark.django_db(transaction=True)
 async def test_get_schema_status_rejects_empty_workspace_id():
     """A missing workspace_id is rejected server-side, not silently accepted.
 

--- a/tests/test_mcp_audit_actor.py
+++ b/tests/test_mcp_audit_actor.py
@@ -18,6 +18,7 @@ from mcp_server.server import query
 
 
 @pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
 async def test_tool_context_logs_actor_when_provided(caplog):
     """tool_context records user_id and thread_id when threaded through."""
     with caplog.at_level(logging.INFO, logger="mcp_server.audit"):
@@ -34,6 +35,7 @@ async def test_tool_context_logs_actor_when_provided(caplog):
 
 
 @pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
 async def test_tool_context_omits_empty_actor(caplog):
     """Empty actor fields are not noise-logged (context-free / operator tools)."""
     with caplog.at_level(logging.INFO, logger="mcp_server.audit"):

--- a/tests/test_mcp_auth.py
+++ b/tests/test_mcp_auth.py
@@ -1,0 +1,71 @@
+"""Shared-secret caller authentication for the MCP HTTP server (arch #253, 01#6).
+
+The streamable-HTTP MCP server previously trusted any caller on the internal
+network — every tenant-scoped tool resolved context purely from the
+``workspace_id`` argument with no principal check. A co-located process, an SSRF,
+or a dev port-forward could call ``teardown_schema(confirm=True, workspace_id=...)``
+to destroy or read any workspace's data.
+
+We add defense-in-depth: a shared secret (``MCP_SHARED_SECRET``) sent in the
+``X-Scout-MCP-Secret`` header on every request. Wrong/missing secret -> 401. When
+the secret is unset (local dev) the check is disabled (fail-open) so dev keeps
+working, matching how other Scout secrets degrade.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+from starlette.applications import Starlette
+from starlette.responses import PlainTextResponse
+from starlette.routing import Route
+
+from mcp_server.auth import SHARED_SECRET_HEADER, SharedSecretMiddleware
+
+
+def _probe_app() -> Starlette:
+    async def ok(_request):
+        return PlainTextResponse("ok")
+
+    return Starlette(routes=[Route("/mcp", ok, methods=["GET", "POST"])])
+
+
+async def _get(app, headers=None):
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        return await client.get("/mcp", headers=headers or {})
+
+
+@pytest.mark.asyncio
+async def test_request_without_secret_is_rejected():
+    app = _probe_app()
+    app.add_middleware(SharedSecretMiddleware, secret="topsecret")
+    resp = await _get(app)
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_request_with_wrong_secret_is_rejected():
+    app = _probe_app()
+    app.add_middleware(SharedSecretMiddleware, secret="topsecret")
+    resp = await _get(app, headers={SHARED_SECRET_HEADER: "nope"})
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_request_with_correct_secret_is_accepted():
+    app = _probe_app()
+    app.add_middleware(SharedSecretMiddleware, secret="topsecret")
+    resp = await _get(app, headers={SHARED_SECRET_HEADER: "topsecret"})
+    assert resp.status_code == 200
+    assert resp.text == "ok"
+
+
+@pytest.mark.asyncio
+async def test_unset_secret_disables_check_fail_open():
+    """With no configured secret (empty), the middleware lets requests through so
+    local dev keeps working. Production deploy configs set the secret."""
+    app = _probe_app()
+    app.add_middleware(SharedSecretMiddleware, secret="")
+    resp = await _get(app)
+    assert resp.status_code == 200

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -21,6 +21,7 @@ class TestMCPClient:
         import apps.agents.mcp_client as mod
 
         mod.reset_circuit_breaker()
+        mod.reset_tools_cache()
 
         mock_client = AsyncMock()
         mock_tool = AsyncMock()
@@ -30,19 +31,55 @@ class TestMCPClient:
         with patch("apps.agents.mcp_client.MultiServerMCPClient", return_value=mock_client):
             with patch.object(mod, "settings") as mock_settings:
                 mock_settings.MCP_SERVER_URL = "http://localhost:8100/mcp"
+                mock_settings.MCP_SHARED_SECRET = ""
                 tools = await mod.get_mcp_tools()
 
         assert len(tools) == 1
         assert tools[0].name == "query"
         mock_client.get_tools.assert_awaited_once()
         mod.reset_circuit_breaker()
+        mod.reset_tools_cache()
 
     @pytest.mark.asyncio
-    async def test_get_mcp_tools_creates_new_client_each_call(self):
-        """get_mcp_tools creates a fresh client on each call (no singleton)."""
+    async def test_get_mcp_tools_caches_static_tool_schemas(self):
+        """get_mcp_tools caches the tool list (schemas are static) so a second
+        call does NOT do another tools/list HTTP round trip (arch #253, 10#1)."""
         import apps.agents.mcp_client as mod
 
         mod.reset_circuit_breaker()
+        mod.reset_tools_cache()
+
+        mock_client = AsyncMock()
+        mock_tool = AsyncMock()
+        mock_tool.name = "query"
+        mock_client.get_tools.return_value = [mock_tool]
+
+        with (
+            patch(
+                "apps.agents.mcp_client.MultiServerMCPClient", return_value=mock_client
+            ) as MockCls,
+            patch.object(mod, "settings") as mock_settings,
+        ):
+            mock_settings.MCP_SERVER_URL = "http://localhost:8100/mcp"
+            mock_settings.MCP_SHARED_SECRET = ""
+            first = await mod.get_mcp_tools()
+            second = await mod.get_mcp_tools()
+
+        assert first == second
+        # Second call reuses the cache: no second client construction / tools/list.
+        assert MockCls.call_count == 1
+        mock_client.get_tools.assert_awaited_once()
+        mod.reset_circuit_breaker()
+        mod.reset_tools_cache()
+
+    @pytest.mark.asyncio
+    async def test_get_mcp_tools_sends_shared_secret_header(self):
+        """The MCP client sends the shared secret in the connection headers so the
+        server's SharedSecretMiddleware accepts the call (arch #253, 01#6)."""
+        import apps.agents.mcp_client as mod
+
+        mod.reset_circuit_breaker()
+        mod.reset_tools_cache()
 
         mock_client = AsyncMock()
         mock_client.get_tools.return_value = []
@@ -54,11 +91,39 @@ class TestMCPClient:
             patch.object(mod, "settings") as mock_settings,
         ):
             mock_settings.MCP_SERVER_URL = "http://localhost:8100/mcp"
-            await mod.get_mcp_tools()
+            mock_settings.MCP_SHARED_SECRET = "s3cr3t"
             await mod.get_mcp_tools()
 
-        assert MockCls.call_count == 2
+        conn = MockCls.call_args.args[0]["scout-data"]
+        assert conn["headers"]["X-Scout-MCP-Secret"] == "s3cr3t"
         mod.reset_circuit_breaker()
+        mod.reset_tools_cache()
+
+    @pytest.mark.asyncio
+    async def test_get_mcp_tools_omits_header_when_secret_unset(self):
+        """No header is sent when the secret is unset (dev fail-open path)."""
+        import apps.agents.mcp_client as mod
+
+        mod.reset_circuit_breaker()
+        mod.reset_tools_cache()
+
+        mock_client = AsyncMock()
+        mock_client.get_tools.return_value = []
+
+        with (
+            patch(
+                "apps.agents.mcp_client.MultiServerMCPClient", return_value=mock_client
+            ) as MockCls,
+            patch.object(mod, "settings") as mock_settings,
+        ):
+            mock_settings.MCP_SERVER_URL = "http://localhost:8100/mcp"
+            mock_settings.MCP_SHARED_SECRET = ""
+            await mod.get_mcp_tools()
+
+        conn = MockCls.call_args.args[0]["scout-data"]
+        assert "headers" not in conn or not conn["headers"]
+        mod.reset_circuit_breaker()
+        mod.reset_tools_cache()
 
     @pytest.mark.asyncio
     async def test_circuit_breaker_opens_after_failures(self):

--- a/tests/test_mcp_db_resilience.py
+++ b/tests/test_mcp_db_resilience.py
@@ -1,0 +1,58 @@
+"""MCP server DB-connection resilience (arch #253, finding 08#0).
+
+The MCP server is a long-lived Django-ORM process with no HTTP request cycle,
+exactly like the procrastinate worker. A DB connection that dies underneath it
+(RDS restart/upgrade, idle TCP timeout) is reused — closed — forever, so after
+the next RDS maintenance window every ORM-touching MCP tool call fails until the
+process restarts (the June 2026 22h-outage class, fixed only for the worker).
+
+``tool_context`` wraps every MCP tool call, so it is the per-call hook where we
+mirror the worker's ``close_old_connections`` hygiene: close a dead/stale
+connection before the body so it re-opens, and close after so nothing leaks
+between calls.
+"""
+
+from __future__ import annotations
+
+import pytest
+from asgiref.sync import sync_to_async
+from django.contrib.auth import get_user_model
+from django.db import OperationalError, connections
+
+from mcp_server.envelope import tool_context
+
+User = get_user_model()
+
+
+def _kill_default_connection():
+    """Close the underlying psycopg connection behind Django's back — the exact
+    state the MCP process was stuck in after an RDS maintenance window."""
+    conn = connections["default"]
+    conn.ensure_connection()
+    conn.connection.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_tool_context_recovers_from_dead_connection():
+    """An ORM call inside tool_context succeeds even when the connection died
+    since the previous tool call — tool_context closes the dead connection on
+    entry so the ORM re-opens it."""
+    await sync_to_async(_kill_default_connection)()
+
+    async with tool_context("list_tables", "ws-1") as tc:
+        # Would raise OperationalError without the entry-time cleanup.
+        count = await User.objects.acount()
+        tc["result"] = {"success": True}
+
+    assert count == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_orm_call_fails_on_dead_connection_without_recovery():
+    """Control: documents the failure mode tool_context's cleanup exists to fix."""
+    await sync_to_async(_kill_default_connection)()
+    with pytest.raises(OperationalError):
+        await User.objects.acount()
+    await sync_to_async(lambda: connections["default"].close())()

--- a/tests/test_mcp_entitlement.py
+++ b/tests/test_mcp_entitlement.py
@@ -1,0 +1,171 @@
+"""MCP tool entitlement scoping (arch #253, finding 01#6).
+
+Tenant-scoped MCP tools previously trusted whatever id the caller supplied:
+
+* ``run_materialization``'s membership guard PASSED for any user when
+  ``user_id=''`` (the empty-user_id filter was skipped, returning every
+  membership in the workspace).
+* ``cancel_materialization`` / ``get_materialization_status`` accepted any
+  LLM-supplied ``run_id`` and resolved a ``MaterializationRun`` from ANY
+  workspace — a run in workspace B could be cancelled/inspected from a chat
+  scoped to workspace A.
+
+These tests pin the fix: an empty user_id is denied, and cancel/status are
+scoped to the calling workspace.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from django.contrib.auth import get_user_model
+
+from apps.users.models import Tenant, TenantMembership
+from apps.workspaces.models import (
+    MaterializationRun,
+    SchemaState,
+    TenantSchema,
+    Workspace,
+    WorkspaceTenant,
+)
+from mcp_server.server import (
+    cancel_materialization,
+    get_materialization_status,
+    run_materialization,
+)
+
+User = get_user_model()
+
+
+async def _make_workspace_with_run(*, email, ext_id, schema_name, run_state):
+    """Create a workspace + tenant + active schema + one materialization run."""
+    user = await User.objects.acreate_user(email=email, password="x")
+    ws = await Workspace.objects.acreate(name=f"W-{ext_id}", created_by=user)
+    tenant = await Tenant.objects.acreate(
+        external_id=ext_id, provider="commcare", canonical_name=f"T-{ext_id}"
+    )
+    await WorkspaceTenant.objects.acreate(workspace=ws, tenant=tenant)
+    await TenantMembership.objects.acreate(tenant=tenant, user=user)
+    ts = await TenantSchema.objects.acreate(
+        tenant=tenant, schema_name=schema_name, state=SchemaState.ACTIVE
+    )
+    run = await MaterializationRun.objects.acreate(
+        tenant_schema=ts,
+        pipeline="commcare_sync",
+        state=run_state,
+        started_at=datetime.now(UTC),
+    )
+    return user, ws, run
+
+
+# --- run_materialization user_id='' bypass ---
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_run_materialization_denies_empty_user_id():
+    """An empty user_id must be denied — it previously passed the membership
+    guard for any user (the empty filter returned every membership)."""
+    user = await User.objects.acreate_user(email="empty@b.c", password="x")
+    ws = await Workspace.objects.acreate(name="W-empty", created_by=user)
+    tenant = await Tenant.objects.acreate(
+        external_id="te", provider="commcare", canonical_name="Empty Tenant"
+    )
+    await WorkspaceTenant.objects.acreate(workspace=ws, tenant=tenant)
+    await TenantMembership.objects.acreate(tenant=tenant, user=user)
+    from apps.chat.models import Thread
+
+    thread = await Thread.objects.acreate(workspace=ws, user=user)
+
+    result = await run_materialization(
+        workspace_id=str(ws.id),
+        user_id="",  # the bypass: empty user_id
+        thread_id=str(thread.id),
+        tool_call_id="tc-empty",
+    )
+
+    assert result["success"] is False
+    assert result["error"]["code"] in {"VALIDATION_ERROR", "NOT_FOUND"}
+
+
+# --- cancel_materialization scoping ---
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_cancel_materialization_rejects_run_from_other_workspace():
+    _, _ws_a, _ = await _make_workspace_with_run(
+        email="a@b.c", ext_id="ta", schema_name="t_a", run_state=MaterializationRun.RunState.STARTED
+    )
+    _, ws_b, run_b = await _make_workspace_with_run(
+        email="b@b.c", ext_id="tb", schema_name="t_b", run_state=MaterializationRun.RunState.STARTED
+    )
+
+    # Caller is scoped to workspace A but supplies workspace B's run_id.
+    result = await cancel_materialization(run_id=str(run_b.id), workspace_id=str(_ws_a.id))
+
+    assert result["success"] is False
+    assert result["error"]["code"] == "NOT_FOUND"
+    # The run in B must NOT have been cancelled.
+    await run_b.arefresh_from_db()
+    assert run_b.state == MaterializationRun.RunState.STARTED
+    assert ws_b  # silence unused
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_cancel_materialization_allows_run_in_own_workspace():
+    _, ws, run = await _make_workspace_with_run(
+        email="own@b.c",
+        ext_id="to",
+        schema_name="t_o",
+        run_state=MaterializationRun.RunState.STARTED,
+    )
+
+    result = await cancel_materialization(run_id=str(run.id), workspace_id=str(ws.id))
+
+    assert result["success"] is True
+    await run.arefresh_from_db()
+    assert run.state == MaterializationRun.RunState.CANCELLED
+
+
+# --- get_materialization_status scoping ---
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_status_rejects_run_from_other_workspace():
+    _, ws_a, _ = await _make_workspace_with_run(
+        email="sa@b.c",
+        ext_id="tsa",
+        schema_name="t_sa",
+        run_state=MaterializationRun.RunState.COMPLETED,
+    )
+    _, _ws_b, run_b = await _make_workspace_with_run(
+        email="sb@b.c",
+        ext_id="tsb",
+        schema_name="t_sb",
+        run_state=MaterializationRun.RunState.COMPLETED,
+    )
+
+    result = await get_materialization_status(run_id=str(run_b.id), workspace_id=str(ws_a.id))
+
+    assert result["success"] is False
+    assert result["error"]["code"] == "NOT_FOUND"
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_status_allows_run_in_own_workspace():
+    _, ws, run = await _make_workspace_with_run(
+        email="so@b.c",
+        ext_id="tso",
+        schema_name="t_so",
+        run_state=MaterializationRun.RunState.COMPLETED,
+    )
+
+    result = await get_materialization_status(run_id=str(run.id), workspace_id=str(ws.id))
+
+    assert result["success"] is True
+    assert result["data"]["run_id"] == str(run.id)

--- a/tests/test_mcp_entitlement.py
+++ b/tests/test_mcp_entitlement.py
@@ -21,6 +21,7 @@ from datetime import UTC, datetime
 import pytest
 from django.contrib.auth import get_user_model
 
+from apps.chat.models import Thread
 from apps.users.models import Tenant, TenantMembership
 from apps.workspaces.models import (
     MaterializationRun,
@@ -74,8 +75,6 @@ async def test_run_materialization_denies_empty_user_id():
     )
     await WorkspaceTenant.objects.acreate(workspace=ws, tenant=tenant)
     await TenantMembership.objects.acreate(tenant=tenant, user=user)
-    from apps.chat.models import Thread
-
     thread = await Thread.objects.acreate(workspace=ws, user=user)
 
     result = await run_materialization(

--- a/tests/test_mcp_pool.py
+++ b/tests/test_mcp_pool.py
@@ -1,0 +1,84 @@
+"""Managed-DB connection pooling for the MCP server (arch #253, finding 10#1).
+
+Previously every MCP query/describe/list opened a fresh psycopg TLS connection.
+We now reuse a shared ``AsyncConnectionPool``, keyed by the base DB identity
+(host/port/dbname/user) rather than the per-schema search_path — so two
+different schemas in the same managed DB share one pool, and a second query does
+not pay another TLS handshake.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mcp_server.services import pool as pool_mod
+
+
+@pytest.fixture(autouse=True)
+def _clear_pools():
+    pool_mod._pools.clear()
+    yield
+    pool_mod._pools.clear()
+
+
+def _base_params(schema):
+    return {
+        "host": "db.example.com",
+        "port": 5432,
+        "dbname": "scout",
+        "user": "scout_app",
+        "password": "pw",
+        "sslmode": "require",
+        # per-schema option that must NOT affect the pool key
+        "options": f"-c search_path={schema},public -c statement_timeout=30000",
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_pool_reuses_pool_for_same_base_db():
+    """Two contexts on different schemas of the same managed DB share one pool —
+    proving connections are reused, not reopened per schema."""
+    fake_pool = MagicMock()
+    fake_pool.open = AsyncMock()
+
+    with patch.object(pool_mod, "AsyncConnectionPool", return_value=fake_pool) as PoolCls:
+        p1 = await pool_mod.get_pool(_base_params("t_alpha"))
+        p2 = await pool_mod.get_pool(_base_params("t_beta"))
+
+    assert p1 is p2
+    # Pool constructed exactly once despite two different search_paths.
+    assert PoolCls.call_count == 1
+    fake_pool.open.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_get_pool_separate_pools_for_different_dbs():
+    """Different managed databases get distinct pools."""
+    fake_a = MagicMock(open=AsyncMock())
+    fake_b = MagicMock(open=AsyncMock())
+
+    with patch.object(pool_mod, "AsyncConnectionPool", side_effect=[fake_a, fake_b]) as PoolCls:
+        a = _base_params("t_a")
+        b = _base_params("t_b")
+        b["dbname"] = "other_db"
+        pa = await pool_mod.get_pool(a)
+        pb = await pool_mod.get_pool(b)
+
+    assert pa is not pb
+    assert PoolCls.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_base_conninfo_excludes_per_schema_options():
+    """The conninfo passed to the pool carries the base DB identity but not the
+    per-schema search_path options."""
+    fake_pool = MagicMock(open=AsyncMock())
+    with patch.object(pool_mod, "AsyncConnectionPool", return_value=fake_pool) as PoolCls:
+        await pool_mod.get_pool(_base_params("t_x"))
+
+    conninfo = PoolCls.call_args.kwargs["conninfo"]
+    assert "dbname='scout'" in conninfo
+    assert "host='db.example.com'" in conninfo
+    assert "search_path" not in conninfo

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -202,41 +202,24 @@ class TestExecuteQuery:
 # code paths (load_tenant_context + execute_internal_query).
 
 
-# --- Auth token extraction tests ---
-
-
-class TestAuthTokenExtraction:
-    """Test MCP auth token extraction from _meta field."""
-
-    def test_extract_tokens_from_meta(self):
-        from mcp_server.auth import extract_oauth_tokens
-
-        meta = {"oauth_tokens": {"commcare": "tok_abc", "commcare_connect": "tok_xyz"}}
-        assert extract_oauth_tokens(meta) == {"commcare": "tok_abc", "commcare_connect": "tok_xyz"}
-
-    def test_extract_tokens_missing_meta(self):
-        from mcp_server.auth import extract_oauth_tokens
-
-        assert extract_oauth_tokens({}) == {}
-
-    def test_extract_tokens_none_meta(self):
-        from mcp_server.auth import extract_oauth_tokens
-
-        assert extract_oauth_tokens(None) == {}
+# --- Audit log scrubbing ---
 
 
 class TestAuditLogScrubbing:
-    """Test that oauth_tokens are scrubbed from audit log extra_fields."""
+    """scrub_extra_fields removes any keys listed in _SCRUB_KEYS from audit
+    extra_fields. The set is currently empty (the oauth_tokens transport was
+    removed, arch #253 / 01#0); the hook stays for future sensitive fields."""
 
-    def test_scrub_removes_oauth_tokens(self):
+    def test_scrub_removes_listed_keys(self):
+        from mcp_server import envelope
         from mcp_server.envelope import scrub_extra_fields
 
-        extra = {"sql": "SELECT 1", "oauth_tokens": {"commcare": "secret"}}
-        scrubbed = scrub_extra_fields(extra)
-        assert "oauth_tokens" not in scrubbed
+        with patch.object(envelope, "_SCRUB_KEYS", frozenset({"secret"})):
+            scrubbed = scrub_extra_fields({"sql": "SELECT 1", "secret": "x"})
+        assert "secret" not in scrubbed
         assert scrubbed["sql"] == "SELECT 1"
 
-    def test_scrub_noop_when_no_tokens(self):
+    def test_scrub_noop_when_nothing_to_scrub(self):
         from mcp_server.envelope import scrub_extra_fields
 
         extra = {"sql": "SELECT 1"}

--- a/tests/test_mcp_tenant_tools.py
+++ b/tests/test_mcp_tenant_tools.py
@@ -143,6 +143,18 @@ def _make_async_conn(mock_cursor):
     return mock_conn
 
 
+def _make_pool_for_conn(mock_conn):
+    """Build a mock AsyncConnectionPool whose .connection() yields ``mock_conn``.
+
+    Queries now acquire connections from the shared managed-DB pool (arch #253,
+    10#1) rather than opening a fresh ``psycopg.AsyncConnection`` per call, so
+    tests patch ``get_pool`` to return this fake pool.
+    """
+    pool = MagicMock()
+    pool.connection.return_value = mock_conn  # mock_conn is its own async ctx mgr
+    return AsyncMock(return_value=pool)
+
+
 class TestExecuteAsyncParameterized:
     """Test the low-level async execution function."""
 
@@ -157,8 +169,8 @@ class TestExecuteAsyncParameterized:
         mock_conn = _make_async_conn(mock_cursor)
 
         with patch(
-            "psycopg.AsyncConnection.connect",
-            new=AsyncMock(return_value=mock_conn),
+            "mcp_server.services.query.get_pool",
+            new=_make_pool_for_conn(mock_conn),
         ):
             result = await _execute_async_parameterized(
                 tenant_context,
@@ -168,9 +180,10 @@ class TestExecuteAsyncParameterized:
                 30,
             )
 
-        # Verify all three execute calls: SET search_path, SET timeout, actual query
+        # SET search_path, SET timeout, actual query, then RESET ALL on return.
         execute_calls = mock_cursor.execute.call_args_list
-        assert len(execute_calls) == 3
+        assert len(execute_calls) == 4
+        assert "RESET ALL" in str(execute_calls[-1])
 
         # Verify the actual query was called with params
         final_call = execute_calls[2]
@@ -194,8 +207,8 @@ class TestExecuteAsyncParameterized:
         mock_conn = _make_async_conn(mock_cursor)
 
         with patch(
-            "psycopg.AsyncConnection.connect",
-            new=AsyncMock(return_value=mock_conn),
+            "mcp_server.services.query.get_pool",
+            new=_make_pool_for_conn(mock_conn),
         ):
             result = await _execute_async_parameterized(
                 tenant_context,
@@ -224,6 +237,10 @@ def _fake_sync_to_async(fn):
     return wrapper
 
 
+# Tool handlers run inside tool_context, which now manages DB connections
+# (close_old_connections) on every call (arch #253, 08#0), so every tool-invoking
+# test touches the connection layer and needs the DB enabled.
+@pytest.mark.django_db(transaction=True)
 class TestListTablesTool:
     async def test_success_returns_enriched_tables(self, tenant_id, tenant_context):
         from mcp_server.server import list_tables
@@ -331,6 +348,7 @@ class TestListTablesTool:
 PATCH_PIPELINE_DESCRIBE_TABLE = "mcp_server.server.pipeline_describe_table"
 
 
+@pytest.mark.django_db(transaction=True)
 class TestDescribeTableTool:
     async def test_success_returns_enriched_columns(self, tenant_id, tenant_context):
         from mcp_server.server import describe_table
@@ -430,6 +448,7 @@ class TestDescribeTableTool:
 PATCH_PIPELINE_GET_METADATA = "mcp_server.server.pipeline_get_metadata"
 
 
+@pytest.mark.django_db(transaction=True)
 class TestGetMetadataTool:
     async def test_returns_tables_and_relationships(self, tenant_id, tenant_context):
         from mcp_server.server import get_metadata
@@ -631,6 +650,7 @@ PATCH_TENANT_SCHEMA = "apps.workspaces.models.TenantSchema"
 PATCH_MATERIALIZATION_RUN = "apps.workspaces.models.MaterializationRun"
 
 
+@pytest.mark.django_db(transaction=True)
 class TestGetSchemaStatusTool:
     """Test the get_schema_status MCP tool."""
 
@@ -712,6 +732,7 @@ class TestGetSchemaStatusTool:
 PATCH_SCHEMA_MANAGER = "apps.workspaces.services.schema_manager.SchemaManager"
 
 
+@pytest.mark.django_db(transaction=True)
 class TestTeardownSchemaTool:
     """Test the teardown_schema MCP tool."""
 
@@ -752,6 +773,7 @@ class TestTeardownSchemaTool:
         assert result["error"]["code"] == NOT_FOUND
 
 
+@pytest.mark.django_db(transaction=True)
 class TestListPipelines:
     def test_returns_available_pipelines(self):
         import asyncio
@@ -779,6 +801,7 @@ class TestListPipelines:
         assert result["data"]["pipelines"][0]["provider"] == "commcare"
 
 
+@pytest.mark.django_db(transaction=True)
 class TestGetMaterializationStatus:
     def test_returns_run_status(self):
         import asyncio
@@ -802,11 +825,19 @@ class TestGetMaterializationStatus:
         mock_run.tenant_schema.schema_name = "dimagi"
         del mock_run.tenant_schema.tenant_membership
 
-        with patch("mcp_server.server.MaterializationRun") as mock_cls:
+        with (
+            patch("mcp_server.server.MaterializationRun") as mock_cls,
+            # The run-belongs-to-workspace scoping (arch #253, 01#6) is exercised
+            # by tests/test_mcp_entitlement.py; here we isolate the status logic.
+            patch(
+                "mcp_server.server._run_belongs_to_workspace",
+                new=AsyncMock(return_value=True),
+            ),
+        ):
             mock_cls.objects.select_related.return_value.aget = AsyncMock(return_value=mock_run)
             from mcp_server.server import get_materialization_status
 
-            result = asyncio.run(get_materialization_status(run_id=run_id))
+            result = asyncio.run(get_materialization_status(run_id=run_id, workspace_id="ws-1"))
 
         assert result["success"] is True
         assert result["data"]["run_id"] == run_id
@@ -834,6 +865,7 @@ class TestGetMaterializationStatus:
         assert result["error"]["code"] == "NOT_FOUND"
 
 
+@pytest.mark.django_db(transaction=True)
 class TestCancelMaterialization:
     def test_cancel_in_progress_run(self):
         import asyncio
@@ -851,7 +883,13 @@ class TestCancelMaterialization:
         del mock_run.tenant_schema.tenant_membership
         mock_run.asave = AsyncMock()
 
-        with patch("mcp_server.server.MaterializationRun") as mock_cls:
+        with (
+            patch("mcp_server.server.MaterializationRun") as mock_cls,
+            patch(
+                "mcp_server.server._run_belongs_to_workspace",
+                new=AsyncMock(return_value=True),
+            ),
+        ):
             mock_cls.objects.select_related.return_value.aget = AsyncMock(return_value=mock_run)
             mock_cls.RunState.STARTED = "started"
             mock_cls.RunState.DISCOVERING = "discovering"
@@ -861,7 +899,7 @@ class TestCancelMaterialization:
             mock_cls.RunState.CANCELLED = "cancelled"
             from mcp_server.server import cancel_materialization
 
-            result = asyncio.run(cancel_materialization(run_id=run_id))
+            result = asyncio.run(cancel_materialization(run_id=run_id, workspace_id="ws-1"))
 
         assert result["success"] is True
         assert result["data"]["cancelled"] is True
@@ -889,7 +927,13 @@ class TestCancelMaterialization:
         mock_run.tenant_schema.schema_name = "dimagi"
         del mock_run.tenant_schema.tenant_membership
 
-        with patch("mcp_server.server.MaterializationRun") as mock_cls:
+        with (
+            patch("mcp_server.server.MaterializationRun") as mock_cls,
+            patch(
+                "mcp_server.server._run_belongs_to_workspace",
+                new=AsyncMock(return_value=True),
+            ),
+        ):
             mock_cls.objects.select_related.return_value.aget = AsyncMock(return_value=mock_run)
             mock_cls.RunState.STARTED = "started"
             mock_cls.RunState.DISCOVERING = "discovering"
@@ -898,7 +942,7 @@ class TestCancelMaterialization:
             mock_cls.RunState.FAILED = "failed"
             from mcp_server.server import cancel_materialization
 
-            result = asyncio.run(cancel_materialization(run_id=run_id))
+            result = asyncio.run(cancel_materialization(run_id=run_id, workspace_id="ws-1"))
 
         assert result["success"] is False
         assert "not in progress" in result["error"]["message"].lower()

--- a/tests/test_mcp_workspace_routing.py
+++ b/tests/test_mcp_workspace_routing.py
@@ -4,6 +4,7 @@ import pytest
 
 
 @pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
 async def test_query_tool_uses_workspace_context_when_workspace_id_provided():
     """When workspace_id is provided, query should call load_workspace_context."""
     mock_ctx = MagicMock()
@@ -35,6 +36,7 @@ async def test_query_tool_uses_workspace_context_when_workspace_id_provided():
 
 
 @pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
 async def test_query_tool_requires_workspace_id():
     """When workspace_id is empty, query should return a validation error."""
     from mcp_server.server import query

--- a/tests/test_oauth_tokens.py
+++ b/tests/test_oauth_tokens.py
@@ -7,7 +7,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from allauth.socialaccount.models import SocialAccount, SocialApp, SocialToken
-from asgiref.sync import async_to_sync
 from cryptography.fernet import Fernet
 from django.conf import settings
 from django.contrib.sites.models import Site
@@ -78,94 +77,6 @@ class TestCommCareConnectProvider:
 
     def test_provider_in_installed_apps(self):
         assert "apps.users.providers.commcare_connect" in settings.INSTALLED_APPS
-
-
-class AsyncList:
-    """Wraps a list to support async iteration for mocking Django async querysets."""
-
-    def __init__(self, items):
-        self._items = items
-
-    def __aiter__(self):
-        return self._aiter()
-
-    async def _aiter(self):
-        for item in self._items:
-            yield item
-
-
-class TestGetUserOAuthTokens:
-    """Test the get_user_oauth_tokens helper in mcp_client."""
-
-    def _make_social_token(self, provider, token, token_secret="refresh_tok", expires_at=None):
-        """Build a mock SocialToken."""
-        st = MagicMock()
-        st.account.provider = provider
-        st.token = token
-        st.token_secret = token_secret
-        st.expires_at = expires_at
-        return st
-
-    @patch("apps.agents.mcp_client.SocialToken")
-    def test_returns_tokens_for_connected_providers(self, mock_social_token_cls):
-        from apps.agents.mcp_client import get_user_oauth_tokens
-
-        user = MagicMock()
-        user.pk = 1
-
-        mock_qs = MagicMock()
-        mock_social_token_cls.objects.filter.return_value = mock_qs
-        mock_qs.select_related.return_value = AsyncList(
-            [
-                self._make_social_token("commcare", "hq_token_123"),
-                self._make_social_token("commcare_connect", "connect_token_456"),
-            ]
-        )
-
-        result = async_to_sync(get_user_oauth_tokens)(user)
-        assert result == {
-            "commcare": "hq_token_123",
-            "commcare_connect": "connect_token_456",
-        }
-
-    @patch("apps.agents.mcp_client.SocialToken")
-    def test_returns_empty_dict_for_no_tokens(self, mock_social_token_cls):
-        from apps.agents.mcp_client import get_user_oauth_tokens
-
-        user = MagicMock()
-        user.pk = 1
-
-        mock_qs = MagicMock()
-        mock_social_token_cls.objects.filter.return_value = mock_qs
-        mock_qs.select_related.return_value = AsyncList([])
-
-        result = async_to_sync(get_user_oauth_tokens)(user)
-        assert result == {}
-
-    @patch("apps.agents.mcp_client.SocialToken")
-    def test_skips_non_commcare_providers(self, mock_social_token_cls):
-        from apps.agents.mcp_client import get_user_oauth_tokens
-
-        user = MagicMock()
-        user.pk = 1
-
-        mock_qs = MagicMock()
-        mock_social_token_cls.objects.filter.return_value = mock_qs
-        mock_qs.select_related.return_value = AsyncList(
-            [
-                self._make_social_token("google", "google_token"),
-                self._make_social_token("commcare", "hq_token"),
-            ]
-        )
-
-        result = async_to_sync(get_user_oauth_tokens)(user)
-        assert result == {"commcare": "hq_token"}
-
-    def test_returns_empty_dict_for_none_user(self):
-        from apps.agents.mcp_client import get_user_oauth_tokens
-
-        result = async_to_sync(get_user_oauth_tokens)(None)
-        assert result == {}
 
 
 class TestTokenRefresh:
@@ -240,32 +151,6 @@ class TestTokenRefresh:
         from apps.users.services.token_refresh import token_needs_refresh
 
         assert token_needs_refresh(None) is False
-
-
-@pytest.mark.django_db
-class TestGraphOAuthConfig:
-    """Test that build_agent_graph accepts oauth_tokens gracefully."""
-
-    @patch("apps.agents.graph.base.ChatAnthropic")
-    @patch("apps.agents.graph.base.KnowledgeRetriever")
-    def test_build_graph_accepts_oauth_tokens(self, mock_kr, mock_llm, workspace):
-        """build_agent_graph should accept oauth_tokens without error."""
-        from apps.agents.graph.base import build_agent_graph
-
-        mock_kr_instance = MagicMock()
-        mock_kr_instance.retrieve.return_value = ""
-        mock_kr.return_value = mock_kr_instance
-
-        mock_llm_instance = MagicMock()
-        mock_llm_instance.bind_tools.return_value = mock_llm_instance
-        mock_llm.return_value = mock_llm_instance
-
-        # Should not raise (returns a coroutine — check it's not None)
-        graph = build_agent_graph(
-            workspace=workspace,
-            oauth_tokens={"commcare": "test_token"},
-        )
-        assert graph is not None
 
 
 @pytest.mark.django_db

--- a/tests/test_query_role_isolation.py
+++ b/tests/test_query_role_isolation.py
@@ -37,6 +37,14 @@ def _make_async_conn(mock_cursor):
     return mock_conn
 
 
+def _make_pool_for_conn(mock_conn):
+    """Mock AsyncConnectionPool whose .connection() yields ``mock_conn`` — queries
+    acquire from the shared managed-DB pool now (arch #253, 10#1)."""
+    pool = MagicMock()
+    pool.connection.return_value = mock_conn
+    return AsyncMock(return_value=pool)
+
+
 class TestSetRoleIsolation:
     def _make_ctx(self, schema_name="test_domain"):
         return QueryContext(
@@ -54,8 +62,8 @@ class TestSetRoleIsolation:
         mock_conn = _make_async_conn(mock_cursor)
 
         with patch(
-            "psycopg.AsyncConnection.connect",
-            new=AsyncMock(return_value=mock_conn),
+            "mcp_server.services.query.get_pool",
+            new=_make_pool_for_conn(mock_conn),
         ):
             ctx = self._make_ctx()
             await _execute_async(ctx, "SELECT 1", 30)
@@ -65,9 +73,10 @@ class TestSetRoleIsolation:
         first_call_str = str(execute_calls[0])
         assert "SET ROLE" in first_call_str
         assert "test_domain_ro" in first_call_str
-        # Last call before cursor.close should be RESET ROLE
-        last_call_str = str(execute_calls[-1])
-        assert "RESET ROLE" in last_call_str
+        # Cleanup before the pooled connection returns: RESET ROLE then RESET ALL.
+        call_strs = [str(c) for c in execute_calls]
+        assert any("RESET ROLE" in c for c in call_strs)
+        assert "RESET ALL" in call_strs[-1]
 
     @pytest.mark.asyncio
     async def test_reset_role_on_query_error(self):
@@ -78,21 +87,22 @@ class TestSetRoleIsolation:
             None,  # SET statement_timeout succeeds
             Exception("query failed"),  # actual query fails
             None,  # RESET ROLE succeeds
+            None,  # RESET ALL succeeds
         ]
 
         mock_conn = _make_async_conn(mock_cursor)
 
         with patch(
-            "psycopg.AsyncConnection.connect",
-            new=AsyncMock(return_value=mock_conn),
+            "mcp_server.services.query.get_pool",
+            new=_make_pool_for_conn(mock_conn),
         ):
             ctx = self._make_ctx()
             with contextlib.suppress(Exception):
                 await _execute_async(ctx, "SELECT bad", 30)
 
-        # RESET ROLE should still have been called
-        last_call_str = str(mock_cursor.execute.call_args_list[-1])
-        assert "RESET ROLE" in last_call_str
+        # RESET ROLE must still have run after the query error (before RESET ALL).
+        call_strs = [str(c) for c in mock_cursor.execute.call_args_list]
+        assert any("RESET ROLE" in c for c in call_strs)
 
 
 class TestRoleErrorClassification:

--- a/tests/test_recipe_materialization_integration.py
+++ b/tests/test_recipe_materialization_integration.py
@@ -64,7 +64,6 @@ async def test_recipe_agent_materializes_headlessly_without_crash(workspace, use
 
     with (
         patch("apps.recipes.services.runner.get_mcp_tools", new=AsyncMock(return_value=[])),
-        patch("apps.recipes.services.runner.get_user_oauth_tokens", new=AsyncMock(return_value={})),
         patch("apps.agents.graph.base.ChatAnthropic", return_value=mock_llm),
     ):
         run_row = await RecipeRun.objects.acreate(

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -617,9 +617,8 @@ class TestRecipeRunner:
     @pytest.mark.asyncio
     @patch("apps.recipes.services.runner.build_agent_graph", new_callable=AsyncMock)
     @patch("apps.recipes.services.runner.get_mcp_tools", new_callable=AsyncMock)
-    @patch("apps.recipes.services.runner.get_user_oauth_tokens", new_callable=AsyncMock)
     async def test_recipe_runner_builds_headless_graph(
-        self, mock_oauth, mock_mcp, mock_build, recipe, user, recipe_step_1
+        self, mock_mcp, mock_build, recipe, user, recipe_step_1
     ):
         """The runner must build the agent graph in HEADLESS mode (interactive=
         False), with no checkpointer, passing its job_id — so the agent gets the
@@ -627,7 +626,6 @@ class TestRecipeRunner:
         crash on the recipe's synthetic thread_id."""
         values = {"region": "North", "limit": 10, "start_date": "2024-01-01"}
         mock_mcp.return_value = []
-        mock_oauth.return_value = {}
         stub_graph = Mock()
         stub_graph.ainvoke = AsyncMock(return_value={"messages": []})
         mock_build.return_value = stub_graph

--- a/tests/test_resume_thread_task.py
+++ b/tests/test_resume_thread_task.py
@@ -100,7 +100,7 @@ async def test_resume_appends_system_message_and_invokes_agent():
     mock_agent.ainvoke = AsyncMock(return_value={"messages": []})
     with patch(
         "apps.workspaces.tasks._build_agent_for_resume",
-        AsyncMock(return_value=(mock_agent, {})),
+        AsyncMock(return_value=mock_agent),
     ):
         result = await resume_thread_after_materialization(
             None,
@@ -118,11 +118,9 @@ async def test_resume_appends_system_message_and_invokes_agent():
     assert messages[0].content.startswith("[__system_resume__]")
     assert "completed" in messages[0].content
     # Pin the runtime config's REAL, consumed contract: the checkpointer routes
-    # the resume to the right conversation via configurable.thread_id. (We do not
-    # assert on `oauth_tokens` — it is currently dead plumbing: build_agent_graph
-    # accepts the kwarg and the resume forwards it into config, but nothing in the
-    # graph reads it. Pinning it would codify dead plumbing as contract — 12#0
-    # item 4.)
+    # the resume to the right conversation via configurable.thread_id. The dead
+    # OAuth-token plumbing that used to ride along in this config was removed
+    # (arch #253, finding 01#0).
     config = call_args.args[1]
     assert config["configurable"]["thread_id"] == str(thread.id)
 
@@ -166,7 +164,7 @@ async def test_resume_failed_or_cancelled_prompt_is_honest(
     mock_agent.ainvoke = AsyncMock(return_value={"messages": []})
     with patch(
         "apps.workspaces.tasks._build_agent_for_resume",
-        AsyncMock(return_value=(mock_agent, {})),
+        AsyncMock(return_value=mock_agent),
     ):
         result = await resume_thread_after_materialization(None, thread_job_id=str(tj.id))
 
@@ -244,7 +242,7 @@ async def test_resume_no_runs_still_invokes_agent_with_explanation():
     mock_agent.ainvoke = AsyncMock(return_value={"messages": []})
     with patch(
         "apps.workspaces.tasks._build_agent_for_resume",
-        AsyncMock(return_value=(mock_agent, {})),
+        AsyncMock(return_value=mock_agent),
     ):
         result = await resume_thread_after_materialization(None, thread_job_id=str(tj.id))
 
@@ -296,7 +294,7 @@ async def test_resume_partial_maps_to_failed():
     mock_agent.ainvoke = AsyncMock(return_value={"messages": []})
     with patch(
         "apps.workspaces.tasks._build_agent_for_resume",
-        AsyncMock(return_value=(mock_agent, {})),
+        AsyncMock(return_value=mock_agent),
     ):
         result = await resume_thread_after_materialization(None, thread_job_id=str(tj.id))
 
@@ -342,7 +340,7 @@ async def test_resume_invokes_agent_for_cancelled_threadjob():
     mock_agent.ainvoke = AsyncMock(return_value={"messages": []})
     with patch(
         "apps.workspaces.tasks._build_agent_for_resume",
-        AsyncMock(return_value=(mock_agent, {})),
+        AsyncMock(return_value=mock_agent),
     ):
         result = await resume_thread_after_materialization(
             None,
@@ -395,7 +393,7 @@ async def test_resume_bumps_thread_updated_at_on_success():
     mock_agent.ainvoke = AsyncMock(return_value={"messages": []})
     with patch(
         "apps.workspaces.tasks._build_agent_for_resume",
-        AsyncMock(return_value=(mock_agent, {})),
+        AsyncMock(return_value=mock_agent),
     ):
         result = await resume_thread_after_materialization(None, thread_job_id=str(tj.id))
 
@@ -451,7 +449,7 @@ async def test_resume_does_not_clobber_concurrent_cancel_during_ainvoke():
     mock_agent.ainvoke = AsyncMock(side_effect=flip_to_cancelled_then_return)
     with patch(
         "apps.workspaces.tasks._build_agent_for_resume",
-        AsyncMock(return_value=(mock_agent, {})),
+        AsyncMock(return_value=mock_agent),
     ):
         result = await resume_thread_after_materialization(None, thread_job_id=str(tj.id))
 
@@ -503,7 +501,7 @@ async def test_resume_does_not_force_cancelled_status_when_runs_completed():
     mock_agent.ainvoke = AsyncMock(return_value={"messages": []})
     with patch(
         "apps.workspaces.tasks._build_agent_for_resume",
-        AsyncMock(return_value=(mock_agent, {})),
+        AsyncMock(return_value=mock_agent),
     ):
         result = await resume_thread_after_materialization(None, thread_job_id=str(tj.id))
 
@@ -566,7 +564,7 @@ async def test_resume_partial_run_surfaces_per_source_state_in_prompt():
     mock_agent.ainvoke = AsyncMock(return_value={"messages": []})
     with patch(
         "apps.workspaces.tasks._build_agent_for_resume",
-        AsyncMock(return_value=(mock_agent, {})),
+        AsyncMock(return_value=mock_agent),
     ):
         result = await resume_thread_after_materialization(None, thread_job_id=str(tj.id))
 
@@ -679,7 +677,7 @@ async def test_resume_cas_rejects_already_running_threadjob():
     mock_agent.ainvoke = AsyncMock(return_value={"messages": []})
     with patch(
         "apps.workspaces.tasks._build_agent_for_resume",
-        AsyncMock(return_value=(mock_agent, {})),
+        AsyncMock(return_value=mock_agent),
     ):
         result = await resume_thread_after_materialization(
             None,
@@ -723,7 +721,7 @@ async def test_resume_recursion_limit_is_lowered_from_default():
     mock_agent.ainvoke = AsyncMock(return_value={"messages": []})
     with patch(
         "apps.workspaces.tasks._build_agent_for_resume",
-        AsyncMock(return_value=(mock_agent, {})),
+        AsyncMock(return_value=mock_agent),
     ):
         await resume_thread_after_materialization(None, thread_job_id=str(tj.id))
 
@@ -766,7 +764,7 @@ async def test_ainvoke_timeout_marks_failed_and_persists_message():
 
     with patch(
         "apps.workspaces.tasks._build_agent_for_resume",
-        AsyncMock(return_value=(mock_agent, {})),
+        AsyncMock(return_value=mock_agent),
     ):
         result = await resume_thread_after_materialization(None, thread_job_id=str(tj.id))
 
@@ -805,7 +803,7 @@ async def test_ainvoke_exception_marks_failed_and_persists_message():
 
     with patch(
         "apps.workspaces.tasks._build_agent_for_resume",
-        AsyncMock(return_value=(mock_agent, {})),
+        AsyncMock(return_value=mock_agent),
     ):
         result = await resume_thread_after_materialization(None, thread_job_id=str(tj.id))
 
@@ -839,7 +837,7 @@ async def test_successful_ainvoke_logs_bookends(caplog):
     caplog.set_level(logging.INFO, logger="apps.workspaces.tasks")
     with patch(
         "apps.workspaces.tasks._build_agent_for_resume",
-        AsyncMock(return_value=(mock_agent, {})),
+        AsyncMock(return_value=mock_agent),
     ):
         result = await resume_thread_after_materialization(None, thread_job_id=str(tj.id))
 
@@ -874,7 +872,7 @@ async def test_resume_emits_langfuse_span_on_each_outcome():
     with (
         patch(
             "apps.workspaces.tasks._build_agent_for_resume",
-            AsyncMock(return_value=(mock_agent, {})),
+            AsyncMock(return_value=mock_agent),
         ),
         patch(
             "apps.workspaces.tasks._resume_langfuse_span",
@@ -927,7 +925,7 @@ async def test_resume_agent_failure_sets_error_summary():
     mock_agent.ainvoke = AsyncMock(side_effect=RuntimeError("LLM 503"))
     with patch(
         "apps.workspaces.tasks._build_agent_for_resume",
-        AsyncMock(return_value=(mock_agent, {})),
+        AsyncMock(return_value=mock_agent),
     ):
         result = await resume_thread_after_materialization(None, thread_job_id=str(tj.id))
 
@@ -987,7 +985,7 @@ async def test_resume_partial_run_sets_threadjob_error_summary():
     mock_agent.ainvoke = AsyncMock(return_value={"messages": []})
     with patch(
         "apps.workspaces.tasks._build_agent_for_resume",
-        AsyncMock(return_value=(mock_agent, {})),
+        AsyncMock(return_value=mock_agent),
     ):
         result = await resume_thread_after_materialization(None, thread_job_id=str(tj.id))
 
@@ -1024,7 +1022,7 @@ async def test_resume_no_runs_sets_helpful_error_summary():
     mock_agent.ainvoke = AsyncMock(return_value={"messages": []})
     with patch(
         "apps.workspaces.tasks._build_agent_for_resume",
-        AsyncMock(return_value=(mock_agent, {})),
+        AsyncMock(return_value=mock_agent),
     ):
         await resume_thread_after_materialization(None, thread_job_id=str(tj.id))
 
@@ -1099,7 +1097,7 @@ async def test_resume_surfaces_view_schema_failure_for_multi_tenant():
     mock_agent.ainvoke = AsyncMock(return_value={"messages": []})
     with patch(
         "apps.workspaces.tasks._build_agent_for_resume",
-        AsyncMock(return_value=(mock_agent, {})),
+        AsyncMock(return_value=mock_agent),
     ):
         result = await resume_thread_after_materialization(None, thread_job_id=str(tj.id))
 
@@ -1140,7 +1138,7 @@ async def test_resume_cascade_teardown_view_schema_advises_rerun():
     mock_agent.ainvoke = AsyncMock(return_value={"messages": []})
     with patch(
         "apps.workspaces.tasks._build_agent_for_resume",
-        AsyncMock(return_value=(mock_agent, {})),
+        AsyncMock(return_value=mock_agent),
     ):
         result = await resume_thread_after_materialization(None, thread_job_id=str(tj.id))
 
@@ -1175,7 +1173,7 @@ async def test_resume_plain_completed_for_multi_tenant_active_view_schema():
     mock_agent.ainvoke = AsyncMock(return_value={"messages": []})
     with patch(
         "apps.workspaces.tasks._build_agent_for_resume",
-        AsyncMock(return_value=(mock_agent, {})),
+        AsyncMock(return_value=mock_agent),
     ):
         result = await resume_thread_after_materialization(None, thread_job_id=str(tj.id))
 

--- a/tests/test_threadjob_janitor.py
+++ b/tests/test_threadjob_janitor.py
@@ -247,7 +247,7 @@ async def test_janitor_persists_synthetic_message_on_stuck_running():
         patch("apps.workspaces.tasks.resume_thread_after_materialization") as resume,
         patch(
             "apps.workspaces.tasks._build_agent_for_resume",
-            new=AsyncMock(return_value=(mock_agent, {})),
+            new=AsyncMock(return_value=mock_agent),
         ),
     ):
         resume.defer_async = AsyncMock(return_value=None)

--- a/tests/test_to_thread_db_resilience.py
+++ b/tests/test_to_thread_db_resilience.py
@@ -1,0 +1,59 @@
+"""Dead-connection hygiene for sync ORM run on asyncio.to_thread pool threads
+(arch #253, finding 08#0).
+
+``build_view_schema`` (heavy sync ORM) and ``run_pipeline`` (the whole
+ORM-writing materialization) run via ``asyncio.to_thread`` on default-executor
+pool threads. Those threads have their own thread-local Django connection that
+the worker task decorator's cleanup (which only reaches the async-ORM thread)
+cannot reach — so a pool thread holding a connection that died since the last
+run poisons view-schema rebuilds and refreshes. ``_to_thread_fresh_db`` runs
+``close_old_connections`` on the SAME pool thread, immediately before the body,
+so the body re-opens a fresh connection — without ever closing the connection a
+synchronous test/request on the calling thread is using.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from apps.workspaces import tasks as workspace_tasks
+from apps.workspaces.tasks import _to_thread_fresh_db
+
+
+@pytest.mark.asyncio
+async def test_to_thread_fresh_db_closes_connections_before_body(monkeypatch):
+    """The wrapper closes stale/dead connections BEFORE running the body, on the
+    pool thread, and forwards args/return value."""
+    order: list[str] = []
+
+    def _fake_close():
+        order.append("close")
+
+    def _body(a, b, *, kw):
+        order.append("body")
+        return (a, b, kw)
+
+    monkeypatch.setattr(workspace_tasks, "close_old_connections", _fake_close)
+
+    result = await _to_thread_fresh_db(_body, 1, 2, kw=3)
+
+    assert result == (1, 2, 3)
+    # close_old_connections must run first, then the body — never the reverse.
+    assert order == ["close", "body"]
+
+
+@pytest.mark.asyncio
+async def test_to_thread_fresh_db_closes_even_if_body_raises(monkeypatch):
+    """Cleanup runs before the body, so a body that fails still got a fresh
+    connection (the failure is not caused by a stale one)."""
+    order: list[str] = []
+    monkeypatch.setattr(workspace_tasks, "close_old_connections", lambda: order.append("close"))
+
+    def _body():
+        order.append("body")
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await _to_thread_fresh_db(_body)
+
+    assert order == ["close", "body"]


### PR DESCRIPTION
## What & why

Hardens the standalone MCP data server (`mcp_server/`) along the four axes in arch issue #253. Closes #253.

The MCP server is an internal, long-lived FastMCP (streamable-HTTP) process reached only by the Django API and the Procrastinate worker. It previously (1) accepted any caller on the internal network, (2) had no dead-DB-connection hygiene (the same 22h-outage class fixed only for the worker), (3) opened a fresh TLS connection per query, and (4) carried dead OAuth-token plumbing paid for on every chat turn.

Per-finding changes:

### `01#6` — caller authentication + entitlement (security)
- **Shared-secret middleware**: new `SharedSecretMiddleware` (`mcp_server/auth.py`) checks `X-Scout-MCP-Secret` against `MCP_SHARED_SECRET` on every request, wired into the streamable-HTTP app (`mcp_server/server.py::_run_streamable_http`, which now builds the Starlette app itself so the secret check fires ahead of any MCP session/tool dispatch). Constant-time compare. **Fail-open when the secret is unset** (local dev, loopback-only) with a one-time warning — matches how other Scout secrets degrade; production deploy configs set it. *(flagged below)*
- **Clients send the secret**: the agent's MCP client (`apps/agents/mcp_client.py`) attaches the header in the connection config; this covers the Django API (chat), the worker (resume task), and recipes — all route through `get_mcp_tools`. Added `MCP_SHARED_SECRET` to `config/settings/base.py`, `.env.example`, `docker-compose.yml` (mcp-server + api), and the Kamal configs `deploy.yml` (API), `deploy-mcp.yml` (server), `deploy-worker.yml` (worker).
- **`run_materialization` `user_id=''` bypass fixed**: `_resolve_workspace_memberships` now requires a non-empty `user_id` (the empty-user filter previously returned every membership, so the guard passed for any/no user).
- **`cancel_materialization`/`get_materialization_status` scoped**: both now take an injected `workspace_id` and reject a `run_id` whose tenant isn't in the calling workspace (returning the same `NOT_FOUND` so cross-workspace runs can't be probed). Added both to `MCP_TOOL_NAMES` so the graph injects/hides `workspace_id`; moved them out of `CONTEXT_FREE_TOOLS` in the contract test.

### `08#0` — dead-DB-connection hygiene (correctness)
- **MCP process**: `tool_context` (`mcp_server/envelope.py`, wraps every tool call) now runs `close_old_connections()` before and after each call on the asgiref thread-sensitive executor — mirroring the worker's `TEMPORARY` decorator (`config/procrastinate.py`). After an RDS maintenance window the next tool call re-opens a fresh connection instead of failing forever.
- **`to_thread` ORM sites**: new `_to_thread_fresh_db` wrapper in `apps/workspaces/tasks.py` runs `close_old_connections()` on the pool thread immediately before the body, applied to the previously-unguarded `run_pipeline` (bare refresh path) and both `build_view_schema` to_thread sites. The cleanup runs inside the threaded callable, so it never closes a connection a request/test on the calling thread is using.

### `10#1` — connection pooling + client/tool reuse (cost-perf)
- **Managed-DB pool**: new `mcp_server/services/pool.py` provides a lazily-created `AsyncConnectionPool` keyed by the base DB identity (host/port/dbname/user), reused across queries; `_execute_async`/`_execute_async_parameterized` (`mcp_server/services/query.py`) acquire from it instead of opening a fresh TLS connection per call, and `RESET ROLE`/`RESET ALL` before returning a connection to the pool. This also benefits the API process's artifact source queries (`apps/artifacts/views.py` imports the same `execute_query`).
- **MCP client/tool cache**: `get_mcp_tools` caches the static tool list, so the per-chat-message `tools/list` HTTP round trip happens only once per process. Each cached tool still opens its own MCP session per call. (System-prompt per-table caching is left to sibling #254 per the issue.)

### `01#0` — delete dead OAuth-token plumbing (velocity)
- Removed `get_user_oauth_tokens`/`COMMCARE_PROVIDERS` (mcp_client), the `oauth_tokens` param of `build_agent_graph` (never read), the `config['oauth_tokens']` entries (set top-level, injected/persisted by nothing), `extract_oauth_tokens` (`mcp_server/auth.py`, zero non-test callers), `TenantContext.oauth_tokens`, and the `oauth_tokens` entry in the audit `_SCRUB_KEYS`. Updated chat view, resume task, recipe runner, and their tests. Real credentials still flow worker-side via `aresolve_credential`/`TenantConnection` — untouched.

## Sibling sweep (required on bug/incident fixes)

- **Grep used:**
  - `grep -rnE 'oauth_tokens|get_user_oauth_tokens|extract_oauth_tokens|COMMCARE_PROVIDERS'` (dead OAuth)
  - `grep -rnE 'AsyncConnection.connect|get_managed_db_connection|psycopg.connect'` (fresh-connection-per-op)
  - `grep -rnE 'streamable_http_app|mcp.run|FastMCP\('` (unauthenticated MCP entrypoints)
- **Sibling sites found & disposition:**
  - [x] dead OAuth — only the explanatory comment in `mcp_server/envelope.py` remains; all live references removed.
  - [x] MCP HTTP entrypoint — single one (`mcp_server/server.py`), now behind the shared-secret middleware. stdio transport is local-only and unaffected.
  - [x] read-path fresh connections — `_execute_async`/`_execute_async_parameterized` (the hot read path + artifact queries) now pooled.
  - [ ] **write-path raw connections** (`get_managed_db_connection`/`psycopg.connect` in `materializer.py` writers/loaders, `schema_manager.py` DDL, `apps/workspaces/api/views.py`, `backfill_readonly_roles.py`) — **deliberately not pooled**: these are infrequent per-materialization DDL/writer connections with their own transaction lifecycles, out of scope for the read-query pooling in `10#1` and risky to share. Noted for a future pass if profiling shows it matters.

## Testing

New tests: `test_mcp_auth.py` (secret accepted/rejected/fail-open), `test_mcp_entitlement.py` (`user_id=''` denied; cross-workspace `run_id` rejected, own-workspace allowed), `test_mcp_db_resilience.py` (`tool_context` recovers a dead connection), `test_to_thread_db_resilience.py` (`_to_thread_fresh_db` closes-then-runs), `test_mcp_pool.py` (pool reused per base DB, not per schema). Updated `test_mcp_client.py` (header + cache), `test_query_role_isolation.py` + `test_mcp_tenant_tools.py` (pool checkout + `RESET ALL`), `test_oauth_tokens.py`/`test_mcp_server.py`/`test_resume_thread_task.py`/`test_recipes.py` (dead-OAuth removal), `test_chat_mcp_contract.py`/`test_mcp_audit_actor.py`/`test_mcp_workspace_routing.py` (tool calls now touch the connection layer -> `django_db`).

Full backend suite green locally. `ruff check`/`ruff format --check` clean on changed files; `makemigrations --check` reports no changes.

## Notes for reviewers

- **Decision needed / flagged**: `MCP_SHARED_SECRET` unset -> **fail-open** (check disabled, warning logged), so dev keeps working without configuration. The conservative alternative (fail-closed / refuse to start) would block local dev; I chose fail-open to match Scout's secret-degradation convention. Confirm this is acceptable for prod posture (the deploy configs DO set the secret).
- **`#254` rebase awareness**: I did **not** touch the shared `DATABASES`/`CONN_*` settings in `config/settings/base.py` — the dead-connection fix is a per-process/per-call guard, not a global setting — so #254's base.py edits should rebase cleanly. The only base.py change here is the additive `MCP_SHARED_SECRET` env read. `apps/workspaces/tasks.py` gained `_to_thread_fresh_db` + 3 call-site swaps; keep that in mind if #254 also edits tasks.py.
- Two tools moved from `CONTEXT_FREE_TOOLS` into `MCP_TOOL_NAMES`; the real-wire contract test still passes (FastMCP ignores the extra injected `user_id`/`thread_id`/`tool_call_id`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HpAA218jN8dR5SMJTM3Ur4
