### PR TITLE
fix(email): set SES region so workspace-invite emails send (SCOUT-DJANGO-22)

### DIFF
--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -30,12 +30,15 @@ SECURE_HSTS_SECONDS = 31536000  # 1 year
 SECURE_HSTS_INCLUDE_SUBDOMAINS = True
 SECURE_HSTS_PRELOAD = True
 
-# Transactional email via Amazon SES, mirroring Connect/OCS. ANYMAIL={} means
-# no keys in env — boto3's default credential chain uses the worker/API EC2
-# instance role (scout-production stack), which must have ses:SendEmail. The
-# EMAIL_BACKEND / DEFAULT_FROM_EMAIL env overrides still win if set at deploy.
+# Amazon SES via the EC2 instance role (no keys in env; role needs ses:SendEmail).
+# region_name is required: the role gives credentials but not a region, and the
+# container has no AWS_REGION, so boto3 raises NoRegionError without it (SCOUT-DJANGO-22).
 EMAIL_BACKEND = env("EMAIL_BACKEND", default="anymail.backends.amazon_ses.EmailBackend")
-ANYMAIL = {}
+ANYMAIL = {
+    "AMAZON_SES_CLIENT_PARAMS": {
+        "region_name": env("AWS_SES_REGION", default="us-east-1"),
+    },
+}
 
 LOGGING = {
     "version": 1,

--- a/tests/test_email_task.py
+++ b/tests/test_email_task.py
@@ -4,6 +4,15 @@ import pytest
 from django.core import mail
 
 from apps.users.tasks import send_email
+from config.settings import production
+
+
+def test_production_ses_config_specifies_region():
+    """SCOUT-DJANGO-22: the EC2 instance role gives boto3 credentials but no
+    region, so ANYMAIL must set region_name or every send raises NoRegionError.
+    Dev/test use the console/locmem backend, so only prod exercises the client.
+    """
+    assert production.ANYMAIL["AMAZON_SES_CLIENT_PARAMS"]["region_name"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem
Production hotfix. The first real workspace-invite send failed with:

> `NoRegionError: You must specify a region.` — `apps.users.tasks.send_email` (SCOUT-DJANGO-22, release `4a68477`)

The Anymail Amazon SES backend builds a boto3 SES client using the EC2 instance role. The instance role provides **credentials but not a region**, and the container has no `AWS_REGION` set, so botocore can't resolve an endpoint and raises `NoRegionError` on every send. `ANYMAIL = {}` left the region unspecified.

## Fix
Pass `region_name` explicitly via `ANYMAIL["AMAZON_SES_CLIENT_PARAMS"]` (per the [Anymail SES docs](https://anymail.dev/en/stable/esps/amazon_ses/#settings)), configurable with `AWS_SES_REGION`, default `us-east-1` (where the verified `dimagi.com` identity lives).

## Why CI didn't catch it
Dev and test use the console / locmem email backends, so the boto3 SES client is only ever constructed in production. Added a regression test (`test_production_ses_config_specifies_region`) that asserts the prod `ANYMAIL` config carries a region — it `KeyError`s against the old `{}`.

## Verification
- `pytest tests/test_email_task.py tests/test_deploy_environment.py tests/test_deploy_secrets.py` → 9 passed
- ruff check + format clean

After merge: auto-deploys to prod; then re-run the smoke test (invite an address you control) to confirm the send succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)