### PR TITLE
fix(infra): BatchGetSecretValue needs Resource '*' so Kamal deploys can read secrets

### DIFF
--- a/infra/scout-stack.yml
+++ b/infra/scout-stack.yml
@@ -509,19 +509,16 @@ Resources:
                   - !Sub 'arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:COMMCARE_*'
                   - !Sub 'arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:CONNECT_*'
                   - !Sub 'arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:OCS_*'
-              # `kamal secrets fetch` calls BatchGetSecretValue with an explicit
-              # --secret-id-list, so per-secret authorization against these
-              # prefixes is enough — no need for the account-wide Resource '*'
-              # this replaces (arch 10#9). The RDS secret is read via
-              # GetSecretValue above, not batched, so it is not listed here.
+              # `kamal secrets fetch` calls BatchGetSecretValue with a name
+              # *filter*, not --secret-id-list, so IAM authorizes the action
+              # against Resource '*' — prefix-scoped resources are denied
+              # ("no identity-based policy allows the action"). Resource must be
+              # '*' here; the secret *values* stay gated by the prefix-scoped
+              # GetSecretValue above, so this does not widen what can be read.
               - Effect: Allow
                 Action:
                   - secretsmanager:BatchGetSecretValue
-                Resource:
-                  - !Sub 'arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:SCOUT_*'
-                  - !Sub 'arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:COMMCARE_*'
-                  - !Sub 'arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:CONNECT_*'
-                  - !Sub 'arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:OCS_*'
+                Resource: '*'
 
   # ── Observability / detection layer (arch #257, finding 08#7) ────
   # The stack previously created log groups but NOTHING converted a dead

--- a/tests/test_infra_security.py
+++ b/tests/test_infra_security.py
@@ -88,19 +88,33 @@ def _statement_resources(stmt: dict) -> list:
     return [resource] if isinstance(resource, str) else resource
 
 
-def test_batch_get_secret_value_not_account_wide():
-    """kamal fetches secrets with BatchGetSecretValue; it must not be on '*'.
-
-    Granting BatchGetSecretValue on Resource '*' lets the CI role batch-read
-    every secret in the account. kamal passes an explicit --secret-id-list, so
-    per-secret authorization against the scout-namespaced prefixes is sufficient
-    (arch 10#9).
+def test_batch_get_secret_value_is_account_wide():
+    """kamal's aws_secrets_manager adapter fetches secrets with a name *filter*,
+    not --secret-id-list, so IAM only authorizes BatchGetSecretValue against
+    Resource '*' — a prefix-scoped resource is denied outright (PR #335,
+    correcting the arch 10#9 assumption this test used to encode). Actual
+    secret *values* stay gated by the still-scoped GetSecretValue statement
+    (see test_get_secret_value_scoped_to_scout_prefixes below), so this does
+    not widen what the role can read — only the batch/list action.
     """
     statements = _statements_for_action("secretsmanager:BatchGetSecretValue")
     assert statements, "expected a BatchGetSecretValue statement (kamal uses it to fetch secrets)"
     for stmt in statements:
+        assert _statement_resources(stmt) == ["*"], (
+            "secretsmanager:BatchGetSecretValue must be granted on Resource '*' — "
+            "kamal's adapter uses a name filter, which IAM only authorizes against '*' "
+            "(arch 10#9, corrected by PR #335)."
+        )
+
+
+def test_get_secret_value_scoped_to_scout_prefixes():
+    """GetSecretValue — the action that actually returns secret material — must
+    stay scoped to the scout-namespaced prefixes the deploy reads, even though
+    BatchGetSecretValue (above) is necessarily Resource '*'.
+    """
+    for stmt in _statements_for_action("secretsmanager:GetSecretValue"):
         assert "*" not in _statement_resources(stmt), (
-            "secretsmanager:BatchGetSecretValue must not be granted on Resource '*' — "
+            "secretsmanager:GetSecretValue must not be granted on Resource '*' — "
             "scope it to the scout-namespaced secret prefixes the deploy fetches (arch 10#9)."
         )
 


### PR DESCRIPTION
## Incident
Production deploys fail at the first `kamal deploy` with:
> `AccessDeniedException ... scout-github-deploy is not authorized to perform secretsmanager:BatchGetSecretValue because no identity-based policy allows the action`

This surfaced when the arch #329 infra changes (merged June, never applied to the live stack until today) were finally applied via `update-stack`.

## Root cause
`.kamal/secrets` uses `kamal secrets fetch --adapter aws_secrets_manager NAME…`, whose adapter calls `batch-get-secret-value` with a **name filter**. IAM evaluates filter-based `BatchGetSecretValue` against Resource `*`; the prefix-scoped resource from arch 10#9 never matches, so it's denied. The code comment's assumption (`--secret-id-list`) was incorrect.

## Fix
`BatchGetSecretValue` → `Resource: '*'`. Secret **values** remain protected by the still prefix-scoped `GetSecretValue` statement, so this does not widen what the role can actually read — only the batch/list action, which is required to be `*` when using filters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)