### PR TITLE
arch #252: credential lifetime for long jobs (mid-run OAuth refresh, retry hardening)

### DIFF
--- a/apps/users/services/credential_resolver.py
+++ b/apps/users/services/credential_resolver.py
@@ -18,6 +18,23 @@ from mcp_server.envelope import AUTH_TOKEN_EXPIRED
 
 logger = logging.getLogger(__name__)
 
+_PROVIDER_LABELS = {
+    "commcare": "CommCare",
+    "commcare_connect": "CommCare Connect",
+    "ocs": "Open Chat Studio",
+}
+
+
+def _reauth_message(provider: str) -> str:
+    """User-facing 'reconnect your account' guidance for an expired token."""
+    label = _PROVIDER_LABELS.get(provider)
+    who = f"Your {label} sign-in" if label else "Your sign-in"
+    what = f"reconnect your {label} account" if label else "reconnect your account"
+    return (
+        f"{who} has expired or been revoked and could not be renewed "
+        f"automatically. Please {what} and retry."
+    )
+
 
 class CredentialResolutionError(Exception):
     """Raised when a credential exists but cannot be used for a *known,
@@ -79,7 +96,13 @@ async def aget_fresh_access_token(user, provider: str) -> str | None:
     token_obj = await _social_token_qs(user, provider).select_related("account", "app").afirst()
     if token_obj is None:
         return None
-    cred = await _aresolve_oauth_credential(token_obj, provider)
+    try:
+        cred = await _aresolve_oauth_credential(token_obj, provider)
+    except CredentialResolutionError:
+        # A refresh failure means no usable token. Callers of this helper only
+        # want a live token (e.g. share-time tenant-access refresh) and treat
+        # None as "skip"; surface None rather than raising into them.
+        return None
     return cred["value"]
 
 
@@ -141,17 +164,25 @@ async def aresolve_credential(membership) -> dict | None:
 
 
 async def _aresolve_oauth_credential(token_obj, provider: str) -> dict:
-    """Build an OAuth credential dict, refreshing the token if near expiry."""
-    token_value = token_obj.token
+    """Build an OAuth credential dict, refreshing the token if near expiry.
+
+    Fails closed (raises ``CredentialResolutionError`` with ``AUTH_TOKEN_EXPIRED``)
+    when the token is at/near expiry and cannot be renewed. Serving a known-stale
+    token only provisions a schema and burns the discover phase before the first
+    authenticated request 401s, and no 401 downstream maps to actionable
+    re-authentication guidance — so we surface "reconnect your account" up front
+    instead of a doomed run (arch #252, finding 14#4).
+    """
+    token_url = get_token_url(provider)
+    can_refresh = bool(token_url and token_obj.token_secret and token_obj.app)
 
     if token_needs_refresh(token_obj.expires_at):
-        token_url = get_token_url(provider)
-        if token_url and token_obj.token_secret:
-            try:
-                token_value = await refresh_oauth_token(token_obj, token_url)
-            except TokenRefreshError:
-                logger.warning(
-                    "Token refresh failed for provider %s, using existing token", provider
-                )
+        if not can_refresh:
+            raise CredentialResolutionError(AUTH_TOKEN_EXPIRED, _reauth_message(provider))
+        try:
+            return {"type": "oauth", "value": await refresh_oauth_token(token_obj, token_url)}
+        except TokenRefreshError as e:
+            logger.warning("Token refresh failed for provider %s; failing closed", provider)
+            raise CredentialResolutionError(AUTH_TOKEN_EXPIRED, _reauth_message(provider)) from e
 
-    return {"type": "oauth", "value": token_value}
+    return {"type": "oauth", "value": token_obj.token}

--- a/apps/users/services/credential_resolver.py
+++ b/apps/users/services/credential_resolver.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 
 from allauth.socialaccount.models import SocialToken
 
@@ -12,6 +13,7 @@ from apps.users.services.token_refresh import (
     TokenRefreshError,
     get_token_url,
     refresh_oauth_token,
+    refresh_oauth_token_sync,
     token_needs_refresh,
 )
 from mcp_server.envelope import AUTH_TOKEN_EXPIRED
@@ -163,6 +165,22 @@ async def aresolve_credential(membership) -> dict | None:
     return await _aresolve_oauth_credential(token_obj, conn.provider)
 
 
+def _make_token_refresher(token_obj, token_url: str) -> Callable[[], str]:
+    """Return a sync callable a loader invokes on a mid-run 401 to mint a fresh
+    access token (arch #252, finding 14#3).
+
+    It runs on the materialization worker thread (``asyncio.to_thread``), so it
+    uses the blocking refresh + sync-ORM persistence. It closes over the same
+    ``token_obj`` the proactive refresh mutated, so a second mid-run refresh
+    reuses the rotated refresh token.
+    """
+
+    def _refresh() -> str:
+        return refresh_oauth_token_sync(token_obj, token_url)
+
+    return _refresh
+
+
 async def _aresolve_oauth_credential(token_obj, provider: str) -> dict:
     """Build an OAuth credential dict, refreshing the token if near expiry.
 
@@ -172,17 +190,25 @@ async def _aresolve_oauth_credential(token_obj, provider: str) -> dict:
     authenticated request 401s, and no 401 downstream maps to actionable
     re-authentication guidance — so we surface "reconnect your account" up front
     instead of a doomed run (arch #252, finding 14#4).
+
+    When a refresh is possible the credential carries a ``refresh`` callable so
+    loaders can renew the token mid-run and survive a token whose lifetime is
+    shorter than the run — CommCare's 15-min OAuth TTL (finding 14#3).
     """
     token_url = get_token_url(provider)
     can_refresh = bool(token_url and token_obj.token_secret and token_obj.app)
 
+    token_value = token_obj.token
     if token_needs_refresh(token_obj.expires_at):
         if not can_refresh:
             raise CredentialResolutionError(AUTH_TOKEN_EXPIRED, _reauth_message(provider))
         try:
-            return {"type": "oauth", "value": await refresh_oauth_token(token_obj, token_url)}
+            token_value = await refresh_oauth_token(token_obj, token_url)
         except TokenRefreshError as e:
             logger.warning("Token refresh failed for provider %s; failing closed", provider)
             raise CredentialResolutionError(AUTH_TOKEN_EXPIRED, _reauth_message(provider)) from e
 
-    return {"type": "oauth", "value": token_obj.token}
+    cred: dict = {"type": "oauth", "value": token_value}
+    if can_refresh:
+        cred["refresh"] = _make_token_refresher(token_obj, token_url)
+    return cred

--- a/apps/users/services/token_refresh.py
+++ b/apps/users/services/token_refresh.py
@@ -2,11 +2,14 @@
 
 Handles refreshing expired OAuth tokens for the OAuth providers.
 
-``refresh_oauth_token`` (async) is the proactive path: the credential resolver
-renews a near-expiry token at task start, and ``providers_view`` renews on poll.
-There is no reactive (post-401) refresh on the credential seam today — a loader
-401 raises a provider ``AuthError`` that no handler maps back to refresh-and-retry
-(arch #252, finding 14#4).
+Two entry points:
+
+- ``refresh_oauth_token`` (async): the proactive path. The credential resolver
+  renews a near-expiry token at task start, and ``providers_view`` renews on poll.
+- ``refresh_oauth_token_sync`` (sync): the reactive path. A loader running under
+  ``asyncio.to_thread`` calls it on a mid-run 401 to renew a token whose lifetime
+  is shorter than the run (CommCare's 15-min OAuth TTL) without bridging back to
+  the event loop (arch #252, findings 14#3/14#4).
 """
 
 from __future__ import annotations
@@ -15,6 +18,7 @@ import logging
 from datetime import timedelta
 
 import httpx
+import requests
 from django.conf import settings
 from django.utils import timezone
 
@@ -95,4 +99,47 @@ async def refresh_oauth_token(social_token, token_url: str) -> str:
     await social_token.asave()
 
     logger.info("Successfully refreshed OAuth token for app %s", social_token.app.client_id)
+    return social_token.token
+
+
+def refresh_oauth_token_sync(social_token, token_url: str) -> str:
+    """Blocking OAuth refresh for the materialization worker thread.
+
+    Mirrors ``refresh_oauth_token`` but uses ``requests`` + sync ORM so a loader
+    running under ``asyncio.to_thread`` can renew a token mid-run (arch #252,
+    finding 14#3). The rotated token is persisted so the next run's proactive
+    refresh sees it; a persistence failure is non-fatal — the in-memory token is
+    still usable for the remainder of this run.
+    """
+    try:
+        response = requests.post(
+            token_url,
+            data={
+                "grant_type": "refresh_token",
+                "refresh_token": social_token.token_secret,
+                "client_id": social_token.app.client_id,
+                "client_secret": social_token.app.secret,
+            },
+            timeout=30,
+        )
+        response.raise_for_status()
+    except Exception as e:
+        logger.exception("Sync token refresh failed for app %s", social_token.app.client_id)
+        raise TokenRefreshError(f"Failed to refresh OAuth token: {e}") from e
+
+    data = response.json()
+    social_token.token = data["access_token"]
+    if data.get("refresh_token"):
+        social_token.token_secret = data["refresh_token"]
+    if data.get("expires_in"):
+        social_token.expires_at = timezone.now() + timedelta(seconds=data["expires_in"])
+    try:
+        social_token.save(update_fields=["token", "token_secret", "expires_at"])
+    except Exception:
+        logger.warning(
+            "Failed to persist mid-run refreshed token for app %s",
+            social_token.app.client_id,
+            exc_info=True,
+        )
+    logger.info("Successfully refreshed OAuth token (sync) for app %s", social_token.app.client_id)
     return social_token.token

--- a/apps/users/services/token_refresh.py
+++ b/apps/users/services/token_refresh.py
@@ -1,7 +1,12 @@
 """OAuth token refresh service.
 
-Handles refreshing expired OAuth tokens for CommCare providers.
-Called proactively (before token expires) and reactively (after 401).
+Handles refreshing expired OAuth tokens for the OAuth providers.
+
+``refresh_oauth_token`` (async) is the proactive path: the credential resolver
+renews a near-expiry token at task start, and ``providers_view`` renews on poll.
+There is no reactive (post-401) refresh on the credential seam today — a loader
+401 raises a provider ``AuthError`` that no handler maps back to refresh-and-retry
+(arch #252, finding 14#4).
 """
 
 from __future__ import annotations

--- a/apps/workspaces/tasks.py
+++ b/apps/workspaces/tasks.py
@@ -67,6 +67,25 @@ MATERIALIZATION_FAILED_MESSAGE = (
 logger = logging.getLogger(__name__)
 
 
+# Substrings that mark a per-source failure as an expired/revoked-credential
+# problem so the user is told to reconnect rather than just "check the
+# connection" (arch #252, finding 14#4). Loader auth errors carry both the
+# class-name suffix and the actionable "reconnect your ... account" guidance;
+# an HTTP 401 anywhere on the seam is the underlying signal.
+_AUTH_FAILURE_MARKERS = ("AuthError", "reconnect your", "HTTP 401")
+_REAUTH_GUIDANCE = (
+    "This looks like an expired or revoked sign-in — reconnect the affected "
+    "account (Settings → Connections) and re-run materialization."
+)
+
+
+def _looks_like_auth_failure(error: str | None) -> bool:
+    """True when a per-source error string reads as a credential/401 failure."""
+    if not error:
+        return False
+    return any(marker in error for marker in _AUTH_FAILURE_MARKERS)
+
+
 def _no_pipeline_error(registry, provider: str) -> str:
     """Build the 'no pipeline for provider' error, distinguishing cause (07#7).
 
@@ -138,7 +157,10 @@ def _compose_failure_summary(runs: list[MaterializationRun]) -> str:
         # No per-source detail (failure before any source ran) — surface run state.
         states = sorted({r.state for r in runs})
         return f"Materialization {'/'.join(states)}."
-    return ". ".join(parts) + "."
+    summary = ". ".join(parts) + "."
+    if any(_looks_like_auth_failure(err) for _, err in failed_sources):
+        summary += " " + _REAUTH_GUIDANCE
+    return summary
 
 
 @task
@@ -1274,6 +1296,17 @@ async def resume_thread_after_materialization(context, thread_job_id: str) -> di
     # pre-CAS tj.state snapshot, which mislabelled a Stop-click that raced with
     # completion as "cancelled" when the data had actually loaded).
     status, summary = await _aggregate_materialization_state(tj.procrastinate_job_id)
+    auth_failure = any(
+        _looks_like_auth_failure(str(src.get("error")))
+        for tenant in summary
+        for src in (tenant.get("sources") or {}).values()
+    )
+    reauth_line = (
+        f" At least one source failed authentication: {_REAUTH_GUIDANCE} Tell the "
+        f"user explicitly to reconnect the affected account."
+        if auth_failure
+        else ""
+    )
 
     workspace = tj.thread.workspace
     user = tj.thread.user
@@ -1341,7 +1374,7 @@ async def resume_thread_after_materialization(context, thread_job_id: str) -> di
             f"failed or skipped. A source with state=in_progress or state=failed "
             f"and a non-null resume_last_id has partially-loaded rows that the "
             f"next materialization will continue from — do NOT query its table "
-            f"as if it were complete. Per-tenant: {summary}"
+            f"as if it were complete.{reauth_line} Per-tenant: {summary}"
         )
     elif status == "failed":
         body = (
@@ -1352,7 +1385,7 @@ async def resume_thread_after_materialization(context, thread_job_id: str) -> di
             f"that the data load failed (this is commonly caused by expired or "
             f"revoked credentials), summarize the per-source errors below, and "
             f"suggest checking the workspace's connection before retrying. Do NOT "
-            f"silently re-run materialization. Per-tenant: {summary}"
+            f"silently re-run materialization.{reauth_line} Per-tenant: {summary}"
         )
     elif status == "cancelled":
         body = (

--- a/mcp_server/loaders/_http.py
+++ b/mcp_server/loaders/_http.py
@@ -1,0 +1,56 @@
+"""Shared HTTP hardening for the API loaders.
+
+Centralises the bounded ``urllib3`` retry policy so CommCare, Connect, and OCS
+loaders share one transport that survives transient upstream failures and
+throttles without pinning the sole materialization worker thread (arch #252).
+"""
+
+from __future__ import annotations
+
+from urllib3.util.retry import Retry
+
+# urllib3 honours a server ``Retry-After`` header verbatim when
+# ``respect_retry_after_header=True`` — with NO upper bound (``backoff_max``
+# caps only the exponential path). Loaders run on the single materialization
+# worker thread, so an upstream throttle advertising a large ``Retry-After``
+# would park that sole thread for the full value, up to ``total`` times per
+# request, uncancellable (arch #252, finding 14#6). Clamp the honoured value so
+# one throttle response costs at most this many seconds of sleep.
+MAX_RETRY_AFTER_SECONDS = 30
+
+RETRY_TOTAL = 3
+RETRY_STATUS_FORCELIST = (500, 502, 503, 504, 408, 429)
+RETRY_BACKOFF_FACTOR = 2.0
+
+
+class BoundedRetry(Retry):
+    """``urllib3.Retry`` that caps a server-supplied ``Retry-After``.
+
+    Everything else is stock urllib3 behaviour; only the honoured
+    ``Retry-After`` is clamped to ``MAX_RETRY_AFTER_SECONDS``.
+    """
+
+    def get_retry_after(self, response):
+        retry_after = super().get_retry_after(response)
+        if retry_after is None:
+            return None
+        return min(retry_after, MAX_RETRY_AFTER_SECONDS)
+
+
+def build_retry() -> Retry:
+    """Return the shared bounded retry policy for loader sessions.
+
+    ``backoff_factor=2.0`` yields 0s/2s/4s waits between the 4 total attempts
+    on the exponential path; a server ``Retry-After`` is honoured but capped at
+    ``MAX_RETRY_AFTER_SECONDS``. ``raise_on_status=False`` lets callers inspect
+    the final response (status, headers) and raise a typed export error rather
+    than propagating a raw ``requests.HTTPError``.
+    """
+    return BoundedRetry(
+        total=RETRY_TOTAL,
+        backoff_factor=RETRY_BACKOFF_FACTOR,
+        status_forcelist=list(RETRY_STATUS_FORCELIST),
+        allowed_methods=["GET"],
+        respect_retry_after_header=True,
+        raise_on_status=False,
+    )

--- a/mcp_server/loaders/_http.py
+++ b/mcp_server/loaders/_http.py
@@ -7,7 +7,13 @@ throttles without pinning the sole materialization worker thread (arch #252).
 
 from __future__ import annotations
 
+import logging
+from collections.abc import Callable
+
+import requests
 from urllib3.util.retry import Retry
+
+logger = logging.getLogger(__name__)
 
 # urllib3 honours a server ``Retry-After`` header verbatim when
 # ``respect_retry_after_header=True`` — with NO upper bound (``backoff_max``
@@ -54,3 +60,37 @@ def build_retry() -> Retry:
         respect_retry_after_header=True,
         raise_on_status=False,
     )
+
+
+# Returns a fresh OAuth access token (or None when no refresh is possible).
+TokenRefresher = Callable[[], "str | None"]
+
+
+def get_with_auth_refresh(
+    session: requests.Session,
+    url: str,
+    *,
+    refresh: TokenRefresher | None = None,
+    **kwargs,
+) -> requests.Response:
+    """GET ``url`` and, on a 401, refresh the OAuth token once and retry.
+
+    ``refresh`` (when provided) mints a fresh access token — the mid-run
+    reactive refresh that lets a load outlive a short-lived OAuth token
+    (arch #252, finding 14#3). It is consulted only on a 401 (an expiry
+    signal); a 403 is a permission error left to the caller. On refresh
+    failure the original 401 response is returned so the caller raises its
+    provider ``AuthError`` (fail closed — never a stale retry).
+    """
+    resp = session.get(url, **kwargs)
+    if resp.status_code != 401 or refresh is None:
+        return resp
+    try:
+        new_token = refresh()
+    except Exception:
+        logger.warning("Mid-run token refresh failed; surfacing auth error", exc_info=True)
+        return resp
+    if not new_token:
+        return resp
+    session.headers["Authorization"] = f"Bearer {new_token}"
+    return session.get(url, **kwargs)

--- a/mcp_server/loaders/commcare_base.py
+++ b/mcp_server/loaders/commcare_base.py
@@ -13,7 +13,7 @@ from urllib.parse import urljoin
 import requests
 from requests.adapters import HTTPAdapter
 
-from mcp_server.loaders._http import build_retry
+from mcp_server.loaders._http import build_retry, get_with_auth_refresh
 
 logger = logging.getLogger(__name__)
 
@@ -57,6 +57,9 @@ class CommCareBaseLoader:
 
     def __init__(self, domain: str, credential: dict[str, str]) -> None:
         self.domain = domain
+        # A mid-run token refresher (OAuth only); None for API keys, which never
+        # expire mid-run (arch #252, finding 14#3).
+        self._refresh = credential.get("refresh")
         self._session = requests.Session()
         self._session.headers.update(build_auth_header(credential))
         adapter = HTTPAdapter(max_retries=build_retry())
@@ -82,7 +85,9 @@ class CommCareBaseLoader:
         (bounded, capped Retry-After); a surviving non-2xx becomes a typed
         error rather than a bare ``requests.HTTPError``.
         """
-        resp = self._session.get(url, params=params, timeout=HTTP_TIMEOUT)
+        resp = get_with_auth_refresh(
+            self._session, url, refresh=self._refresh, params=params, timeout=HTTP_TIMEOUT
+        )
         if resp.status_code in (401, 403):
             raise CommCareAuthError(
                 f"CommCare authentication failed for domain {self.domain} "

--- a/mcp_server/loaders/commcare_base.py
+++ b/mcp_server/loaders/commcare_base.py
@@ -11,6 +11,9 @@ import logging
 from urllib.parse import urljoin
 
 import requests
+from requests.adapters import HTTPAdapter
+
+from mcp_server.loaders._http import build_retry
 
 logger = logging.getLogger(__name__)
 
@@ -21,6 +24,17 @@ HTTP_TIMEOUT: tuple[int, int] = (10, 120)
 
 class CommCareAuthError(Exception):
     """Raised when CommCare returns a 401 or 403 response."""
+
+
+class CommCareExportError(Exception):
+    """Raised on unrecoverable CommCare export failures.
+
+    Covers malformed responses (invalid JSON, a missing page-collection key)
+    and non-2xx responses that survive the retry policy. CommCare HQ actively
+    rate-limits its APIs (HTTP 429 + Retry-After by design), so a bare
+    ``raise_for_status`` with no retry turned an expected throttle into a run
+    failure (arch #252, findings 12#4/03#6).
+    """
 
 
 def build_auth_header(credential: dict[str, str]) -> dict[str, str]:
@@ -45,6 +59,9 @@ class CommCareBaseLoader:
         self.domain = domain
         self._session = requests.Session()
         self._session.headers.update(build_auth_header(credential))
+        adapter = HTTPAdapter(max_retries=build_retry())
+        self._session.mount("https://", adapter)
+        self._session.mount("http://", adapter)
 
     def _resolve_next_url(self, base_url: str, next_url: str | None) -> str | None:
         """Resolve a potentially-relative ``next`` URL from a CommCare API response.
@@ -59,11 +76,30 @@ class CommCareBaseLoader:
         return urljoin(base_url, next_url)
 
     def _get(self, url: str, params: dict | None = None) -> requests.Response:
-        """GET a URL, raising CommCareAuthError on 401/403."""
+        """GET a URL, raising on auth failure or an unrecoverable status.
+
+        Transient 5xx/429 responses are retried by the session adapter
+        (bounded, capped Retry-After); a surviving non-2xx becomes a typed
+        error rather than a bare ``requests.HTTPError``.
+        """
         resp = self._session.get(url, params=params, timeout=HTTP_TIMEOUT)
         if resp.status_code in (401, 403):
             raise CommCareAuthError(
-                f"CommCare auth failed for domain {self.domain}: HTTP {resp.status_code}"
+                f"CommCare authentication failed for domain {self.domain} "
+                f"(HTTP {resp.status_code}). Your CommCare sign-in has likely expired "
+                f"or been revoked — please reconnect your CommCare account and retry."
             )
-        resp.raise_for_status()
+        if resp.status_code >= 400:
+            raise CommCareExportError(
+                f"CommCare export request failed for domain {self.domain}: "
+                f"HTTP {resp.status_code} for {url}"
+            )
         return resp
+
+    def _get_json(self, url: str, params: dict | None = None) -> dict:
+        """GET a URL and parse JSON, raising CommCareExportError on invalid JSON."""
+        resp = self._get(url, params=params)
+        try:
+            return resp.json()
+        except ValueError as e:
+            raise CommCareExportError(f"CommCare API returned invalid JSON for {url}: {e}") from e

--- a/mcp_server/loaders/commcare_cases.py
+++ b/mcp_server/loaders/commcare_cases.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 import logging
 from collections.abc import Iterator
 
-from mcp_server.loaders.commcare_base import CommCareAuthError, CommCareBaseLoader  # noqa: F401
+from mcp_server.loaders.commcare_base import (  # noqa: F401
+    CommCareAuthError,
+    CommCareBaseLoader,
+    CommCareExportError,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -43,13 +47,22 @@ class CommCareCaseLoader(CommCareBaseLoader):
         subsequent pages yield ``None``. (Case API v2 has no tastypie
         ``meta`` envelope — the total lives in ``matching_records``.)
         """
-        url = f"{_BASE_URL}/a/{self.domain}/api/case/v2/"
+        initial_url = f"{_BASE_URL}/a/{self.domain}/api/case/v2/"
+        url: str | None = initial_url
         params: dict = {"limit": self.page_size}
         total_loaded = 0
         first_page = True
         while url:
-            data = self._get(url, params=params).json()
-            cases = [_normalize_case(c) for c in data.get("cases", [])]
+            data = self._get_json(url, params=params)
+            if "cases" not in data:
+                # A well-formed empty page still carries ``"cases": []``; a
+                # missing key means the envelope changed under us — fail loudly
+                # rather than silently completing the source with 0 rows
+                # (arch #252, finding 03#6).
+                raise CommCareExportError(
+                    f"CommCare Case API response missing 'cases' key for {url}"
+                )
+            cases = [_normalize_case(c) for c in data["cases"]]
             page_total: int | None = None
             if first_page:
                 matching = data.get("matching_records")
@@ -65,7 +78,10 @@ class CommCareCaseLoader(CommCareBaseLoader):
                     self.domain,
                 )
                 yield cases, page_total
-            url = data.get("next")
+            # Case API v2 may return a relative ``next`` cursor; resolve it
+            # against the base URL like forms/metadata do (8774864) so a
+            # non-absolute value doesn't raise MissingSchema (finding 03#6).
+            url = self._resolve_next_url(initial_url, data.get("next"))
             params = {}
 
     def load(self) -> list[dict]:

--- a/mcp_server/loaders/commcare_forms.py
+++ b/mcp_server/loaders/commcare_forms.py
@@ -12,7 +12,7 @@ import logging
 from collections.abc import Iterator
 from typing import Any
 
-from mcp_server.loaders.commcare_base import CommCareBaseLoader
+from mcp_server.loaders.commcare_base import CommCareBaseLoader, CommCareExportError
 
 logger = logging.getLogger(__name__)
 
@@ -48,8 +48,15 @@ class CommCareFormLoader(CommCareBaseLoader):
         first_page = True
         first_meta_total: int | None = None
         while url:
-            data = self._get(url, params=params).json()
-            forms = [_normalize_form(raw) for raw in data.get("objects", [])]
+            data = self._get_json(url, params=params)
+            if "objects" not in data:
+                # TastyPie always returns ``"objects": []`` for an empty page;
+                # a missing key signals an envelope change — fail rather than
+                # silently completing the source empty (arch #252, finding 03#6).
+                raise CommCareExportError(
+                    f"CommCare Form API response missing 'objects' key for {url}"
+                )
+            forms = [_normalize_form(raw) for raw in data["objects"]]
             page_total: int | None = None
             if first_page:
                 meta_total = data.get("meta", {}).get("total_count")

--- a/mcp_server/loaders/connect_base.py
+++ b/mcp_server/loaders/connect_base.py
@@ -13,7 +13,12 @@ from urllib.parse import parse_qs, urlparse
 
 import requests
 from requests.adapters import HTTPAdapter
-from urllib3.util.retry import Retry
+
+from mcp_server.loaders._http import (
+    RETRY_STATUS_FORCELIST,
+    RETRY_TOTAL,
+    build_retry,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -27,14 +32,6 @@ HTTP_TIMEOUT: tuple[int, int] = (10, 300)
 # `/export/opp_org_program_list/` used by ConnectMetadataLoader — are
 # unaffected.
 EXPORT_ACCEPT_HEADER = "application/json; version=2.0"
-
-# Bounded retry policy for transient upstream failures. backoff_factor=2.0
-# yields waits of 0s, 2s, 4s, 8s between the 4 total attempts (~14s worst case).
-# raise_on_status=False lets us inspect the final response (headers, status)
-# so we can surface upstream Sentry trace IDs rather than just propagating
-# the raw requests.HTTPError.
-RETRY_TOTAL = 3
-RETRY_STATUS_FORCELIST = (500, 502, 503, 504, 408, 429)
 
 
 def _extract_last_id(url: str, params: dict | None) -> int | None:
@@ -56,17 +53,6 @@ def _extract_last_id(url: str, params: dict | None) -> int | None:
         return int(values[0])
     except (TypeError, ValueError):
         return None
-
-
-def _build_retry() -> Retry:
-    return Retry(
-        total=RETRY_TOTAL,
-        backoff_factor=2.0,
-        status_forcelist=list(RETRY_STATUS_FORCELIST),
-        allowed_methods=["GET"],
-        respect_retry_after_header=True,
-        raise_on_status=False,
-    )
 
 
 class ConnectAuthError(Exception):
@@ -125,7 +111,7 @@ class ConnectBaseLoader:
         self.base_url = base_url.rstrip("/")
         self._session = requests.Session()
         self._session.headers.update({"Authorization": f"Bearer {credential['value']}"})
-        adapter = HTTPAdapter(max_retries=_build_retry())
+        adapter = HTTPAdapter(max_retries=build_retry())
         self._session.mount("https://", adapter)
         self._session.mount("http://", adapter)
 

--- a/mcp_server/loaders/connect_base.py
+++ b/mcp_server/loaders/connect_base.py
@@ -18,6 +18,7 @@ from mcp_server.loaders._http import (
     RETRY_STATUS_FORCELIST,
     RETRY_TOTAL,
     build_retry,
+    get_with_auth_refresh,
 )
 
 logger = logging.getLogger(__name__)
@@ -109,6 +110,9 @@ class ConnectBaseLoader:
             except ImportError:
                 base_url = self.DEFAULT_BASE_URL
         self.base_url = base_url.rstrip("/")
+        # A mid-run token refresher (OAuth only); None for API keys (arch #252,
+        # finding 14#3).
+        self._refresh = credential.get("refresh")
         self._session = requests.Session()
         self._session.headers.update({"Authorization": f"Bearer {credential['value']}"})
         adapter = HTTPAdapter(max_retries=build_retry())
@@ -117,7 +121,9 @@ class ConnectBaseLoader:
 
     def _get(self, url: str, params: dict | None = None) -> requests.Response:
         """GET a URL, raising ConnectAuthError on 401/403."""
-        resp = self._session.get(url, params=params, timeout=HTTP_TIMEOUT)
+        resp = get_with_auth_refresh(
+            self._session, url, refresh=self._refresh, params=params, timeout=HTTP_TIMEOUT
+        )
         if resp.status_code in (401, 403):
             raise ConnectAuthError(
                 f"Connect auth failed for opportunity {self.opportunity_id}: "
@@ -178,8 +184,13 @@ class ConnectBaseLoader:
             # the redirect and preserves the Authorization header on
             # same-host upgrades. See test_follows_http_to_https_redirect
             # _on_next_url for the regression pin.
-            resp = self._session.get(
-                url, params=request_params, headers=headers, timeout=HTTP_TIMEOUT
+            resp = get_with_auth_refresh(
+                self._session,
+                url,
+                refresh=self._refresh,
+                params=request_params,
+                headers=headers,
+                timeout=HTTP_TIMEOUT,
             )
             if resp.status_code in (401, 403):
                 raise ConnectAuthError(

--- a/mcp_server/loaders/ocs_base.py
+++ b/mcp_server/loaders/ocs_base.py
@@ -7,6 +7,9 @@ from collections.abc import Iterator
 
 import requests
 from django.conf import settings
+from requests.adapters import HTTPAdapter
+
+from mcp_server.loaders._http import build_retry
 
 logger = logging.getLogger(__name__)
 
@@ -21,6 +24,16 @@ OCS_MAX_PAGE_SIZE = 1500
 
 class OCSAuthError(Exception):
     """Raised when OCS returns a 401 or 403 response."""
+
+
+class OCSExportError(Exception):
+    """Raised on unrecoverable OCS export failures.
+
+    Covers invalid JSON, a missing ``results`` key, and non-2xx responses that
+    survive the retry policy. Mirrors ConnectExportError so a malformed
+    response fails loudly instead of yielding a silently-empty page
+    (arch #252, finding 03#6).
+    """
 
 
 class OCSBaseLoader:
@@ -47,15 +60,37 @@ class OCSBaseLoader:
             self._session.headers.update({"X-api-key": credential["value"]})
         else:
             self._session.headers.update({"Authorization": f"Bearer {credential['value']}"})
+        adapter = HTTPAdapter(max_retries=build_retry())
+        self._session.mount("https://", adapter)
+        self._session.mount("http://", adapter)
 
     def _get(self, url: str, params: dict | None = None) -> requests.Response:
+        """GET a URL, raising on auth failure or an unrecoverable status.
+
+        Transient 5xx/429 responses are retried by the session adapter; a
+        surviving non-2xx becomes a typed error rather than a bare HTTPError.
+        """
         resp = self._session.get(url, params=params, timeout=HTTP_TIMEOUT)
         if resp.status_code in (401, 403):
             raise OCSAuthError(
-                f"OCS auth failed for experiment {self.experiment_id}: HTTP {resp.status_code}"
+                f"OCS authentication failed for experiment {self.experiment_id} "
+                f"(HTTP {resp.status_code}). Your Open Chat Studio sign-in has likely "
+                f"expired or been revoked — please reconnect your account and retry."
             )
-        resp.raise_for_status()
+        if resp.status_code >= 400:
+            raise OCSExportError(
+                f"OCS export request failed for experiment {self.experiment_id}: "
+                f"HTTP {resp.status_code} for {url}"
+            )
         return resp
+
+    def _get_json(self, url: str, params: dict | None = None) -> dict:
+        """GET a URL and parse JSON, raising OCSExportError on invalid JSON."""
+        resp = self._get(url, params=params)
+        try:
+            return resp.json()
+        except ValueError as e:
+            raise OCSExportError(f"OCS API returned invalid JSON for {url}: {e}") from e
 
     def _paginate(
         self, url: str, params: dict | None = None
@@ -71,14 +106,12 @@ class OCSBaseLoader:
         current_params: dict | None = params
         first_page = True
         while current_url:
-            resp = self._session.get(current_url, params=current_params, timeout=HTTP_TIMEOUT)
-            if resp.status_code in (401, 403):
-                raise OCSAuthError(
-                    f"OCS auth failed for experiment {self.experiment_id}: HTTP {resp.status_code}"
-                )
-            resp.raise_for_status()
-            payload = resp.json()
-            page = payload.get("results", [])
+            payload = self._get_json(current_url, params=current_params)
+            if "results" not in payload:
+                # A missing ``results`` key means the envelope changed — fail
+                # rather than yielding a silently-empty page (finding 03#6).
+                raise OCSExportError(f"OCS API response missing 'results' key for {current_url}")
+            page = payload["results"]
             if first_page:
                 total = payload.get("count")
                 if not isinstance(total, int):

--- a/mcp_server/loaders/ocs_base.py
+++ b/mcp_server/loaders/ocs_base.py
@@ -9,7 +9,7 @@ import requests
 from django.conf import settings
 from requests.adapters import HTTPAdapter
 
-from mcp_server.loaders._http import build_retry
+from mcp_server.loaders._http import build_retry, get_with_auth_refresh
 
 logger = logging.getLogger(__name__)
 
@@ -55,6 +55,9 @@ class OCSBaseLoader:
         if base_url is None:
             base_url = getattr(settings, "OCS_URL", self.DEFAULT_BASE_URL)
         self.base_url = base_url.rstrip("/")
+        # A mid-run token refresher (OAuth only); None for API keys (arch #252,
+        # finding 14#3).
+        self._refresh = credential.get("refresh")
         self._session = requests.Session()
         if credential.get("type") == "api_key":
             self._session.headers.update({"X-api-key": credential["value"]})
@@ -70,7 +73,9 @@ class OCSBaseLoader:
         Transient 5xx/429 responses are retried by the session adapter; a
         surviving non-2xx becomes a typed error rather than a bare HTTPError.
         """
-        resp = self._session.get(url, params=params, timeout=HTTP_TIMEOUT)
+        resp = get_with_auth_refresh(
+            self._session, url, refresh=self._refresh, params=params, timeout=HTTP_TIMEOUT
+        )
         if resp.status_code in (401, 403):
             raise OCSAuthError(
                 f"OCS authentication failed for experiment {self.experiment_id} "

--- a/mcp_server/loaders/ocs_experiments.py
+++ b/mcp_server/loaders/ocs_experiments.py
@@ -15,8 +15,7 @@ class OCSExperimentLoader(OCSBaseLoader):
 
     def load_pages(self) -> Iterator[tuple[list[dict], int | None]]:
         url = f"{self.base_url}/api/experiments/{self.experiment_id}/"
-        resp = self._get(url)
-        data = resp.json()
+        data = self._get_json(url)
         row = {
             "experiment_id": str(data.get("id") or self.experiment_id),
             "name": data.get("name") or "",

--- a/mcp_server/loaders/ocs_messages.py
+++ b/mcp_server/loaders/ocs_messages.py
@@ -48,8 +48,10 @@ class OCSMessageLoader(OCSBaseLoader):
         total_messages = 0
         for session_id in session_ids:
             detail_url = f"{self.base_url}/api/sessions/{session_id}/"
-            detail_resp = self._get(detail_url)
-            messages = detail_resp.json().get("messages") or []
+            # A session with no messages legitimately omits/empties the key, so
+            # a missing ``messages`` is treated as empty (not an error) — but the
+            # JSON parse itself is validated via _get_json (finding 03#6).
+            messages = self._get_json(detail_url).get("messages") or []
             rows = [_map_message(session_id, idx, msg) for idx, msg in enumerate(messages)]
             total_messages += len(rows)
             yield rows, total_sessions

--- a/mcp_server/loaders/ocs_metadata.py
+++ b/mcp_server/loaders/ocs_metadata.py
@@ -14,8 +14,7 @@ class OCSMetadataLoader(OCSBaseLoader):
 
     def load(self) -> dict:
         url = f"{self.base_url}/api/experiments/{self.experiment_id}/"
-        resp = self._get(url)
-        detail = resp.json()
+        detail = self._get_json(url)
         logger.info(
             "Loaded metadata for OCS experiment %s: %s",
             self.experiment_id,

--- a/tests/test_loader_http.py
+++ b/tests/test_loader_http.py
@@ -1,0 +1,53 @@
+"""Tests for the shared loader HTTP hardening (arch #252, finding 14#6)."""
+
+from __future__ import annotations
+
+import io
+
+from urllib3.response import HTTPResponse
+
+from mcp_server.loaders._http import (
+    MAX_RETRY_AFTER_SECONDS,
+    RETRY_STATUS_FORCELIST,
+    RETRY_TOTAL,
+    BoundedRetry,
+    build_retry,
+)
+
+
+def _response(headers: dict) -> HTTPResponse:
+    return HTTPResponse(
+        body=io.BytesIO(b""),
+        headers=headers,
+        status=429,
+        version=11,
+        version_string="HTTP/1.1",
+        reason="",
+        preload_content=False,
+        decode_content=False,
+    )
+
+
+def test_build_retry_returns_bounded_retry():
+    retry = build_retry()
+    assert isinstance(retry, BoundedRetry)
+    assert retry.total == RETRY_TOTAL
+    assert retry.respect_retry_after_header is True
+    assert 429 in RETRY_STATUS_FORCELIST
+
+
+def test_retry_after_is_capped():
+    retry = build_retry()
+    # An upstream advertising a 10-minute Retry-After must not park the worker
+    # for 10 minutes.
+    assert retry.get_retry_after(_response({"Retry-After": "600"})) == MAX_RETRY_AFTER_SECONDS
+
+
+def test_small_retry_after_passes_through():
+    retry = build_retry()
+    assert retry.get_retry_after(_response({"Retry-After": "5"})) == 5
+
+
+def test_absent_retry_after_is_none():
+    retry = build_retry()
+    assert retry.get_retry_after(_response({})) is None

--- a/tests/test_loader_http.py
+++ b/tests/test_loader_http.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import io
+from unittest.mock import MagicMock
 
 from urllib3.response import HTTPResponse
 
@@ -12,7 +13,15 @@ from mcp_server.loaders._http import (
     RETRY_TOTAL,
     BoundedRetry,
     build_retry,
+    get_with_auth_refresh,
 )
+
+
+def _fake_session(responses):
+    session = MagicMock()
+    session.headers = {}
+    session.get.side_effect = responses
+    return session
 
 
 def _response(headers: dict) -> HTTPResponse:
@@ -51,3 +60,51 @@ def test_small_retry_after_passes_through():
 def test_absent_retry_after_is_none():
     retry = build_retry()
     assert retry.get_retry_after(_response({})) is None
+
+
+class TestGetWithAuthRefresh:
+    def test_401_triggers_refresh_and_retries_once(self):
+        resp401 = MagicMock(status_code=401)
+        resp200 = MagicMock(status_code=200)
+        session = _fake_session([resp401, resp200])
+        refresh = MagicMock(return_value="new-token")
+
+        result = get_with_auth_refresh(session, "https://x/y", refresh=refresh, timeout=(1, 1))
+
+        assert result is resp200
+        refresh.assert_called_once()
+        assert session.get.call_count == 2
+        assert session.headers["Authorization"] == "Bearer new-token"
+
+    def test_no_refresh_when_none(self):
+        resp401 = MagicMock(status_code=401)
+        session = _fake_session([resp401])
+        result = get_with_auth_refresh(session, "https://x/y", refresh=None, timeout=(1, 1))
+        assert result is resp401
+        assert session.get.call_count == 1
+
+    def test_403_is_not_refreshed(self):
+        resp403 = MagicMock(status_code=403)
+        session = _fake_session([resp403])
+        refresh = MagicMock(return_value="new-token")
+        result = get_with_auth_refresh(session, "https://x/y", refresh=refresh, timeout=(1, 1))
+        assert result is resp403
+        refresh.assert_not_called()
+        assert session.get.call_count == 1
+
+    def test_refresh_failure_returns_original_401(self):
+        resp401 = MagicMock(status_code=401)
+        session = _fake_session([resp401])
+        refresh = MagicMock(side_effect=RuntimeError("boom"))
+        result = get_with_auth_refresh(session, "https://x/y", refresh=refresh, timeout=(1, 1))
+        # Original 401 returned so the caller raises its provider AuthError.
+        assert result is resp401
+        assert session.get.call_count == 1
+
+    def test_empty_new_token_does_not_retry(self):
+        resp401 = MagicMock(status_code=401)
+        session = _fake_session([resp401])
+        refresh = MagicMock(return_value=None)
+        result = get_with_auth_refresh(session, "https://x/y", refresh=refresh, timeout=(1, 1))
+        assert result is resp401
+        assert session.get.call_count == 1

--- a/tests/test_loader_midrun_refresh.py
+++ b/tests/test_loader_midrun_refresh.py
@@ -1,0 +1,92 @@
+"""Mid-run 401 -> refresh -> retry across loaders (arch #252, finding 14#3).
+
+A CommCare OAuth token lives ~15 min; a large sync exceeds that and 401s
+mid-load. The loaders consult a ``refresh`` callable on the credential to mint
+a fresh token and retry the failing page, so the run outlives the token.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from mcp_server.loaders.commcare_cases import CommCareCaseLoader
+from mcp_server.loaders.connect_visits import ConnectVisitLoader
+from mcp_server.loaders.ocs_sessions import OCSSessionLoader
+
+
+def _resp(status_code, json_body=None):
+    r = MagicMock(status_code=status_code)
+    r.json.return_value = json_body or {}
+    return r
+
+
+class TestCommCareMidRunRefresh:
+    def test_401_midrun_refreshes_and_continues(self):
+        refresh = MagicMock(return_value="fresh-token")
+        credential = {"type": "oauth", "value": "stale-token", "refresh": refresh}
+
+        page1 = _resp(
+            200, {"next": "?cursor=2", "matching_records": 2, "cases": [{"case_id": "1"}]}
+        )
+        unauthorized = _resp(401)
+        page2 = _resp(200, {"next": None, "cases": [{"case_id": "2"}]})
+
+        with patch("mcp_server.loaders.commcare_base.requests.Session") as sess_cls:
+            session = MagicMock()
+            session.headers = {}
+            sess_cls.return_value = session
+            # Page 1 ok, then the token expires (401), refresh, retry -> page 2.
+            session.get.side_effect = [page1, unauthorized, page2]
+            loader = CommCareCaseLoader(domain="d", credential=credential)
+            cases = loader.load()
+
+        assert [c["case_id"] for c in cases] == ["1", "2"]
+        refresh.assert_called_once()
+        assert session.headers["Authorization"] == "Bearer fresh-token"
+
+    def test_no_refresh_callable_still_raises_auth_error(self):
+        from mcp_server.loaders.commcare_base import CommCareAuthError
+
+        credential = {"type": "api_key", "value": "u:k"}  # no refresh
+        with patch("mcp_server.loaders.commcare_base.requests.Session") as sess_cls:
+            session = MagicMock()
+            session.headers = {}
+            sess_cls.return_value = session
+            session.get.return_value = _resp(401)
+            loader = CommCareCaseLoader(domain="d", credential=credential)
+            try:
+                loader.load()
+                raised = False
+            except CommCareAuthError:
+                raised = True
+        assert raised
+
+
+class TestConnectMidRunRefresh:
+    def test_401_on_export_page_refreshes_and_retries(self):
+        refresh = MagicMock(return_value="fresh-token")
+        credential = {"type": "oauth", "value": "stale", "refresh": refresh}
+        loader = ConnectVisitLoader(
+            opportunity_id=1, credential=credential, base_url="https://c.example"
+        )
+        unauthorized = _resp(401)
+        page = _resp(200, {"next": None, "results": [{"id": 1}], "count": 1})
+        with patch.object(loader._session, "get", side_effect=[unauthorized, page]):
+            rows = [r for pg, _ in loader.load_pages() for r in pg]
+        assert [r["visit_id"] for r in rows] == [1]
+        refresh.assert_called_once()
+
+
+class TestOCSMidRunRefresh:
+    def test_401_on_paginate_refreshes_and_retries(self):
+        refresh = MagicMock(return_value="fresh-token")
+        credential = {"type": "oauth", "value": "stale", "refresh": refresh}
+        loader = OCSSessionLoader(
+            experiment_id="e1", credential=credential, base_url="https://o.example"
+        )
+        unauthorized = _resp(401)
+        page = _resp(200, {"results": [{"id": "s1"}], "next": None})
+        with patch.object(loader._session, "get", side_effect=[unauthorized, page]):
+            rows = [r for pg, _ in loader.load_pages() for r in pg]
+        assert [r["session_id"] for r in rows] == ["s1"]
+        refresh.assert_called_once()

--- a/tests/test_loader_retry_hardening.py
+++ b/tests/test_loader_retry_hardening.py
@@ -1,0 +1,156 @@
+"""Retry + error-shape hardening for CommCare/OCS loaders (arch #252, 12#4/03#6).
+
+Connect already had bounded retry + typed export errors; these tests pin the
+matching behaviour on the CommCare and OCS loaders and the CommCare cases
+relative-``next`` fix that forms/metadata already had (8774864).
+"""
+
+from __future__ import annotations
+
+import io
+from unittest.mock import MagicMock, patch
+
+import pytest
+from urllib3.connectionpool import HTTPSConnectionPool
+from urllib3.response import HTTPResponse
+
+from mcp_server.loaders._http import RETRY_TOTAL
+from mcp_server.loaders.commcare_base import CommCareExportError
+from mcp_server.loaders.commcare_cases import CommCareCaseLoader
+from mcp_server.loaders.commcare_forms import CommCareFormLoader
+from mcp_server.loaders.ocs_base import OCSExportError
+from mcp_server.loaders.ocs_sessions import OCSSessionLoader
+
+CRED = {"type": "api_key", "value": "u:k"}
+
+
+def _make_urllib3_response(status, body=b"", headers=None):
+    return HTTPResponse(
+        body=io.BytesIO(body),
+        headers=headers or {},
+        status=status,
+        version=11,
+        version_string="HTTP/1.1",
+        reason="",
+        preload_content=False,
+        decode_content=False,
+    )
+
+
+def _drive_with_statuses(scripted):
+    """Patch urllib3's pool so the real retry adapter sees scripted responses."""
+    queue = list(scripted)
+    calls: list[dict] = []
+
+    def fake_make_request(self, conn, method, url, **kwargs):
+        spec = queue.pop(0) if len(queue) > 1 else queue[0]
+        status, body, headers = spec
+        calls.append({"method": method, "url": url, "status": status})
+        return _make_urllib3_response(status, body, headers)
+
+    ctx = patch.multiple(
+        HTTPSConnectionPool,
+        _make_request=fake_make_request,
+        _get_conn=lambda self, timeout=None: MagicMock(),
+        _put_conn=lambda self, conn: None,
+    )
+    return ctx, calls
+
+
+def _no_backoff(loader):
+    adapter = loader._session.get_adapter("https://www.commcarehq.org/")
+    adapter.max_retries.backoff_factor = 0
+    return loader
+
+
+class TestCommCareRetry:
+    def test_retries_5xx_then_succeeds(self):
+        loader = _no_backoff(CommCareCaseLoader(domain="d", credential=CRED))
+        ctx, calls = _drive_with_statuses(
+            [
+                (500, b"", {}),
+                (500, b"", {}),
+                (
+                    200,
+                    b'{"cases": [{"case_id": "c1"}], "matching_records": 1}',
+                    {"Content-Type": "application/json"},
+                ),
+            ]
+        )
+        with ctx:
+            cases = loader.load()
+        assert [c["case_id"] for c in cases] == ["c1"]
+        assert len(calls) == 3
+
+    def test_raises_export_error_after_exhausting_retries(self):
+        loader = _no_backoff(CommCareCaseLoader(domain="d", credential=CRED))
+        ctx, calls = _drive_with_statuses([(503, b"", {})])
+        with ctx, pytest.raises(CommCareExportError):
+            loader.load()
+        assert len(calls) == RETRY_TOTAL + 1
+
+
+class TestCommCareErrorShape:
+    def test_cases_missing_key_raises(self):
+        resp = MagicMock(status_code=200)
+        resp.json.return_value = {"next": None, "matching_records": 0}
+        with patch("mcp_server.loaders.commcare_base.requests.Session") as sess_cls:
+            session = MagicMock()
+            sess_cls.return_value = session
+            session.get.return_value = resp
+            with pytest.raises(CommCareExportError):
+                CommCareCaseLoader(domain="d", credential=CRED).load()
+
+    def test_forms_missing_key_raises(self):
+        resp = MagicMock(status_code=200)
+        resp.json.return_value = {"meta": {"next": None}}
+        with patch("mcp_server.loaders.commcare_base.requests.Session") as sess_cls:
+            session = MagicMock()
+            sess_cls.return_value = session
+            session.get.return_value = resp
+            with pytest.raises(CommCareExportError):
+                CommCareFormLoader(domain="d", credential=CRED).load()
+
+    def test_invalid_json_raises(self):
+        resp = MagicMock(status_code=200)
+        resp.json.side_effect = ValueError("boom")
+        with patch("mcp_server.loaders.commcare_base.requests.Session") as sess_cls:
+            session = MagicMock()
+            sess_cls.return_value = session
+            session.get.return_value = resp
+            with pytest.raises(CommCareExportError):
+                CommCareCaseLoader(domain="d", credential=CRED).load()
+
+
+class TestCommCareCasesRelativeNext:
+    def test_relative_next_url_is_resolved(self):
+        """Case API v2 may return a bare/relative ``next``; it must be resolved
+        against the base URL rather than fed to requests as-is (MissingSchema)."""
+        page1 = MagicMock(status_code=200)
+        page1.json.return_value = {
+            "next": "?cursor=abc",
+            "matching_records": 2,
+            "cases": [{"case_id": "c1"}],
+        }
+        page2 = MagicMock(status_code=200)
+        page2.json.return_value = {"next": None, "cases": [{"case_id": "c2"}]}
+        with patch("mcp_server.loaders.commcare_base.requests.Session") as sess_cls:
+            session = MagicMock()
+            sess_cls.return_value = session
+            session.get.side_effect = [page1, page2]
+            cases = CommCareCaseLoader(domain="dimagi", credential=CRED).load()
+        assert [c["case_id"] for c in cases] == ["c1", "c2"]
+        second_url = session.get.call_args_list[1].args[0]
+        assert second_url == "https://www.commcarehq.org/a/dimagi/api/case/v2/?cursor=abc"
+
+
+class TestOCSErrorShape:
+    def test_missing_results_key_raises(self):
+        loader = OCSSessionLoader(
+            experiment_id="e1", credential={"type": "oauth", "value": "t"}, base_url="https://o.ex"
+        )
+        resp = MagicMock(status_code=200)
+        resp.json.return_value = {"next": None}
+        with patch.object(loader._session, "get", return_value=resp):
+            with pytest.raises(OCSExportError):
+                list(loader.load_pages())

--- a/tests/test_mcp_token_refresh.py
+++ b/tests/test_mcp_token_refresh.py
@@ -102,3 +102,62 @@ class TestCredentialResolverTokenRefresh:
         ):
             with pytest.raises(CredentialResolutionError):
                 await _aresolve_oauth_credential(mock_token, "commcare")
+
+    @pytest.mark.asyncio
+    async def test_valid_oauth_credential_carries_refresh_callable(self):
+        """A refreshable OAuth credential exposes a ``refresh`` callable so
+        loaders can renew the token mid-run (arch #252, finding 14#3)."""
+        from apps.users.services.credential_resolver import _aresolve_oauth_credential
+
+        mock_token = MagicMock()
+        mock_token.token = "valid"
+        mock_token.token_secret = "refresh-token"
+        mock_token.app = MagicMock()
+        mock_token.expires_at = timezone.now() + timedelta(hours=1)
+
+        with patch(
+            "apps.users.services.credential_resolver.token_needs_refresh", return_value=False
+        ):
+            result = await _aresolve_oauth_credential(mock_token, "commcare")
+        assert result["value"] == "valid"
+        assert callable(result["refresh"])
+
+
+class TestSyncTokenRefresh:
+    def test_refresh_oauth_token_sync_updates_and_persists(self):
+        from apps.users.services.token_refresh import refresh_oauth_token_sync
+
+        social_token = MagicMock()
+        social_token.token_secret = "old-refresh"
+        social_token.app.client_id = "cid"
+        social_token.app.secret = "secret"
+
+        response = MagicMock()
+        response.json.return_value = {
+            "access_token": "brand-new",
+            "refresh_token": "rotated-refresh",
+            "expires_in": 900,
+        }
+        with patch(
+            "apps.users.services.token_refresh.requests.post", return_value=response
+        ) as mock_post:
+            new = refresh_oauth_token_sync(social_token, "https://token/")
+
+        assert new == "brand-new"
+        assert social_token.token == "brand-new"
+        assert social_token.token_secret == "rotated-refresh"
+        social_token.save.assert_called_once()
+        mock_post.assert_called_once()
+
+    def test_refresh_oauth_token_sync_raises_on_http_error(self):
+        from apps.users.services.token_refresh import (
+            TokenRefreshError,
+            refresh_oauth_token_sync,
+        )
+
+        social_token = MagicMock()
+        response = MagicMock()
+        response.raise_for_status.side_effect = RuntimeError("500")
+        with patch("apps.users.services.token_refresh.requests.post", return_value=response):
+            with pytest.raises(TokenRefreshError):
+                refresh_oauth_token_sync(social_token, "https://token/")

--- a/tests/test_mcp_token_refresh.py
+++ b/tests/test_mcp_token_refresh.py
@@ -56,12 +56,18 @@ class TestCredentialResolverTokenRefresh:
             assert result["value"] == "still-valid-token"
 
     @pytest.mark.asyncio
-    async def test_refresh_failure_returns_original_token(self):
-        from apps.users.services.credential_resolver import _aresolve_oauth_credential
+    async def test_refresh_failure_fails_closed(self):
+        """arch #252 (14#4): a refresh failure at/near expiry must fail closed
+        with actionable reconnect guidance, not fall back to a stale token."""
+        from apps.users.services.credential_resolver import (
+            CredentialResolutionError,
+            _aresolve_oauth_credential,
+        )
         from apps.users.services.token_refresh import TokenRefreshError
+        from mcp_server.envelope import AUTH_TOKEN_EXPIRED
 
         mock_token = MagicMock()
-        mock_token.token = "maybe-still-works"
+        mock_token.token = "known-stale-token"
         mock_token.expires_at = timezone.now() - timedelta(minutes=1)
 
         with (
@@ -71,6 +77,28 @@ class TestCredentialResolverTokenRefresh:
                 new_callable=AsyncMock,
                 side_effect=TokenRefreshError("fail"),
             ),
+            pytest.raises(CredentialResolutionError) as exc,
         ):
-            result = await _aresolve_oauth_credential(mock_token, "commcare")
-            assert result["value"] == "maybe-still-works"
+            await _aresolve_oauth_credential(mock_token, "commcare")
+        assert exc.value.code == AUTH_TOKEN_EXPIRED
+        assert "reconnect" in exc.value.message.lower()
+
+    @pytest.mark.asyncio
+    async def test_near_expiry_with_no_refresh_capability_fails_closed(self):
+        """No refresh token / no token URL and the token is near expiry: fail
+        closed rather than provisioning a doomed run (arch #252, 14#4)."""
+        from apps.users.services.credential_resolver import (
+            CredentialResolutionError,
+            _aresolve_oauth_credential,
+        )
+
+        mock_token = MagicMock()
+        mock_token.token = "near-expiry"
+        mock_token.token_secret = ""  # no refresh token
+        mock_token.expires_at = timezone.now() - timedelta(minutes=1)
+
+        with patch(
+            "apps.users.services.credential_resolver.token_needs_refresh", return_value=True
+        ):
+            with pytest.raises(CredentialResolutionError):
+                await _aresolve_oauth_credential(mock_token, "commcare")

--- a/tests/test_ocs_data_loaders.py
+++ b/tests/test_ocs_data_loaders.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 import pytest
-import requests
 
-from mcp_server.loaders.ocs_base import OCSAuthError
+from mcp_server.loaders.ocs_base import OCSAuthError, OCSExportError
 from mcp_server.loaders.ocs_experiments import OCSExperimentLoader
 from mcp_server.loaders.ocs_messages import OCSMessageLoader
 from mcp_server.loaders.ocs_participants import OCSParticipantLoader
@@ -304,24 +303,23 @@ def test_experiment_loader_raises_auth_error_on_403():
 
 
 def test_experiment_loader_raises_on_server_error():
-    """A 5xx (no retry policy in OCS) propagates via raise_for_status rather
-    than being swallowed into an empty page."""
+    """A 5xx that survives the retry policy surfaces as a typed OCSExportError
+    rather than being swallowed into an empty page (arch #252, finding 03#6)."""
     loader = OCSExperimentLoader(experiment_id="exp-1", credential=CREDENTIAL, base_url=BASE_URL)
     resp = MagicMock(status_code=500)
-    resp.raise_for_status.side_effect = requests.HTTPError("500 Server Error")
     with patch.object(loader._session, "get", return_value=resp):
-        with pytest.raises(requests.HTTPError):
+        with pytest.raises(OCSExportError):
             list(loader.load_pages())
 
 
 def test_experiment_loader_raises_on_malformed_json():
-    """A 200 with a non-JSON body must raise (ValueError from .json()), not
-    yield a partial/empty row set."""
+    """A 200 with a non-JSON body must raise OCSExportError (wrapping the
+    ValueError from .json()), not yield a partial/empty row set."""
     loader = OCSExperimentLoader(experiment_id="exp-1", credential=CREDENTIAL, base_url=BASE_URL)
     resp = MagicMock(status_code=200)
     resp.json.side_effect = ValueError("No JSON object could be decoded")
     with patch.object(loader._session, "get", return_value=resp):
-        with pytest.raises(ValueError):
+        with pytest.raises(OCSExportError):
             list(loader.load_pages())
 
 
@@ -375,9 +373,7 @@ def test_participant_loader_yields_first_page_count():
     page = MagicMock(status_code=200)
     page.json.return_value = {
         "count": 42,
-        "results": [
-            {"id": "p1", "identifier": "part1", "name": "John", "platform": "api"}
-        ],
+        "results": [{"id": "p1", "identifier": "part1", "name": "John", "platform": "api"}],
         "next": None,
     }
     with patch.object(loader._session, "get", return_value=page):

--- a/tests/test_reauth_failure_mapping.py
+++ b/tests/test_reauth_failure_mapping.py
@@ -1,0 +1,55 @@
+"""Reauth guidance mapping in the failure summary (arch #252, finding 14#4)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from apps.workspaces.tasks import _compose_failure_summary, _looks_like_auth_failure
+
+
+def _run(sources: dict, state: str = "failed"):
+    return SimpleNamespace(result={"sources": sources}, state=state)
+
+
+def test_looks_like_auth_failure_detects_markers():
+    assert _looks_like_auth_failure(
+        "CommCareAuthError: CommCare authentication failed ... reconnect your CommCare account"
+    )
+    assert _looks_like_auth_failure("OCSAuthError: HTTP 401")
+    assert not _looks_like_auth_failure("ConnectExportError: HTTP 500 for ...")
+    assert not _looks_like_auth_failure(None)
+
+
+def test_summary_appends_reauth_guidance_on_auth_failure():
+    runs = [
+        _run(
+            {
+                "cases": {
+                    "state": "failed",
+                    "rows": 0,
+                    "error": (
+                        "CommCareAuthError: CommCare authentication failed for domain d "
+                        "(HTTP 401). Please reconnect your CommCare account and retry."
+                    ),
+                }
+            }
+        )
+    ]
+    summary = _compose_failure_summary(runs)
+    assert "reconnect the affected account" in summary.lower()
+
+
+def test_summary_omits_reauth_guidance_for_non_auth_failure():
+    runs = [
+        _run(
+            {
+                "visits": {
+                    "state": "failed",
+                    "rows": 0,
+                    "error": "ConnectExportError: HTTP 500 for /export/...",
+                }
+            }
+        )
+    ]
+    summary = _compose_failure_summary(runs)
+    assert "reconnect" not in summary.lower()


### PR DESCRIPTION
## Credential lifetime for long jobs (CommCare 15-min OAuth TTL)

Addresses the `credential-lifetime-long-jobs` cluster: a CommCare-OAuth
materialization exceeding ~15 min was structurally impossible (one credential
snapshot per run, no mid-run/401 refresh, stale-token fallback, no "reconnect
your account" mapping), plus CommCare/OCS retry hardening and an uncancellable
uncapped Retry-After sleep.

### Findings → fixes

**`14#3` (CORE) — one credential snapshot per run, no mid-run/401 refresh → FIXED.**
Thread an optional sync `refresh` callable through the credential dict. On a
loader 401 (only), a shared `get_with_auth_refresh` wrapper refreshes the token
once, rewrites the `Bearer` header, and retries the same request; on refresh
failure it returns the original 401 so the loader raises its `AuthError` (fail
closed). `credential_resolver` attaches the callable when a refresh token + token
URL exist, closing over the same `SocialToken` the proactive refresh mutated (so a
second mid-run refresh reuses the rotated refresh token). `token_refresh` gains
`refresh_oauth_token_sync` (blocking `requests` + sync ORM, usable from the
`asyncio.to_thread` worker without bridging to the event loop) which persists the
rotated token (non-fatal on failure). API-key credentials carry no refresh callable.

**`14#4` — stale-token fallback + no 401→reauth mapping + false docstring → FIXED.**
`aresolve_credential` no longer falls back to a known-stale token on refresh
failure; it fails closed with `CredentialResolutionError(AUTH_TOKEN_EXPIRED, ...)`
and actionable "reconnect your account" guidance, matching the OCS team-mismatch
guard — giving `AUTH_TOKEN_EXPIRED` a central producer on the resolve path. Auth
failures (loader `AuthError` / HTTP 401 / reconnect markers) are now detected in
the failure summary and the resume prompt and mapped to explicit reconnect
guidance. Fixed the false `token_refresh.py` docstring; loader auth-error messages
now carry actionable reconnect text. (`aget_fresh_access_token` swallows the new
error and returns `None`, leaving the share-time refresh path unchanged.)

**`12#4` + `03#6` — CommCare/OCS no retry + swallow malformed responses → FIXED.**
Mounted the shared bounded retry adapter (handles CommCare HQ's designed 429 +
Retry-After) on the CommCare and OCS sessions. Malformed responses now raise typed
`CommCareExportError` / `OCSExportError` (surviving non-2xx, invalid JSON, or a
missing `cases`/`objects`/`results` collection key) instead of silently completing
a source with 0 rows. CommCare cases missed the relative-`next` fix (8774864) that
forms/metadata already had — resolved against the base URL so a non-absolute cursor
no longer raises `MissingSchema`.

**`14#6` — Connect Retry-After honored uncapped, false "~14s" comment → FIXED.**
Extracted the retry policy into a shared `BoundedRetry` that clamps the honored
`Retry-After` to `MAX_RETRY_AFTER_SECONDS` (30s), so one throttle response can't
park the sole worker thread for minutes (×3/request). Removed the false comment.
(The sleep remains synchronous/uncancellable; capping bounds the worst case — a
cancellable async retry loop is a larger change, noted below.)

### Deferred / surfaced (design-gated — documented, not invented)

**`14#7` — concurrent interactive refresh may revoke a running load's token.**
Deferred. Lowest-confidence item; depends on unverified upstream
django-oauth-toolkit revocation behavior. The mid-run refresh added here reduces
exposure (a run whose token is revoked mid-load now refreshes-and-retries on the
resulting 401 instead of dying). **Proposal:** if this is confirmed in production,
give the interactive `providers_view` poll a short "do not refresh while a
materialization is in flight for this connection" guard (e.g. skip proactive
refresh when an active `MaterializationRun` exists for the tenant), rather than
racing the running load's token. Not built here to avoid speculative coupling
between the settings poll and the run lifecycle.

**`09#3` — mid-rematerialization read consistency differs across providers.**
Deferred (cross-provider consistency design decision, and it lives in
writer/schema-manager code outside this PR's credential-seam lane). Connect writers
commit DROP+CREATE then grow tables page-by-page (concurrent reads see
silently-partial tables); CommCare/OCS hold DROP in one transaction (concurrent
reads block on ACCESS EXCLUSIVE until statement_timeout). **Proposal:** adopt one
uniform strategy — the blue-green `_r`-schema swap already used by the refresh path
is the natural fit (build into a shadow schema, then atomically repoint) so
concurrent readers always see a complete prior snapshot and never a partial or
blocked one. This is a materializer/schema-manager change and should be scoped as
its own issue.

### Tests
- New: `test_loader_http.py` (BoundedRetry cap + `get_with_auth_refresh`),
  `test_loader_retry_hardening.py` (CommCare/OCS retry + error-shape + cases
  relative-next), `test_loader_midrun_refresh.py` (401→refresh→retry across all
  three providers), `test_reauth_failure_mapping.py`, sync-refresh + fail-closed
  cases in `test_mcp_token_refresh.py`.
- Full backend suite green (1613 passed), `ruff check`/`format` clean,
  `test_async_conventions.py` green.

Closes #252
