### PR TITLE
docs: design specs for #251 (status/catalog module) + #267 (content-satellite redesign)

### DIFF
--- a/docs/superpowers/specs/2026-07-03-content-satellite-redesign-design.md
+++ b/docs/superpowers/specs/2026-07-03-content-satellite-redesign-design.md
@@ -1,0 +1,159 @@
+# Content-satellite redesign — recipes + knowledge + artifacts
+
+**Date:** 2026-07-03
+**Issue:** arch #267 — "[DESIGN] Content-satellite redesign: recipes + knowledge + artifacts" (cluster `content-satellite-redesign`, wave 2, `design-gated`, `tier:design`). Folds in the **#241 residual** (workspace-scope transforms never materialize) and relates to **#318** (learning-lifecycle).
+**Status:** Design — awaiting Brian's sign-off. **No implementation until approved.** This is a *product-shape* decision as much as an architecture one.
+**Author:** design window (research: 3 read-only mapping passes over recipes / knowledge / artifacts)
+
+## Problem
+
+Wave-1/2 fixes restored recipes, knowledge, and artifacts to **working-as-designed** (recipe runner async-first, headless materialization, `TableKnowledge` re-keyed to logical names, artifact multi-tenant render, sandbox isolation). #267 asks the separate question: **is the current design what we want?** Three "content satellites" grew independently and now share nothing but accidental structure, while the cross-cutting concerns they *should* share (sharing/privacy, provenance, drift-integrity, lifecycle) are each solved differently or not at all.
+
+The concrete symptoms that make this a redesign rather than more point-fixes:
+
+1. **Three satellites, zero shared spine.** `Recipe`, `Artifact`, `TableKnowledge`/`KnowledgeEntry`/`AgentLearning` are all workspace-scoped, all soft-deletable, all attributed to a `created_by` user — and each re-implements soft-delete, sharing, and provenance from scratch, inconsistently. There is **no coupling between the three apps** (grep-confirmed: recipes import neither knowledge nor artifacts; artifacts import none of them). Coupling is inverted and accidental: `apps/chat/thread_views.py` and the agent tools reach *into* artifacts.
+
+2. **Sharing/privacy is three different models.** `Recipe` and `RecipeRun` each carry `is_shared` + `is_public` + auto-minted `share_token` (`recipes/models.py:55-70,294-336`), with a live `AllowAny` public route `PublicRecipeRunView` (`recipes/api/views.py:204-220`). `Artifact` has **no per-artifact sharing** — it's exposed publicly only transitively through a shared chat thread, and then **source-only, never live data** (`chat/thread_views.py:53-64`). Knowledge has no sharing at all. A user cannot reason about "who can see this" consistently across the three.
+
+3. **Provenance is a loose string.** `Artifact.conversation_id` is a `CharField(255)` matched against a thread id (`artifacts/models.py:84`), not an FK — `Artifact.objects.filter(conversation_id=str(thread_id))`. A recipe that produces an artifact records the linkage only inside `RecipeRun.step_results[0]["artifacts_created"]` (extracted from tool messages, `runner.py:144-159`). There is no first-class "this content came from this thread / this recipe / against this tenant's data" record — which is exactly what sharing, revocation (#249), and drift-detection all need.
+
+4. **The #241 residual: workspace-scope transforms never materialize.** `TransformationScope` has `SYSTEM/TENANT/WORKSPACE` (`transformations/models.py:9-12`), but `_run_transform_phase` calls `run_transformation_pipeline` **without a workspace** (`materializer.py:1080`), and the executor only appends the WORKSPACE stage when a workspace is passed (`executor.py:67-74`). So `scope=WORKSPACE` assets are creatable via API but run **only** through the manual `/runs/trigger/` endpoint (no UI) — never during materialization. The documented root cause (`materializer.py:1067-1079`) is structural: **materialization is tenant-scoped, `Workspace↔Tenant` is M2M (`WorkspaceTenant`), so there is no single workspace context at materialize time.**
+
+5. **The same scope mismatch drives the `sync_column_notes` fan-out.** Knowledge is **workspace-scoped**; materialization is **tenant-scoped**. So when materialization wants to write column notes it must fan **one tenant → all of that tenant's workspaces** (`materializer.py:255-256`, commcare_connect only). The #241 gap and the column-notes fan-out are the **same root defect** viewed from two directions.
+
+6. **The learning lifecycle (#318) is inert.** `AgentLearning` advertises an adaptive loop in its `help_text`, but `increase_confidence`/`decrease_confidence` are called only from Django admin (`knowledge/models.py:186-196`, `admin.py:162-173`); `times_applied` bumps only on a byte-identical `iexact` re-save (`learning_tool.py:158-161`) — never for LLM prose; drifted learnings never retire. The retriever renders "(applied N times)" implying usage that isn't tracked.
+
+7. **Knowledge retrieval is a stable-order dump, not retrieval.** `KnowledgeRetriever` ignores its `user_question` ("for API compatibility only; no relevance index", `retriever.py:47-51`) and concatenates entries in stable order into a 6000-char budget inside the **cacheable prompt prefix** (`base.py:801-834`, `_SYSTEM_PROMPT_TTL=60s`). As a workspace's knowledge grows past the budget, later entries silently fall out with no relevance ranking.
+
+8. **CLAUDE.md advertises models that don't exist.** The knowledge app is described as holding "golden queries, eval runs" — **no such model exists** (grep-confirmed; `KnowledgeEntry` replaced the former `VerifiedQuery`/`CanonicalMetric`/`BusinessRule`). Either build them or correct the description.
+
+## Goals
+
+- Decide the **target shape** for user- and agent-generated content: repair three separate satellites, or give them a shared spine. Get an explicit product call from Brian.
+- Whatever the shape: make **sharing/privacy one model**, make **provenance first-class**, and make **drift-integrity** (content referencing tables/columns that may change) a designed property rather than an accident.
+- Resolve the **#241 workspace-transform scope question** with an explicit answer, not another "documented residual."
+- Give the **learning lifecycle (#318)** a real capture→apply→retire loop, designed alongside (not bolted onto) knowledge.
+- Reconcile the docs with reality (golden queries / eval runs).
+
+## Non-goals (explicit)
+
+- **Recipe runtime.** Already redone: async-first runner + headless `interactive=False` graph + background `run_recipe` task + 202/poll (see `2026-06-16-recipes-async-restoration-design.md` and the `2026-06-17-recipe-headless-materialization` plan, both implemented). #267 is about the **content/data model and lifecycle**, not execution.
+- **The tenancy/permission substrate (#249/#250).** Fixed input (`2026-06-18-tenant-access-refresh-design.md`). #267 *consumes* the centralized authorizer and the live-tenant rule; it does not redesign them. But it must **surface** where the current content sharing model bypasses them (below).
+- **Rewriting the dbt confinement / low-privilege execution** — that part of #241 shipped (`executor.py:140-149`, `TransformStageError`).
+- **The status/catalog consolidation (#251)** — its own spec (`2026-07-03-status-catalog-module-design.md`). #267 depends on #251's canonical **logical-name catalog** as the drift-integrity anchor (below).
+
+## Current-state map
+
+### Recipes (`apps/recipes/`)
+- `Recipe`: workspace-scoped (nullable FK), `prompt` TextField with `{{var}}` placeholders + `variables` JSON, `created_by`, soft-delete trio, `is_shared`/`is_public`/`share_token`. `RecipeStep` model is **vestigial** (runner executes single `Recipe.prompt`; admin doc confirms, arch #260).
+- `RecipeRun`: `step_results` JSON (single-element list: prompt/response/tools_used/artifacts_created/timestamps), its own `is_shared`/`is_public`/`share_token`, `run_by`.
+- Runtime (done): `recipe_run_view` → 202, `run_recipe` Procrastinate task (`queue="recipes"`), `RecipeRunner.execute_async` builds `interactive=False` headless graph. A run *may* invoke the blocking `run_materialization` tool.
+- Public: `PublicRecipeRunView` (`AllowAny`, `authentication_classes=[]`) serves a run by `share_token`. **`RecipeRunDetailView` has PATCH only, no GET** — yet the runtime docs say clients poll `GET .../runs/<id>/`; only the list route has GET (a doc/impl gap to confirm).
+
+### Artifacts (`apps/artifacts/`)
+- Single polymorphic `Artifact` (`ArtifactType`: react/html/markdown/plotly/svg): `code` (source), `data` (static config JSON), `source_queries` (list of `{name,sql}`), `version` + `parent_artifact` chain, `conversation_id` **CharField** (loose thread join), workspace-scoped, soft-delete.
+- **Live, not snapshot:** the agent is instructed *not* to embed results; `ArtifactQueryDataView` re-runs `source_queries` at render (60s cache, `asyncio.gather`) through `load_workspace_context` (multi-tenant → `ws_*` view schema).
+- Created by the agent mid-chat via `create_artifact`/`update_artifact` tools (`artifacts/tools/artifact_tool.py`); `update` creates a new versioned row.
+- Render: server `sandbox/` HTML template with per-request CSP nonce, embedded in an `<iframe sandbox="allow-scripts allow-modals">` (**no `allow-same-origin`** by design). Public path (shared thread) renders html/svg only, react/plotly as source `<pre>` — live tenant data never served publicly.
+- No per-artifact share token; export html works, png/pdf 501.
+
+### Knowledge (`apps/knowledge/`)
+- `TableKnowledge`: workspace-scoped, keyed on **logical** `table_name` (re-keyed off physical schema by #262 migration `0003`), annotations (`description`, `use_cases`, `column_notes`, `related_tables`, …); managed via the **workspaces data-dictionary API**, not the knowledge API; `column_notes` auto-populated during materialization for commcare_connect via `sync_column_notes`.
+- `KnowledgeEntry`: title + markdown `content` + `tags`; zip export/import (import has correctness gaps per #262, mostly shipped).
+- `AgentLearning`: agent-created via `save_learning`; `confidence_score`/`times_applied`/`is_active`; inert lifecycle (#318).
+- `KnowledgeRetriever`: dumps entries + table context + top-20 learnings into the cacheable prompt prefix, stable-order, 6000-char budget, no relevance retrieval.
+- **No golden-query / eval-run models** anywhere.
+
+### The shared shape (what could be a spine)
+All three are: workspace-scoped (nullable FK) · soft-deletable (`is_deleted`/`deleted_at`/`deleted_by` + a soft-delete manager) · attributed (`created_by`) · UUID PK · potentially shareable · reference workspace data that can drift. They differ in: cardinality (recipe→runs, artifact→versions, knowledge→annotations/learnings), whether they store source vs snapshot, and their sharing surface.
+
+## Proposed design
+
+Because #267 is explicitly a "brainstorm → spec before committing to repair-in-place vs rethink," the core deliverable is the **decision framing** plus a recommended phased path. Three coherent options:
+
+### Option A — Repair-in-place, keep three satellites (minimal)
+Keep the three apps and models. Fix only the concrete gaps: consistent sharing helpers, #241 answer, #318 loop, docs reconciliation. No shared base model.
+- **Pro:** smallest blast radius; each fix is a small PR; no migration risk.
+- **Con:** leaves three divergent implementations of sharing/soft-delete/provenance; the next feature re-forks them; "who can see this" stays inconsistent.
+
+### Option B — Shared content spine, models stay separate (recommended)
+Keep three distinct models (their lifecycles genuinely differ) but extract the **cross-cutting concerns** into one shared spine used by all three:
+- **`ContentBase` mixin / abstract model**: UUID PK, `workspace` FK, `created_by`, soft-delete, timestamps — one implementation, one soft-delete manager, one admin pattern.
+- **One sharing/ACL model**: a single `Share`/visibility concept (private / workspace / public-token) applied uniformly to recipes, runs, artifacts, and knowledge entries — replacing the two bespoke `is_shared`/`is_public`/`share_token` copies and giving artifacts the per-artifact sharing they lack. **Routed through the #250 permission layer + the #249 authorizer** so a public token still respects live-tenant revocation (closes the `PublicRecipeRunView`/public-thread `AllowAny` residual R2 from the tenant design).
+- **First-class provenance**: replace `Artifact.conversation_id` CharField with a real provenance record (thread FK / recipe FK / tenant(s) the data came from), shared by artifacts and recipe runs. Enables drift-detection and correct revocation.
+- **Drift-integrity against #251's logical catalog**: content that names tables/columns (artifact `source_queries`, knowledge `table_name`/`related_tables`, learning `applies_to_tables`) references the **canonical logical-name catalog** from #251, so drift is *detectable* (and, for learnings, a retirement trigger).
+- **Pro:** one mental model for sharing/provenance/drift; artifacts gain sharing; tenancy holes close; each satellite keeps its natural lifecycle.
+- **Con:** touches all three apps + a migration to move `conversation_id`/sharing fields onto the spine; must land carefully alongside #249/#250.
+
+### Option C — Full unification into one `Content` model (rethink)
+Collapse artifacts/knowledge-entries/recipes into a single polymorphic `Content` table with a `kind` discriminator and per-kind payload.
+- **Pro:** maximal reuse; one API, one sharing model, one export/import.
+- **Con:** the three lifecycles (versioned live-query code / prompt-template + runs / curated annotations + agent learnings) are different enough that a single table becomes a bag of nullable columns; large migration; high risk; overfits a "they look similar" observation. **Rejected** unless Brian wants a ground-up content platform.
+
+**Recommendation: Option B**, phased so each phase is independently shippable and the tenancy-sensitive pieces (sharing/provenance) land in coordination with the #249/#250 window.
+
+### The #241 workspace-transform fork (must be decided — folded into #267)
+The M2M scope mismatch means "run workspace-scoped transforms during materialization" is genuinely ill-defined today. Options:
+- **A1 — Run the WORKSPACE stage after the view schema is built**, per workspace, not per tenant. The view schema *is* the single workspace context that's missing at tenant-materialize time. Workspace transforms would build on top of the unioned `ws_*` views. Cleanest fit for the multi-tenant model.
+- **A2 — Drop `scope=WORKSPACE` transforms entirely.** They have no UI, never run in the shipped product, and orphan/stale silently. If nobody uses them, delete the scope and the dead executor stage.
+- **A3 — Keep manual-trigger-only, add a UI + staleness marker.** Lowest architectural change; keeps the footgun that a workspace-scoped table survives raw reloads with stale contents.
+- *Recommendation:* **A2 unless there's a live use case**; if there is, **A1** (build workspace transforms on the view schema post-build). This is a Brian call — it decides whether "workspace transforms" is a product feature at all.
+
+### The #318 learning-lifecycle design (alongside #267)
+Design the loop, don't bolt it on:
+- **Application-counting seam** on the *real* agent path — increment `times_applied` when a learning is actually injected *and* the subsequent query succeeds, not on `iexact` re-save.
+- **Confirm/contradict signals** from the runtime: a query that succeeds after applying a learning → `increase_confidence`; a contradicting correction → `decrease_confidence`.
+- **Retirement:** age out / deactivate learnings whose `applies_to_tables` no longer exist in the #251 logical catalog, or whose confidence decays below a floor.
+- Reconcile the `help_text` and the retriever's "(applied N times)" with whatever ships.
+
+## Data-model / migration implications
+
+- **Option B spine:** an abstract `ContentBase` is code-only (Django abstract models add no table). The **sharing model** is either a new `Share` table (FK to the content object, generic or per-type) or shared fields promoted onto the spine — a migration either way, but additive. The **provenance** change replaces `Artifact.conversation_id` (CharField) with an FK/record — a data migration to backfill existing artifacts by matching the current string join (`conversation_id == thread.id`), then drop the CharField.
+- **#241 A2 (drop WORKSPACE scope):** migration to delete `scope=WORKSPACE` `TransformationAsset` rows (audited) + remove the enum value + the executor stage. A1 (run post-view-build) is code + a new materialization phase, no schema change.
+- **#318:** likely no new columns (fields exist); a possible `retired_at`/`last_applied_at` addition. Mostly wiring.
+- **Docs:** correct CLAUDE.md's "golden queries, eval runs" (they don't exist) — or make them real (Decision below).
+
+## Phased implementation plan
+
+Each phase independently shippable; tenancy-sensitive phases gated on #249/#250 landing.
+
+**Phase 0 — Reconcile docs + delete vestigial `RecipeStep`** (arch #260) and confirm/fix the `RecipeRunDetailView` GET gap. Pure cleanup, no risk. Correct CLAUDE.md's golden-query/eval-run description.
+
+**Phase 1 — `ContentBase` spine (code-only).** Extract the shared soft-delete/attribution/timestamp mixin; migrate the three models to inherit it with **no behavior change** (abstract model → no migration). Golden test: existing soft-delete/list behavior unchanged.
+
+**Phase 2 — Unified sharing/ACL, routed through #249/#250.** One visibility model across recipes/runs/artifacts/knowledge; give artifacts per-artifact sharing; make every public-token path re-check the authorizer so revoked tenants lose access (closes R2). **Gated on the tenant-access authorizer being merged.** This is the phase that most needs to co-land with the tenancy window.
+
+**Phase 3 — First-class provenance.** Replace `Artifact.conversation_id` with a provenance record (thread/recipe/tenant); backfill; recipe runs record artifact provenance structurally, not via `step_results` string extraction. Unlocks drift-detection and correct revocation.
+
+**Phase 4 — #241 resolution** (A1 or A2 per Decision). If A2: audited deletion + enum/stage removal. If A1: new post-view-build workspace-transform phase + staleness markers.
+
+**Phase 5 — #318 learning lifecycle.** Application-counting seam + confirm/contradict wiring + retirement against the #251 catalog. Reconcile help_text/retriever text.
+
+**Phase 6 (optional) — knowledge retrieval quality.** If knowledge volume justifies it, replace the stable-order dump with relevance retrieval (keeps the 6000-char budget honest as workspaces grow). Own decision below.
+
+## Test strategy
+
+- **Spine (Phase 1):** golden-master that soft-delete/list/attribution behavior is byte-identical across the three apps post-refactor.
+- **Sharing (Phase 2):** matrix — private/workspace/public × member/non-member/anonymous × live-tenant/revoked-tenant — asserting a revoked tenant loses access even via a previously-minted public token.
+- **Provenance (Phase 3):** backfill correctness (every existing artifact's new provenance matches its old `conversation_id` join); recipe-produced artifacts link structurally.
+- **#241 (Phase 4):** A2 — no `WORKSPACE` asset survives; A1 — a workspace transform builds on the view schema and is marked stale when inputs reload.
+- **#318 (Phase 5):** `times_applied` increments on real application; confidence moves on confirm/contradict; a learning whose tables vanish from the #251 catalog retires.
+- Async DB tests: `@pytest.mark.asyncio` + `@pytest.mark.django_db(transaction=True)`; new interactive UI elements get `data-testid` per `CLAUDE.md`.
+
+## Cross-cutting collisions
+
+- **#249/#250 (tenancy/permission, live window — fixed input).** Phase 2 (sharing) and Phase 3 (provenance) are the collision surface: the unified sharing model **must** be built on the centralized authorizer, and every `AllowAny` public path (`PublicRecipeRunView`, public thread → artifacts) must re-check live-tenant access — this is the R2 residual the tenant design explicitly deferred. **Do not design the sharing model in isolation from that window.** Provenance's "which tenant(s) did this content's data come from" is also what makes per-tenant revocation of shared content possible.
+- **#251 (status/catalog, sibling design).** #267's drift-integrity and #318's retirement both **depend on #251's canonical logical-name catalog** as the stable key. Sequence #251 first (or co-design the catalog interface). `TableKnowledge` already re-keyed to logical names (#262) — the same anchor.
+- **#255 (background robustness, in-flight).** Recipe runs execute on the `recipes` Procrastinate queue and can block on materialization; the #241-A1 option adds a materialization phase — coordinate any new phase with #255's per-tenant locking and janitor so a workspace-transform stage doesn't become a new zombie class. If A2 (drop scope), no collision.
+- **#262 (knowledge correctness, merged).** Built on — logical-name keying, import fixes. Don't regress.
+
+## Decisions needed from Brian
+
+1. **Target shape: A (repair-in-place) / B (shared spine, separate models) / C (full unification)?** *Recommendation: **B** — one spine for sharing/provenance/soft-delete, three models keep their lifecycles.*
+2. **Unified sharing model + close the public-token tenancy hole?** Give artifacts per-artifact sharing and route every public-token path through the #249 authorizer so revoked tenants lose access. *Recommendation: yes, co-landed with the tenancy window (Phase 2).*
+3. **#241 workspace-scope transforms — A1 (run post-view-build) / A2 (drop the scope) / A3 (manual-only + UI)?** The deepest fork; decides whether workspace transforms are a product feature. *Recommendation: **A2** unless there is a real use case, in which case **A1**.*
+4. **#318 learning lifecycle — build the real capture→apply→retire loop now, alongside #267?** *Recommendation: yes (Phase 5); retirement keyed on the #251 catalog.*
+5. **Provenance — replace `Artifact.conversation_id` CharField with a first-class provenance record?** Needed for drift-detection and correct revocation. *Recommendation: yes (Phase 3).*
+6. **Knowledge retrieval — invest in relevance retrieval, or keep the stable-order 6000-char dump?** *Recommendation: keep the dump until a workspace's knowledge volume demonstrably overflows the budget; then Phase 6.*
+7. **Golden queries / eval runs — build the models CLAUDE.md advertises, or correct the docs?** They don't exist today. *Recommendation: correct the docs now (Phase 0); build only if there's a product need (a "verified query" library is plausibly valuable but is its own feature).*
+8. **`sync_column_notes` tenant→all-workspaces fan-out — accept, or rescope?** Same M2M root as #241; the answer likely follows Decision 3. *Recommendation: revisit under whichever #241 option is chosen.*

--- a/docs/superpowers/specs/2026-07-03-status-catalog-module-design.md
+++ b/docs/superpowers/specs/2026-07-03-status-catalog-module-design.md
@@ -1,0 +1,183 @@
+# One status/catalog module — single source of world-state truth
+
+**Date:** 2026-07-03
+**Issue:** arch #251 — "One status/catalog module (single source of world-state truth)" (cluster `status-catalog-module`, wave 2, `design-gated`)
+**Status:** Design — awaiting Brian's sign-off. **No implementation until approved.**
+**Author:** design window (research: 2 read-only mapping passes over the status + catalog surfaces)
+
+## Problem
+
+"Has this workspace's data loaded, and what tables exist?" is answered by **~7 independent status derivations** and **5 divergent table-catalog listers**, computed from three different substrates (`MaterializationRun.result`, live `information_schema`, `TransformationAsset` ORM) with different state predicates. They disagree in ways the agent and the user can both see — this is the contradictory-schema-response class that produced the #190 panic loop (18 SQL queries across 25 turns because `list_tables` said a table existed and `describe_table`/`query` said `NOT_FOUND`).
+
+Concrete, user-visible divergences (all verified against `main`):
+
+1. **`last_synced_at` COMPLETED-only vs "loaded and ready" COMPLETED|PARTIAL.** The status API derives `last_synced_at` from `MaterializationRun.state=COMPLETED` only (`apps/workspaces/api/workspace_views.py:163-170, 310-319`), so a tenant whose runs always end `PARTIAL` shows `last_synced_at: null` in the UI, while the multi-tenant prompt says "Data is loaded and ready. Last updated: …" from a `COMPLETED|PARTIAL` filter (`apps/agents/graph/base.py:442-470`). Same data, opposite story.
+
+2. **`SchemaState.MATERIALIZING` has 0 production writers and 15 readers.** No code in `apps/` or `mcp_server/` ever assigns `MATERIALIZING` (grep-verified; `provision()` goes `PROVISIONING→ACTIVE` at `schema_manager.py:106,140`; the materializer only touches `MaterializationRun.RunState`). Yet 15 sites branch on it (census in Appendix A). The single-tenant "materialization already in progress — do NOT trigger another" prompt branch (`base.py:318`) can therefore **never fire**; in-progress is actually carried by `MaterializationRun.state ∈ ACTIVE_STATES`, which is why the multi-tenant twin (`base.py:404-411`) redundantly also checks `active_run`.
+
+3. **The "usable schema" predicate forks three ways.** During any multi-tenant rebuild window: the query router `load_workspace_context` accepts `WorkspaceViewSchema.state == ACTIVE` only (`mcp_server/context.py:121-125`); `get_schema_status` accepts `ACTIVE|MATERIALIZING` (a dead arm) (`server.py:824`); the prompt's "not ready" predicate is `vs is None OR vs.state != ACTIVE` (`base.py:422`). So during a rebuild `get_schema_status` can say `not_provisioned` (inviting a redundant `run_materialization`) while the query tool says "trigger a rebuild" though one is already running.
+
+4. **`get_schema_status` reads an extinct result shape.** Single-tenant, it reads `last_run.result["tables"]` / `["table"]+["rows_loaded"]` (`server.py:802-808`), but the materializer persists only `{sources, pipeline, transforms}` (`materializer.py:473-477`). Neither key matches, so it always returns `tables: []` with `state: active` even after a fully successful run — disagreeing with `list_tables` in the same conversation (a #190 input).
+
+5. **Five catalog listers disagree** on source-of-truth, physical-existence reconciliation, and `stg_*` filtering (matrix in Appendix B). The prompt's `transformation_aware_list_tables` advertises terminal `TransformationAsset`s **by name with no physical-existence check** (`metadata.py:309-320`), while the MCP `list_tables` tool lists only reconciled raw sources — the prompt can name tables the agent's own tool omits. `get_metadata` looks up `TenantSchema` by `ctx.schema_name`, which for multi-tenant is the `ws_*` view schema and never matches → returns `table_count=0`.
+
+6. **`TenantMetadata` is per-membership, read three ways.** The materializer writes it to the triggering user's `TenantMembership` only (`materializer.py:547-549`, `OneToOneField` to membership at `models.py:279`); the prompt reads **user-scoped** (`base.py:351-353` — nothing for a user who never materialized), while MCP `describe_table`/`get_metadata` and the DRF dictionary read **any-membership** (`server.py:219,283`; `views.py:293`). Same tenant/table, different annotations per user and per surface.
+
+7. **`commcare_sync` fallback in four places.** Pipeline resolution falls back to `registry.get("commcare_sync")` when it fails — including for OCS/Connect tenants — silently using wrong-provider metadata (`base.py:329`, `server.py:83-103`, `views.py:389-395,583-589`), plus two hardcoded literals (`base.py:843`, `materializer.py:1979`). Only `server.py:_resolve_pipeline_config` is factored.
+
+8. **dbt-model listing is fail-open.** `pipeline_list_tables` drops sources whose physical table is absent (fail-closed) but lists dbt models optimistically when the live-table set is empty (`metadata.py:96-98`). Currently moot — **no shipped pipeline YAML declares `transforms`, so `dbt_models == []` for every pipeline** (`pipeline_registry.py:73`) — but latent: a transient DB error yields a phantom-only catalog that instructs re-materialization.
+
+## Goals
+
+- **One status derivation.** A single function computes canonical world-state; the status API, both prompt builders, and the MCP `get_schema_status` tool all consume it. No surface re-derives.
+- **One table catalog.** A single catalog service backs the prompt, the MCP `list_tables`/`get_metadata` tools, and the DRF data-dictionary — same source-of-truth, same physical reconciliation, same `stg_*` policy, one metadata read scope.
+- **Truthful by construction.** Reconciliation is uniform (fail-closed); a dead-key read can never silently return `[]`; a wrong-provider fallback surfaces an error instead of lying (aligns with #256).
+- **A read-model that layers on top of #255, not under it.** #251 owns *derivation and presentation*; #255 owns the *write side* (janitors, locking, run reconciliation). See collisions below.
+
+## Non-goals (explicit)
+
+- **Any write-side robustness owned by #255** — no janitor, no per-tenant advisory lock, no `MaterializationRun` stale-reconciliation, no dependency-graph ownership between tenant/view schemas. #251 reads their state; it does not manage it.
+- **The tenancy/permission substrate (#249/#250).** The status/catalog module runs **after** the centralized authorizer (`apps/workspaces/access.py`, per `2026-06-18-tenant-access-refresh-design.md`) has resolved workspace + live-tenant access. It does not re-implement access checks. Treated as a fixed input.
+- **Reviving dbt transforms in the pipeline YAMLs.** The dead `dbt_models` loops are noted, not fed; workspace-scope transforms are #267/#241's problem.
+- **New observability** (owned by #257, merged): this consolidation makes the existing `last_error` / status surfaces consistent; it does not add alarms.
+
+## Current-state map
+
+### Two state vocabularies (source enums)
+
+- `SchemaState` (`models.py:15-21`), used by both `TenantSchema.state` and `WorkspaceViewSchema.state`: `PROVISIONING, ACTIVE, MATERIALIZING, EXPIRED, TEARDOWN, FAILED`.
+- `MaterializationRun.RunState` + `ACTIVE_STATES` (`models.py:62-80`): `STARTED, DISCOVERING, LOADING, TRANSFORMING, COMPLETED, PARTIAL, FAILED, CANCELLED, STALE`; `ACTIVE_STATES = {started, discovering, loading, transforming}`.
+- **No `last_synced_at` column exists** on any model — always derived at read-time from `MaterializationRun.completed_at`.
+
+### Status derivations (the "~7")
+
+| # | Site | Substrate | "in-progress" / "ready" predicate |
+|---|---|---|---|
+| S1 | `_derive_schema_status` `workspace_views.py:84-105` (the shared oracle → `available/provisioning/unavailable/failed`) | TenantSchema.state counts + view_schema.state | single-tenant: ready iff **all** tenant schemas ACTIVE; multi: keyed on view_schema.state only |
+| S2 | `WorkspaceListView` / `WorkspaceDetailView` `last_synced_at` `workspace_views.py:163-170, 310-319` | `MaterializationRun.state=COMPLETED` | COMPLETED-only |
+| S3 | single-tenant prompt `base.py:287-382` | `TenantSchema ACTIVE\|MATERIALIZING` + `tables[0].materialized_at` | MATERIALIZING branch (dead) |
+| S4 | multi-tenant prompt `base.py:392-479` | `WorkspaceViewSchema` + `MaterializationRun ∈ ACTIVE_STATES` + COMPLETED\|PARTIAL | in-progress = `active_run OR vs.state==MATERIALIZING`; ready = `vs.state==ACTIVE` |
+| S5 | MCP `get_schema_status` single `server.py:774-819` | `TenantSchema ACTIVE\|MATERIALIZING`; `last_run.result` dead-key read | tables always `[]` |
+| S6 | MCP `get_schema_status` multi `server.py:821-881` | `WorkspaceViewSchema ACTIVE\|MATERIALIZING`; FAILED→`SCHEMA_BUILD_FAILED`; `workspace_list_tables` | ACTIVE\|MATERIALIZING |
+| S7 | `load_tenant_context` / `load_workspace_context` `context.py:51-139` | tenant: ACTIVE\|MATERIALIZING; view: **ACTIVE only** | routing gate |
+| — | jobs poll `jobs_views.py:83-163` (frontend `useWorkspaceJobs.ts`, 3s) | `ThreadJob.state ∈ ACTIVE_STATES` + `MaterializationRun.progress` | **not** SchemaState-driven; separate axis (in-flight *jobs*, not *world-state*) |
+
+Frontend maps `schema_status` → UI state at `frontend/src/api/workspaces.ts:62-95` (`available→ready`, `provisioning→loading`, `unavailable→empty`, `failed→empty`, fallback `last_synced_at != null ? ready : empty`). `RefreshStatusView` (`views.py:511-539`) exists but has no frontend caller; the live signal is `schema_status` on the workspace payload plus the 3s jobs poll.
+
+### Catalog listers (the "5")
+
+Full matrix in Appendix B. Summary: `transformation_aware_list_tables` (prompt), `pipeline_list_tables` (MCP `list_tables`), `workspace_list_tables` (view-schema VIEWs), `get_schema_status` single-tenant (run.result blob), `_sync_pipeline_list_tables` (DRF dictionary). `stg_*` is hidden **only** in the DRF paths (`views.py:416,569`). Physical reconciliation is present for raw sources everywhere except `get_schema_status` single-tenant and the terminal-asset branch of `transformation_aware_list_tables`.
+
+### Boundary reality
+
+The "standalone MCP server" boundary is already bidirectional fiction: `mcp_server.services.metadata` imports `apps.workspaces`/`apps.transformations` models (`metadata.py:16-18`), while `apps.agents`/`apps.workspaces` import the listers back out of `mcp_server` (7 files, Appendix C). Any consolidation must pick a canonical home and make the dependency direction explicit — this is a decision, below.
+
+## Proposed design
+
+### Recommended: a canonical read-model service (Option A), adopted surface-by-surface
+
+Introduce **one module** that is the single source of truth for world-state and catalog, computed on read from the existing substrates. Every surface delegates to it; no surface re-derives. It is a pure read-model — it never writes schema/run state (that stays with the materializer/#255).
+
+**Shape (names illustrative; final in the plan):**
+
+```
+world_state.py (NEW)
+  @dataclass WorldState:
+      status: Literal["available","provisioning","unavailable","failed"]
+      in_progress: bool            # from MaterializationRun.state ∈ ACTIVE_STATES — the ONE definition
+      last_synced_at: datetime|None
+      last_error: str|None         # from WorkspaceViewSchema.last_error / run failure
+      is_multi_tenant: bool
+  async def derive_world_state(workspace) -> WorldState        # replaces S1–S7's status logic
+
+catalog.py (NEW)
+  @dataclass CatalogTable: name, type, logical_name, row_count, materialized_at, verified: bool
+  async def list_catalog(context) -> list[CatalogTable]        # replaces the 5 listers
+  async def describe(context, table) -> TableDescription       # one column/metadata path
+      # ONE TenantMetadata read scope (below); ONE stg_* policy; uniform fail-closed reconciliation
+```
+
+- **`in_progress` has one definition:** `MaterializationRun.state ∈ ACTIVE_STATES` for the workspace's tenants (plus the view-schema rebuild window). The dead `SchemaState.MATERIALIZING` arms are deleted (see Decision 2).
+- **`last_synced_at` has one definition** (see Decision 3).
+- **Catalog reconciliation is uniform and fail-closed** for both sources and dbt models (Decision 6); the dead-key `run.result["tables"]` read is deleted — single-tenant catalog comes from the same reconciled path as multi-tenant.
+- **One `stg_*` policy** across prompt + tools + dictionary (Decision 4).
+- **One `TenantMetadata` read scope** (Decision 5).
+- **Pipeline resolution** goes through the single factored `_resolve_pipeline_config`, and the `commcare_sync` fallback becomes a truthful error, not a silent wrong-provider substitution (Decision 7, aligns with #256).
+
+**Home + direction (Decision 1):** the module lives in `apps/` (models live there; it is async Django ORM) and `mcp_server` imports it — formalizing the direction that already exists de-facto and removing `mcp_server.services.metadata`'s reverse import of `apps` models over time.
+
+**Why this option:** lowest blast radius that actually closes the divergence — it removes duplication by *substitution* (each surface swaps its bespoke logic for a call), so each phase is independently shippable and testable against the surface it touches, and it never contends with #255's write paths (it only reads run/schema rows).
+
+### Rejected alternatives
+
+- **Option B — denormalized status columns** (write `status` + `last_synced_at` onto `Workspace`/schema rows at each transition). Reads get trivially cheap and consistent, but every writer must be updated in lockstep — and those writers are exactly the materializer/janitor/teardown paths **#255 is actively reworking**. This creates a direct collision (two windows editing the same transition sites) and re-introduces the "15 readers of a state nobody reliably writes" failure mode if a transition is missed. Rejected: couples a read concern to #255's write surface.
+- **Option C — event-sourced WorldState projection table** updated by a listener on run/schema events. Cleanest long-term separation, but it needs an event bus we don't have, a backfill, and its own reconciliation (a missed event = stale projection), which overlaps #255's janitor ownership. Over-engineered for a platform with one worker; revisit only if the read-model service proves too slow. Rejected: cost/complexity far exceeds the problem.
+
+## Data-model / migration implications
+
+Option A is **almost entirely code** — it moves logic into two modules and repoints callers. Specifically:
+
+- **No new tables** for status/catalog derivation itself.
+- **`SchemaState.MATERIALIZING` removal (Decision 2):** if we drop the enum value, a data migration must map any stray `MATERIALIZING` rows (none expected in prod; grep shows only test fixtures) to `PROVISIONING` or `ACTIVE`. Lower-risk alternative: keep the enum member, delete only the dead **reader** arms — no migration. Recommended: keep the member, delete the readers (avoids a migration and any collision with a future #255 use).
+- **`TenantMetadata` scope (Decision 5):** making metadata canonical per-tenant (rather than per-membership) is the one change that *could* need a migration (collapse N membership rows → 1 tenant row). The zero-migration path is to keep the model per-membership but define a single deterministic read (e.g. "most-recently-discovered live membership"), respecting #249's archived-membership filter. Recommended: zero-migration read-rule first; per-tenant model as a follow-up.
+
+## Phased implementation plan
+
+Each phase is independently shippable, independently testable, and leaves the tree green. Ordering puts the pure-derivation consolidation first (no behavior change intended) and the behavior-changing policy decisions in later, separately-reviewable phases.
+
+**Phase 1 — `world_state.derive_world_state` + adopt in the status API.** Extract S1/S2 into the canonical function; `WorkspaceListView`/`WorkspaceDetailView` call it. Golden-master test: for a matrix of (tenant states × run states × view-schema states) the emitted `schema_status`/`last_synced_at` equal today's — except the intentional `last_synced_at` fix (Decision 3), which gets its own asserted test. No prompt/MCP change yet.
+
+**Phase 2 — adopt `derive_world_state` in both prompt builders and the MCP `get_schema_status` tool.** S3–S7 delegate. This is where the divergences (1)(3)(4) close: the prompt, the tool, and the API now tell one story. Delete the dead-key `run.result["tables"]` read; single-tenant catalog comes from Phase 3's path (interim: from the reconciled sources). Contract test: `get_schema_status`, the prompt block, and the status API agree across the rebuild window and the PARTIAL-run case.
+
+**Phase 3 — `catalog.list_catalog` + `catalog.describe`; adopt in MCP `list_tables`/`get_metadata`, the prompt lister, and the DRF dictionary.** One reconciled, fail-closed catalog; one `stg_*` policy (Decision 4); fix `get_metadata`'s `ws_*` lookup miss. This is the #190-class fix: `list_tables` and `describe_table` can no longer contradict. Regression test reproducing the #190 sequence (list says X exists → describe must not say NOT_FOUND for the same catalog).
+
+**Phase 4 — one `TenantMetadata` read scope (Decision 5) + kill the `commcare_sync` silent fallback (Decision 7).** Column annotations become surface-independent and user-independent; wrong-provider resolution surfaces a truthful error. Test: same tenant/table yields identical annotations from prompt, MCP, and dictionary; an unresolvable pipeline returns an error envelope, not commcare metadata.
+
+**Phase 5 (optional cleanup) — dbt fail-closed (Decision 6) + retire the dead `dbt_models` loops** or leave them behind a fail-closed reconciliation so a future YAML with `transforms` is safe by construction. Lowest urgency (currently dead code).
+
+## Test strategy
+
+- **Golden-master before/after** for `derive_world_state` (Phase 1) over the full state matrix — the safety net proving "consolidation ≠ behavior change" except where a decision intentionally changes it.
+- **Cross-surface agreement tests** (Phases 2–4): parametrized fixtures assert the status API, the prompt block, the MCP tool, and the DRF dictionary return the same world-state / catalog / annotations for the same workspace. These are the tests whose *absence* let the 7-way divergence accumulate.
+- **#190 regression:** the contradictory-catalog scenario (list_tables lists a table the same-context describe_table 404s) must be impossible by construction.
+- **Failure-mode tests:** transient `information_schema` error → fail-closed empty (never phantom-listed); unresolvable provider → truthful error (never silent commcare_sync).
+- Async DB tests use `@pytest.mark.asyncio` + `@pytest.mark.django_db(transaction=True)` per `CLAUDE.md`.
+
+## Cross-cutting collisions
+
+- **#255 (in-flight, background robustness).** #251 is a *read* consolidation; #255 owns the *writes*. Explicit contract: **#251 never writes `SchemaState`/`RunState` and never adds a janitor or lock.** The one shared surface is the **representation of "in-progress."** #251 standardizes reads on `MaterializationRun.state ∈ ACTIVE_STATES`. If #255's per-tenant mutual-exclusion (finding 03#3) wants a written in-progress signal, it should use a Postgres **advisory lock** or its own run-state, **not** revive `SchemaState.MATERIALIZING` — otherwise it re-creates the dead-state divergence #251 just removed. **Flag for the two windows to agree on before either lands** (Decision 2). Also: #255's cascade-FAILED honesty (07#9) already partly shipped via #256 (`WorkspaceViewSchema.last_error`, `state:failed`); `derive_world_state` consumes `last_error` and must not regress it.
+- **#249/#250 (tenancy/permission, live window — fixed input).** The catalog/status module runs **after** `resolve_workspace_access` (`apps/workspaces/access.py`). It must not re-implement the membership check, and — critically for Decision 5 — its `TenantMetadata` read must honor the **live-membership** filter (archived `TenantMembership` rows are tombstones; reading annotations from an archived member's row would leak revoked-tenant context into a prompt). The canonical metadata read-rule must filter `archived_at IS NULL`.
+- **#252/#255/#261 batch (in-flight).** No file-level collision expected beyond the `MATERIALIZING`/in-progress representation above; the catalog service reads `MaterializationRun.result`/`.progress` which the batch may reshape — Phase 3 should depend on the *reconciled* live catalog, not the `run.result` blob shape, precisely so a `result`-shape change (theirs) can't re-break the catalog (ours).
+
+## Decisions needed from Brian
+
+1. **Canonical module home + dependency direction.** Recommend: `apps/workspaces/services/{world_state,catalog}.py`, with `mcp_server` importing from `apps` (formalizes today's de-facto direction; lets us delete `mcp_server.services.metadata`'s reverse import of `apps` models over time). Alternative: keep the shared logic in `mcp_server.services` (apps already import it) if you want to preserve MCP-as-library. *Recommendation: apps-owned.*
+2. **How is "materialization in progress" represented?** Recommend: standardize all reads on `MaterializationRun.state ∈ ACTIVE_STATES`; **keep** the `SchemaState.MATERIALIZING` enum member but **delete its 15 dead reader arms** (no migration). This must be agreed with the #255 window — if #255 needs a *written* in-progress signal for per-tenant locking, it should use an advisory lock, not `MATERIALIZING`. *Recommendation: ACTIVE_STATES + delete dead readers; #255 uses advisory lock.*
+3. **`last_synced_at` semantics.** Recommend: `COMPLETED|PARTIAL` (a PARTIAL run *did* load data — matching the prompt's "loaded and ready"), so the UI stops showing `null` for perpetually-PARTIAL tenants. Alternative: keep COMPLETED-only and change the prompt to match. *Recommendation: COMPLETED|PARTIAL everywhere.*
+4. **`stg_*` visibility policy — the real product question.** Today the DRF dictionary hides `stg_*` while the agent prompt advertises terminal `stg_*` assets. Should the agent see staging/terminal transformation assets as queryable tables? Options: (a) show terminal assets, hide intermediate `stg_*`; (b) hide all `stg_*` from every surface; (c) show everything. This depends on whether transforms are a product feature (ties to #267/#241). *Recommendation: (a), and reconcile with #267.*
+5. **`TenantMetadata` read scope.** Recommend: one deterministic read — "most-recently-discovered **live** membership for the tenant" (respects #249 archived filter), zero migration. Follow-up: promote metadata to per-tenant (one row) with a migration. *Recommendation: deterministic live-membership read now; per-tenant model later.*
+6. **dbt-model reconciliation.** Recommend: make dbt-model listing fail-closed like sources (drop the optimistic branch), so the currently-dead loops are safe if a pipeline ever declares `transforms`. Low urgency. *Recommendation: fail-closed.*
+7. **`commcare_sync` fallback.** Recommend: remove the silent wrong-provider fallback at all four sites; an unresolvable pipeline returns a truthful error (per #256), not commcare metadata for an OCS/Connect tenant. *Recommendation: truthful error.*
+
+---
+
+## Appendix A — `SchemaState.MATERIALIZING` reader census (15 production sites, 0 writers)
+
+`base.py:298,318,411`; `workspace_views.py:130,293`; `workspace_service.py:88,97,102`; `schema_manager.py:78,113`; `views.py:34,53`; `context.py:66`; `server.py:778,824`. Writers appear only in test fixtures (`test_materialize_workspace_task.py:376`, `test_workspace_service.py:133`, `test_agent_graph.py:129`, `test_schema_context.py:52,307`).
+
+## Appendix B — catalog lister divergence matrix
+
+| Path | file:line | Source | Physical check | `stg_` hidden | sync/async | TenantMetadata scope |
+|---|---|---|---|---|---|---|
+| `transformation_aware_list_tables` | `metadata.py:269` | Run + TransformationAsset | raw: yes / assets: **no** | no | async | via `base.py` user-scoped |
+| `pipeline_list_tables` | `metadata.py:29` | `Run.result[sources]` + dbt_models | sources fail-closed / dbt fail-open | no | async | n/a |
+| `workspace_list_tables` | `metadata.py:161` | `information_schema` VIEWs | inherent | n/a | async | n/a |
+| `get_schema_status` (single) | `server.py:799` | `Run.result` blob (dead key) | **none** → `[]` | no | async | n/a |
+| `_sync_pipeline_list_tables` | `views.py:148` | `Run.result` + dbt_models | sources fail-closed / dbt fail-open | caller filters | sync | n/a |
+| `DataDictionaryView` | `views.py:413` | `_sync_pipeline_list_tables` | via live set | **yes (416)** | sync | any-membership |
+| `TableDetailView` | `views.py:567` | `_sync_pipeline_list_tables` | via live set | **yes (569)** | sync | any-membership |
+| `describe_table`/`get_metadata` | `server.py:219/283` | `information_schema.columns` | inherent | no | async | any-membership |
+
+## Appendix C — module-boundary imports (`apps/*` → `mcp_server` internals)
+
+`apps/agents/graph/base.py:38-45` (context, pipeline_registry, metadata×4); `apps/agents/mcp_client.py:19` (auth); `apps/workspaces/api/views.py:25` (pipeline_registry); `apps/workspaces/tasks.py:40-42` (loaders, pipeline_registry, materializer); `apps/artifacts/views.py:27-28` (context, query); `apps/transformations/services/executor.py:28` (dbt_runner); `apps/users/services/credential_resolver.py:17` (envelope). Reverse: `mcp_server/services/metadata.py:16-18` imports `apps.workspaces`/`apps.transformations` models.


### PR DESCRIPTION
Two **design-gated** Wave-2 architecture-review specs — approval-ready, **code-free**. These are for inline review/sign-off; nothing gets implemented until the decisions below are made. Not assigning a code reviewer — design sign-off is Brian's call.

## `docs/superpowers/specs/2026-07-03-status-catalog-module-design.md` — #251
World-state is derived ~7 ways and tables are listed 5 ways, from three different substrates, with user-visible divergence (the #190 panic-loop input class). Recommends **one read-model service** (`world_state` + `catalog`) that every surface delegates to, **layering on top of #255's write side** (it reads run/schema state, never writes it). Standardizes "in-progress" on `MaterializationRun.ACTIVE_STATES` and retires the dead `SchemaState.MATERIALIZING` readers (0 writers, 15 readers), unifies the `TenantMetadata` read scope, and makes pipeline resolution truthful instead of silently falling back to `commcare_sync`.

**Top decisions:** (2) how to represent "in-progress" — coordinate with #255 so it uses an advisory lock, not a revived `MATERIALIZING`; (3) `last_synced_at` COMPLETED vs COMPLETED|PARTIAL; (4) whether the agent should see `stg_*`/terminal transform assets (ties to #267); (5) `TenantMetadata` read scope (must honor #249 archived-membership filter).

## `docs/superpowers/specs/2026-07-03-content-satellite-redesign-design.md` — #267
Recipes/knowledge/artifacts grew independently and share nothing but accidental structure; sharing/provenance/drift-integrity are each solved differently or not at all. Recommends **Option B — a shared content spine** (one sharing/ACL model, first-class provenance, drift-integrity against #251's logical catalog) with the three models keeping their distinct lifecycles. Folds in the **#241 residual** (workspace-scope transforms never materialize — rooted in the Workspace↔Tenant M2M scope mismatch) and the **#318** learning lifecycle. Recipe *runtime* is out of scope (already redone).

**Top decisions:** (1) target shape A/B/C (recommend B); (3) #241 — run workspace transforms post-view-build (A1) vs drop the scope (A2, recommended absent a use case); (2) unified sharing that routes public-token paths through the #249/#250 authorizer (closes the R2 residual).

## Guardrails observed
- Only #251 and #267. Did **not** touch #249/#250 (treated the tenant-access-refresh design as a fixed input) or the in-flight #252/#255/#261 batch — collisions are called out explicitly in each spec.
- No feature code; docs-only branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)