### PR TITLE
fix(email): worker sends SES via scoped IAM keys, not the instance role

### DIFF
--- a/.kamal/secrets
+++ b/.kamal/secrets
@@ -62,3 +62,14 @@ MANAGED_DATABASE_URL=$DATABASE_URL
 # found in .kamal/secrets". App falls back to LocMemCache if REDIS_URL is empty (base.py).
 REDIS_URL=redis://${SCOUT_REDIS_ENDPOINT}:6379/0
 
+
+## SES (workspace-invite email) — dedicated send-only IAM user (scout-ses-worker).
+# The worker's scout_shared bridge container can't reach the instance role under
+# IMDS hop limit 1 (arch #329), so it sends via these scoped static keys
+# (ses:SendEmail/SendRawEmail only). Only deploy-worker.yml lists them in its
+# secret block; production.py wires them into ANYMAIL when present.
+SES_SECRETS=$(kamal secrets fetch --adapter aws_secrets_manager SCOUT_SES_ACCESS_KEY_ID SCOUT_SES_SECRET_ACCESS_KEY)
+
+AWS_SES_ACCESS_KEY_ID=$(kamal secrets extract SCOUT_SES_ACCESS_KEY_ID $SES_SECRETS)
+AWS_SES_SECRET_ACCESS_KEY=$(kamal secrets extract SCOUT_SES_SECRET_ACCESS_KEY $SES_SECRETS)
+

--- a/config/deploy-worker.yml
+++ b/config/deploy-worker.yml
@@ -55,6 +55,12 @@ env:
     # The resume task's get_mcp_tools call authenticates to the MCP server with
     # this shared secret (arch #253, 01#6). MUST match deploy-mcp.yml.
     - MCP_SHARED_SECRET
+    # Dedicated send-only SES keys (IAM user scout-ses-worker). The worker sends
+    # invite email but its scout_shared bridge container can't reach the instance
+    # role under IMDS hop limit 1 (arch #329), so it authenticates to SES with
+    # these instead. Only the worker gets them — see production.py ANYMAIL.
+    - AWS_SES_ACCESS_KEY_ID
+    - AWS_SES_SECRET_ACCESS_KEY
 
 ssh:
   user: scout

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -30,14 +30,26 @@ SECURE_HSTS_SECONDS = 31536000  # 1 year
 SECURE_HSTS_INCLUDE_SUBDOMAINS = True
 SECURE_HSTS_PRELOAD = True
 
-# Amazon SES via the EC2 instance role (no keys in env; role needs ses:SendEmail).
-# region_name is required: the role gives credentials but not a region, and the
-# container has no AWS_REGION, so boto3 raises NoRegionError without it (SCOUT-DJANGO-22).
+# Amazon SES. region_name is required: the container has no AWS_REGION, so boto3
+# raises NoRegionError without it (SCOUT-DJANGO-22).
 EMAIL_BACKEND = env("EMAIL_BACKEND", default="anymail.backends.amazon_ses.EmailBackend")
+_ses_client_params = {
+    "region_name": env("AWS_SES_REGION", default="us-east-1"),
+}
+# The Procrastinate worker sends invite email but runs on the scout_shared Docker
+# bridge, where IMDS hop limit 1 (arch #329) blocks it from reaching the instance
+# role. When these dedicated send-only keys (IAM user scout-ses-worker,
+# ses:SendEmail/SendRawEmail only) are present it authenticates with them instead;
+# unset (API/MCP containers, local dev) -> boto3 falls back to the instance role /
+# default credential chain. Keeping the keys off the instance role means an SSRF on
+# the API can neither reach IMDS (hop 1) nor read these keys (worker-only).
+_ses_access_key = env("AWS_SES_ACCESS_KEY_ID", default=None)
+_ses_secret_key = env("AWS_SES_SECRET_ACCESS_KEY", default=None)
+if _ses_access_key and _ses_secret_key:
+    _ses_client_params["aws_access_key_id"] = _ses_access_key
+    _ses_client_params["aws_secret_access_key"] = _ses_secret_key
 ANYMAIL = {
-    "AMAZON_SES_CLIENT_PARAMS": {
-        "region_name": env("AWS_SES_REGION", default="us-east-1"),
-    },
+    "AMAZON_SES_CLIENT_PARAMS": _ses_client_params,
 }
 
 LOGGING = {


### PR DESCRIPTION
## Problem
Workspace-invite email was failing in prod with `NoCredentialsError`. The Procrastinate worker (which does the actual SES send) runs on the `scout_shared` Docker bridge, and IMDSv2 **hop limit 1** (arch #329 SSRF hardening) blocks a bridge-network container from reaching the EC2 instance-role credentials. Email was only kept alive by a **live, undocumented** change of the IMDS hop limit to **2** — which re-opens the exact SSRF→IMDS hole #329 closed, and silently reverts to 1 on any `update-stack` (→ email breaks again).

## Fix (permanent, secure)
Give the worker its own dedicated IAM user **`scout-ses-worker`** scoped to `ses:SendEmail`/`ses:SendRawEmail` **only**, delivered as **Secrets Manager → Kamal secret → worker env**:

- `config/settings/production.py`: wire `AWS_SES_ACCESS_KEY_ID` / `AWS_SES_SECRET_ACCESS_KEY` into anymail's `AMAZON_SES_CLIENT_PARAMS` when present. Unset (API/MCP containers, local dev) → falls back to the default credential chain, so **no other container changes behavior**.
- `config/deploy-worker.yml`: add the two keys to the worker `secret:` block (worker-only).
- `.kamal/secrets`: fetch `SCOUT_SES_ACCESS_KEY_ID` / `SCOUT_SES_SECRET_ACCESS_KEY` from Secrets Manager.

This lets us **restore IMDS hop limit 1**: an SSRF on the API can now reach neither IMDS (hop 1) **nor** these keys (worker-only, least-exposed container).

## Live infra done alongside this PR (not in CFN)
- Created IAM user `scout-ses-worker` + inline policy `scout-ses-send-only` (send-only).
- Created its access key; stored in Secrets Manager as `SCOUT_SES_ACCESS_KEY_ID` / `SCOUT_SES_SECRET_ACCESS_KEY`.
- Verified a real `ses:SendEmail` using only these scoped keys succeeds.
- After deploy: revert IMDS hop limit 2 → 1 (matches repo/#329).

## Verification
- `ruff` clean; `tests/test_email_task.py` + `tests/test_invite_notifications.py` pass.
- Confirmed `ANYMAIL` client params include the keys when env is set and omit them (instance-role fallback) when unset.
- Post-merge: watch worker deploy, send a test invite, confirm no Sentry `NoCredentialsError`, then flip hop limit to 1 and re-confirm send.

🤖 Generated with [Claude Code](https://claude.com/claude-code)