### PR TITLE
fix(deploy): resolve MCP_SHARED_SECRET in .kamal/secrets so prod deploys boot

### DIFF
--- a/.kamal/secrets
+++ b/.kamal/secrets
@@ -36,6 +36,17 @@ DB_CREDENTIAL_KEY=$(kamal secrets extract SCOUT_DB_CREDENTIAL_KEY $DJANGO_SECRET
 ANTHROPIC_API_KEY=$(kamal secrets extract SCOUT_ANTHROPIC_API_KEY $DJANGO_SECRETS)
 
 
+## MCP shared-secret — caller auth between the API/worker and the MCP server (arch #253).
+# deploy.yml (API), deploy-worker.yml, and deploy-mcp.yml all list MCP_SHARED_SECRET in
+# their `secret:` block; the API/worker send it as X-Scout-MCP-Secret and the MCP server
+# verifies it (mcp_server/auth.py). Without this line kamal cannot resolve the secret and
+# the MCP container fails to boot ("Secret 'MCP_SHARED_SECRET' not found in .kamal/secrets").
+# Requires SCOUT_MCP_SHARED_SECRET to exist in AWS Secrets Manager (us-east-1).
+MCP_SECRETS=$(kamal secrets fetch --adapter aws_secrets_manager SCOUT_MCP_SHARED_SECRET)
+
+MCP_SHARED_SECRET=$(kamal secrets extract SCOUT_MCP_SHARED_SECRET $MCP_SECRETS)
+
+
 ## RDS
 # Use separate script to handle encodeing and more complex secret extraction
 # Requires that the SCOUT_RDS_ENDPOINT is already in the env. See scripts/fetch-deploy-env.sh


### PR DESCRIPTION
## Problem

Production deploys have failed on **every push to `main` since 2026-06-26** (`#319`–`#324`). The `test` gate passes; the `deploy` job dies at **Deploy MCP**:

```
ERROR (Kamal::ConfigurationError): Secret 'MCP_SHARED_SECRET' not found in .kamal/secrets
```

**Root cause:** PR #319 (arch #253, MCP caller auth) added `MCP_SHARED_SECRET` to the `secret:` blocks of `config/deploy.yml`, `config/deploy-mcp.yml`, and `config/deploy-worker.yml`, but never added a line to **resolve** it in `.kamal/secrets`. Kamal can't find the referenced secret, the MCP container fails to boot, and the whole deploy aborts. Nothing has reached prod since ~`#317` — roughly six PRs' worth of changes are built but not live.

## Fix

Add an MCP block to `.kamal/secrets` that fetches `SCOUT_MCP_SHARED_SECRET` from AWS Secrets Manager and extracts it to `MCP_SHARED_SECRET`, mirroring the existing Langfuse/Django blocks. All three configs read the same resolved value, so the `X-Scout-MCP-Secret` the API/worker send matches what the MCP server verifies (`mcp_server/auth.py`).

## ⚠️ Operator prerequisite before merging

`SCOUT_MCP_SHARED_SECRET` **must exist in AWS Secrets Manager (us-east-1)** before this merges, or the fetch resolves to nothing and the MCP deploy still fails (and, worse, MCP would boot with auth silently disabled — fail-open per `mcp_server/auth.py`). Create it with a strong random value, e.g.:

```
aws secretsmanager create-secret --name SCOUT_MCP_SHARED_SECRET \
  --secret-string "$(openssl rand -hex 32)" --region us-east-1 --profile scout
```

Once the secret exists, merging to `main` will trigger a deploy that should pass the Deploy MCP step. Since all three services resolve the same `.kamal/secrets` value, the caller secret and server secret match automatically.

## Verification done

- `bash -n .kamal/secrets` parses.
- New `MCP_SHARED_SECRET=` top-level assignment present; env var name matches the unprefixed name referenced by all three deploy configs.
- `fetch-deploy-env.sh` only pulls CloudFormation infra outputs, not app secrets — no change needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SxtpXTEsuK79vQHkTcJ2M5