### PR TITLE
arch #255: background-work robustness — reconcilers, cancel/pool/stream fixes, TTL & view-schema correctness

### DIFF
--- a/apps/chat/checkpointer.py
+++ b/apps/chat/checkpointer.py
@@ -1,5 +1,6 @@
 """Lazy singleton for the LangGraph async PostgreSQL checkpointer."""
 
+import asyncio
 import logging
 
 from django.conf import settings
@@ -13,45 +14,71 @@ logger = logging.getLogger(__name__)
 
 _checkpointer = None
 _pool = None
+# Serializes initialization so two concurrent cold-start requests can't interleave
+# (the second used to close the first's half-open pool, failing its setup — arch
+# #255, 08#1).
+_init_lock = asyncio.Lock()
+
+
+def _pool_is_usable(pool) -> bool:
+    """True if ``pool`` exists and has not been closed."""
+    return pool is not None and not getattr(pool, "closed", False)
 
 
 async def ensure_checkpointer(*, force_new: bool = False):
     global _checkpointer, _pool
+
     if _checkpointer is not None and not force_new:
         return _checkpointer
 
-    try:
-        database_url = get_database_url()
+    async with _init_lock:
+        # Re-check under the lock: another coroutine may have finished the build
+        # while we were waiting, in which case reuse it instead of rebuilding.
+        if _checkpointer is not None and not force_new:
+            return _checkpointer
 
-        if _pool is not None:
-            await _pool.close()
+        try:
+            database_url = get_database_url()
 
-        _pool = AsyncConnectionPool(
-            conninfo=database_url,
-            max_size=20,
-            open=False,
-            kwargs={
-                "autocommit": True,
-                "prepare_threshold": 0,
-            },
-        )
-        await _pool.open(wait=True, timeout=10)
+            # Reuse the existing pool if it is still open. force_new rebuilds the
+            # (cheap, stateless) saver but MUST NOT close a pool that other
+            # in-flight chat streams are borrowing from for checkpoint writes —
+            # closing it turned one request's transient error into a failure for
+            # every concurrent conversation in this worker (arch #255, 08#1). The
+            # borrow-time health check below recycles individually-dead
+            # connections, so a full pool rebuild is rarely needed anyway.
+            if not _pool_is_usable(_pool):
+                _pool = AsyncConnectionPool(
+                    conninfo=database_url,
+                    max_size=20,
+                    open=False,
+                    # Health-check each connection on checkout so a dead pooled
+                    # connection (after a DB blip) is recycled instead of handed
+                    # out mid-write.
+                    check=AsyncConnectionPool.check_connection,
+                    kwargs={
+                        "autocommit": True,
+                        "prepare_threshold": 0,
+                    },
+                )
+                await _pool.open(wait=True, timeout=10)
 
-        _checkpointer = AsyncPostgresSaver(_pool)
-        await _checkpointer.setup()
-        logger.info("PostgreSQL checkpointer initialized")
-    except Exception as e:
-        if settings.DEBUG:
-            logger.warning(
-                "PostgreSQL checkpointer unavailable, using MemorySaver (DEBUG only): %s", e
-            )
-            _checkpointer = MemorySaver()
-        else:
-            logger.error(
-                "PostgreSQL checkpointer failed in production — conversation history unavailable: %s",
-                e,
-                exc_info=True,
-            )
-            raise
+            _checkpointer = AsyncPostgresSaver(_pool)
+            await _checkpointer.setup()
+            logger.info("PostgreSQL checkpointer initialized")
+        except Exception as e:
+            if settings.DEBUG:
+                logger.warning(
+                    "PostgreSQL checkpointer unavailable, using MemorySaver (DEBUG only): %s", e
+                )
+                _checkpointer = MemorySaver()
+            else:
+                logger.error(
+                    "PostgreSQL checkpointer failed in production — conversation history "
+                    "unavailable: %s",
+                    e,
+                    exc_info=True,
+                )
+                raise
 
     return _checkpointer

--- a/apps/chat/checkpointer.py
+++ b/apps/chat/checkpointer.py
@@ -14,9 +14,7 @@ logger = logging.getLogger(__name__)
 
 _checkpointer = None
 _pool = None
-# Serializes initialization so two concurrent cold-start requests can't interleave
-# (the second used to close the first's half-open pool, failing its setup — arch
-# #255, 08#1).
+# Serialize init so concurrent cold starts don't race the half-open pool (arch #255 08#1).
 _init_lock = asyncio.Lock()
 
 
@@ -40,21 +38,14 @@ async def ensure_checkpointer(*, force_new: bool = False):
         try:
             database_url = get_database_url()
 
