### PR TITLE
perf(agents): Anthropic prompt caching + history/knowledge budgets (#254 PR1/3)

### DIFF
--- a/apps/agents/graph/base.py
+++ b/apps/agents/graph/base.py
@@ -32,7 +32,7 @@ from langchain_core.messages import AIMessage, SystemMessage, ToolMessage
 from langgraph.graph import END, StateGraph
 from langgraph.prebuilt import ToolNode
 
-from apps.agents.graph.state import AgentState
+from apps.agents.graph.state import AgentState, prune_messages
 from apps.agents.prompts.artifact_prompt import ARTIFACT_PROMPT_ADDITION
 from apps.agents.prompts.base_system import BASE_SYSTEM_PROMPT
 from apps.agents.tools.artifact_tool import create_artifact_tools
@@ -109,6 +109,19 @@ INJECTED_TOOL_PARAMS = frozenset({"workspace_id", "user_id", "thread_id", "tool_
 # Configuration constants
 DEFAULT_MAX_TOKENS = 4096
 SCHEMA_CONTEXT_CHAR_BUDGET = 6000
+
+# Anthropic prompt-caching breakpoint (arch #254, finding 02#3).
+#
+# Default 5-minute ephemeral TTL — breaks even at ~2 reads (write is 1.25x, read
+# ~0.1x), which a single K-tool agent turn (K+1 LLM calls sharing one prefix)
+# clears immediately. A 1-hour TTL ({"type": "ephemeral", "ttl": "1h"}) costs 2x
+# to write and needs ~3 reads to pay off; switch to it only if traffic is bursty
+# with multi-minute idle gaps between turns. langchain-anthropic renders the
+# request as tools -> system -> messages, so a breakpoint on the LAST system
+# block caches the tool schemas AND the frozen system prefix together; a second
+# breakpoint passed as the ``cache_control`` kwarg to ``ainvoke`` lands on the
+# most-recent message block, caching the replayed conversation history.
+PROMPT_CACHE_CONTROL: dict[str, str] = {"type": "ephemeral"}
 
 # Circuit-breaker thresholds for the escalation node. If the last N tool
 # messages all carry one of these error codes, the agent has drifted from
@@ -561,6 +574,27 @@ def _llm_tool_schemas(tools: list, hidden_params: list[str]) -> list:
     return result
 
 
+def _build_cached_system_message(stable: str, volatile: str) -> SystemMessage:
+    """Build a list-content SystemMessage with an Anthropic cache breakpoint.
+
+    The stable prefix gets a ``cache_control`` breakpoint as its last block;
+    because langchain-anthropic renders ``tools -> system -> messages``, that one
+    breakpoint caches the tool schemas AND the frozen system prefix together
+    (arch #254, finding 02#3). The volatile suffix (tenant context + schema
+    availability with row counts/timestamps) follows WITHOUT a breakpoint, so a
+    new materialization changes only post-breakpoint bytes and leaves the cached
+    prefix intact.
+
+    list-content SystemMessages are passed through to the Anthropic ``system``
+    field with their ``cache_control`` preserved (langchain_anthropic
+    ``_format_messages``).
+    """
+    blocks: list[dict] = [{"type": "text", "text": stable, "cache_control": PROMPT_CACHE_CONTROL}]
+    if volatile and volatile.strip():
+        blocks.append({"type": "text", "text": volatile})
+    return SystemMessage(content=blocks)
+
+
 def _make_injecting_tool_node(
     base_tool_node: ToolNode,
     injections: dict[str, str],
@@ -668,11 +702,14 @@ async def build_agent_graph(
     llm_tool_schemas = _llm_tool_schemas(tools, hidden_params=hidden_params)
     llm_with_tools = llm.bind_tools(llm_tool_schemas)
 
-    # --- Build system prompt ---
-    system_prompt = await _build_system_prompt(workspace, user, interactive=interactive)
+    # --- Build system prompt (stable cacheable prefix + volatile suffix) ---
+    stable_prompt, volatile_prompt = await _build_system_prompt(
+        workspace, user, interactive=interactive
+    )
     logger.debug(
-        "System prompt assembled: %d characters for workspace %s",
-        len(system_prompt),
+        "System prompt assembled: %d stable + %d volatile chars for workspace %s",
+        len(stable_prompt),
+        len(volatile_prompt),
         workspace.id,
     )
 
@@ -688,10 +725,22 @@ async def build_agent_graph(
 
         This node prepends the system prompt to the messages and invokes
         the LLM. The LLM may respond with text, tool calls, or both.
+
+        History is bounded with ``prune_messages`` so per-turn input tokens
+        don't grow without limit as a thread ages (arch #254, finding 01#3 —
+        query tool results up to 500 rows of JSON were otherwise replayed
+        verbatim on every later call). Anthropic prompt-caching breakpoints are
+        attached so the static prefix and the (now bounded) history are billed
+        at cache-read rates (finding 02#3).
         """
         state_messages = list(state["messages"])
         # Filter out any prior system messages to avoid duplicates across cycles
         state_messages = [m for m in state_messages if not isinstance(m, SystemMessage)]
+
+        # Bound replayed history. recursion_limit caps tool iterations, not the
+        # conversation length; without this the full message list (including
+        # large query results) is re-sent on every LLM call (01#3).
+        state_messages = prune_messages(state_messages)
 
         # Defensive guard: ensure every AIMessage with tool_calls is followed
         # by matching ToolMessages. If not, inject synthetic error ToolMessages
@@ -724,8 +773,10 @@ async def build_agent_graph(
                         )
                         answered_ids.add(tc_id)
 
-        messages = [SystemMessage(content=system_prompt), *repaired]
-        response = await llm_with_tools.ainvoke(messages)
+        messages = [_build_cached_system_message(stable_prompt, volatile_prompt), *repaired]
+        # The cache_control kwarg lands on the last eligible message block,
+        # caching the (pruned) conversation-history prefix (arch #254, 02#3).
+        response = await llm_with_tools.ainvoke(messages, cache_control=PROMPT_CACHE_CONTROL)
         return {"messages": [response]}
 
     def should_continue(state: AgentState) -> Literal["tools", "__end__"]:
@@ -864,23 +915,38 @@ def _build_tools(
     return tools
 
 
-async def _build_system_prompt(workspace: Workspace, user, interactive: bool = True) -> str:
+async def _build_system_prompt(
+    workspace: Workspace, user, interactive: bool = True
+) -> tuple[str, str]:
     """
-    Assemble the complete system prompt for a workspace.
+    Assemble the system prompt for a workspace as a (stable, volatile) split.
 
     The prompt is built from:
     1. BASE_SYSTEM_PROMPT: Core agent behavior and formatting
     2. ARTIFACT_PROMPT_ADDITION: Instructions for creating artifacts
     3. Workspace system prompt: Workspace-specific instructions
-    4. Knowledge retriever output: Metrics, rules, learnings
+    4. Knowledge retriever output: Metrics, rules, learnings (budget-capped)
     5. Tenant context: Tenant name, provider, query config (single-tenant only)
+    6. Data Availability: schema state, table list, row counts, timestamps
+
+    Sections 1–4 are *stable* — they change rarely (a workspace-instruction or
+    knowledge edit invalidates the per-process cache key below). Sections 5–6
+    are *volatile*: the ``## Data Availability`` block embeds row counts and the
+    last-materialized timestamp, which change on every materialization.
+
+    Returning the two halves separately lets the agent node place an Anthropic
+    ``cache_control`` breakpoint on the stable prefix (so the large frozen base
+    prompt + ~15 tool schemas cache together and are billed at cache-read rates)
+    while the volatile block sits AFTER the breakpoint — a new materialization
+    no longer rewrites the cached prefix bytes and defeats every cache hit
+    (arch #254, finding 02#3, prefix-stability half).
 
     Args:
         workspace: The Workspace model instance.
         user: The User model instance (used to scope tenant metadata lookup).
 
     Returns:
-        Complete system prompt string.
+        ``(stable_prefix, volatile_suffix)``. ``volatile_suffix`` may be "".
     """
     cache_key = _system_prompt_cache_key(workspace, user, interactive)
     cached = _system_prompt_cache.get(cache_key)
@@ -889,16 +955,22 @@ async def _build_system_prompt(workspace: Workspace, user, interactive: bool = T
         if time.monotonic() - timestamp < _SYSTEM_PROMPT_TTL:
             return value
 
-    sections = [BASE_SYSTEM_PROMPT]
-    sections.append(ARTIFACT_PROMPT_ADDITION)
+    # --- Stable sections (cacheable prefix) ---
+    stable_sections = [BASE_SYSTEM_PROMPT, ARTIFACT_PROMPT_ADDITION]
 
     if workspace.system_prompt:
-        sections.append(f"\n## Workspace Instructions\n\n{workspace.system_prompt}\n")
+        stable_sections.append(f"\n## Workspace Instructions\n\n{workspace.system_prompt}\n")
 
     retriever = KnowledgeRetriever(workspace)
     knowledge_context = await retriever.retrieve()
     if knowledge_context:
-        sections.append(f"\n## Knowledge Base\n\n{knowledge_context}\n")
+        # The retriever already emits a top-level ``## Knowledge Base`` heading;
+        # don't wrap it in a second one (arch #254, finding 01#4 — duplicated
+        # nested heading).
+        stable_sections.append(f"\n{knowledge_context}\n")
+
+    # --- Volatile sections (after the cache breakpoint) ---
+    volatile_sections: list[str] = []
 
     tenant_count = await workspace.tenants.acount()
 
@@ -907,7 +979,7 @@ async def _build_system_prompt(workspace: Workspace, user, interactive: bool = T
         pipeline_config = get_registry().get_by_provider(tenant.provider)
         pipeline_name = pipeline_config.name if pipeline_config else "commcare_sync"
 
-        sections.append(f"""
+        volatile_sections.append(f"""
 ## Tenant Context
 
 - Tenant: {tenant.canonical_name} ({tenant.external_id})
@@ -924,9 +996,9 @@ When results are truncated, suggest adding filters or using aggregations to redu
 
         # Pre-fetch schema state and table metadata — no need to call get_schema_status at runtime.
         schema_context = await _fetch_schema_context(tenant, user, interactive)
-        sections.append(f"\n## Data Availability\n\n{schema_context}\n")
+        volatile_sections.append(f"\n## Data Availability\n\n{schema_context}\n")
     elif tenant_count > 1:
-        sections.append("""
+        volatile_sections.append("""
 ## Query Configuration
 
 - Maximum rows per query: 500
@@ -935,9 +1007,11 @@ When results are truncated, suggest adding filters or using aggregations to redu
 When results are truncated, suggest adding filters or using aggregations to reduce the result size.
 """)
         schema_context = await _fetch_multi_tenant_schema_context(workspace, user, interactive)
-        sections.append(f"\n## Data Availability\n\n{schema_context}\n")
+        volatile_sections.append(f"\n## Data Availability\n\n{schema_context}\n")
 
-    result = "\n".join(sections)
+    stable = "\n".join(stable_sections)
+    volatile = "\n".join(volatile_sections)
+    result = (stable, volatile)
 
     _system_prompt_cache[cache_key] = (result, time.monotonic())
 

--- a/apps/knowledge/api/views.py
+++ b/apps/knowledge/api/views.py
@@ -25,6 +25,12 @@ logger = logging.getLogger(__name__)
 DEFAULT_PAGE_SIZE = 50
 MAX_PAGE_SIZE = 200
 
+# Cap the total *decompressed* size of an import archive (arch #254, 01#4). A
+# small zip can decompress to gigabytes; without a guard a READ member could
+# inflate the knowledge base, which is concatenated into the system prompt and
+# re-billed on every LLM call. 25 MB is far above any legitimate markdown export.
+MAX_IMPORT_DECOMPRESSED_BYTES = 25 * 1024 * 1024
+
 KNOWLEDGE_TYPES = {
     "entry": {
         "model": KnowledgeEntry,
@@ -298,6 +304,21 @@ class KnowledgeImportView(APIView):
         except zipfile.BadZipFile:
             return Response(
                 {"error": "Invalid zip file."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        # Reject decompression bombs before reading any member: the zip's own
+        # directory advertises each member's uncompressed size (arch #254, 01#4).
+        total_uncompressed = sum(info.file_size for info in zf.infolist())
+        if total_uncompressed > MAX_IMPORT_DECOMPRESSED_BYTES:
+            return Response(
+                {
+                    "error": (
+                        "Import archive is too large when decompressed "
+                        f"({total_uncompressed} bytes; limit "
+                        f"{MAX_IMPORT_DECOMPRESSED_BYTES})."
+                    )
+                },
                 status=status.HTTP_400_BAD_REQUEST,
             )
 

--- a/apps/knowledge/services/retriever.py
+++ b/apps/knowledge/services/retriever.py
@@ -15,6 +15,21 @@ if TYPE_CHECKING:
     from apps.workspaces.models import Workspace
 
 
+# Total character budget for the knowledge context injected into the system
+# prompt (arch #254, finding 01#4). Without a cap the retriever concatenated
+# ALL KnowledgeEntry + ALL TableKnowledge rows verbatim (only learnings were
+# capped), so a bulk import could grow the prompt arbitrarily — and the whole
+# block is re-billed on every LLM call. Mirrors the 6000-char schema budget in
+# the graph. Knowledge is the first-billed, cacheable section, so keeping it
+# bounded keeps the cached prefix small and stable.
+KNOWLEDGE_CONTEXT_CHAR_BUDGET = 6000
+
+_TRUNCATION_NOTICE = (
+    "\n\n*(Knowledge context truncated to fit the prompt budget — "
+    "open the Knowledge page to see the full set.)*"
+)
+
+
 class KnowledgeRetriever:
     """
     Retrieves and formats knowledge context for an agent's system prompt.
@@ -31,7 +46,15 @@ class KnowledgeRetriever:
         self.workspace = workspace
 
     async def retrieve(self, user_question: str = "") -> str:
-        """Retrieve and format all relevant knowledge as markdown."""
+        """Retrieve and format all relevant knowledge as markdown.
+
+        The combined output is bounded by ``KNOWLEDGE_CONTEXT_CHAR_BUDGET`` so a
+        large knowledge base (or a bulk import) can't inflate — and re-bill on
+        every LLM call — the system prompt without limit (arch #254, 01#4).
+        ``user_question`` is accepted for API compatibility; there is no
+        relevance-ranking index today, so entries are included in a stable
+        (title / table-name) order until the budget is exhausted.
+        """
         sections: list[str] = []
 
         entries_section = await self._format_knowledge_entries()
@@ -46,7 +69,11 @@ class KnowledgeRetriever:
         if learnings_section:
             sections.append(learnings_section)
 
-        return "\n\n".join(sections)
+        combined = "\n\n".join(sections)
+        if len(combined) > KNOWLEDGE_CONTEXT_CHAR_BUDGET:
+            keep = KNOWLEDGE_CONTEXT_CHAR_BUDGET - len(_TRUNCATION_NOTICE)
+            combined = combined[: max(0, keep)].rstrip() + _TRUNCATION_NOTICE
+        return combined
 
     async def _format_knowledge_entries(self) -> str:
         """Format knowledge entries as markdown sections."""

--- a/tests/agents/test_metadata_provenance_eval.py
+++ b/tests/agents/test_metadata_provenance_eval.py
@@ -179,7 +179,8 @@ class TestAssembledSystemPromptIncludesRule:
         # Schema context will be the "no data" branch (no TenantSchema row in
         # the test DB), which is fine — we're checking the BASE_SYSTEM_PROMPT
         # portion is included end-to-end.
-        prompt = await _build_system_prompt(workspace, user)
+        # _build_system_prompt returns a (stable, volatile) split (arch #254).
+        prompt = "\n".join(await _build_system_prompt(workspace, user))
         assert "## Metadata vs. Verified Counts" in prompt
         assert "materialized_row_count" in prompt
         assert "NEVER report" in prompt

--- a/tests/agents/test_panic_loop_eval.py
+++ b/tests/agents/test_panic_loop_eval.py
@@ -69,7 +69,8 @@ class TestAssembledSystemPromptIncludesEscalationRule:
     @pytest.mark.django_db(transaction=True)
     @pytest.mark.asyncio
     async def test_assembled_prompt_contains_escalation_section(self, workspace, user):
-        prompt = await _build_system_prompt(workspace, user)
+        # _build_system_prompt returns a (stable, volatile) split (arch #254).
+        prompt = "\n".join(await _build_system_prompt(workspace, user))
         assert "## When the Schema is Broken" in prompt
         assert "STOP exploring" in prompt
         assert "pg_namespace" in prompt

--- a/tests/agents/test_schema_context.py
+++ b/tests/agents/test_schema_context.py
@@ -239,7 +239,8 @@ async def test_build_system_prompt_no_schema_status_call():
         mock_reg.return_value.get.return_value = MagicMock()
         mock_full.return_value = ""
 
-        prompt = await _build_system_prompt(mock_workspace, MagicMock())
+        # _build_system_prompt returns a (stable, volatile) split (arch #254).
+        prompt = "\n".join(await _build_system_prompt(mock_workspace, MagicMock()))
 
     assert "call `get_schema_status`" not in prompt
     assert "start of every conversation" not in prompt
@@ -433,7 +434,8 @@ async def test_build_system_prompt_multi_tenant_no_data_pre_fetched():
         MockMR.objects.filter.return_value.afirst = AsyncMock(return_value=None)
         MockMR.ACTIVE_STATES = frozenset({"started", "discovering", "loading", "transforming"})
 
-        prompt = await _build_system_prompt(ws, MagicMock())
+        # _build_system_prompt returns a (stable, volatile) split (arch #254).
+        prompt = "\n".join(await _build_system_prompt(ws, MagicMock()))
 
     assert "## Data Availability" in prompt
     assert "No data has been loaded yet" in prompt

--- a/tests/test_agent_graph.py
+++ b/tests/test_agent_graph.py
@@ -144,7 +144,8 @@ class TestSystemPrompt:
     async def test_data_availability_section_present(self, workspace, user):
         from apps.agents.graph.base import _build_system_prompt
 
-        prompt = await _build_system_prompt(workspace, user)
+        # _build_system_prompt returns a (stable, volatile) split (arch #254).
+        prompt = "\n".join(await _build_system_prompt(workspace, user))
 
         assert "Data Availability" in prompt
         # Schema context is now pre-fetched; no instruction to call get_schema_status
@@ -157,7 +158,8 @@ class TestSystemPrompt:
     async def test_data_availability_covers_not_provisioned_case(self, workspace, user):
         from apps.agents.graph.base import _build_system_prompt
 
-        prompt = await _build_system_prompt(workspace, user)
+        # _build_system_prompt returns a (stable, volatile) split (arch #254).
+        prompt = "\n".join(await _build_system_prompt(workspace, user))
 
         # Agent must know to run materialization when no data exists
         assert "No data has been loaded yet" in prompt or "loading" in prompt.lower()

--- a/tests/test_agent_graph_model_config.py
+++ b/tests/test_agent_graph_model_config.py
@@ -27,7 +27,8 @@ async def test_llm_model_comes_from_settings():
         patch("apps.agents.graph.base._build_tools", return_value=[]),
         patch(
             "apps.agents.graph.base._build_system_prompt",
-            new=AsyncMock(return_value="prompt"),
+            # Returns a (stable, volatile) split since arch #254 (02#3).
+            new=AsyncMock(return_value=("prompt", "")),
         ),
     ):
         await build_agent_graph(workspace, user)

--- a/tests/test_agent_graph_prompt_caching.py
+++ b/tests/test_agent_graph_prompt_caching.py
@@ -1,0 +1,260 @@
+"""Tests for Anthropic prompt caching + history/knowledge budgets (arch #254).
+
+Covers findings:
+
+- ``02#3`` — the agent attaches an Anthropic ``cache_control`` breakpoint to the
+  stable system prefix (tools + frozen system render together and cache) and to
+  the most-recent conversation turn, so the large static prefix and the replayed
+  history are billed at cache-read rates rather than full input on every call.
+- ``01#3`` — conversation history is bounded (``prune_messages`` is actually
+  wired into the agent node) so per-turn input tokens don't grow without limit.
+- ``02#3`` (prefix-stability half) — volatile row-counts / timestamps are NOT in
+  the cached system prefix; they live after the breakpoint, so a new
+  materialization doesn't invalidate the cached prefix.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
+
+from apps.agents.graph import base as graph_base
+from apps.agents.graph.state import DEFAULT_MAX_MESSAGES, prune_messages
+
+
+def _cache_breakpoint_blocks(content) -> list[dict]:
+    """Return content blocks carrying a cache_control breakpoint."""
+    if not isinstance(content, list):
+        return []
+    return [b for b in content if isinstance(b, dict) and b.get("cache_control")]
+
+
+@pytest.mark.asyncio
+async def test_system_prompt_split_into_stable_and_volatile(monkeypatch):
+    """_build_system_prompt returns a (stable, volatile) split.
+
+    The stable section holds the frozen base prompt + knowledge; the volatile
+    section holds tenant context / schema availability (row counts, timestamps).
+    """
+    graph_base._system_prompt_cache.clear()
+    workspace = MagicMock()
+    workspace.id = "ws-split"
+    workspace.system_prompt = "WS instructions"
+    workspace.tenants = MagicMock()
+    workspace.tenants.acount = AsyncMock(return_value=0)
+    user = MagicMock()
+    user.id = "u1"
+
+    with patch("apps.agents.graph.base.KnowledgeRetriever") as MockRetriever:
+        mock_retriever = MagicMock()
+        mock_retriever.retrieve = AsyncMock(return_value="## Knowledge Base\n\nMetric X")
+        MockRetriever.return_value = mock_retriever
+
+        stable, volatile = await graph_base._build_system_prompt(workspace, user)
+
+    assert isinstance(stable, str)
+    assert isinstance(volatile, str)
+    # The base prompt + workspace instructions + knowledge are stable.
+    assert "WS instructions" in stable
+    assert "Metric X" in stable
+
+
+@pytest.mark.asyncio
+async def test_volatile_schema_not_in_stable_prefix(monkeypatch):
+    """Row counts / last-materialized timestamps must live in the volatile section.
+
+    Caching keys off exact prefix bytes; a per-materialization row count in the
+    cached prefix would defeat every cache hit (02#3 prefix-stability half).
+    """
+    graph_base._system_prompt_cache.clear()
+    workspace = MagicMock()
+    workspace.id = "ws-vol"
+    workspace.system_prompt = ""
+    workspace.tenants = MagicMock()
+    workspace.tenants.acount = AsyncMock(return_value=1)
+    tenant = MagicMock()
+    tenant.canonical_name = "Acme"
+    tenant.external_id = "acme"
+    tenant.get_provider_display = MagicMock(return_value="CommCare")
+    tenant.provider = "commcare"
+    workspace.tenants.afirst = AsyncMock(return_value=tenant)
+    user = MagicMock()
+    user.id = "u2"
+
+    schema_block = "Data is loaded. Last updated: 2026-06-25. cases (1,234 rows)"
+
+    with (
+        patch("apps.agents.graph.base.KnowledgeRetriever") as MockRetriever,
+        patch(
+            "apps.agents.graph.base._fetch_schema_context",
+            new=AsyncMock(return_value=schema_block),
+        ),
+        patch("apps.agents.graph.base.get_registry") as mock_reg,
+    ):
+        MockRetriever.return_value = MagicMock(retrieve=AsyncMock(return_value=""))
+        mock_reg.return_value.get_by_provider.return_value = MagicMock(name="pc")
+
+        stable, volatile = await graph_base._build_system_prompt(workspace, user)
+
+    # The volatile schema text (row counts + timestamp) is NOT in the cached prefix.
+    assert "1,234 rows" not in stable
+    assert "2026-06-25" not in stable
+    assert "1,234 rows" in volatile
+
+
+@pytest.mark.asyncio
+async def test_agent_node_applies_cache_control_breakpoints():
+    """agent_node builds a list-content SystemMessage with a cache breakpoint and
+    passes cache_control through to ainvoke for the conversation history.
+    """
+    workspace = MagicMock()
+    workspace.id = "ws-cc"
+    user = MagicMock()
+    user.id = "u3"
+
+    captured = {}
+
+    async def fake_ainvoke(messages, **kwargs):
+        captured["messages"] = messages
+        captured["kwargs"] = kwargs
+        return AIMessage(content="ok")
+
+    mock_llm = MagicMock()
+    mock_llm.bind_tools.return_value = MagicMock(ainvoke=AsyncMock(side_effect=fake_ainvoke))
+
+    with (
+        patch("apps.agents.graph.base.ChatAnthropic", return_value=mock_llm),
+        patch("apps.agents.graph.base._build_tools", return_value=[]),
+        patch(
+            "apps.agents.graph.base._build_system_prompt",
+            new=AsyncMock(return_value=("STABLE PREFIX", "VOLATILE SUFFIX")),
+        ),
+    ):
+        graph = await graph_base.build_agent_graph(workspace, user)
+
+    # Drive a single agent turn through the compiled graph.
+    state = {
+        "messages": [HumanMessage(content="hi")],
+        "workspace_id": "ws-cc",
+        "user_id": "u3",
+        "user_role": "analyst",
+        "thread_id": "t1",
+    }
+    await graph.ainvoke(state, {"recursion_limit": 5})
+
+    # The history cache breakpoint: cache_control kwarg passed to ainvoke.
+    assert captured["kwargs"].get("cache_control") == {"type": "ephemeral"}
+
+    # The system message is a list of content blocks; the last stable block
+    # carries a cache_control breakpoint (caches tools + system together).
+    sys_msgs = [m for m in captured["messages"] if isinstance(m, SystemMessage)]
+    assert sys_msgs, "expected a SystemMessage in the invoked messages"
+    sys_content = sys_msgs[0].content
+    assert isinstance(sys_content, list), "system content must be list-of-blocks to cache"
+    bp = _cache_breakpoint_blocks(sys_content)
+    assert len(bp) == 1, "exactly one cache breakpoint on the stable system block"
+    assert "STABLE PREFIX" in bp[0]["text"]
+    # The volatile suffix must come AFTER the breakpoint (uncached, last block).
+    assert any("VOLATILE SUFFIX" in b.get("text", "") for b in sys_content)
+    last_block = sys_content[-1]
+    assert "VOLATILE SUFFIX" in last_block.get("text", "")
+    assert not last_block.get("cache_control")
+
+
+@pytest.mark.asyncio
+async def test_agent_node_prunes_history():
+    """agent_node bounds replayed history via prune_messages (01#3)."""
+    workspace = MagicMock()
+    workspace.id = "ws-prune"
+    user = MagicMock()
+
+    captured = {}
+
+    async def fake_ainvoke(messages, **kwargs):
+        captured["messages"] = messages
+        return AIMessage(content="done")
+
+    mock_llm = MagicMock()
+    mock_llm.bind_tools.return_value = MagicMock(ainvoke=AsyncMock(side_effect=fake_ainvoke))
+
+    with (
+        patch("apps.agents.graph.base.ChatAnthropic", return_value=mock_llm),
+        patch("apps.agents.graph.base._build_tools", return_value=[]),
+        patch(
+            "apps.agents.graph.base._build_system_prompt",
+            new=AsyncMock(return_value=("S", "V")),
+        ),
+    ):
+        graph = await graph_base.build_agent_graph(workspace, user)
+
+    # Build a long history (well past DEFAULT_MAX_MESSAGES) of alternating turns.
+    history = []
+    for i in range(DEFAULT_MAX_MESSAGES + 30):
+        history.append(HumanMessage(content=f"q{i}"))
+        history.append(AIMessage(content=f"a{i}"))
+    state = {
+        "messages": history,
+        "workspace_id": "ws-prune",
+        "user_id": "u",
+        "user_role": "analyst",
+        "thread_id": "t",
+    }
+    await graph.ainvoke(state, {"recursion_limit": 5})
+
+    # The messages handed to the LLM (excluding the system message) are bounded.
+    non_system = [m for m in captured["messages"] if not isinstance(m, SystemMessage)]
+    assert len(non_system) <= DEFAULT_MAX_MESSAGES
+
+
+def test_anthropic_request_payload_carries_cache_breakpoints():
+    """The wire request langchain-anthropic builds carries cache_control on the
+    system prefix and the last message block.
+
+    The real API reports a non-zero ``usage.cache_read_input_tokens`` only when
+    the request payload presents these ``cache_control`` breakpoints with a
+    stable prefix. We can't hit the live API in CI, so we assert on the exact
+    payload ``ChatAnthropic`` would send (its ``_get_request_payload``) — the
+    deterministic, offline equivalent of verifying cache hits (arch #254, 02#3).
+    """
+    from langchain_anthropic import ChatAnthropic
+
+    from apps.agents.graph.base import (
+        PROMPT_CACHE_CONTROL,
+        _build_cached_system_message,
+    )
+
+    llm = ChatAnthropic(model="claude-opus-4-8", max_tokens=64, api_key="test-key")
+
+    system_msg = _build_cached_system_message("STABLE PREFIX " * 50, "VOLATILE SUFFIX")
+    messages = [system_msg, HumanMessage(content="hello")]
+
+    payload = llm._get_request_payload(messages, cache_control=PROMPT_CACHE_CONTROL)
+
+    # System block (renders after tools) carries the breakpoint -> caches
+    # tools + system together.
+    system = payload["system"]
+    assert isinstance(system, list)
+    stable_blocks = [b for b in system if b.get("cache_control")]
+    assert len(stable_blocks) == 1
+    assert "STABLE PREFIX" in stable_blocks[0]["text"]
+    # The volatile block has NO cache_control and comes last in system.
+    assert system[-1].get("cache_control") is None
+    assert "VOLATILE SUFFIX" in system[-1]["text"]
+
+    # The conversation-history breakpoint landed on the last message block.
+    last_msg = payload["messages"][-1]
+    content = last_msg["content"]
+    assert isinstance(content, list), "expected list content with a cache_control block"
+    assert content[-1].get("cache_control") == PROMPT_CACHE_CONTROL
+
+
+def test_prune_messages_keeps_tool_pairs():
+    """prune_messages never strands a ToolMessage from its AIMessage (01#3)."""
+    msgs = [HumanMessage(content="q")]
+    for i in range(DEFAULT_MAX_MESSAGES):
+        ai = AIMessage(content="", tool_calls=[{"name": "query", "args": {}, "id": f"tc{i}"}])
+        tool = ToolMessage(content="rows", tool_call_id=f"tc{i}", name="query")
+        msgs.extend([ai, tool])
+    pruned = prune_messages(msgs, max_messages=5)
+    # Must not begin with an orphaned ToolMessage.
+    assert not isinstance(pruned[0], ToolMessage)

--- a/tests/test_agent_graph_prompt_caching.py
+++ b/tests/test_agent_graph_prompt_caching.py
@@ -16,9 +16,11 @@ Covers findings:
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from langchain_anthropic import ChatAnthropic
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
 
 from apps.agents.graph import base as graph_base
+from apps.agents.graph.base import PROMPT_CACHE_CONTROL, _build_cached_system_message
 from apps.agents.graph.state import DEFAULT_MAX_MESSAGES, prune_messages
 
 
@@ -216,13 +218,6 @@ def test_anthropic_request_payload_carries_cache_breakpoints():
     payload ``ChatAnthropic`` would send (its ``_get_request_payload``) — the
     deterministic, offline equivalent of verifying cache hits (arch #254, 02#3).
     """
-    from langchain_anthropic import ChatAnthropic
-
-    from apps.agents.graph.base import (
-        PROMPT_CACHE_CONTROL,
-        _build_cached_system_message,
-    )
-
     llm = ChatAnthropic(model="claude-opus-4-8", max_tokens=64, api_key="test-key")
 
     system_msg = _build_cached_system_message("STABLE PREFIX " * 50, "VOLATILE SUFFIX")

--- a/tests/test_knowledge_import_export.py
+++ b/tests/test_knowledge_import_export.py
@@ -163,3 +163,22 @@ def test_import_duplicate_titles_in_zip_does_not_500(auth_client, workspace):
     buf = _zip({"dup.md": render_frontmatter("Dup", [], "New body")})
     resp = _import(auth_client, workspace, buf)
     assert resp.status_code != 500
+
+
+# ── decompressed-size (zip-bomb) guard ───────────────────────────────────────
+
+
+@pytest.mark.django_db
+def test_import_rejects_decompression_bomb(auth_client, workspace):
+    """A small zip that decompresses to a huge payload is rejected, not loaded
+    verbatim into the (re-billed-every-call) knowledge context (arch #254, 01#4).
+    """
+    # ~50 MB of highly-compressible content in a tiny zip member.
+    bomb = render_frontmatter("Bomb", [], "A" * (50 * 1024 * 1024))
+    buf = _zip({"bomb.md": bomb})
+
+    resp = _import(auth_client, workspace, buf)
+
+    assert resp.status_code == status.HTTP_400_BAD_REQUEST
+    # Nothing was imported.
+    assert KnowledgeEntry.objects.filter(workspace=workspace).count() == 0

--- a/tests/test_knowledge_retriever_budget.py
+++ b/tests/test_knowledge_retriever_budget.py
@@ -1,0 +1,79 @@
+"""Knowledge context budget + single-heading tests (arch #254, finding 01#4).
+
+The retriever previously concatenated ALL KnowledgeEntry + ALL TableKnowledge
+rows into the system prompt with no size cap (only learnings were capped). With
+a bulk-import endpoint the prompt could grow arbitrarily and was re-billed on
+every LLM call. It also emitted its own ``## Knowledge Base`` heading which
+``base.py`` then wrapped in a *second* ``## Knowledge Base`` heading.
+"""
+
+import pytest
+
+from apps.knowledge.models import KnowledgeEntry, TableKnowledge
+from apps.knowledge.services.retriever import KNOWLEDGE_CONTEXT_CHAR_BUDGET, KnowledgeRetriever
+
+
+@pytest.mark.django_db(transaction=True)
+class TestKnowledgeBudget:
+    @pytest.mark.asyncio
+    async def test_knowledge_section_respects_byte_budget(self, workspace, user):
+        # Create knowledge whose total content vastly exceeds the budget.
+        big = "X" * 2000
+        for i in range(50):
+            await KnowledgeEntry.objects.acreate(
+                workspace=workspace,
+                title=f"Entry {i}",
+                content=big,
+                tags=["test"],
+                created_by=user,
+            )
+
+        retriever = KnowledgeRetriever(workspace)
+        result = await retriever.retrieve()
+
+        # The rendered knowledge context must be bounded (with a small allowance
+        # for the truncation notice).
+        assert len(result) <= KNOWLEDGE_CONTEXT_CHAR_BUDGET + 200
+
+    @pytest.mark.asyncio
+    async def test_table_knowledge_counts_against_budget(self, workspace, user):
+        big = "Y" * 2000
+        for i in range(50):
+            await TableKnowledge.objects.acreate(
+                workspace=workspace,
+                table_name=f"table_{i}",
+                description=big,
+                updated_by=user,
+            )
+        retriever = KnowledgeRetriever(workspace)
+        result = await retriever.retrieve()
+        assert len(result) <= KNOWLEDGE_CONTEXT_CHAR_BUDGET + 200
+
+    @pytest.mark.asyncio
+    async def test_small_knowledge_not_truncated(self, workspace, user):
+        await KnowledgeEntry.objects.acreate(
+            workspace=workspace,
+            title="MRR",
+            content="Monthly Recurring Revenue",
+            tags=["metric"],
+            created_by=user,
+        )
+        retriever = KnowledgeRetriever(workspace)
+        result = await retriever.retrieve()
+        assert "MRR" in result
+        assert "Monthly Recurring Revenue" in result
+
+    @pytest.mark.asyncio
+    async def test_single_knowledge_base_heading(self, workspace, user):
+        """No duplicated nested '## Knowledge Base' heading (01#4)."""
+        await KnowledgeEntry.objects.acreate(
+            workspace=workspace,
+            title="MRR",
+            content="Monthly Recurring Revenue",
+            tags=["metric"],
+            created_by=user,
+        )
+        retriever = KnowledgeRetriever(workspace)
+        result = await retriever.retrieve()
+        # Exactly one Knowledge Base heading in the retriever output.
+        assert result.count("## Knowledge Base") == 1


### PR DESCRIPTION
## What & why

LLM-token core of arch issue **#254** (Cost/latency floor). This is **PR 1 of 3** — it does **not** close #254 (later PRs cover the rest). Covers findings **02#3**, **01#3**, **01#4**.

### `02#3` — Anthropic prompt caching (the headline)
`ChatAnthropic` was built with only model+max_tokens and **no `cache_control` breakpoint anywhere**, so the large static system prompt + ~15 tool schemas were re-billed at full input rate on every LLM call (K+1 calls per K-tool turn). Worse, embedding row counts/timestamps in the prompt changed the prefix bytes across materializations, defeating any cache.

- `_build_system_prompt` now returns a **(stable, volatile)** pair. Stable = base prompt + artifact prompt + workspace instructions + (budget-capped) knowledge. Volatile = tenant context + `## Data Availability` (row counts, last-materialized timestamp).
- `agent_node` builds a **list-content `SystemMessage`** with a `cache_control` breakpoint on the **last stable block**. langchain-anthropic renders `tools → system → messages`, so that single breakpoint caches the **tool schemas + frozen prefix together**. The volatile block follows the breakpoint, so a new materialization changes only post-breakpoint bytes — the cached prefix survives (this is the prefix-stability half of 02#3).
- A **second breakpoint** (the `cache_control` kwarg to `ainvoke`) lands on the last message block, caching the **replayed conversation history** (the aggressive part, per Brian's decision).
- TTL = default **5-minute ephemeral** (breaks even at ~2 reads). Model is `claude-opus-4-8` → min cacheable prefix **4096 tokens**; the base+artifact prompt alone is ~4250 tokens and tools render before it, so the prefix **clears the bar**.

**cache_control mechanism + verification:** langchain-anthropic 1.3.1 attaches `cache_control` to message/content blocks. List-content `SystemMessage`s are passed through to the Anthropic `system` field with `cache_control` preserved (`_format_messages`); the top-level `cache_control` kwarg auto-applies to the last eligible message block (`_get_request_payload`, lines 1073-1104). `test_anthropic_request_payload_carries_cache_breakpoints` asserts the **exact wire payload** `ChatAnthropic` builds carries both breakpoints — the offline, CI-safe equivalent of asserting `usage.cache_read_input_tokens` is non-zero on a repeated-prefix call (we can't hit the live API in CI).

### `01#3` — history budget
`prune_messages`/`DEFAULT_MAX_MESSAGES` had **zero callers**; history was replayed unbounded (query results up to 500 rows of JSON re-sent on every later LLM call → per-turn tokens grow linearly, lifetime cost ~quadratically). Wired `prune_messages` into `agent_node` so history is bounded and tool-call/result pairs stay intact.

### `01#4` — knowledge budget + duplicated heading + zip-bomb guard
`KnowledgeRetriever.retrieve` concatenated **all** KnowledgeEntry + **all** TableKnowledge rows with no cap (only learnings were capped), and a duplicated nested `## Knowledge Base` heading appeared in every prompt.
- `retrieve` now caps combined output at `KNOWLEDGE_CONTEXT_CHAR_BUDGET` (6000, mirroring the schema budget).
- `base.py` no longer wraps the retriever's own heading in a second `## Knowledge Base`.
- `KnowledgeImportView` rejects decompression bombs via the zip directory's advertised uncompressed sizes before reading any member.

(The `retrieve(user_question)` argument is still ignored — there is no relevance-ranking index today; left in place for API compatibility and documented. The serial-per-table-TLS-connection half of 02#3 is already mitigated by #253's pool.)

## Sibling sweep

- **Grep used:** `grep -rn "cache_control\|bind_tools\|ChatAnthropic" apps/ mcp_server/` and `grep -rn "MAX_AGENT_LEARNINGS\|\.retrieve(" apps/`
- **Sibling sites found & disposition:**
  - [x] `apps/agents/graph/base.py` — the **only** `ChatAnthropic`/`bind_tools` call site (sole uncached LLM call); fixed.
  - [x] `KnowledgeRetriever.retrieve` — the **only** unbounded context injector for the system prompt; capped.
  - [x] Schema context already had a 6000-char budget (`SCHEMA_CONTEXT_CHAR_BUDGET`) — knowledge now matches it.

## Testing

`uv run pytest` on the agent-graph + knowledge suites (all green): new `tests/test_agent_graph_prompt_caching.py` (cache breakpoints on payload, history pruning, volatile-not-in-prefix), `tests/test_knowledge_retriever_budget.py` (byte budget, single heading), zip-bomb guard in `tests/test_knowledge_import_export.py`. Existing tests updated for the `_build_system_prompt` `(stable, volatile)` contract change. `ruff check`/`format` clean; `makemigrations --check` clean.

## Notes for reviewers

- **No `cache_read_input_tokens` assertion against the live API** (can't in CI) — verified via the constructed request payload instead.
- Pruning + history-caching interact: `prune_messages` trims first, then the breakpoint lands on the bounded tail — bounded cache churn, not unbounded.
- Part of a 3-PR series for #254; PR2 (independent cost-perf wins) and PR3 (artifact versioning) follow. Only the final PR will `Closes #254`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HpAA218jN8dR5SMJTM3Ur4