### PR TITLE
fix(auth): stop paging Sentry on expected HQ token-refresh 400s (SCOUT-DJANGO-21)

### DIFF
--- a/apps/users/services/token_refresh.py
+++ b/apps/users/services/token_refresh.py
@@ -86,6 +86,20 @@ async def refresh_oauth_token(social_token, token_url: str) -> str:
                 },
             )
             response.raise_for_status()
+    except httpx.HTTPStatusError as e:
+        # A 4xx (typically 400 invalid_grant on a dead refresh token) is an
+        # expected outcome, not a bug -- log at WARNING with the body so we can
+        # tell invalid_grant (dead token) from invalid_client (bad secret).
+        if 400 <= e.response.status_code < 500:
+            logger.warning(
+                "Token refresh rejected for app %s: HTTP %s %s",
+                social_token.app.client_id,
+                e.response.status_code,
+                e.response.text,
+            )
+        else:
+            logger.exception("Token refresh failed for app %s", social_token.app.client_id)
+        raise TokenRefreshError(f"Failed to refresh OAuth token: {e}") from e
     except Exception as e:
         logger.exception("Token refresh failed for app %s", social_token.app.client_id)
         raise TokenRefreshError(f"Failed to refresh OAuth token: {e}") from e

--- a/tests/test_oauth_tokens.py
+++ b/tests/test_oauth_tokens.py
@@ -2,9 +2,11 @@
 Tests for OAuth token storage, encryption, retrieval, and refresh.
 """
 
+import logging
 from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 from allauth.socialaccount.models import SocialAccount, SocialApp, SocialToken
 from cryptography.fernet import Fernet
@@ -128,6 +130,86 @@ class TestTokenRefresh:
 
         with pytest.raises(TokenRefreshError):
             await refresh_oauth_token(social_token, token_url)
+
+    @pytest.mark.asyncio
+    async def test_refresh_400_logs_warning_not_error(self, httpx_mock, caplog):
+        """A 400 invalid_grant (dead token) is expected: WARNING, no exception log."""
+        from apps.users.services.token_refresh import (
+            TokenRefreshError,
+            refresh_oauth_token,
+        )
+
+        token_url = "https://example.com/oauth/token/"
+        httpx_mock.add_response(
+            url=token_url,
+            method="POST",
+            status_code=400,
+            json={"error": "invalid_grant"},
+        )
+
+        social_token = MagicMock()
+        social_token.token_secret = "dead_refresh_token"
+        social_token.app.client_id = "client_123"
+        social_token.app.secret = "secret_456"
+
+        with caplog.at_level(logging.DEBUG, logger="apps.users.services.token_refresh"):
+            with pytest.raises(TokenRefreshError):
+                await refresh_oauth_token(social_token, token_url)
+
+        records = [r for r in caplog.records if r.name == "apps.users.services.token_refresh"]
+        assert records, "expected a log record"
+        assert all(r.levelno == logging.WARNING for r in records)
+        assert not any(r.levelno >= logging.ERROR for r in records)
+        assert not any(r.exc_info for r in records)
+        assert "invalid_grant" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_refresh_500_logs_exception(self, httpx_mock, caplog):
+        """A 5xx is genuinely unexpected: keep exception-level logging."""
+        from apps.users.services.token_refresh import (
+            TokenRefreshError,
+            refresh_oauth_token,
+        )
+
+        token_url = "https://example.com/oauth/token/"
+        httpx_mock.add_response(url=token_url, method="POST", status_code=503)
+
+        social_token = MagicMock()
+        social_token.token_secret = "old_refresh_token"
+        social_token.app.client_id = "client_123"
+        social_token.app.secret = "secret_456"
+
+        with caplog.at_level(logging.DEBUG, logger="apps.users.services.token_refresh"):
+            with pytest.raises(TokenRefreshError):
+                await refresh_oauth_token(social_token, token_url)
+
+        error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
+        assert error_records, "expected an ERROR/exception-level log record"
+        assert any(r.exc_info for r in error_records)
+
+    @pytest.mark.asyncio
+    async def test_refresh_network_error_logs_exception(self, httpx_mock, caplog):
+        """A network error is unexpected: keep exception-level logging."""
+        from apps.users.services.token_refresh import (
+            TokenRefreshError,
+            refresh_oauth_token,
+        )
+
+        token_url = "https://example.com/oauth/token/"
+        httpx_mock.add_exception(httpx.ConnectError("connection refused"), url=token_url)
+
+        social_token = MagicMock()
+        social_token.token_secret = "old_refresh_token"
+        social_token.app.client_id = "client_123"
+        social_token.app.secret = "secret_456"
+
+        with caplog.at_level(logging.DEBUG, logger="apps.users.services.token_refresh"):
+            with pytest.raises(TokenRefreshError):
+                await refresh_oauth_token(social_token, token_url)
+
+        error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
+        assert error_records, "expected an ERROR/exception-level log record"
+        assert any(r.exc_info for r in error_records)
 
     def test_token_needs_refresh_when_expiring_soon(self):
         from apps.users.services.token_refresh import token_needs_refresh

--- a/tests/test_oauth_tokens.py
+++ b/tests/test_oauth_tokens.py
@@ -15,6 +15,7 @@ from django.contrib.sites.models import Site
 from django.utils import timezone
 
 from apps.users.services.credential_resolver import _social_token_qs
+from apps.users.services.token_refresh import TokenRefreshError, refresh_oauth_token
 
 
 class TestTokenStorageSettings:
@@ -134,11 +135,6 @@ class TestTokenRefresh:
     @pytest.mark.asyncio
     async def test_refresh_400_logs_warning_not_error(self, httpx_mock, caplog):
         """A 400 invalid_grant (dead token) is expected: WARNING, no exception log."""
-        from apps.users.services.token_refresh import (
-            TokenRefreshError,
-            refresh_oauth_token,
-        )
-
         token_url = "https://example.com/oauth/token/"
         httpx_mock.add_response(
             url=token_url,
@@ -166,11 +162,6 @@ class TestTokenRefresh:
     @pytest.mark.asyncio
     async def test_refresh_500_logs_exception(self, httpx_mock, caplog):
         """A 5xx is genuinely unexpected: keep exception-level logging."""
-        from apps.users.services.token_refresh import (
-            TokenRefreshError,
-            refresh_oauth_token,
-        )
-
         token_url = "https://example.com/oauth/token/"
         httpx_mock.add_response(url=token_url, method="POST", status_code=503)
 
@@ -190,11 +181,6 @@ class TestTokenRefresh:
     @pytest.mark.asyncio
     async def test_refresh_network_error_logs_exception(self, httpx_mock, caplog):
         """A network error is unexpected: keep exception-level logging."""
-        from apps.users.services.token_refresh import (
-            TokenRefreshError,
-            refresh_oauth_token,
-        )
-
         token_url = "https://example.com/oauth/token/"
         httpx_mock.add_exception(httpx.ConnectError("connection refused"), url=token_url)
 


### PR DESCRIPTION
## What
`refresh_oauth_token` logged every OAuth refresh failure via `logger.exception`, paging Sentry (SCOUT-DJANGO-21) even for the *expected* case where CommCare HQ returns `400 invalid_grant` on a dead/expired refresh token. It also discarded the response body, hiding whether a 400 was `invalid_grant` (expected) vs `invalid_client` (a real config bug).

## Change
- 4xx refresh failures now log at **WARNING** with the response status + body (so `invalid_grant` vs `invalid_client` is visible), then raise `TokenRefreshError` as before.
- Non-4xx (5xx, network) still log at exception level — those are genuinely unexpected.
- Contract unchanged: any failure still raises `TokenRefreshError`, so callers mark the provider "expired". Success path untouched.
- Tests: 400 → WARNING only (no exc_info), 5xx → exception, network error → exception.

Fixes the Sentry noise; the underlying 400s are dead HQ refresh tokens (HQ access tokens live ~15 min; refresh tokens expire), which is expected and now surfaces as a "reconnect" signal instead of an error page.

## Follow-up (separate ticket, NOT in this PR)
⚠️ OAuth tokens are stored **in plaintext** in `socialaccount_socialtoken`. The `EncryptingSocialAccountAdapter.serialize_instance` only encrypts session copies, not DB rows — so `token`/`token_secret` sit unencrypted at rest. Token-at-rest encryption should be its own change (needs a migration for existing rows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)