### PR TITLE
docs: add commit-hygiene guidance to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,12 @@ Do not write:
 
 Keep the ones you write tight — a single line beats a paragraph. Reserve multi-line blocks for genuinely load-bearing context.
 
+## Commits
+
+Make each commit one logical change — a single feature-level unit that is internally consistent and can be reviewed on its own. Reviewers read large PRs commit by commit, so every commit should leave the tree in a working state and stand alone.
+
+A "change" is one logical thing, not one edit. Split separable work — a bug fix, an unrelated refactor, a new helper — into a commit each, ordered so prerequisites land first. If the commit message needs an "and," it's probably two commits.
+
 ## Testing conventions
 
 ### data-testid attributes


### PR DESCRIPTION
## What & why

Adds a `## Commits` section to CLAUDE.md: make each commit one logical, feature-level change that is internally consistent and reviewable on its own, rather than bundling unrelated work.

Per Simon's review feedback — splitting separate changes into separate commits lets reviewers review by commit, in smaller internally-consistent chunks.

## Notes for reviewers

Docs-only, no behavior change. **FYI / merging straight away** — opened with a review request so it's on your radar, not blocking on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)