-            # Reuse the existing pool if it is still open. force_new rebuilds the
-            # (cheap, stateless) saver but MUST NOT close a pool that other
-            # in-flight chat streams are borrowing from for checkpoint writes —
-            # closing it turned one request's transient error into a failure for
-            # every concurrent conversation in this worker (arch #255, 08#1). The
-            # borrow-time health check below recycles individually-dead
-            # connections, so a full pool rebuild is rarely needed anyway.
+            # force_new rebuilds only the stateless saver; it must NOT close a pool
+            # other in-flight streams are still borrowing for writes (arch #255 08#1).
             if not _pool_is_usable(_pool):
                 _pool = AsyncConnectionPool(
                     conninfo=database_url,
                     max_size=20,
                     open=False,
-                    # Health-check each connection on checkout so a dead pooled
-                    # connection (after a DB blip) is recycled instead of handed
-                    # out mid-write.
+                    # Recycle a dead pooled connection on checkout, not mid-write (arch #255 08#1).
                     check=AsyncConnectionPool.check_connection,
                     kwargs={
                         "autocommit": True,

--- a/apps/chat/stream.py
+++ b/apps/chat/stream.py
@@ -25,6 +25,7 @@ Chunk types used:
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import hashlib
 import json
 import logging
@@ -207,12 +208,22 @@ async def langgraph_to_ui_stream(
         deadline = asyncio.get_event_loop().time() + AGENT_TIMEOUT_SECONDS
 
         while True:
-            if asyncio.get_event_loop().time() > deadline:
+            # Bound the wait for the NEXT event, not just the gap between events:
+            # a stalled LLM/tool call that emits nothing would otherwise never
+            # reach the deadline check (it fires only after an event arrives), so
+            # the 5-min cap could be blown wide open and the response hang until
+            # the client disconnects (arch #255, 02#8).
+            remaining = deadline - asyncio.get_event_loop().time()
+            if remaining <= 0:
                 raise TimeoutError(f"Agent execution exceeded {AGENT_TIMEOUT_SECONDS}s timeout")
             try:
-                event = await event_stream.__anext__()
+                event = await asyncio.wait_for(event_stream.__anext__(), timeout=remaining)
             except StopAsyncIteration:
                 break
+            except TimeoutError as exc:
+                raise TimeoutError(
+                    f"Agent execution exceeded {AGENT_TIMEOUT_SECONDS}s timeout"
+                ) from exc
 
             event_type = event.get("event")
 
@@ -461,6 +472,13 @@ async def langgraph_to_ui_stream(
                     "errorText": f"An error occurred while processing your request. Ref: {ref}",
                 }
             )
+    finally:
+        # Close the underlying event generator on every exit (timeout, error, or
+        # normal break) so a stalled/abandoned ainvoke — and the Anthropic call
+        # behind it — is cancelled promptly instead of running (and billing) until
+        # GC finalizes the orphaned generator (arch #255, 02#8).
+        with contextlib.suppress(Exception):
+            await event_stream.aclose()
 
     if reasoning_started:
         yield _sse({"type": "reasoning-end", "id": reasoning_id})

--- a/apps/chat/stream.py
+++ b/apps/chat/stream.py
@@ -208,11 +208,8 @@ async def langgraph_to_ui_stream(
         deadline = asyncio.get_event_loop().time() + AGENT_TIMEOUT_SECONDS
 
         while True:
-            # Bound the wait for the NEXT event, not just the gap between events:
-            # a stalled LLM/tool call that emits nothing would otherwise never
-            # reach the deadline check (it fires only after an event arrives), so
-            # the 5-min cap could be blown wide open and the response hang until
-            # the client disconnects (arch #255, 02#8).
+            # Bound the wait for the NEXT event: a silent stall (nothing emitted)
+            # would otherwise never reach the deadline check (arch #255 02#8).
             remaining = deadline - asyncio.get_event_loop().time()
             if remaining <= 0:
                 raise TimeoutError(f"Agent execution exceeded {AGENT_TIMEOUT_SECONDS}s timeout")
@@ -473,10 +470,8 @@ async def langgraph_to_ui_stream(
                 }
             )
     finally:
-        # Close the underlying event generator on every exit (timeout, error, or
-        # normal break) so a stalled/abandoned ainvoke — and the Anthropic call
-        # behind it — is cancelled promptly instead of running (and billing) until
-        # GC finalizes the orphaned generator (arch #255, 02#8).
+        # Close the generator on every exit so an abandoned ainvoke (and its
+        # Anthropic call) is cancelled, not left running until GC (arch #255 02#8).
         with contextlib.suppress(Exception):
             await event_stream.aclose()
 

--- a/apps/chat/views.py
+++ b/apps/chat/views.py
@@ -134,17 +134,9 @@ async def chat_view(request):
         )
         return JsonResponse({"error": "Thread not found"}, status=404)
 
-    # Don't stream a live turn while a background resume is mid-ainvoke against
-    # this thread's checkpoint: two concurrent writers to one LangGraph thread can
-    # interleave or drop superstep state, and there is no CAS at this seam. A
-    # materialization ThreadJob is RUNNING only while its resume ainvoke is in
-    # flight, so a RUNNING job here means a resume is writing — ask the user to
-    # retry in a moment (arch #255, 06#9). (The reverse guard — a resume detecting
-    # an in-flight live turn — needs a live-turn marker that does not exist yet;
-    # tracked as follow-up.)
-    # existing_thread is None for a not-yet-created or non-UUID thread_id (the
-    # lookup above tolerates both); scope the RUNNING-job check to the resolved
-    # thread so a client-supplied non-UUID id can't raise on the UUID FK.
+    # A RUNNING resume job means a resume ainvoke is writing this thread's checkpoint;
+    # a concurrent live turn is a second unsynchronized writer (no CAS), so reject it.
+    # Scope to existing_thread so a non-UUID id can't raise on the FK (arch #255 06#9).
     resume_in_flight = (
         existing_thread is not None
         and await ThreadJob.objects.filter(

--- a/apps/chat/views.py
+++ b/apps/chat/views.py
@@ -142,10 +142,16 @@ async def chat_view(request):
     # retry in a moment (arch #255, 06#9). (The reverse guard — a resume detecting
     # an in-flight live turn — needs a live-turn marker that does not exist yet;
     # tracked as follow-up.)
-    resume_in_flight = await ThreadJob.objects.filter(
-        thread_id=thread_id,
-        state=ThreadJob.State.RUNNING,
-    ).aexists()
+    # existing_thread is None for a not-yet-created or non-UUID thread_id (the
+    # lookup above tolerates both); scope the RUNNING-job check to the resolved
+    # thread so a client-supplied non-UUID id can't raise on the UUID FK.
+    resume_in_flight = (
+        existing_thread is not None
+        and await ThreadJob.objects.filter(
+            thread=existing_thread,
+            state=ThreadJob.State.RUNNING,
+        ).aexists()
+    )
     if resume_in_flight:
         return JsonResponse(
             {

--- a/apps/chat/views.py
+++ b/apps/chat/views.py
@@ -26,7 +26,7 @@ from apps.chat.helpers import (
     async_login_required,
     repair_dangling_tool_calls,
 )
-from apps.chat.models import Thread
+from apps.chat.models import Thread, ThreadJob
 from apps.chat.rate_limiting import chat_rate_limit
 from apps.chat.stream import langgraph_to_ui_stream
 from apps.workspaces.services.workspace_service import touch_workspace_schemas
@@ -133,6 +133,29 @@ async def chat_view(request):
             workspace.pk,
         )
         return JsonResponse({"error": "Thread not found"}, status=404)
+
+    # Don't stream a live turn while a background resume is mid-ainvoke against
+    # this thread's checkpoint: two concurrent writers to one LangGraph thread can
+    # interleave or drop superstep state, and there is no CAS at this seam. A
+    # materialization ThreadJob is RUNNING only while its resume ainvoke is in
+    # flight, so a RUNNING job here means a resume is writing — ask the user to
+    # retry in a moment (arch #255, 06#9). (The reverse guard — a resume detecting
+    # an in-flight live turn — needs a live-turn marker that does not exist yet;
+    # tracked as follow-up.)
+    resume_in_flight = await ThreadJob.objects.filter(
+        thread_id=thread_id,
+        state=ThreadJob.State.RUNNING,
+    ).aexists()
+    if resume_in_flight:
+        return JsonResponse(
+            {
+                "error": (
+                    "A background response is still being generated for this "
+                    "conversation. Please retry in a moment."
+                )
+            },
+            status=409,
+        )
 
     try:
         await _upsert_thread(

--- a/apps/workspaces/api/jobs_cancel.py
+++ b/apps/workspaces/api/jobs_cancel.py
@@ -40,9 +40,7 @@ async def cancel_thread_job(thread_job: ThreadJob) -> int:
     ).aupdate(state=ThreadJob.State.CANCELLED, completed_at=now)
 
     try:
-        await app.job_manager.cancel_job_by_id_async(
-            thread_job.procrastinate_job_id, abort=True
-        )
+        await app.job_manager.cancel_job_by_id_async(thread_job.procrastinate_job_id, abort=True)
     except Exception:
         logger.warning(
             "Failed to abort procrastinate job %s",

--- a/apps/workspaces/api/jobs_cancel.py
+++ b/apps/workspaces/api/jobs_cancel.py
@@ -8,10 +8,9 @@ BEFORE procrastinate abort) stays correct.
 import logging
 from datetime import UTC, datetime
 
-from procrastinate.contrib.django.procrastinate_app import current_app
-
 from apps.chat.models import ThreadJob
 from apps.workspaces.models import MaterializationRun
+from config.procrastinate import app
 
 logger = logging.getLogger(__name__)
 
@@ -41,7 +40,7 @@ async def cancel_thread_job(thread_job: ThreadJob) -> int:
     ).aupdate(state=ThreadJob.State.CANCELLED, completed_at=now)
 
     try:
-        await current_app.job_manager.cancel_job_by_id_async(
+        await app.job_manager.cancel_job_by_id_async(
             thread_job.procrastinate_job_id, abort=True
         )
     except Exception:

--- a/apps/workspaces/api/materialization_views.py
+++ b/apps/workspaces/api/materialization_views.py
@@ -6,7 +6,6 @@ import logging
 from datetime import UTC, datetime
 
 from django.http import JsonResponse
-from procrastinate.contrib.django.procrastinate_app import current_app
 
 from apps.chat.models import Thread, ThreadJob
 from apps.users.decorators import async_login_required
@@ -14,6 +13,7 @@ from apps.workspaces.api.jobs_cancel import cancel_thread_job
 from apps.workspaces.models import MaterializationRun
 from apps.workspaces.tasks import materialize_workspace
 from apps.workspaces.workspace_resolver import aresolve_workspace
+from config.procrastinate import app
 
 logger = logging.getLogger(__name__)
 
@@ -87,7 +87,7 @@ async def materialization_cancel_view(request, workspace_id):
         total += orphan_cancelled
         for procrastinate_job_id in orphan_job_ids:
             try:
-                await current_app.job_manager.cancel_job_by_id_async(
+                await app.job_manager.cancel_job_by_id_async(
                     procrastinate_job_id,
                     abort=True,
                 )
@@ -178,7 +178,7 @@ async def materialization_retry_view(request, workspace_id):
         logger.exception("materialization_retry_view: failed to create ThreadJob")
         # Best-effort: cancel the dispatched job so we don't leak background work.
         with contextlib.suppress(Exception):
-            await current_app.job_manager.cancel_job_by_id_async(job_id, abort=True)
+            await app.job_manager.cancel_job_by_id_async(job_id, abort=True)
         return JsonResponse({"error": "Failed to track retry job"}, status=500)
 
     return JsonResponse({"status": "started", "thread_job_id": str(tj.id)})

--- a/apps/workspaces/api/materialization_views.py
+++ b/apps/workspaces/api/materialization_views.py
@@ -46,18 +46,27 @@ async def materialization_cancel_view(request, workspace_id):
         return JsonResponse({"status": "no_active_run", "runs_cancelled": 0})
 
     job_ids = {r.procrastinate_job_id for r in active_runs if r.procrastinate_job_id is not None}
-    # Scope to thread__user so a member can't cancel another member's chat-driven
-    # materialization (which would inject a "cancelled" resume into their thread).
+    # Tenant schemas are SHARED across workspaces, so ``active_runs`` (selected by
+    # this workspace's tenants) also contains runs a sibling workspace started for
+    # the same tenant. Scope to thread__user AND thread__workspace so cancelling
+    # here only cancels runs driven from THIS workspace — never a sibling's run of
+    # a shared tenant (which would inject a "cancelled" resume into their thread —
+    # arch #255, 07#1).
     tjs = [
         tj
         async for tj in ThreadJob.objects.filter(
             procrastinate_job_id__in=job_ids,
             state__in=list(ThreadJob.ACTIVE_STATES),
             thread__user=user,
+            thread__workspace=workspace,
         )
     ]
-    # ALL ThreadJobs (any user) — distinguishes truly-orphan runs (no ThreadJob,
-    # e.g. /refresh/ path) from another user's runs, which we must NOT cancel.
+    # ALL ThreadJobs (any user/workspace) — distinguishes truly-orphan runs (no
+    # ThreadJob, e.g. /refresh/ path) from another user's/workspace's runs, which
+    # we must NOT cancel. The orphan fallback below stays workspace-agnostic on
+    # purpose: an orphan run has no ThreadJob, so cancelling it injects no
+    # "cancelled" resume into any thread — the cross-workspace harm the finding
+    # names is entirely on the tracked path above, now scoped by thread__workspace.
     all_tracked_job_ids = {
         pid
         async for pid in ThreadJob.objects.filter(
@@ -71,7 +80,8 @@ async def materialization_cancel_view(request, workspace_id):
         total += await cancel_thread_job(tj)
         tracked_job_ids.add(tj.procrastinate_job_id)
 
-    # Only truly-orphan runs (no ThreadJob anywhere); other users' runs are skipped.
+    # Only truly-orphan runs (no ThreadJob anywhere); other users'/workspaces'
+    # tracked runs are skipped.
     orphan_job_ids = job_ids - all_tracked_job_ids
     if orphan_job_ids:
         logger.info(

--- a/apps/workspaces/api/materialization_views.py
+++ b/apps/workspaces/api/materialization_views.py
@@ -46,12 +46,9 @@ async def materialization_cancel_view(request, workspace_id):
         return JsonResponse({"status": "no_active_run", "runs_cancelled": 0})
 
     job_ids = {r.procrastinate_job_id for r in active_runs if r.procrastinate_job_id is not None}
-    # Tenant schemas are SHARED across workspaces, so ``active_runs`` (selected by
-    # this workspace's tenants) also contains runs a sibling workspace started for
-    # the same tenant. Scope to thread__user AND thread__workspace so cancelling
-    # here only cancels runs driven from THIS workspace — never a sibling's run of
-    # a shared tenant (which would inject a "cancelled" resume into their thread —
-    # arch #255, 07#1).
+    # Tenant schemas are shared across workspaces, so scope to thread__user AND
+    # thread__workspace — else we cancel a sibling workspace's run of the same
+    # tenant and inject a "cancelled" resume into its thread (arch #255 07#1).
     tjs = [
         tj
         async for tj in ThreadJob.objects.filter(
@@ -61,12 +58,9 @@ async def materialization_cancel_view(request, workspace_id):
             thread__workspace=workspace,
         )
     ]
-    # ALL ThreadJobs (any user/workspace) — distinguishes truly-orphan runs (no
-    # ThreadJob, e.g. /refresh/ path) from another user's/workspace's runs, which
-    # we must NOT cancel. The orphan fallback below stays workspace-agnostic on
-    # purpose: an orphan run has no ThreadJob, so cancelling it injects no
-    # "cancelled" resume into any thread — the cross-workspace harm the finding
-    # names is entirely on the tracked path above, now scoped by thread__workspace.
+    # Match ALL ThreadJobs to tell truly-orphan runs (no ThreadJob, e.g. /refresh/)
+    # from other users'/workspaces' runs. The orphan fallback stays workspace-agnostic
+    # on purpose: an orphan has no ThreadJob, so cancelling injects no resume (arch #255 07#1).
     all_tracked_job_ids = {
         pid
         async for pid in ThreadJob.objects.filter(

--- a/apps/workspaces/management/commands/purge_synced_data.py
+++ b/apps/workspaces/management/commands/purge_synced_data.py
@@ -4,7 +4,12 @@ import logging
 
 from django.core.management.base import BaseCommand
 
-from apps.workspaces.models import TenantMetadata, TenantSchema, Workspace
+from apps.workspaces.models import (
+    TenantMetadata,
+    TenantSchema,
+    Workspace,
+    WorkspaceViewSchema,
+)
 from apps.workspaces.services.schema_manager import SchemaManager
 
 logger = logging.getLogger(__name__)
@@ -12,9 +17,10 @@ logger = logging.getLogger(__name__)
 
 class Command(BaseCommand):
     help = (
-        "Purge all materialized tenant data: drops managed-DB schemas, "
-        "deletes TenantSchema/MaterializationRun/TenantMetadata records, "
-        "and clears data dictionaries. Chat, artifacts, and learnings are preserved."
+        "Purge all materialized tenant data: drops managed-DB tenant AND view "
+        "schemas, deletes TenantSchema/MaterializationRun/TenantMetadata/"
+        "WorkspaceViewSchema records, and clears data dictionaries. Chat, "
+        "artifacts, and learnings are preserved."
     )
 
     def add_arguments(self, parser):
@@ -28,12 +34,14 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         schema_count = TenantSchema.objects.count()
         metadata_count = TenantMetadata.objects.count()
+        view_schema_count = WorkspaceViewSchema.objects.count()
         workspace_count = Workspace.objects.exclude(data_dictionary=None).count()
 
         self.stdout.write(
             self.style.WARNING(
                 f"\nPurge synced data summary:\n"
                 f"  TenantSchema records (+ cascaded MaterializationRun): {schema_count}\n"
+                f"  WorkspaceViewSchema records (+ ws_* schemas): {view_schema_count}\n"
                 f"  TenantMetadata records: {metadata_count}\n"
                 f"  Workspace records with data_dictionary to clear: {workspace_count}\n"
             )
@@ -46,6 +54,23 @@ class Command(BaseCommand):
         manager = SchemaManager()
         teardown_errors = []
 
+        # Drop the multi-tenant view schemas first. Their ws_* physical schemas are
+        # NOT reached by the tenant DROP ... CASCADE below (that only empties the
+        # namespaced views), so without this the ws_* schemas + WorkspaceViewSchema
+        # rows survive as orphans (rows typically still ACTIVE over hollow schemas)
+        # — arch #255, 09#4.
+        for view_schema in WorkspaceViewSchema.objects.all():
+            try:
+                manager.teardown_view_schema(view_schema)
+                self.stdout.write(f"  Dropped view schema: {view_schema.schema_name}")
+            except Exception as exc:
+                teardown_errors.append((view_schema.schema_name, str(exc)))
+                self.stdout.write(
+                    self.style.ERROR(
+                        f"  Failed to drop view schema {view_schema.schema_name}: {exc}"
+                    )
+                )
+
         for tenant_schema in TenantSchema.objects.all():
             try:
                 manager.teardown(tenant_schema)
@@ -56,6 +81,7 @@ class Command(BaseCommand):
                     self.style.ERROR(f"  Failed to drop schema {tenant_schema.schema_name}: {exc}")
                 )
 
+        deleted_view_schemas, _ = WorkspaceViewSchema.objects.all().delete()
         deleted_schemas, _ = TenantSchema.objects.all().delete()
         deleted_metadata, _ = TenantMetadata.objects.all().delete()
         Workspace.objects.update(data_dictionary=None, data_dictionary_generated_at=None)
@@ -64,6 +90,7 @@ class Command(BaseCommand):
             self.style.SUCCESS(
                 f"\nDone.\n"
                 f"  Deleted {deleted_schemas} TenantSchema/MaterializationRun rows\n"
+                f"  Deleted {deleted_view_schemas} WorkspaceViewSchema rows\n"
                 f"  Deleted {deleted_metadata} TenantMetadata rows\n"
                 f"  Cleared data_dictionary on {workspace_count} Workspace(s)\n"
             )

--- a/apps/workspaces/services/schema_manager.py
+++ b/apps/workspaces/services/schema_manager.py
@@ -283,10 +283,8 @@ class SchemaManager:
 
         Returns the WorkspaceViewSchema model instance with state=ACTIVE on success.
         """
-        # Create/reset the row FIRST so an early validation failure (no tenants, or
-        # a tenant with no ACTIVE schema — the partial-materialization case) marks
-        # it FAILED with a reason instead of raising before the row exists and
-        # leaving a resurrected row parked in PROVISIONING (arch #255, 03#1/03#2).
+        # Create/reset the row FIRST so an early validation failure marks it FAILED
+        # instead of leaving a resurrected row in PROVISIONING (arch #255 03#1/03#2).
         view_schema_name = self._view_schema_name(workspace.id)
         vs, _ = WorkspaceViewSchema.objects.get_or_create(
             workspace=workspace,
@@ -463,10 +461,8 @@ class SchemaManager:
             if not conn.closed:
                 conn.close()
 
-        # Reset the inactivity TTL on (re)build: a row resurrected from EXPIRED
-        # keeps its >24h-old last_accessed_at, so without this expire_inactive_schemas
-        # would flip the freshly-rebuilt schema straight back to TEARDOWN on its next
-        # tick — the 2026-06-10 incident-b class, view-schema edition (arch #255, 03#2).
+        # Reset the TTL on (re)build: a row resurrected from EXPIRED keeps its stale
+        # last_accessed_at and expire_inactive_schemas would re-tear-down it (arch #255 03#2).
         vs.state = SchemaState.ACTIVE
         vs.last_error = ""
         vs.last_accessed_at = timezone.now()

--- a/apps/workspaces/services/schema_manager.py
+++ b/apps/workspaces/services/schema_manager.py
@@ -283,26 +283,11 @@ class SchemaManager:
 
         Returns the WorkspaceViewSchema model instance with state=ACTIVE on success.
         """
-        tenants = list(workspace.tenants.all())
-        if not tenants:
-            raise ValueError(f"Workspace {workspace.id} has no tenants")
-
-        active_schemas = {
-            ts.tenant_id: ts
-            for ts in TenantSchema.objects.filter(tenant__in=tenants, state=SchemaState.ACTIVE)
-        }
-        tenant_schemas: list[tuple[str, Tenant]] = []  # (schema_name, tenant)
-        for tenant in tenants:
-            ts = active_schemas.get(tenant.id)
-            if ts is None:
-                raise ValueError(
-                    f"Tenant '{tenant.external_id}' has no active schema. "
-                    "Run a data refresh for this tenant before building the view schema."
-                )
-            tenant_schemas.append((ts.schema_name, tenant))
-
+        # Create/reset the row FIRST so an early validation failure (no tenants, or
+        # a tenant with no ACTIVE schema — the partial-materialization case) marks
+        # it FAILED with a reason instead of raising before the row exists and
+        # leaving a resurrected row parked in PROVISIONING (arch #255, 03#1/03#2).
         view_schema_name = self._view_schema_name(workspace.id)
-
         vs, _ = WorkspaceViewSchema.objects.get_or_create(
             workspace=workspace,
             defaults={"schema_name": view_schema_name, "state": SchemaState.PROVISIONING},
@@ -311,6 +296,30 @@ class SchemaManager:
             vs.schema_name = view_schema_name
         vs.state = SchemaState.PROVISIONING
         vs.save(update_fields=["schema_name", "state"])
+
+        try:
+            tenants = list(workspace.tenants.all())
+            if not tenants:
+                raise ValueError(f"Workspace {workspace.id} has no tenants")
+
+            active_schemas = {
+                ts.tenant_id: ts
+                for ts in TenantSchema.objects.filter(tenant__in=tenants, state=SchemaState.ACTIVE)
+            }
+            tenant_schemas: list[tuple[str, Tenant]] = []  # (schema_name, tenant)
+            for tenant in tenants:
+                ts = active_schemas.get(tenant.id)
+                if ts is None:
+                    raise ValueError(
+                        f"Tenant '{tenant.external_id}' has no active schema. "
+                        "Run a data refresh for this tenant before building the view schema."
+                    )
+                tenant_schemas.append((ts.schema_name, tenant))
+        except ValueError as exc:
+            vs.state = SchemaState.FAILED
+            vs.last_error = str(exc)[:500]
+            vs.save(update_fields=["state", "last_error"])
+            raise
 
         conn = get_managed_db_connection()
         try:
@@ -454,9 +463,14 @@ class SchemaManager:
             if not conn.closed:
                 conn.close()
 
+        # Reset the inactivity TTL on (re)build: a row resurrected from EXPIRED
+        # keeps its >24h-old last_accessed_at, so without this expire_inactive_schemas
+        # would flip the freshly-rebuilt schema straight back to TEARDOWN on its next
+        # tick — the 2026-06-10 incident-b class, view-schema edition (arch #255, 03#2).
         vs.state = SchemaState.ACTIVE
         vs.last_error = ""
-        vs.save(update_fields=["state", "last_error"])
+        vs.last_accessed_at = timezone.now()
+        vs.save(update_fields=["state", "last_error", "last_accessed_at"])
 
         logger.info(
             "Built view schema '%s' for workspace '%s' (%d tenants, %d views)",

--- a/apps/workspaces/tasks.py
+++ b/apps/workspaces/tasks.py
@@ -960,6 +960,16 @@ async def _procrastinate_job_status(job_id: int) -> str | None:
         return None
 
 
+# Explicit procrastinate-status allowlists so an unknown/future status can never
+# fall through into an "act" branch (arch #255, 10#0). Raw strings because we read
+# the status column directly via the ORM (see _procrastinate_job_status).
+# "aborting" is transitional (an abort was requested but the worker hasn't acked) —
+# treat it as in-flight, not terminal.
+_PROCRASTINATE_INFLIGHT_STATUSES = frozenset({"todo", "doing", "aborting"})
+_PROCRASTINATE_FAILED_STATUSES = frozenset({"failed", "aborted", "cancelled"})
+_PROCRASTINATE_SUCCEEDED_STATUS = "succeeded"
+
+
 async def reconcile_stale_thread_job(tj: ThreadJob) -> str | None:
     """Reconcile one stale active ThreadJob against its procrastinate job.
 
@@ -977,7 +987,7 @@ async def reconcile_stale_thread_job(tj: ThreadJob) -> str | None:
     status = await _procrastinate_job_status(tj.procrastinate_job_id)
     if status is None:
         return None
-    if status in {"todo", "doing"}:
+    if status in _PROCRASTINATE_INFLIGHT_STATUSES:
         return None
     if tj.state == ThreadJob.State.RUNNING:
         # A resume task claimed it. Measure staleness from the RESUME phase so we
@@ -1007,9 +1017,10 @@ async def reconcile_stale_thread_job(tj: ThreadJob) -> str | None:
         )
         await _persist_synthetic_failure_message(tj, RESUME_STUCK_RUNNING_MESSAGE)
         return "failed"
-    if status in {"failed", "aborted"}:
-        # The task itself raised — no result for a resume to narrate, so flip
-        # straight to FAILED instead of deferring a resume with nothing to say.
+    if status in _PROCRASTINATE_FAILED_STATUSES:
+        # The task itself failed/was aborted/cancelled — no result for a resume to
+        # narrate, so flip straight to FAILED instead of deferring a resume with
+        # nothing to say.
         summary = await _build_failure_summary_for_job(tj.procrastinate_job_id)
         updated = await ThreadJob.objects.filter(
             id=tj.id,
@@ -1029,7 +1040,17 @@ async def reconcile_stale_thread_job(tj: ThreadJob) -> str | None:
         )
         await _persist_synthetic_failure_message(tj, MATERIALIZATION_FAILED_MESSAGE)
         return "failed"
-    # PENDING job whose materialization finished but was never claimed — safe to
+    if status != _PROCRASTINATE_SUCCEEDED_STATUS:
+        # Unknown/future procrastinate status: never fall into the resume act
+        # branch on a status we don't understand — leave the row for the next tick
+        # (arch #255, 10#0).
+        logger.warning(
+            "Reconcile: unrecognized procrastinate status %r for job %s; skipping",
+            status,
+            tj.procrastinate_job_id,
+        )
+        return None
+    # PENDING job whose materialization SUCCEEDED but was never claimed — safe to
     # defer a fresh resume; the resume task flips the state.
     try:
         await resume_thread_after_materialization.defer_async(thread_job_id=str(tj.id))
@@ -1064,6 +1085,166 @@ async def expire_stale_thread_jobs(timestamp: int = 0) -> dict:
         if action in {"failed", "resumed"}:
             flipped += 1
     return {"flipped": flipped}
+
+
+# A worker that dies hard (SIGKILL after a deploy stop-timeout, OOM, host crash)
+# leaves its procrastinate job 'doing' forever and any MaterializationRun it was
+# writing stuck in an ACTIVE state. Nothing else reconciles it: the ThreadJob
+# janitor iterates ThreadJobs only and returns None for a 'doing' zombie job, and
+# /refresh/-driven runs have no ThreadJob at all. So the UI banner freezes, the
+# resume/status path keeps reporting a live load, and the zombie row is miscounted
+# as active by the cancel endpoint. Detect the dead worker via procrastinate's
+# heartbeat-based stalled-job query and fail the run truthfully (arch #255, 03#9).
+MATERIALIZATION_STALLED_HEARTBEAT_SECONDS = 300
+
+# Terminal procrastinate statuses for a materialization job: the job is finished,
+# so a MaterializationRun still ACTIVE is a zombie the worker never closed out.
+_MATERIALIZATION_TERMINAL_STATUSES = frozenset({"succeeded", "failed", "aborted", "cancelled"})
+
+
+async def _stalled_procrastinate_job_ids() -> set[int]:
+    """Best-effort set of procrastinate job ids whose worker heartbeat is stale.
+
+    Wrapped: if the heartbeat query is unavailable (older schema, connector blip)
+    we degrade to the job-status signal alone rather than failing the whole tick.
+    """
+    try:
+        stalled = await app.job_manager.get_stalled_jobs(
+            seconds_since_heartbeat=MATERIALIZATION_STALLED_HEARTBEAT_SECONDS
+        )
+    except Exception:
+        logger.warning(
+            "reconcile_materialization: get_stalled_jobs failed; relying on the "
+            "job-status signal only this tick",
+            exc_info=True,
+        )
+        return set()
+    return {j.id for j in stalled if j.id is not None}
+
+
+async def _fail_thread_jobs_for_dead_materialization(procrastinate_job_id: int) -> None:
+    """Fail any active ThreadJob(s) owning a dead materialization job, with a
+    truthful summary + synthetic chat message so the UI spinner clears.
+
+    The ThreadJob janitor can't do this for a hard worker death: it returns None
+    for a 'doing' zombie job (correct per-tick, permanent for zombies).
+    """
+    summary = (
+        await _build_failure_summary_for_job(procrastinate_job_id) or MATERIALIZATION_FAILED_MESSAGE
+    )
+    async for tj in ThreadJob.objects.select_related("thread__workspace", "thread__user").filter(
+        procrastinate_job_id=procrastinate_job_id,
+        state__in=list(ThreadJob.ACTIVE_STATES),
+    ):
+        updated = await ThreadJob.objects.filter(
+            id=tj.id,
+            state__in=list(ThreadJob.ACTIVE_STATES),
+        ).aupdate(
+            state=ThreadJob.State.FAILED,
+            completed_at=timezone.now(),
+            error_summary=summary,
+        )
+        if updated:
+            await _persist_synthetic_failure_message(tj, MATERIALIZATION_FAILED_MESSAGE)
+
+
+async def _fail_zombie_materialization_run(run: MaterializationRun, reason: str) -> bool:
+    """CAS-flip an ACTIVE MaterializationRun to FAILED and fail its ThreadJob(s).
+
+    Returns True if this call performed the flip (False if another writer got
+    there first). Truthful: records the reason in result so the resume/aggregate
+    path narrates a real failure instead of a silent "still loading".
+    """
+    now = timezone.now()
+    result = run.result if isinstance(run.result, dict) else {}
+    updated = await MaterializationRun.objects.filter(
+        id=run.id,
+        state__in=list(MaterializationRun.ACTIVE_STATES),
+    ).aupdate(
+        state=MaterializationRun.RunState.FAILED,
+        completed_at=now,
+        result={**result, "error": reason, "reconciled_stale": True},
+    )
+    if not updated:
+        return False
+    logger.warning(
+        "reconcile_materialization: MaterializationRun %s (tenant_schema %s) flipped to "
+        "FAILED — %s",
+        run.id,
+        run.tenant_schema_id,
+        reason,
+    )
+    if run.procrastinate_job_id is not None:
+        await _fail_thread_jobs_for_dead_materialization(run.procrastinate_job_id)
+    return True
+
+
+@app.periodic(cron="*/15 * * * *")
+@task
+async def reconcile_stale_materialization_runs(timestamp: int = 0) -> dict:
+    """Fail MaterializationRuns stuck in an ACTIVE state after a hard worker death.
+
+    A run is a zombie when its procrastinate job is stalled (worker heartbeat gone)
+    or already terminal while the run row never reached a terminal state. A run
+    whose job is still legitimately in flight (live heartbeat, todo/doing) or whose
+    status can't be read this tick is left untouched.
+    """
+    stalled_ids = await _stalled_procrastinate_job_ids()
+    failed = 0
+    async for run in MaterializationRun.objects.filter(
+        state__in=list(MaterializationRun.ACTIVE_STATES),
+    ):
+        job_id = run.procrastinate_job_id
+        if job_id is None:
+            continue
+        status = await _procrastinate_job_status(job_id)
+        if status is None:
+            # Transient read failure — can't tell, so don't touch it this tick.
+            continue
+        is_stalled = job_id in stalled_ids
+        is_terminal = status in _MATERIALIZATION_TERMINAL_STATUSES
+        if not (is_stalled or is_terminal):
+            continue
+        reason = (
+            "The materialization worker stopped responding before the run finished "
+            "(stalled or crashed)."
+            if is_stalled
+            else f"The materialization job ended ({status}) without recording a terminal run state."
+        )
+        if await _fail_zombie_materialization_run(run, reason):
+            failed += 1
+    return {"failed": failed}
+
+
+# procrastinate_jobs / procrastinate_events grow unbounded otherwise: ~144 janitor
+# jobs/day plus every materialization/teardown/rebuild/resume. Keep finalized jobs
+# for a week (forensics + idempotency headroom) then prune (arch #255, 10#0).
+JOB_RETENTION_HOURS = 24 * 7
+
+
+@app.periodic(cron="17 3 * * *")
+@task
+async def prune_old_procrastinate_jobs(timestamp: int = 0) -> dict:
+    """Delete old finalized procrastinate jobs (and their events) so the queue
+    tables don't grow without bound.
+
+    Only 'succeeded' jobs are pruned (delete_old_jobs' default — failed/cancelled/
+    aborted are retained): the reconciler treats an unknown job id as "can't tell,
+    don't touch", so pruning a job still referenced by an active ThreadJob/
+    MaterializationRun would strand it. The 7-day horizon is far longer than the
+    15-minute stale-job janitor's window, so any active row referencing a succeeded
+    job has long since been reconciled before its job becomes prunable (arch #255,
+    10#0, reconciler↔retention coupling).
+    """
+    try:
+        await app.job_manager.delete_old_jobs(nb_hours=JOB_RETENTION_HOURS)
+    except Exception:
+        logger.warning("prune_old_procrastinate_jobs: delete_old_jobs failed", exc_info=True)
+        return {"pruned": False}
+    logger.info(
+        "prune_old_procrastinate_jobs: pruned succeeded jobs older than %sh", JOB_RETENTION_HOURS
+    )
+    return {"pruned": True}
 
 
 async def _build_failure_summary_for_job(procrastinate_job_id: int) -> str:

--- a/apps/workspaces/tasks.py
+++ b/apps/workspaces/tasks.py
@@ -354,13 +354,21 @@ async def materialize_workspace_core(
 
     all_succeeded = all(r.get("success") for r in tenant_results)
 
-    # Multi-tenant workspaces query through a WorkspaceViewSchema UNION ALL that
-    # requires every tenant ACTIVE, so build only after the loop succeeds — and
-    # *before* the resume task fires, so the agent's first list_tables sees the
-    # namespaced view instead of "No active view schema for workspace".
+    # Multi-tenant workspaces query through a WorkspaceViewSchema UNION ALL over
+    # the namespaced views. Any tenant that ran its pipeline DROP-CASCADEd those
+    # views, so a partial/cancelled run leaves them missing — the workspace's OWN
+    # view schema stayed ACTIVE-but-empty and the resume told the agent "answer
+    # what you can" over cascade-dropped views (arch #255, 03#1; the sibling +
+    # teardown paths were fixed by #227-#230, this same-workspace path was missed).
+    #
+    # So (re)build unconditionally for multi-tenant, not just on full success —
+    # *before* the resume fires. build_view_schema is idempotent: it rebuilds over
+    # whatever tenants are ACTIVE (honest partial) or, if a tenant has no active
+    # schema, marks the row FAILED so the resume reports the truth instead of
+    # serving broken views.
     view_schema_outcome: dict | None = None
     workspace_tenant_count = await workspace.workspace_tenants.acount()
-    if workspace_tenant_count > 1 and all_succeeded:
+    if workspace_tenant_count > 1:
         try:
             await _to_thread_fresh_db(SchemaManager().build_view_schema, workspace)
             view_schema_outcome = {"ok": True, "error": None}

--- a/apps/workspaces/tasks.py
+++ b/apps/workspaces/tasks.py
@@ -354,18 +354,9 @@ async def materialize_workspace_core(
 
     all_succeeded = all(r.get("success") for r in tenant_results)
 
-    # Multi-tenant workspaces query through a WorkspaceViewSchema UNION ALL over
-    # the namespaced views. Any tenant that ran its pipeline DROP-CASCADEd those
-    # views, so a partial/cancelled run leaves them missing — the workspace's OWN
-    # view schema stayed ACTIVE-but-empty and the resume told the agent "answer
-    # what you can" over cascade-dropped views (arch #255, 03#1; the sibling +
-    # teardown paths were fixed by #227-#230, this same-workspace path was missed).
-    #
-    # So (re)build unconditionally for multi-tenant, not just on full success —
-    # *before* the resume fires. build_view_schema is idempotent: it rebuilds over
-    # whatever tenants are ACTIVE (honest partial) or, if a tenant has no active
-    # schema, marks the row FAILED so the resume reports the truth instead of
-    # serving broken views.
+    # A partial/cancelled multi-tenant run DROP-CASCADEs some namespaced views,
+    # leaving the workspace's own view schema ACTIVE-but-missing. Rebuild it
+    # unconditionally (not only on full success) before the resume fires (arch #255 03#1).
     view_schema_outcome: dict | None = None
     workspace_tenant_count = await workspace.workspace_tenants.acount()
     if workspace_tenant_count > 1:
@@ -710,12 +701,9 @@ async def rebuild_workspace_view_schema(workspace_id: str) -> dict:
     try:
         vs = await _to_thread_fresh_db(manager.build_view_schema, workspace)
     except Exception:
-        # build_view_schema owns the WorkspaceViewSchema state: it creates/resets
-        # the row before validating, then marks it FAILED (with last_error) on any
-        # failure — including the early "no tenants / tenant has no active schema"
-        # checks (arch #255, 03#2). So we must NOT re-write state here: doing so
-        # risks clobbering a concurrent transition (e.g. TEARDOWN set by
-        # expire_inactive_schemas).
+        # build_view_schema owns the row state (marks it FAILED on any failure), so
+        # don't re-write state here and risk clobbering a concurrent transition —
+        # e.g. TEARDOWN set by expire_inactive_schemas (arch #255 03#2).
         logger.exception("Failed to build view schema for workspace %s", workspace_id)
         return {"error": "Failed to build view schema"}
 
@@ -960,11 +948,8 @@ async def _procrastinate_job_status(job_id: int) -> str | None:
         return None
 
 
-# Explicit procrastinate-status allowlists so an unknown/future status can never
-# fall through into an "act" branch (arch #255, 10#0). Raw strings because we read
-# the status column directly via the ORM (see _procrastinate_job_status).
-# "aborting" is transitional (an abort was requested but the worker hasn't acked) —
-# treat it as in-flight, not terminal.
+# Explicit status allowlists so an unknown/future procrastinate status can't fall
+# into an "act" branch; "aborting" is transitional, so treat it as in-flight (arch #255 10#0).
 _PROCRASTINATE_INFLIGHT_STATUSES = frozenset({"todo", "doing", "aborting"})
 _PROCRASTINATE_FAILED_STATUSES = frozenset({"failed", "aborted", "cancelled"})
 _PROCRASTINATE_SUCCEEDED_STATUS = "succeeded"
@@ -1087,14 +1072,10 @@ async def expire_stale_thread_jobs(timestamp: int = 0) -> dict:
     return {"flipped": flipped}
 
 
-# A worker that dies hard (SIGKILL after a deploy stop-timeout, OOM, host crash)
-# leaves its procrastinate job 'doing' forever and any MaterializationRun it was
-# writing stuck in an ACTIVE state. Nothing else reconciles it: the ThreadJob
-# janitor iterates ThreadJobs only and returns None for a 'doing' zombie job, and
-# /refresh/-driven runs have no ThreadJob at all. So the UI banner freezes, the
-# resume/status path keeps reporting a live load, and the zombie row is miscounted
-# as active by the cancel endpoint. Detect the dead worker via procrastinate's
-# heartbeat-based stalled-job query and fail the run truthfully (arch #255, 03#9).
+# A hard worker death (SIGKILL/OOM/host crash) leaves the procrastinate job 'doing'
+# and its MaterializationRun stuck ACTIVE, and the ThreadJob janitor can't see it
+# (None for a zombie job; /refresh/ runs have no ThreadJob). Detect it via
+# procrastinate's heartbeat stalled-job query and fail the run truthfully (arch #255 03#9).
 MATERIALIZATION_STALLED_HEARTBEAT_SECONDS = 300
 
 # Terminal procrastinate statuses for a materialization job: the job is finished,

--- a/apps/workspaces/tasks.py
+++ b/apps/workspaces/tasks.py
@@ -702,9 +702,12 @@ async def rebuild_workspace_view_schema(workspace_id: str) -> dict:
     try:
         vs = await _to_thread_fresh_db(manager.build_view_schema, workspace)
     except Exception:
-        # build_view_schema already saves state=FAILED before re-raising;
-        # no need to write it again here (doing so risks overwriting a
-        # concurrent state transition, e.g. TEARDOWN set by expire_inactive_schemas).
+        # build_view_schema owns the WorkspaceViewSchema state: it creates/resets
+        # the row before validating, then marks it FAILED (with last_error) on any
+        # failure — including the early "no tenants / tenant has no active schema"
+        # checks (arch #255, 03#2). So we must NOT re-write state here: doing so
+        # risks clobbering a concurrent transition (e.g. TEARDOWN set by
+        # expire_inactive_schemas).
         logger.exception("Failed to build view schema for workspace %s", workspace_id)
         return {"error": "Failed to build view schema"}
 

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -523,6 +523,22 @@ async def cancel_materialization(run_id: str, workspace_id: str = "") -> dict:
         run.result = {**(run.result or {}), "cancelled": True}
         await run.asave(update_fields=["state", "completed_at", "result"])
 
+        # The DB flip above is the authoritative stop signal (the worker's per-page
+        # progress checkpoint reads state==CANCELLED and rolls back the in-flight
+        # source), but on its own it left the procrastinate job running to the next
+        # await and the chat ThreadJob spinning. Mirror the HTTP cancel path
+        # (jobs_cancel.cancel_thread_job): abort the job and flip its ThreadJob so
+        # a mid-load MCP cancel actually unwinds end-to-end (arch #255, 01#1).
+        if run.procrastinate_job_id is not None:
+            with contextlib.suppress(Exception):
+                await procrastinate_app.job_manager.cancel_job_by_id_async(
+                    run.procrastinate_job_id, abort=True
+                )
+            await ThreadJob.objects.filter(
+                procrastinate_job_id=run.procrastinate_job_id,
+                state__in=list(ThreadJob.ACTIVE_STATES),
+            ).aupdate(state=ThreadJob.State.CANCELLED, completed_at=datetime.now(UTC))
+
         tenant_id = run.tenant_schema.tenant.external_id
         schema = run.tenant_schema.schema_name
         logger.info("Cancelled run %s for tenant %s (was: %s)", run_id, tenant_id, previous_state)

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -523,12 +523,9 @@ async def cancel_materialization(run_id: str, workspace_id: str = "") -> dict:
         run.result = {**(run.result or {}), "cancelled": True}
         await run.asave(update_fields=["state", "completed_at", "result"])
 
-        # The DB flip above is the authoritative stop signal (the worker's per-page
-        # progress checkpoint reads state==CANCELLED and rolls back the in-flight
-        # source), but on its own it left the procrastinate job running to the next
-        # await and the chat ThreadJob spinning. Mirror the HTTP cancel path
-        # (jobs_cancel.cancel_thread_job): abort the job and flip its ThreadJob so
-        # a mid-load MCP cancel actually unwinds end-to-end (arch #255, 01#1).
+        # The DB flip above is the stop signal, but alone it left the procrastinate
+        # job running and the ThreadJob spinning. Mirror the HTTP cancel path: abort
+        # the job and flip its ThreadJob so a mid-load cancel unwinds (arch #255 01#1).
         if run.procrastinate_job_id is not None:
             with contextlib.suppress(Exception):
                 await procrastinate_app.job_manager.cancel_job_by_id_async(

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -32,7 +32,6 @@ from django.conf import settings
 from django.core.exceptions import ValidationError as _ValidationError
 from mcp.server.fastmcp import Context, FastMCP
 from mcp.server.transport_security import TransportSecuritySettings
-from procrastinate.contrib.django.procrastinate_app import current_app as _procrastinate_app
 
 from apps.chat.models import Thread, ThreadJob
 from apps.transformations.services.lineage import aget_lineage_chain
@@ -48,6 +47,7 @@ from apps.workspaces.models import (
 )
 from apps.workspaces.services.schema_manager import SchemaManager
 from apps.workspaces.tasks import materialize_workspace
+from config.procrastinate import app as procrastinate_app
 from mcp_server.auth import SharedSecretMiddleware
 from mcp_server.context import load_workspace_context
 from mcp_server.envelope import (
@@ -707,7 +707,7 @@ async def run_materialization(
         except Exception:
             logger.exception("Failed to create ThreadJob; rolling back dispatch")
             with contextlib.suppress(Exception):
-                await _procrastinate_app.job_manager.cancel_job_by_id_async(job_id, abort=True)
+                await procrastinate_app.job_manager.cancel_job_by_id_async(job_id, abort=True)
             tc["result"] = error_response(INTERNAL_ERROR, "Failed to track job")
             return tc["result"]
 

--- a/mcp_server/services/materializer.py
+++ b/mcp_server/services/materializer.py
@@ -490,11 +490,9 @@ def run_pipeline(
             "Run %s state changed externally (cancelled?); preserving current DB state", run.id
         )
 
-    # Start the inactivity TTL from completion, not from the provision-time
-    # snapshot this in-memory instance captured at run start: an H-hour load would
-    # otherwise persist a last_accessed_at that is H hours old, rewinding the 24h
-    # TTL clock by the full run duration — re-opening the 2026-06-10 "janitor drops
-    # a fresh schema" class for long loads plus quiet users (arch #255, 04#0).
+    # Start the TTL from completion, not the provision-time snapshot this instance
+    # captured at run start — else an H-hour load rewinds the 24h clock by H hours
+    # (arch #255 04#0).
     tenant_schema.state = "active"
     tenant_schema.last_accessed_at = timezone.now()
     tenant_schema.save(update_fields=["state", "last_accessed_at"])

--- a/mcp_server/services/materializer.py
+++ b/mcp_server/services/materializer.py
@@ -490,7 +490,13 @@ def run_pipeline(
             "Run %s state changed externally (cancelled?); preserving current DB state", run.id
         )
 
+    # Start the inactivity TTL from completion, not from the provision-time
+    # snapshot this in-memory instance captured at run start: an H-hour load would
+    # otherwise persist a last_accessed_at that is H hours old, rewinding the 24h
+    # TTL clock by the full run duration — re-opening the 2026-06-10 "janitor drops
+    # a fresh schema" class for long loads plus quiet users (arch #255, 04#0).
     tenant_schema.state = "active"
+    tenant_schema.last_accessed_at = timezone.now()
     tenant_schema.save(update_fields=["state", "last_accessed_at"])
 
     total_rows = sum(s.get("rows", 0) for s in source_results.values())

--- a/tests/test_chat_stream_tool_cards.py
+++ b/tests/test_chat_stream_tool_cards.py
@@ -6,7 +6,9 @@ the real tool input and parse-safe JSON output, so progress / Stop / failure
 cards and rich rendering work LIVE -- not only after a page reload.
 """
 
+import asyncio
 import json
+from unittest.mock import patch
 
 import pytest
 from langchain_core.messages import ToolMessage
@@ -243,6 +245,52 @@ async def test_tool_runtime_in_input_does_not_crash_stream():
     # The injected, non-serializable runtime must not surface in the card.
     assert "runtime" not in start["input"]
     assert "workspace_id" not in start["input"]
+
+
+class _StallingStream:
+    """An event stream that never yields — models a hung LLM/tool call."""
+
+    def __init__(self):
+        self.aclosed = False
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        await asyncio.Event().wait()  # hang forever
+
+    async def aclose(self):
+        self.aclosed = True
+
+
+class _StallingAgent:
+    def __init__(self, stream_obj):
+        self._stream = stream_obj
+
+    def astream_events(self, input_state, *, config, version):
+        return self._stream
+
+
+@pytest.mark.asyncio
+async def test_stream_times_out_on_stalled_event_and_closes_generator():
+    """arch #255, 02#8: a stalled call that emits no events must still trip the
+    deadline (the wait for the NEXT event is bounded), and the abandoned
+    generator must be aclose()d so the in-flight ainvoke/Anthropic call is
+    cancelled rather than leaking until GC."""
+    stalling = _StallingStream()
+    agent = _StallingAgent(stalling)
+    with patch.object(stream, "AGENT_TIMEOUT_SECONDS", 0.2):
+        chunks = [
+            c
+            async for c in stream.langgraph_to_ui_stream(
+                agent, {}, {"configurable": {"thread_id": "t1"}}
+            )
+        ]
+    parsed = _parse_sse(chunks)
+    assert any(
+        c.get("type") == "error" and "timed out" in c.get("errorText", "").lower() for c in parsed
+    ), "a stalled stream must emit a timeout error chunk"
+    assert stalling.aclosed is True, "the abandoned event generator must be closed on timeout"
 
 
 def test_sse_survives_non_serializable_values():

--- a/tests/test_chat_thread_ownership.py
+++ b/tests/test_chat_thread_ownership.py
@@ -10,7 +10,7 @@ from django.contrib.auth import get_user_model
 from django.db import OperationalError
 from django.test import AsyncClient
 
-from apps.chat.models import Thread
+from apps.chat.models import Thread, ThreadJob
 from apps.chat.views import _upsert_thread
 from apps.users.models import Tenant, TenantMembership
 from apps.workspaces.models import (
@@ -77,6 +77,51 @@ async def test_chat_rejects_foreign_thread_id():
     # Specifically, if it reaches the ownership check, it should be 404
     if resp.status_code == 404:
         assert b"Thread not found" in resp.content
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_chat_rejects_turn_while_resume_running_on_same_thread():
+    """arch #255, 06#9: a live chat turn must not stream while a background resume
+    is mid-ainvoke against the same thread's checkpoint (two concurrent writers to
+    one LangGraph thread can interleave superstep state). A RUNNING materialization
+    ThreadJob signals the in-flight resume, so the turn is rejected with 409."""
+    user = await User.objects.acreate_user(email="resume-race@b.c", password="x")
+    ws = await Workspace.objects.acreate(name="W-resume-race", created_by=user)
+    tenant = await Tenant.objects.acreate(
+        external_id="t-rr", provider="commcare", canonical_name="RR Tenant"
+    )
+    await WorkspaceTenant.objects.acreate(workspace=ws, tenant=tenant)
+    await WorkspaceMembership.objects.acreate(
+        workspace=ws, user=user, role=WorkspaceRole.READ_WRITE
+    )
+    await TenantMembership.objects.acreate(user=user, tenant=tenant)
+    thread = await Thread.objects.acreate(workspace=ws, user=user)
+    await ThreadJob.objects.acreate(
+        thread=thread,
+        job_type="materialization",
+        procrastinate_job_id=660091,
+        tool_call_id="tc-rr",
+        state=ThreadJob.State.RUNNING,
+    )
+
+    # Plain client: @csrf_protect is bypassed when the client does not enforce
+    # CSRF, keeping this test focused on the 06#9 concurrency guard.
+    client = AsyncClient()
+    await client.alogin(email="resume-race@b.c", password="x")
+    resp = await client.post(
+        "/api/chat/",
+        data=json.dumps(
+            {
+                "messages": [{"role": "user", "content": "follow-up while resume runs"}],
+                "workspaceId": str(ws.id),
+                "threadId": str(thread.id),
+            }
+        ),
+        content_type="application/json",
+    )
+    assert resp.status_code == 409
+    assert b"background response" in resp.content.lower()
 
 
 @pytest.mark.asyncio

--- a/tests/test_checkpointer_pool.py
+++ b/tests/test_checkpointer_pool.py
@@ -1,0 +1,132 @@
+"""Pool-lifecycle tests for the LangGraph checkpointer singleton (arch #255, 08#1).
+
+The module-global AsyncConnectionPool + AsyncPostgresSaver had three defects:
+an unsynchronized init race (a second cold start closed the first's half-open
+pool), force_new closing the shared pool out from under concurrent streams, and
+no borrow-time health check. These tests lock in the fixed behavior with the
+pool/saver fully mocked so no real Postgres is needed.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import apps.chat.checkpointer as ckpt
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_globals():
+    """Each test starts from a clean singleton and restores it afterwards."""
+    ckpt._checkpointer = None
+    ckpt._pool = None
+    ckpt._init_lock = asyncio.Lock()
+    yield
+    ckpt._checkpointer = None
+    ckpt._pool = None
+
+
+def _make_pool():
+    pool = MagicMock(name="AsyncConnectionPool")
+    pool.closed = False
+    pool.open = AsyncMock(return_value=None)
+    pool.close = AsyncMock(return_value=None)
+    return pool
+
+
+@pytest.mark.asyncio
+async def test_concurrent_cold_starts_build_a_single_pool():
+    """Two concurrent ensure_checkpointer() calls must init exactly one pool —
+    the init lock serializes them instead of racing two half-open pools."""
+    pools = []
+
+    def _pool_factory(*args, **kwargs):
+        p = _make_pool()
+        pools.append(p)
+        return p
+
+    saver = MagicMock()
+    saver.setup = AsyncMock(return_value=None)
+
+    with (
+        patch.object(ckpt, "AsyncConnectionPool", side_effect=_pool_factory) as pool_cls,
+        patch.object(ckpt, "AsyncPostgresSaver", return_value=saver),
+        patch.object(ckpt, "get_database_url", return_value="postgresql://x/y"),
+    ):
+        pool_cls.check_connection = MagicMock()
+        results = await asyncio.gather(
+            ckpt.ensure_checkpointer(),
+            ckpt.ensure_checkpointer(),
+        )
+
+    assert len(pools) == 1, "concurrent cold starts must not each build a pool"
+    assert results[0] is results[1] is saver
+
+
+@pytest.mark.asyncio
+async def test_force_new_reuses_open_pool_and_does_not_close_it():
+    """force_new must rebuild the saver over the SAME open pool — never close a
+    pool other in-flight streams are borrowing from for checkpoint writes."""
+    existing_pool = _make_pool()
+    ckpt._pool = existing_pool
+    ckpt._checkpointer = MagicMock(name="old_saver")
+
+    new_saver = MagicMock(name="new_saver")
+    new_saver.setup = AsyncMock(return_value=None)
+
+    with (
+        patch.object(ckpt, "AsyncConnectionPool") as pool_cls,
+        patch.object(ckpt, "AsyncPostgresSaver", return_value=new_saver),
+        patch.object(ckpt, "get_database_url", return_value="postgresql://x/y"),
+    ):
+        pool_cls.check_connection = MagicMock()
+        result = await ckpt.ensure_checkpointer(force_new=True)
+
+    existing_pool.close.assert_not_awaited()
+    pool_cls.assert_not_called()  # reused the open pool, no new one built
+    assert ckpt._pool is existing_pool
+    assert result is new_saver
+
+
+@pytest.mark.asyncio
+async def test_pool_created_with_borrow_time_health_check():
+    """A freshly built pool must pass check= so dead pooled connections are
+    recycled on checkout rather than handed out mid-write."""
+    saver = MagicMock()
+    saver.setup = AsyncMock(return_value=None)
+
+    with (
+        patch.object(ckpt, "AsyncConnectionPool", return_value=_make_pool()) as pool_cls,
+        patch.object(ckpt, "AsyncPostgresSaver", return_value=saver),
+        patch.object(ckpt, "get_database_url", return_value="postgresql://x/y"),
+    ):
+        pool_cls.check_connection = MagicMock(name="check_connection")
+        await ckpt.ensure_checkpointer()
+
+    _, kwargs = pool_cls.call_args
+    assert kwargs.get("check") is pool_cls.check_connection
+
+
+@pytest.mark.asyncio
+async def test_closed_pool_is_rebuilt():
+    """If the existing pool has been closed, ensure_checkpointer builds a new one
+    rather than reusing the dead pool."""
+    dead_pool = _make_pool()
+    dead_pool.closed = True
+    ckpt._pool = dead_pool
+    ckpt._checkpointer = None
+
+    fresh_pool = _make_pool()
+    saver = MagicMock()
+    saver.setup = AsyncMock(return_value=None)
+
+    with (
+        patch.object(ckpt, "AsyncConnectionPool", return_value=fresh_pool) as pool_cls,
+        patch.object(ckpt, "AsyncPostgresSaver", return_value=saver),
+        patch.object(ckpt, "get_database_url", return_value="postgresql://x/y"),
+    ):
+        pool_cls.check_connection = MagicMock()
+        await ckpt.ensure_checkpointer()
+
+    pool_cls.assert_called_once()
+    assert ckpt._pool is fresh_pool

--- a/tests/test_jobs_endpoints.py
+++ b/tests/test_jobs_endpoints.py
@@ -928,13 +928,8 @@ async def test_reconcile_leaves_fresh_running_resume_alone_even_when_job_termina
 # ---------------------------------------------------------------------------
 # 12#0 item 2 / arch #255 02#5: exercise the REAL app binding in cancel_thread_job
 #
-# The other cancel tests patch apps.workspaces.api.jobs_cancel.app, replacing the
-# module-level binding. That masks the risk the finding names: jobs_cancel used to
-# do `from ...procrastinate_app import current_app` (the import-time FutureApp
-# binding that broke the worker-side janitor before it moved to the ORM). It now
-# imports the lazy `app` (ProxyApp) from config.procrastinate, which resolves the
-# job_manager after AppConfig.ready — so an import-order regression can no longer
-# silently disable the abort. This test locks that in.
+# jobs_cancel now imports the lazy ProxyApp (not an import-time FutureApp binding),
+# so an import-order regression can't silently disable the abort (arch #255 02#5).
 #
 # These tests leave the binding intact and patch the abort at the JobManager
 # CLASS level, so the real binding must resolve for the abort to fire.

--- a/tests/test_jobs_endpoints.py
+++ b/tests/test_jobs_endpoints.py
@@ -396,7 +396,7 @@ async def test_cancel_job_flips_state_and_aborts_procrastinate():
     client = AsyncClient()
     await client.alogin(email="a@b.c", password="x")
 
-    with patch("apps.workspaces.api.jobs_cancel.current_app") as mock_app:
+    with patch("apps.workspaces.api.jobs_cancel.app") as mock_app:
         mock_app.job_manager.cancel_job_by_id_async = AsyncMock(return_value=None)
         resp = await client.post(f"/api/workspaces/{ws.id}/jobs/{tj.id}/cancel/")
     assert resp.status_code == 200
@@ -487,7 +487,7 @@ async def test_cancel_does_not_overwrite_terminal_threadjob():
         state=ThreadJob.State.COMPLETED,  # Already terminal — resume just finished
     )
     # Call cancel_thread_job directly to exercise the race window
-    with patch("apps.workspaces.api.jobs_cancel.current_app") as mock_app:
+    with patch("apps.workspaces.api.jobs_cancel.app") as mock_app:
         mock_app.job_manager.cancel_job_by_id_async = AsyncMock(return_value=None)
         await cancel_thread_job(tj)
 
@@ -925,25 +925,28 @@ async def test_reconcile_leaves_fresh_running_resume_alone_even_when_job_termina
 
 
 # ---------------------------------------------------------------------------
-# 12#0 item 2: exercise the REAL current_app binding in cancel_thread_job
+# 12#0 item 2 / arch #255 02#5: exercise the REAL app binding in cancel_thread_job
 #
-# The other cancel tests patch apps.workspaces.api.jobs_cancel.current_app,
-# replacing the module-level import-time binding. That masks the risk the
-# finding names: jobs_cancel does `from ...procrastinate_app import current_app`
-# (a surviving sibling of the binding that broke the worker-side janitor before
-# it moved to the ORM). If that binding ever resolved to procrastinate's
-# FutureApp blueprint, `current_app.job_manager` would raise AttributeError and
-# the abort would be silently swallowed by cancel_thread_job's try/except.
+# The other cancel tests patch apps.workspaces.api.jobs_cancel.app, replacing the
+# module-level binding. That masks the risk the finding names: jobs_cancel used to
+# do `from ...procrastinate_app import current_app` (the import-time FutureApp
+# binding that broke the worker-side janitor before it moved to the ORM). It now
+# imports the lazy `app` (ProxyApp) from config.procrastinate, which resolves the
+# job_manager after AppConfig.ready — so an import-order regression can no longer
+# silently disable the abort. This test locks that in.
 #
 # These tests leave the binding intact and patch the abort at the JobManager
 # CLASS level, so the real binding must resolve for the abort to fire.
 # ---------------------------------------------------------------------------
 
 
-def test_jobs_cancel_current_app_binding_is_live_not_a_blueprint():
-    """The surviving-sibling binding must resolve to a real App exposing a
-    usable job_manager — not procrastinate's not-ready FutureApp blueprint."""
-    job_manager = jobs_cancel.current_app.job_manager
+def test_jobs_cancel_app_binding_is_live_not_a_blueprint():
+    """The abort binding must resolve to a real App exposing a usable
+    job_manager — not procrastinate's not-ready FutureApp blueprint."""
+    from procrastinate.contrib.django.procrastinate_app import FutureApp
+
+    assert not isinstance(jobs_cancel.app, FutureApp)
+    job_manager = jobs_cancel.app.job_manager
     assert hasattr(job_manager, "cancel_job_by_id_async")
 
 

--- a/tests/test_jobs_endpoints.py
+++ b/tests/test_jobs_endpoints.py
@@ -7,6 +7,7 @@ from django.contrib.auth import get_user_model
 from django.core.cache import cache
 from django.test import AsyncClient
 from django.utils import timezone
+from procrastinate.contrib.django.procrastinate_app import FutureApp
 from procrastinate.manager import JobManager
 
 from apps.chat.models import Thread, ThreadJob
@@ -943,8 +944,6 @@ async def test_reconcile_leaves_fresh_running_resume_alone_even_when_job_termina
 def test_jobs_cancel_app_binding_is_live_not_a_blueprint():
     """The abort binding must resolve to a real App exposing a usable
     job_manager — not procrastinate's not-ready FutureApp blueprint."""
-    from procrastinate.contrib.django.procrastinate_app import FutureApp
-
     assert not isinstance(jobs_cancel.app, FutureApp)
     job_manager = jobs_cancel.app.job_manager
     assert hasattr(job_manager, "cancel_job_by_id_async")

--- a/tests/test_materialization_reconciler.py
+++ b/tests/test_materialization_reconciler.py
@@ -1,0 +1,265 @@
+"""Tests for the stuck-MaterializationRun reconciler and job retention
+(arch #255, 03#9 + 10#0) and the reconcile_stale_thread_job allowlist hardening.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from django.contrib.auth import get_user_model
+
+from apps.chat.models import Thread, ThreadJob
+from apps.users.models import Tenant
+from apps.workspaces.models import (
+    MaterializationRun,
+    SchemaState,
+    TenantSchema,
+    Workspace,
+)
+from apps.workspaces.tasks import (
+    JOB_RETENTION_HOURS,
+    prune_old_procrastinate_jobs,
+    reconcile_stale_materialization_runs,
+    reconcile_stale_thread_job,
+)
+
+User = get_user_model()
+
+
+async def _make_run(*, job_id, state=MaterializationRun.RunState.LOADING, with_threadjob=False):
+    user = await User.objects.acreate_user(email=f"recon{job_id}@b.c", password="x")
+    ws = await Workspace.objects.acreate(name=f"W-{job_id}", created_by=user)
+    tenant = await Tenant.objects.acreate(
+        external_id=f"t{job_id}", provider="commcare", canonical_name=f"T{job_id}"
+    )
+    schema = await TenantSchema.objects.acreate(
+        tenant=tenant, schema_name=f"s_{job_id}", state=SchemaState.ACTIVE
+    )
+    run = await MaterializationRun.objects.acreate(
+        tenant_schema=schema,
+        pipeline="commcare_sync",
+        state=state,
+        procrastinate_job_id=job_id,
+    )
+    tj = None
+    if with_threadjob:
+        thread = await Thread.objects.acreate(workspace=ws, user=user)
+        tj = await ThreadJob.objects.acreate(
+            thread=thread,
+            job_type="materialization",
+            procrastinate_job_id=job_id,
+            tool_call_id=f"tc{job_id}",
+            state=ThreadJob.State.PENDING,
+        )
+    return run, tj
+
+
+# --- 03#9: stuck MaterializationRun reconciler --------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_reconciler_fails_stalled_run_and_threadjob():
+    """A LOADING run whose worker heartbeat is stale is a zombie: the reconciler
+    flips it FAILED and fails its owning ThreadJob so the UI spinner clears."""
+    run, tj = await _make_run(job_id=770001, with_threadjob=True)
+
+    with (
+        patch(
+            "apps.workspaces.tasks._stalled_procrastinate_job_ids",
+            new=AsyncMock(return_value={770001}),
+        ),
+        patch(
+            "apps.workspaces.tasks._procrastinate_job_status",
+            new=AsyncMock(return_value="doing"),  # zombie: doing but worker gone
+        ),
+        patch(
+            "apps.workspaces.tasks._persist_synthetic_failure_message",
+            new=AsyncMock(return_value=None),
+        ),
+    ):
+        result = await reconcile_stale_materialization_runs()
+
+    assert result == {"failed": 1}
+    await run.arefresh_from_db()
+    assert run.state == MaterializationRun.RunState.FAILED
+    assert run.completed_at is not None
+    assert run.result.get("reconciled_stale") is True
+    await tj.arefresh_from_db()
+    assert tj.state == ThreadJob.State.FAILED
+    assert tj.error_summary
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_reconciler_leaves_live_run_untouched():
+    """A run whose job is 'doing' with a LIVE heartbeat (not stalled) is a healthy
+    long load — the reconciler must not touch it."""
+    run, _ = await _make_run(job_id=770002)
+
+    with (
+        patch(
+            "apps.workspaces.tasks._stalled_procrastinate_job_ids",
+            new=AsyncMock(return_value=set()),
+        ),
+        patch(
+            "apps.workspaces.tasks._procrastinate_job_status",
+            new=AsyncMock(return_value="doing"),
+        ),
+    ):
+        result = await reconcile_stale_materialization_runs()
+
+    assert result == {"failed": 0}
+    await run.arefresh_from_db()
+    assert run.state == MaterializationRun.RunState.LOADING
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_reconciler_fails_run_with_terminal_job():
+    """A run stuck ACTIVE while its procrastinate job is already terminal
+    (succeeded/failed) is a zombie the worker never closed out — fail it."""
+    run, _ = await _make_run(job_id=770003)
+
+    with (
+        patch(
+            "apps.workspaces.tasks._stalled_procrastinate_job_ids",
+            new=AsyncMock(return_value=set()),
+        ),
+        patch(
+            "apps.workspaces.tasks._procrastinate_job_status",
+            new=AsyncMock(return_value="failed"),
+        ),
+        patch(
+            "apps.workspaces.tasks._persist_synthetic_failure_message",
+            new=AsyncMock(return_value=None),
+        ),
+    ):
+        result = await reconcile_stale_materialization_runs()
+
+    assert result == {"failed": 1}
+    await run.arefresh_from_db()
+    assert run.state == MaterializationRun.RunState.FAILED
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_reconciler_skips_when_status_unknown():
+    """A transient status-read failure (None) must not fail the run this tick."""
+    run, _ = await _make_run(job_id=770004)
+
+    with (
+        patch(
+            "apps.workspaces.tasks._stalled_procrastinate_job_ids",
+            new=AsyncMock(return_value=set()),
+        ),
+        patch(
+            "apps.workspaces.tasks._procrastinate_job_status",
+            new=AsyncMock(return_value=None),
+        ),
+    ):
+        result = await reconcile_stale_materialization_runs()
+
+    assert result == {"failed": 0}
+    await run.arefresh_from_db()
+    assert run.state == MaterializationRun.RunState.LOADING
+
+
+# --- 10#0: allowlist hardening + retention ------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_reconcile_thread_job_skips_unknown_status():
+    """An unrecognized/future procrastinate status must NOT fall into the resume
+    act branch — the ThreadJob is left for the next tick."""
+    _, tj = await _make_run(job_id=770005, with_threadjob=True)
+
+    with (
+        patch(
+            "apps.workspaces.tasks._procrastinate_job_status",
+            new=AsyncMock(return_value="some_future_status"),
+        ),
+        patch("apps.workspaces.tasks.resume_thread_after_materialization") as resume,
+    ):
+        resume.defer_async = AsyncMock(return_value=None)
+        action = await reconcile_stale_thread_job(tj)
+
+    assert action is None
+    resume.defer_async.assert_not_called()
+    await tj.arefresh_from_db()
+    assert tj.state == ThreadJob.State.PENDING
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_reconcile_thread_job_skips_aborting_status():
+    """'aborting' is transitional (abort requested, not yet acked) — treat it as
+    in-flight, not terminal."""
+    _, tj = await _make_run(job_id=770006, with_threadjob=True)
+
+    with (
+        patch(
+            "apps.workspaces.tasks._procrastinate_job_status",
+            new=AsyncMock(return_value="aborting"),
+        ),
+        patch("apps.workspaces.tasks.resume_thread_after_materialization") as resume,
+    ):
+        resume.defer_async = AsyncMock(return_value=None)
+        action = await reconcile_stale_thread_job(tj)
+
+    assert action is None
+    resume.defer_async.assert_not_called()
+    await tj.arefresh_from_db()
+    assert tj.state == ThreadJob.State.PENDING
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_reconcile_thread_job_fails_on_cancelled_status():
+    """A PENDING ThreadJob whose job is 'cancelled' has nothing to resume — flip
+    it FAILED rather than deferring a resume (allowlist now includes cancelled)."""
+    _, tj = await _make_run(job_id=770007, with_threadjob=True)
+
+    with (
+        patch(
+            "apps.workspaces.tasks._procrastinate_job_status",
+            new=AsyncMock(return_value="cancelled"),
+        ),
+        patch(
+            "apps.workspaces.tasks._persist_synthetic_failure_message",
+            new=AsyncMock(return_value=None),
+        ),
+        patch("apps.workspaces.tasks.resume_thread_after_materialization") as resume,
+    ):
+        resume.defer_async = AsyncMock(return_value=None)
+        action = await reconcile_stale_thread_job(tj)
+
+    assert action == "failed"
+    resume.defer_async.assert_not_called()
+    await tj.arefresh_from_db()
+    assert tj.state == ThreadJob.State.FAILED
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_prune_old_jobs_calls_delete_old_jobs_with_horizon():
+    """The retention task prunes finalized jobs via delete_old_jobs at the
+    configured horizon (succeeded-only default — no include_* flags)."""
+    delete = AsyncMock(return_value=None)
+    with patch("apps.workspaces.tasks.app") as mock_app:
+        mock_app.job_manager.delete_old_jobs = delete
+        result = await prune_old_procrastinate_jobs()
+
+    assert result == {"pruned": True}
+    delete.assert_awaited_once_with(nb_hours=JOB_RETENTION_HOURS)
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_prune_old_jobs_degrades_gracefully_on_error():
+    """A delete_old_jobs failure is best-effort — logged, not raised."""
+    with patch("apps.workspaces.tasks.app") as mock_app:
+        mock_app.job_manager.delete_old_jobs = AsyncMock(side_effect=RuntimeError("boom"))
+        result = await prune_old_procrastinate_jobs()
+
+    assert result == {"pruned": False}

--- a/tests/test_materialize_workspace_task.py
+++ b/tests/test_materialize_workspace_task.py
@@ -218,12 +218,15 @@ async def test_materialize_workspace_skips_view_rebuild_for_single_tenant(
 
 @pytest.mark.asyncio
 @pytest.mark.django_db(transaction=True)
-async def test_materialize_workspace_skips_view_rebuild_when_any_tenant_failed(
+async def test_materialize_workspace_reconciles_view_schema_when_any_tenant_failed(
     multi_tenant_workspace, tenant_membership_obj, context_with_job_id
 ):
-    """When even one tenant pipeline fails, the view rebuild would itself
-    fail (it requires every tenant to have an ACTIVE schema), so we skip
-    it rather than burning a noisy traceback."""
+    """arch #255, 03#1: when even one tenant pipeline fails, the tenant DROP
+    already cascade-dropped the workspace's own namespaced views, so the view
+    schema MUST be reconciled (rebuilt over surviving tenants, or marked FAILED)
+    rather than left ACTIVE-but-broken while the resume says "answer what you
+    can". build_view_schema is idempotent and owns the FAILED marking, so it is
+    always invoked for a multi-tenant workspace."""
     mock_manager = MagicMock()
 
     with (
@@ -244,7 +247,7 @@ async def test_materialize_workspace_skips_view_rebuild_when_any_tenant_failed(
         )
 
     assert result["all_succeeded"] is False
-    mock_manager.build_view_schema.assert_not_called()
+    mock_manager.build_view_schema.assert_called_once_with(multi_tenant_workspace)
 
 
 @pytest.mark.asyncio

--- a/tests/test_materialize_workspace_task.py
+++ b/tests/test_materialize_workspace_task.py
@@ -941,9 +941,7 @@ async def test_legacy_cancel_orphan_path_skips_other_users_runs(
 
 @pytest.mark.asyncio
 @pytest.mark.django_db(transaction=True)
-async def test_legacy_cancel_does_not_cancel_own_run_in_sibling_workspace(
-    workspace, user, tenant
-):
+async def test_legacy_cancel_does_not_cancel_own_run_in_sibling_workspace(workspace, user, tenant):
     """arch #255, 07#1: tenant schemas are shared across workspaces, so a run the
     SAME user started from a sibling workspace B (sharing the tenant) shows up in
     workspace A's active-run query. Cancelling from A must NOT cancel B's

--- a/tests/test_materialize_workspace_task.py
+++ b/tests/test_materialize_workspace_task.py
@@ -514,7 +514,7 @@ async def test_cancel_endpoint_marks_runs_cancelled(workspace, user, tenant):
     client = AsyncClient()
     await client.alogin(email=user.email, password="testpass123")
 
-    with patch("apps.workspaces.api.jobs_cancel.current_app") as mock_app:
+    with patch("apps.workspaces.api.jobs_cancel.app") as mock_app:
         mock_app.job_manager.cancel_job_by_id_async = AsyncMock(return_value=1)
         resp = await client.post(f"/api/workspaces/{workspace.id}/materialization/cancel/")
 
@@ -751,8 +751,8 @@ async def test_legacy_cancel_handles_mixed_tracked_and_orphan_runs(workspace, us
     await client.alogin(email=user.email, password="testpass123")
 
     with (
-        patch("apps.workspaces.api.jobs_cancel.current_app") as mock_tracked_app,
-        patch("apps.workspaces.api.materialization_views.current_app") as mock_orphan_app,
+        patch("apps.workspaces.api.jobs_cancel.app") as mock_tracked_app,
+        patch("apps.workspaces.api.materialization_views.app") as mock_orphan_app,
     ):
         mock_tracked_app.job_manager.cancel_job_by_id_async = AsyncMock(return_value=1)
         mock_orphan_app.job_manager.cancel_job_by_id_async = AsyncMock(return_value=1)
@@ -819,8 +819,8 @@ async def test_legacy_cancel_does_not_cancel_other_users_threadjob(
     client = AsyncClient()
     await client.alogin(email=other_user.email, password="otherpass123")
     with (
-        patch("apps.workspaces.api.jobs_cancel.current_app") as mock_tracked_app,
-        patch("apps.workspaces.api.materialization_views.current_app") as mock_orphan_app,
+        patch("apps.workspaces.api.jobs_cancel.app") as mock_tracked_app,
+        patch("apps.workspaces.api.materialization_views.app") as mock_orphan_app,
     ):
         mock_tracked_app.job_manager.cancel_job_by_id_async = AsyncMock(return_value=1)
         mock_orphan_app.job_manager.cancel_job_by_id_async = AsyncMock(return_value=1)
@@ -906,8 +906,8 @@ async def test_legacy_cancel_orphan_path_skips_other_users_runs(
     client = AsyncClient()
     await client.alogin(email=other_user.email, password="otherpass123")
     with (
-        patch("apps.workspaces.api.jobs_cancel.current_app") as mock_tracked_app,
-        patch("apps.workspaces.api.materialization_views.current_app") as mock_orphan_app,
+        patch("apps.workspaces.api.jobs_cancel.app") as mock_tracked_app,
+        patch("apps.workspaces.api.materialization_views.app") as mock_orphan_app,
     ):
         mock_tracked_app.job_manager.cancel_job_by_id_async = AsyncMock(return_value=1)
         mock_orphan_app.job_manager.cancel_job_by_id_async = AsyncMock(return_value=1)
@@ -934,6 +934,59 @@ async def test_legacy_cancel_orphan_path_skips_other_users_runs(
         1002,
         abort=True,
     )
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_legacy_cancel_does_not_cancel_own_run_in_sibling_workspace(
+    workspace, user, tenant
+):
+    """arch #255, 07#1: tenant schemas are shared across workspaces, so a run the
+    SAME user started from a sibling workspace B (sharing the tenant) shows up in
+    workspace A's active-run query. Cancelling from A must NOT cancel B's
+    chat-driven run — doing so injects a "cancelled" resume into B's thread. The
+    thread__workspace filter on the tracked-cancel path prevents it."""
+    sibling_ws = await Workspace.objects.acreate(name="sibling-ws", created_by=user)
+    await WorkspaceTenant.objects.acreate(workspace=sibling_ws, tenant=tenant)
+
+    schema = await TenantSchema.objects.acreate(
+        tenant=tenant, schema_name="test_sibling_cancel", state=SchemaState.ACTIVE
+    )
+    # A run driven from the sibling workspace B's chat (owned by the same user).
+    b_run = await MaterializationRun.objects.acreate(
+        tenant_schema=schema,
+        pipeline="commcare_sync",
+        state=MaterializationRun.RunState.LOADING,
+        procrastinate_job_id=888,
+    )
+    b_thread = await Thread.objects.acreate(workspace=sibling_ws, user=user)
+    b_tj = await ThreadJob.objects.acreate(
+        thread=b_thread,
+        job_type="materialization",
+        procrastinate_job_id=888,
+        tool_call_id="tc-sibling",
+        state=ThreadJob.State.RUNNING,
+    )
+
+    client = AsyncClient()
+    await client.alogin(email=user.email, password="testpass123")
+    with (
+        patch("apps.workspaces.api.jobs_cancel.app") as mock_tracked_app,
+        patch("apps.workspaces.api.materialization_views.app") as mock_orphan_app,
+    ):
+        mock_tracked_app.job_manager.cancel_job_by_id_async = AsyncMock(return_value=1)
+        mock_orphan_app.job_manager.cancel_job_by_id_async = AsyncMock(return_value=1)
+        # Cancel from workspace A (the `workspace` fixture), not the sibling.
+        resp = await client.post(f"/api/workspaces/{workspace.id}/materialization/cancel/")
+
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "no_active_run"
+    # B's run + ThreadJob are untouched — no cross-workspace cancel.
+    await b_run.arefresh_from_db()
+    assert b_run.state == MaterializationRun.RunState.LOADING
+    await b_tj.arefresh_from_db()
+    assert b_tj.state == ThreadJob.State.RUNNING
+    mock_orphan_app.job_manager.cancel_job_by_id_async.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_materializer.py
+++ b/tests/test_materializer.py
@@ -88,6 +88,11 @@ class TestRunPipeline:
         assert result["status"] == "completed"
         assert result["run_id"] == "run-1"
         assert "cases" in result["sources"]
+        # arch #255, 04#0: completion refreshes last_accessed_at to ~now so a long
+        # load does not persist the stale provision-time snapshot and rewind the TTL.
+        assert isinstance(schema.last_accessed_at, timezone.datetime)
+        assert timezone.now() - schema.last_accessed_at < timedelta(seconds=30)
+        schema.save.assert_called_with(update_fields=["state", "last_accessed_at"])
 
     def test_progress_updater_called_full_sequence(self):
         """Progress updater must be called for each phase transition with a

--- a/tests/test_mcp_tenant_tools.py
+++ b/tests/test_mcp_tenant_tools.py
@@ -12,8 +12,10 @@ import pytest
 from django.contrib.auth import get_user_model
 from django.test import override_settings
 
+from apps.chat.models import Thread, ThreadJob
 from apps.users.models import Tenant
 from apps.workspaces.models import (
+    MaterializationRun,
     SchemaState,
     TenantSchema,
     Workspace,
@@ -877,6 +879,9 @@ class TestCancelMaterialization:
         mock_run.id = uuid.UUID(run_id)
         mock_run.state = "loading"
         mock_run.result = {}
+        # No procrastinate job here — the abort / ThreadJob flip is exercised in a
+        # dedicated real-models test below (arch #255, 01#1).
+        mock_run.procrastinate_job_id = None
         # Real model path: TenantSchema.tenant -> Tenant.external_id (12#0 item 3).
         mock_run.tenant_schema.tenant.external_id = "dimagi"
         mock_run.tenant_schema.schema_name = "dimagi"
@@ -946,6 +951,53 @@ class TestCancelMaterialization:
 
         assert result["success"] is False
         assert "not in progress" in result["error"]["message"].lower()
+
+
+@pytest.mark.django_db(transaction=True)
+async def test_cancel_materialization_aborts_job_and_flips_threadjob():
+    """arch #255, 01#1: a mid-load MCP cancel must not only write CANCELLED but
+    also abort the procrastinate job and flip the owning chat ThreadJob, so the
+    load actually unwinds and the chat spinner clears (matching the HTTP cancel
+    path). Before the fix it left the job running and the ThreadJob active."""
+    from mcp_server.server import cancel_materialization
+
+    User = get_user_model()
+    user = await User.objects.acreate_user(email="mcpcancel@b.c", password="x")
+    ws = await Workspace.objects.acreate(name="W-mcpcancel", created_by=user)
+    tenant = await Tenant.objects.acreate(
+        external_id="mcpc", provider="commcare", canonical_name="MCPC"
+    )
+    await WorkspaceTenant.objects.acreate(workspace=ws, tenant=tenant)
+    schema = await TenantSchema.objects.acreate(
+        tenant=tenant, schema_name="s_mcpc", state=SchemaState.ACTIVE
+    )
+    thread = await Thread.objects.acreate(workspace=ws, user=user)
+    tj = await ThreadJob.objects.acreate(
+        thread=thread,
+        job_type="materialization",
+        procrastinate_job_id=990011,
+        tool_call_id="tc-mcpc",
+        state=ThreadJob.State.PENDING,
+    )
+    run = await MaterializationRun.objects.acreate(
+        tenant_schema=schema,
+        pipeline="commcare_sync",
+        state=MaterializationRun.RunState.LOADING,
+        procrastinate_job_id=990011,
+    )
+
+    abort = AsyncMock(return_value=None)
+    with patch("mcp_server.server.procrastinate_app") as mock_app:
+        mock_app.job_manager.cancel_job_by_id_async = abort
+        result = await cancel_materialization(run_id=str(run.id), workspace_id=str(ws.id))
+
+    assert result["success"] is True
+    abort.assert_awaited_once_with(990011, abort=True)
+    await run.arefresh_from_db()
+    assert run.state == MaterializationRun.RunState.CANCELLED
+    await tj.arefresh_from_db()
+    assert tj.state == ThreadJob.State.CANCELLED
+    assert tj.completed_at is not None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_purge_synced_data.py
+++ b/tests/test_purge_synced_data.py
@@ -4,7 +4,14 @@ import pytest
 from django.core.management import call_command
 
 from apps.users.models import TenantMembership, User
-from apps.workspaces.models import MaterializationRun, TenantMetadata, TenantSchema, Workspace
+from apps.workspaces.models import (
+    MaterializationRun,
+    SchemaState,
+    TenantMetadata,
+    TenantSchema,
+    Workspace,
+    WorkspaceViewSchema,
+)
 
 
 @pytest.fixture
@@ -108,6 +115,33 @@ def test_purge_clears_data_dictionary(workspace):
     assert workspace.data_dictionary is None
     assert workspace.data_dictionary_generated_at is None
     assert Workspace.objects.filter(id=workspace.id).exists()  # workspace preserved
+
+
+@pytest.fixture
+def view_schema(workspace):
+    return WorkspaceViewSchema.objects.create(
+        workspace=workspace,
+        schema_name="ws_deadbeefdeadbeef",
+        state=SchemaState.ACTIVE,
+    )
+
+
+@pytest.mark.django_db
+def test_purge_drops_and_deletes_view_schemas(tenant_schema, view_schema):
+    """arch #255, 09#4: --confirm must drop the ws_* physical view schemas and
+    delete the WorkspaceViewSchema rows — not orphan them over hollow schemas."""
+    with (
+        patch("apps.workspaces.management.commands.purge_synced_data.SchemaManager.teardown"),
+        patch(
+            "apps.workspaces.management.commands.purge_synced_data."
+            "SchemaManager.teardown_view_schema"
+        ) as mock_view_teardown,
+    ):
+        call_command("purge_synced_data", confirm=True)
+
+    mock_view_teardown.assert_called_once()
+    assert WorkspaceViewSchema.objects.count() == 0
+    assert TenantSchema.objects.count() == 0
 
 
 @pytest.mark.django_db

--- a/tests/test_purge_synced_data.py
+++ b/tests/test_purge_synced_data.py
@@ -139,7 +139,7 @@ def test_purge_drops_and_deletes_view_schemas(tenant_schema, view_schema):
     ):
         call_command("purge_synced_data", confirm=True)
 
-    mock_view_teardown.assert_called_once()
+    mock_view_teardown.assert_any_call(view_schema)
     assert WorkspaceViewSchema.objects.count() == 0
     assert TenantSchema.objects.count() == 0
 

--- a/tests/test_run_materialization_fire_and_ack.py
+++ b/tests/test_run_materialization_fire_and_ack.py
@@ -95,7 +95,7 @@ async def test_run_materialization_rolls_back_dispatch_when_threadjob_create_fai
     with (
         patch("mcp_server.server.materialize_workspace") as mw,
         patch("mcp_server.server.ThreadJob.objects.acreate", side_effect=Exception("DB down")),
-        patch("mcp_server.server._procrastinate_app") as proc_app,
+        patch("mcp_server.server.procrastinate_app") as proc_app,
     ):
         mw.defer_async = AsyncMock(return_value=job_mock)
         proc_app.job_manager.cancel_job_by_id_async = cancel_mock

--- a/tests/test_view_schema_builder.py
+++ b/tests/test_view_schema_builder.py
@@ -790,6 +790,61 @@ def test_build_view_schema_records_last_error_on_failure(workspace, tenant):
         WorkspaceViewSchema.objects.filter(workspace=workspace).delete()
 
 
+@pytest.mark.django_db
+def test_build_view_schema_reactivating_expired_row_resets_ttl(workspace, tenant):
+    """arch #255, 03#2: rebuilding a row resurrected from EXPIRED must reset
+    last_accessed_at, or expire_inactive_schemas flips the freshly-rebuilt schema
+    straight back to TEARDOWN on its next tick."""
+    from datetime import timedelta
+
+    from django.utils import timezone
+
+    mock_cursor = MagicMock()
+    mock_cursor.fetchall.return_value = []
+    mock_conn = MagicMock()
+    mock_conn.closed = False
+    mock_conn.cursor.return_value = mock_cursor
+
+    ts = TenantSchema.objects.create(
+        tenant=tenant, schema_name="test_domain_expired", state=SchemaState.ACTIVE
+    )
+    stale = timezone.now() - timedelta(days=3)
+    WorkspaceViewSchema.objects.create(
+        workspace=workspace,
+        schema_name="ws_expired_row",
+        state=SchemaState.EXPIRED,
+        last_accessed_at=stale,
+    )
+    try:
+        with patch(
+            "apps.workspaces.services.schema_manager.get_managed_db_connection",
+            return_value=mock_conn,
+        ):
+            vs = SchemaManager().build_view_schema(workspace)
+        assert vs.state == SchemaState.ACTIVE
+        vs.refresh_from_db()
+        assert vs.last_accessed_at > stale
+        assert timezone.now() - vs.last_accessed_at < timedelta(seconds=30)
+    finally:
+        ts.delete()
+        WorkspaceViewSchema.objects.filter(workspace=workspace).delete()
+
+
+@pytest.mark.django_db
+def test_build_view_schema_missing_active_schema_marks_row_failed(workspace, tenant):
+    """arch #255, 03#1/03#2: when a tenant has no ACTIVE schema (e.g. a partial
+    multi-tenant materialization), the build must mark the row FAILED with a
+    reason rather than raising before the row exists and parking it."""
+    # tenant has no ACTIVE TenantSchema at all → early validation failure.
+    with pytest.raises(ValueError, match="no active schema"):
+        SchemaManager().build_view_schema(workspace)
+
+    vs = WorkspaceViewSchema.objects.get(workspace=workspace)
+    assert vs.state == SchemaState.FAILED
+    assert "no active schema" in vs.last_error
+    WorkspaceViewSchema.objects.filter(workspace=workspace).delete()
+
+
 def _role_grant_schemas(cursor, role_name: str) -> set[str]:
     """Return the set of schemas on which ``role_name`` holds a direct ACL entry."""
     cursor.execute(

--- a/tests/test_view_schema_builder.py
+++ b/tests/test_view_schema_builder.py
@@ -1,8 +1,10 @@
 import os
+from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
 import pytest
 from django.contrib.auth import get_user_model
+from django.utils import timezone
 from psycopg import sql as psycopg_sql
 
 from apps.users.models import Tenant
@@ -795,10 +797,6 @@ def test_build_view_schema_reactivating_expired_row_resets_ttl(workspace, tenant
     """arch #255, 03#2: rebuilding a row resurrected from EXPIRED must reset
     last_accessed_at, or expire_inactive_schemas flips the freshly-rebuilt schema
     straight back to TEARDOWN on its next tick."""
-    from datetime import timedelta
-
-    from django.utils import timezone
-
     mock_cursor = MagicMock()
     mock_cursor.fetchall.return_value = []
     mock_conn = MagicMock()


### PR DESCRIPTION
## Background-work robustness (arch #255)

Drives the concrete findings of the 16-finding `background-work-robustness` cluster to a reviewable state. Each fix is TDD'd and lands as its own commit. Design-gated and migration-risk findings are surfaced (with concrete proposals) rather than invented.

Verified current state first — several findings were already partly addressed by #317 (truthful cancel → CANCELLED), #319 (MCP cancel/status scoped to workspace), #311 (janitor logging), #328 (tenant-access). Only the residuals are fixed here; nothing prior is regressed.

### Fixed (concrete)

| id | fix |
|----|-----|
| **`02#5`** | Swap the three surviving `current_app` (FutureApp) sibling sites (`mcp_server/server.py`, `materialization_views.py`, `jobs_cancel.py`) to the lazy `app` (ProxyApp) from `config/procrastinate.py`, so an import-order regression can no longer silently disable procrastinate aborts. |
| **`01#1`** | MCP `cancel_materialization` now aborts the procrastinate job and flips the owning ThreadJob (it already wrote CANCELLED after #290, but left the job running and the chat spinner spinning). Mirrors the HTTP cancel path. |
| **`07#1`** | `materialization_cancel_view` scopes the tracked-cancel path by `thread__workspace` so cancelling from workspace A no longer cancels the same user's chat-driven run of a shared tenant in sibling workspace B (which injected a "cancelled" resume into B's thread). The orphan fallback stays workspace-agnostic on purpose — an orphan run has no ThreadJob, so cancelling it injects no resume into any thread. |
| **`04#0`** | `run_pipeline` completion now refreshes `last_accessed_at` to completion time instead of persisting the provision-time snapshot, so a long (H-hour) load no longer rewinds the 24h TTL clock by the run duration. |
| **`03#2`** | `build_view_schema` resets `last_accessed_at` on (re)build so a row resurrected from EXPIRED isn't immediately re-torn-down; the row is now created/reset **before** tenant validation so early "no tenants / tenant has no active schema" failures mark it FAILED (with a reason) instead of parking in PROVISIONING. Fixed the false comment in `rebuild_workspace_view_schema`. |
| **`03#1`** | Multi-tenant materialization now (re)builds the workspace's own view schema unconditionally (not only on full success), before the resume fires. A partial/cancelled run's tenant DROP cascade-dropped the ws_* views; leaving the schema ACTIVE made the resume tell the agent "answer what you can" over missing views. `build_view_schema` is idempotent and owns the FAILED marking. |
| **`08#1`** | Checkpointer pool: add an `asyncio` init lock (with double-check) so concurrent cold starts don't race; create the pool with `check=AsyncConnectionPool.check_connection` (borrow-time health check); and make `force_new` rebuild only the stateless saver over the still-open pool instead of closing a pool other in-flight streams are using. |
| **`02#8`** | `langgraph_to_ui_stream` wraps `event_stream.__anext__()` in `asyncio.wait_for(remaining)` so a stalled LLM/tool call that emits nothing still trips the 300s deadline, and `aclose()`s the generator in a `finally` so the abandoned ainvoke/Anthropic call is cancelled instead of leaking. |
| **`03#9`** | New periodic `reconcile_stale_materialization_runs`: detects a MaterializationRun stuck in an ACTIVE state after a hard worker death via procrastinate 3.8's heartbeat-based `get_stalled_jobs` (or a terminal job status), fails it truthfully, and fails its owning ThreadJob(s) with a synthetic chat message so the frozen UI banner clears. The ThreadJob janitor couldn't do this — it returns None for a `doing` zombie. |
| **`10#0`** | New daily `prune_old_procrastinate_jobs` (`delete_old_jobs`, 7-day horizon, succeeded-only) bounds `procrastinate_jobs`/`procrastinate_events` growth. Hardened `reconcile_stale_thread_job`'s status handling into explicit in-flight / failed / succeeded allowlists so an unknown/future status can never fall into the resume act branch (`aborting` now skips, `cancelled` now fails). The reconciler↔retention coupling is defused by the horizon being far longer than the 15-min stale-job window. |
| **`09#4`** | `purge_synced_data` now drops the ws_* view schemas and deletes the WorkspaceViewSchema rows, instead of orphaning them (ACTIVE rows over hollow schemas) after the tenant DROP CASCADE. |
| **`06#9`** | `chat_view` rejects a live turn with 409 when a RUNNING materialization ThreadJob owns the thread (a resume ainvoke is mid-flight against the same checkpoint — no CAS at this seam). See deferred note for the reverse guard. |

### Deferred / surfaced (not invented — concrete proposal below)

- **`03#3` — per-tenant mutual exclusion (design-gated).** No advisory lock keys materialization to a tenant schema, so two threads/workspaces sharing a tenant can run parallel `run_pipeline` against the same physical schema (interleaved DROP/CREATE/INSERT). **Proposal:** take a pg session advisory lock keyed on a hash of `tenant_schema` at dispatch (`pg_try_advisory_lock`), acquired around the load phase; on contention, either wait or short-circuit with an "already materializing this tenant" result. **Not implemented** here to avoid colliding with the #252 credential-lifetime work inside `materialize_workspace_core`.
- **`08#2` — single worker at concurrency 1 (design/infra).** All background work serializes through one slot and every deploy SIGKILLs in-flight jobs. Raising `--concurrency` interacts directly with `03#3` (per-tenant locking) and with `tasks.py`'s one-task-at-a-time timing assumptions, and needs a graceful-shutdown / `stop_wait_time` decision. Surfaced for infra design. (This PR's `03#9` reconciler makes the SIGKILL case self-heal, and `10#0` retention is the separable, safe part.)
- **`09#5` — dependency-graph choke-point owner (design).** The tenant↔view-schema dependency is reconciled by 6+ hand-maintained hooks with 4 unhooked mutation paths and 5 inconsistent TTL keep-alive implementations. A single owned reconciler/choke-point is a design change beyond this PR; surfaced. (This PR closes one same-workspace hole via `03#1` but does not centralize the contract.)
- **`01#2` — ThreadJob created after `defer_async` (migration risk).** The clean fix (pre-create ThreadJob with a nullable `procrastinate_job_id`, then patch it in) needs a migration the original TODO explicitly skipped. **Proposal:** make `procrastinate_job_id` nullable, create the ThreadJob PENDING before `defer_async` inside one `transaction.atomic()`, then `aupdate` the job id — removing the dispatch/creation race and the `_defer_resume_for_job` sleep-poll hedge. **Deferred** as medium-risk (schema migration + touches the resume lifecycle) to keep this PR reviewable; the existing hedge + janitor keep it correct today.
- **LangGraph checkpoint pruning (part of `10#0`).** Procrastinate job/event retention is implemented; pruning LangGraph checkpoints is a product-gated conversation-history retention decision (how long to keep chat history), so it's surfaced rather than chosen here.
- **`06#9` reverse guard.** The resume task detecting an in-flight live turn needs a live-turn marker that doesn't exist yet; the chat-side guard is implemented, the resume-side is surfaced.

### Cross-lane note
Shares `apps/workspaces/tasks.py` and `mcp_server/services/materializer.py` with the #252 (credential-lifetime) agent. This PR touches only its own territory (never the credential/OAuth threading, error-mapping funcs, or the `aresolve_credential` call site) and does not add per-tenant locking inside `materialize_workspace_core`, so the two branches should rebase cleanly.

### Tests
New/updated tests across `test_materialization_reconciler.py` (new), `test_checkpointer_pool.py` (new), `test_chat_stream_tool_cards.py`, `test_chat_thread_ownership.py`, `test_materialize_workspace_task.py`, `test_materializer.py`, `test_view_schema_builder.py`, `test_purge_synced_data.py`, `test_mcp_tenant_tools.py`, `test_jobs_endpoints.py`, `test_threadjob_janitor.py`. Full relevant suite (236 tests) green; `ruff check` + `ruff format` clean on all changed files.

Closes #255
