### PR TITLE
fix(auth): stop connect-flow 500 (NoReverseMatch on socialaccount_connections) — SCOUT-DJANGO-25

### DIFF
--- a/apps/users/adapters.py
+++ b/apps/users/adapters.py
@@ -104,6 +104,23 @@ class EncryptingSocialAccountAdapter(DefaultSocialAccountAdapter):
         )
         raise ImmediateHttpResponse(redirect("account_login"))
 
+    def get_connect_redirect_url(self, request, socialaccount):
+        """Where allauth sends the browser after a ``?process=connect`` round-trip.
+
+        allauth's default reverses ``socialaccount_connections``, a name that
+        lives in ``allauth.socialaccount.urls`` — which Scout deliberately does
+        NOT mount (see apps/users/allauth_urls.py). That reverse raises
+        NoReverseMatch and, because allauth evaluates it eagerly (before the
+        ``or sociallogin.get_redirect_url(...)`` fallback), the connect flow 500s
+        even when the SPA passes a valid ``?next=`` (prod SCOUT-DJANGO-25).
+
+        Point at the SPA connections page instead, honoring any mount prefix
+        (FORCE_SCRIPT_NAME → SCRIPT_NAME in request meta) the same way the
+        artifact sandbox does.
+        """
+        script_name = request.META.get("SCRIPT_NAME", "").rstrip("/")
+        return f"{script_name}/settings/connections"
+
 
 def encrypt_credential(plaintext: str) -> str:
     """Fernet-encrypt a credential string using DB_CREDENTIAL_KEY."""

--- a/tests/test_oauth_tokens.py
+++ b/tests/test_oauth_tokens.py
@@ -6,12 +6,16 @@ from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
 from allauth.socialaccount.models import SocialAccount, SocialApp, SocialToken
 from cryptography.fernet import Fernet
 from django.conf import settings
 from django.contrib.sites.models import Site
+from django.test import RequestFactory
+from django.urls import NoReverseMatch
 from django.utils import timezone
 
+from apps.users.adapters import EncryptingSocialAccountAdapter
 from apps.users.services.credential_resolver import _social_token_qs
 
 
@@ -61,6 +65,34 @@ class TestTokenEncryptionAdapter:
         """Should raise ValueError when DB_CREDENTIAL_KEY is not set."""
         with pytest.raises(ValueError, match="DB_CREDENTIAL_KEY"):
             adapter.encrypt_token("some_token")
+
+
+class TestConnectRedirectUrl:
+    """The ``?process=connect`` flow must not reverse the unmounted
+    ``socialaccount_connections`` URL name (prod SCOUT-DJANGO-25)."""
+
+    def test_returns_spa_connections_path(self):
+        request = RequestFactory().get("/accounts/google/login/", {"process": "connect"})
+        url = EncryptingSocialAccountAdapter().get_connect_redirect_url(request, None)
+        assert url == "/settings/connections"
+
+    def test_honors_mount_prefix(self):
+        request = RequestFactory().get("/accounts/google/login/")
+        request.META["SCRIPT_NAME"] = "/scout"
+        url = EncryptingSocialAccountAdapter().get_connect_redirect_url(request, None)
+        assert url == "/scout/settings/connections"
+
+    def test_does_not_raise_no_reverse_match(self):
+        request = RequestFactory().get("/accounts/google/login/")
+        url = EncryptingSocialAccountAdapter().get_connect_redirect_url(request, None)
+        assert url
+
+    def test_default_adapter_would_raise(self):
+        """Guard: allauth's default reverses a name Scout doesn't mount, so the
+        override is load-bearing — if this stops raising, revisit the override."""
+        request = RequestFactory().get("/accounts/google/login/")
+        with pytest.raises(NoReverseMatch):
+            DefaultSocialAccountAdapter().get_connect_redirect_url(request, None)
 
 
 class TestCommCareConnectProvider:


### PR DESCRIPTION
## What
When a logged-in user connects a provider from Settings→Connections (`/accounts/<provider>/login/?process=connect`), allauth's CONNECT flow eagerly calls `get_connect_redirect_url()`, whose default reverses `socialaccount_connections`. Scout deliberately does **not** mount `allauth.socialaccount.urls` (see `apps/users/allauth_urls.py`), so that reverse raises `NoReverseMatch` → unhandled **500** (prod Sentry **SCOUT-DJANGO-25**). Because allauth evaluates the default eagerly (before the `or sociallogin.get_redirect_url(...)` fallback), even the SPA's valid `?next=/settings/connections` can't save it.

## Change
- Override `get_connect_redirect_url` in `EncryptingSocialAccountAdapter` to return the SPA connections page (`/settings/connections`), honoring any mount prefix (`SCRIPT_NAME`/`FORCE_SCRIPT_NAME`) the same way the artifact sandbox does.
- Tests (`TestConnectRedirectUrl`): asserts the SPA path, prefix handling, no-raise, and a regression guard proving the stock `DefaultSocialAccountAdapter` still raises `NoReverseMatch` (so the override stays load-bearing).

## Notes
- Login path and allowlist-rejection redirect are untouched; only the connect redirect target changes.
- No full OAuth-round-trip view test (would require standing up the provider handshake); covered at the adapter-method level + the allauth-default regression guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)