### PR TITLE
feat(workspaces): intrusive lost-access UX + stop defaulting into dead workspaces

### DIFF
--- a/apps/workspaces/api/workspace_views.py
+++ b/apps/workspaces/api/workspace_views.py
@@ -236,6 +236,15 @@ class WorkspaceListView(APIView):
         memberships = list(memberships)
         schema_statuses = _schema_status_for_workspaces([m.workspace for m in memberships])
 
+        # Bulk live-access check, one query for the whole list. A workspace is
+        # accessible iff it has no tenants OR the user shares a live tenant with
+        # it — the same rule apps/workspaces/access.py enforces per request. We
+        # surface it here (rather than filtering rows out) so the client can keep
+        # orphaned workspaces addressable by URL while gating them in the UI.
+        user_live_tenant_ids = set(
+            TenantMembership.objects.filter(user=request.user).values_list("tenant_id", flat=True)
+        )
+
         results = []
         for m in memberships:
             tenants = [
@@ -246,6 +255,8 @@ class WorkspaceListView(APIView):
                 }
                 for wt in m.workspace.workspace_tenants.all()
             ]
+            ws_tenant_ids = [wt.tenant_id for wt in m.workspace.workspace_tenants.all()]
+            has_access = not ws_tenant_ids or bool(set(ws_tenant_ids) & user_live_tenant_ids)
             results.append(
                 {
                     "id": str(m.workspace.id),
@@ -254,6 +265,7 @@ class WorkspaceListView(APIView):
                     "is_auto_created": m.workspace.is_auto_created,
                     "role": m.role,
                     "tenants": tenants,
+                    "has_access": has_access,
                     "member_count": m.member_count,
                     "schema_status": schema_statuses.get(m.workspace.id, "unavailable"),
                     "last_synced_at": (m.last_synced_at.isoformat() if m.last_synced_at else None),

--- a/frontend/src/api/workspaces.ts
+++ b/frontend/src/api/workspaces.ts
@@ -18,6 +18,10 @@ export interface WorkspaceListItem {
   is_auto_created: boolean
   role: "read" | "read_write" | "manage"
   tenants: WorkspaceListTenant[]
+  // Live upstream access. The server returns every membership (so orphaned
+  // workspaces stay addressable by URL) and flags the ones the user has lost
+  // tenant access to. Absent on older cached payloads — treat missing as true.
+  has_access?: boolean
   member_count: number
   schema_status: SchemaStatus
   last_synced_at: string | null
@@ -130,6 +134,15 @@ export function workspaceHasData(ws: {
   last_synced_at?: string | null
 }): boolean {
   return workspaceDataState(ws) === "ready"
+}
+
+/**
+ * Whether the user still has live upstream access to a workspace. The server
+ * omits `has_access` on older cached payloads; treat missing as accessible so a
+ * stale payload never locks the whole app behind the lost-access modal.
+ */
+export function workspaceHasAccess(ws: { has_access?: boolean }): boolean {
+  return ws.has_access !== false
 }
 
 // ── Workspace CRUD ─────────────────────────────────────────────────────────

--- a/frontend/src/components/AppLayout/AppLayout.tsx
+++ b/frontend/src/components/AppLayout/AppLayout.tsx
@@ -4,6 +4,7 @@ import { Sidebar } from "@/components/Sidebar"
 import { ErrorBoundary } from "@/components/ErrorBoundary"
 import { ArtifactPanel } from "@/components/ArtifactPanel/ArtifactPanel"
 import { OfflineBanner } from "@/components/OfflineBanner/OfflineBanner"
+import { LostAccessModal } from "@/components/LostAccessModal/LostAccessModal"
 import { useNetworkStatus } from "@/hooks/useNetworkStatus"
 import { useAppStore } from "@/store/store"
 import { WorkspaceJobsProvider } from "@/contexts/WorkspaceJobsContext"
@@ -62,6 +63,7 @@ export function AppLayout() {
         </div>
         <ArtifactPanel />
         <OfflineBanner />
+        <LostAccessModal />
       </div>
     </WorkspaceJobsProvider>
   )

--- a/frontend/src/components/LostAccessModal/LostAccessModal.test.tsx
+++ b/frontend/src/components/LostAccessModal/LostAccessModal.test.tsx
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { MemoryRouter } from "react-router-dom"
+import { LostAccessModal } from "./LostAccessModal"
+import { useAppStore } from "@/store/store"
+
+const navigate = vi.fn()
+vi.mock("react-router-dom", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("react-router-dom")>()),
+  useNavigate: () => navigate,
+}))
+
+const ws = (id: string, has_access: boolean, provider = "commcare") => ({
+  id,
+  name: id,
+  display_name: id,
+  is_auto_created: false,
+  role: "manage" as const,
+  tenants: [{ id: `t-${id}`, tenant_name: id, provider }],
+  has_access,
+  member_count: 1,
+  schema_status: "available" as const,
+  last_synced_at: null,
+  created_at: "2026-01-01T00:00:00Z",
+})
+
+function renderModal() {
+  return render(
+    <MemoryRouter>
+      <LostAccessModal />
+    </MemoryRouter>,
+  )
+}
+
+describe("LostAccessModal", () => {
+  beforeEach(() => {
+    navigate.mockClear()
+    useAppStore.setState({ domainsStatus: "loaded", domains: [], activeDomainId: null })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("does not render while domains are still loading", () => {
+    useAppStore.setState({ domainsStatus: "loading", domains: [ws("skelly", false)], activeDomainId: "skelly" })
+    renderModal()
+    expect(screen.queryByTestId("lost-access-modal")).toBeNull()
+  })
+
+  it("does not render when the active workspace still has access", () => {
+    useAppStore.setState({ domains: [ws("live", true)], activeDomainId: "live" })
+    renderModal()
+    expect(screen.queryByTestId("lost-access-modal")).toBeNull()
+  })
+
+  it("gates and names the provider when the active workspace lost access", () => {
+    useAppStore.setState({
+      domains: [ws("skelly", false), ws("live", true)],
+      activeDomainId: "skelly",
+    })
+    renderModal()
+
+    expect(screen.getByTestId("lost-access-modal")).toBeInTheDocument()
+    expect(screen.getByText(/lost access to “skelly”/)).toBeInTheDocument()
+    expect(screen.getByText("CommCare")).toBeInTheDocument()
+    // Only accessible workspaces appear in the picker.
+    expect(screen.getByTestId("lost-access-goto-live")).toBeInTheDocument()
+    expect(screen.queryByTestId("lost-access-goto-skelly")).toBeNull()
+  })
+
+  it("switches to a chosen accessible workspace", async () => {
+    useAppStore.setState({
+      domains: [ws("skelly", false), ws("live", true)],
+      activeDomainId: "skelly",
+    })
+    renderModal()
+
+    await userEvent.click(screen.getByTestId("lost-access-goto-live"))
+
+    expect(useAppStore.getState().activeDomainId).toBe("live")
+    expect(navigate).toHaveBeenCalledWith(expect.stringContaining("/live/chat"))
+  })
+
+  it("tells the user when they have no accessible workspaces", () => {
+    useAppStore.setState({ domains: [ws("skelly", false)], activeDomainId: "skelly" })
+    renderModal()
+
+    expect(screen.getByTestId("lost-access-modal")).toBeInTheDocument()
+    expect(screen.queryByTestId("lost-access-picker")).toBeNull()
+    expect(screen.getByText(/don’t have access to any workspaces/)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/LostAccessModal/LostAccessModal.tsx
+++ b/frontend/src/components/LostAccessModal/LostAccessModal.tsx
@@ -1,0 +1,109 @@
+import { useMemo } from "react"
+import { useNavigate } from "react-router-dom"
+import { AlertTriangle } from "lucide-react"
+import { useAppStore } from "@/store/store"
+import { workspaceHasAccess } from "@/api/workspaces"
+import { getProviderMeta } from "@/components/WorkspaceBadge/providerMeta"
+import { recordWorkspaceUse } from "@/lib/recentWorkspaces"
+import { workspacePath } from "@/lib/workspacePath"
+
+/** Distinct provider labels for a workspace, e.g. "CommCare" or "CommCare, Open Chat Studio". */
+function providerLabels(tenants: { provider: string }[]): string {
+  const labels = [...new Set(tenants.map((t) => getProviderMeta(t.provider).label))]
+  return labels.join(", ")
+}
+
+/**
+ * A hard, non-dismissible gate shown when the active workspace is one the user
+ * has lost upstream access to. The backend already refuses its data (403), so
+ * the page behind is dead; this makes that legible and the only way out is to
+ * pick a workspace the user can still access. Reachable only via a stale
+ * default or a deep link — the switcher and default-pick avoid orphans.
+ */
+export function LostAccessModal() {
+  const navigate = useNavigate()
+  const domains = useAppStore((s) => s.domains)
+  const domainsStatus = useAppStore((s) => s.domainsStatus)
+  const activeDomainId = useAppStore((s) => s.activeDomainId)
+  const setActiveDomain = useAppStore((s) => s.domainActions.setActiveDomain)
+  const newThread = useAppStore((s) => s.uiActions.newThread)
+
+  const active = domains.find((d) => d.id === activeDomainId)
+  const accessible = useMemo(() => domains.filter(workspaceHasAccess), [domains])
+
+  // Only gate once the list has actually loaded and resolved to an orphan —
+  // never during the initial load, or we'd flash the modal before we know.
+  if (domainsStatus !== "loaded" || !active || workspaceHasAccess(active)) return null
+
+  const source = providerLabels(active.tenants ?? [])
+
+  function goTo(ws: (typeof domains)[number]) {
+    recordWorkspaceUse(ws.id)
+    setActiveDomain(ws.id)
+    newThread()
+    navigate(`${workspacePath(ws)}/chat`)
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="lost-access-title"
+      data-testid="lost-access-modal"
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-background/70 p-4 backdrop-blur-sm"
+    >
+      <div className="w-full max-w-md rounded-lg border bg-card p-6 shadow-xl">
+        <div className="mb-4 flex items-center gap-3">
+          <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-amber-100 text-amber-600 dark:bg-amber-950 dark:text-amber-400">
+            <AlertTriangle className="h-5 w-5" aria-hidden />
+          </span>
+          <h2 id="lost-access-title" className="text-lg font-semibold">
+            You’ve lost access to “{active.display_name}”
+          </h2>
+        </div>
+
+        <p className="text-sm text-muted-foreground">
+          {source ? (
+            <>
+              This is a <span className="font-medium text-foreground">{source}</span> workspace.
+              Your access appears to have been removed upstream. Check your access on {source}, or
+              if you think this is a mistake, reach out to the workspace owner or an admin.
+            </>
+          ) : (
+            <>
+              Your access to this workspace appears to have been removed upstream. If you think
+              this is a mistake, reach out to the workspace owner or an admin.
+            </>
+          )}
+        </p>
+
+        {accessible.length > 0 ? (
+          <div className="mt-5">
+            <p className="mb-2 text-sm font-medium">Go to a workspace you can access:</p>
+            <div className="max-h-56 space-y-1 overflow-y-auto" data-testid="lost-access-picker">
+              {accessible.map((ws) => {
+                const { Icon } = getProviderMeta(ws.tenants?.[0]?.provider)
+                return (
+                  <button
+                    key={ws.id}
+                    data-testid={`lost-access-goto-${ws.id}`}
+                    onClick={() => goTo(ws)}
+                    className="flex w-full items-center gap-2 rounded-md border px-3 py-2 text-left text-sm transition-colors hover:bg-accent hover:text-accent-foreground"
+                  >
+                    <Icon className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden />
+                    <span className="truncate">{ws.display_name}</span>
+                  </button>
+                )
+              })}
+            </div>
+          </div>
+        ) : (
+          <p className="mt-5 rounded-md bg-muted px-3 py-2 text-sm text-muted-foreground">
+            You don’t have access to any workspaces right now. Reconnect your account or ask an
+            admin to restore access.
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/WorkspaceSwitcher/WorkspaceSwitcher.tsx
+++ b/frontend/src/components/WorkspaceSwitcher/WorkspaceSwitcher.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react"
 import { useNavigate, useLocation } from "react-router-dom"
 import { Check, ChevronDown, Loader2, Plus, Search, Settings } from "lucide-react"
 import { useAppStore } from "@/store/store"
-import { workspaceDataState, workspaceHasData } from "@/api/workspaces"
+import { workspaceDataState, workspaceHasData, workspaceHasAccess } from "@/api/workspaces"
 import type { TenantMembership } from "@/store/domainSlice"
 import { getProviderMeta } from "@/components/WorkspaceBadge/providerMeta"
 import { getRecentWorkspaceIds, recordWorkspaceUse } from "@/lib/recentWorkspaces"
@@ -141,6 +141,25 @@ function WorkspaceRow({ ws, active, highlighted, onSelect, onHover, onSettings }
   )
 }
 
+/** A workspace the user has lost upstream access to: shown for context but
+ *  not selectable — the only way in is the lost-access modal's guidance. */
+function LostAccessRow({ ws }: { ws: TenantMembership }) {
+  const { Icon } = getProviderMeta(firstProvider(ws))
+  return (
+    <div
+      data-testid={`domain-item-lost-${ws.id}`}
+      aria-disabled
+      title="You no longer have access to this workspace"
+      style={{ height: ROW_HEIGHT }}
+      className="flex w-full cursor-not-allowed items-center gap-2 rounded-sm px-2 text-left text-sm text-muted-foreground/50"
+    >
+      <Icon className="h-3.5 w-3.5 shrink-0" aria-hidden />
+      <span className="flex-1 truncate">{ws.display_name}</span>
+      <span className="shrink-0 text-xs">No access</span>
+    </div>
+  )
+}
+
 interface WorkspaceSwitcherProps {
   /**
    * Visual treatment of the popover trigger.
@@ -175,30 +194,35 @@ export function WorkspaceSwitcher({ variant = "sidebar" }: WorkspaceSwitcherProp
   const scrollRef = useRef<HTMLDivElement>(null)
   const [scrollTop, setScrollTop] = useState(0)
 
+  // The active workspace may be an orphan reached by deep link, so look across
+  // ALL domains here. Everything else lists only workspaces the user can still
+  // access; lost-access ones surface in a separate, disabled section.
   const activeWorkspace = domains.find((d) => d.id === activeDomainId)
+  const accessible = useMemo(() => domains.filter(workspaceHasAccess), [domains])
+  const lost = useMemo(() => domains.filter((d) => !workspaceHasAccess(d)), [domains])
 
   // Providers present across the user's workspaces, ordered by count desc.
   const providers = useMemo(() => {
     const counts = new Map<string, number>()
-    for (const ws of domains) {
+    for (const ws of accessible) {
       for (const p of new Set((ws.tenants ?? []).map((t) => t.provider))) {
         counts.set(p, (counts.get(p) ?? 0) + 1)
       }
     }
     return [...counts.entries()].sort((a, b) => b[1] - a[1]).map(([value, count]) => ({ value, count }))
-  }, [domains])
+  }, [accessible])
 
   // Segmented controls only earn their space when there's enough to navigate.
-  const showSegments = domains.length >= SEGMENT_MIN_WORKSPACES || providers.length > 1
+  const showSegments = accessible.length >= SEGMENT_MIN_WORKSPACES || providers.length > 1
 
   // Recent workspaces (newest first), filtered to ones the user still has.
   const recent = useMemo(() => {
-    const byId = new Map(domains.map((d) => [d.id, d]))
+    const byId = new Map(accessible.map((d) => [d.id, d]))
     return recentIds
       .map((id) => byId.get(id))
       .filter((d): d is TenantMembership => d != null)
       .slice(0, RECENT_LIMIT)
-  }, [domains, recentIds])
+  }, [accessible, recentIds])
 
   const visible = useMemo(() => {
     const q = search.trim().toLowerCase()
@@ -210,13 +234,13 @@ export function WorkspaceSwitcher({ variant = "sidebar" }: WorkspaceSwitcherProp
     // When searching, ignore the Recent segment and search across everything.
     let base: TenantMembership[]
     if (q) {
-      base = domains
+      base = accessible
     } else if (segment === "recent") {
       base = recent
     } else if (segment === "all") {
-      base = domains
+      base = accessible
     } else {
-      base = domains.filter((ws) => hasProvider(ws, segment))
+      base = accessible.filter((ws) => hasProvider(ws, segment))
     }
 
     let list = base.filter(matchesSearch)
@@ -227,7 +251,20 @@ export function WorkspaceSwitcher({ variant = "sidebar" }: WorkspaceSwitcherProp
       list = [...list].sort((a, b) => a.display_name.localeCompare(b.display_name))
     }
     return list
-  }, [domains, recent, search, segment, hasDataOnly])
+  }, [accessible, recent, search, segment, hasDataOnly])
+
+  // Lost-access workspaces matching the current search, shown disabled below.
+  const lostVisible = useMemo(() => {
+    const q = search.trim().toLowerCase()
+    const list = q
+      ? lost.filter(
+          (ws) =>
+            ws.display_name.toLowerCase().includes(q) ||
+            (ws.tenants ?? []).some((t) => t.tenant_name.toLowerCase().includes(q)),
+        )
+      : lost
+    return [...list].sort((a, b) => a.display_name.localeCompare(b.display_name))
+  }, [lost, search])
 
   function resetView() {
     setHighlight(0)
@@ -320,7 +357,7 @@ export function WorkspaceSwitcher({ variant = "sidebar" }: WorkspaceSwitcherProp
   }
   const segmentCount = (key: SegmentKey): number | null => {
     if (key === "recent") return recent.length || null
-    if (key === "all") return domains.length
+    if (key === "all") return accessible.length
     return providers.find((p) => p.value === key)?.count ?? null
   }
 
@@ -481,7 +518,7 @@ export function WorkspaceSwitcher({ variant = "sidebar" }: WorkspaceSwitcherProp
             style={{ maxHeight: LIST_MAX_HEIGHT }}
             data-testid="workspace-list"
           >
-            {visible.length === 0 ? (
+            {visible.length === 0 && lostVisible.length === 0 ? (
               <p className="px-2 py-6 text-center text-sm text-muted-foreground">
                 {hasDataOnly
                   ? "No workspaces with data yet."
@@ -513,6 +550,15 @@ export function WorkspaceSwitcher({ variant = "sidebar" }: WorkspaceSwitcherProp
                     )
                   })}
                 </div>
+              </div>
+            )}
+
+            {lostVisible.length > 0 && (
+              <div data-testid="workspace-list-lost" className="mt-1 border-t pt-1">
+                <p className="px-2 py-1 text-xs font-medium text-muted-foreground/70">No access</p>
+                {lostVisible.map((ws) => (
+                  <LostAccessRow key={ws.id} ws={ws} />
+                ))}
               </div>
             )}
           </div>

--- a/frontend/src/store/domainSlice.test.ts
+++ b/frontend/src/store/domainSlice.test.ts
@@ -55,3 +55,45 @@ describe("domainSlice.ensureTenant — surfaces failure, not empty (07#6)", () =
     expect(useAppStore.getState().domainsError).toBeNull()
   })
 })
+
+describe("domainSlice.fetchDomains — default pick skips lost-access workspaces", () => {
+  beforeEach(() => {
+    useAppStore.setState({ activeDomainId: null, domains: [], domainsStatus: "idle" })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  const ws = (id: string, has_access: boolean) => ({
+    id,
+    name: id,
+    display_name: id,
+    is_auto_created: false,
+    role: "manage",
+    tenants: [{ id: `t-${id}`, tenant_name: id, provider: "commcare" }],
+    has_access,
+    member_count: 1,
+    schema_status: "available",
+    last_synced_at: null,
+    created_at: "2026-01-01T00:00:00Z",
+  })
+
+  it("defaults to the first accessible workspace, not an orphan listed first", async () => {
+    const { workspaceApi } = await import("@/api/workspaces")
+    vi.spyOn(workspaceApi, "list").mockResolvedValue([ws("skelly", false), ws("live", true)] as never)
+
+    await useAppStore.getState().domainActions.fetchDomains()
+
+    expect(useAppStore.getState().activeDomainId).toBe("live")
+  })
+
+  it("falls back to the first workspace when none are accessible", async () => {
+    const { workspaceApi } = await import("@/api/workspaces")
+    vi.spyOn(workspaceApi, "list").mockResolvedValue([ws("skelly", false)] as never)
+
+    await useAppStore.getState().domainActions.fetchDomains()
+
+    expect(useAppStore.getState().activeDomainId).toBe("skelly")
+  })
+})

--- a/frontend/src/store/domainSlice.ts
+++ b/frontend/src/store/domainSlice.ts
@@ -1,6 +1,6 @@
 import type { StateCreator } from "zustand"
 import { api } from "@/api/client"
-import { workspaceApi, type WorkspaceListItem } from "@/api/workspaces"
+import { workspaceApi, workspaceHasAccess, type WorkspaceListItem } from "@/api/workspaces"
 
 // TenantMembership kept as alias so existing imports continue to work
 export type TenantMembership = WorkspaceListItem & {
@@ -36,11 +36,17 @@ export const createDomainSlice: StateCreator<DomainSlice, [], [], DomainSlice> =
       try {
         const domains = await workspaceApi.list()
         const activeDomainId = get().activeDomainId
+        // Default to the first workspace the user can still access, never an
+        // orphaned one whose upstream access was removed — landing there would
+        // just show the lost-access modal. A deep link to an orphan still works
+        // (the URL→store sync adopts it); this only governs the no-URL default.
+        const defaultId =
+          (domains.find(workspaceHasAccess) ?? domains[0])?.id ?? null
         set({
           domains,
           domainsStatus: "loaded",
           domainsError: null,
-          activeDomainId: activeDomainId ?? (domains[0]?.id ?? null),
+          activeDomainId: activeDomainId ?? defaultId,
         })
       } catch (error) {
         set({

--- a/tests/test_workspace_list_has_access.py
+++ b/tests/test_workspace_list_has_access.py
@@ -1,0 +1,83 @@
+"""GET /api/workspaces/ annotates each workspace with live `has_access`.
+
+The list returns every membership (so orphaned workspaces stay addressable by
+URL), but flags the ones the user has lost upstream tenant access to — the same
+rule apps/workspaces/access.py gates each request with.
+"""
+
+import pytest
+from django.test import Client
+from django.utils import timezone
+
+from apps.users.models import Tenant, TenantMembership
+from apps.workspaces.models import (
+    Workspace,
+    WorkspaceMembership,
+    WorkspaceRole,
+    WorkspaceTenant,
+)
+
+
+@pytest.fixture
+def client():
+    return Client(enforce_csrf_checks=False)
+
+
+def _entry(resp, workspace_id):
+    return next(w for w in resp.json() if w["id"] == str(workspace_id))
+
+
+@pytest.mark.django_db
+def test_member_with_live_tenant_has_access(client, user, workspace):
+    client.force_login(user)
+    resp = client.get("/api/workspaces/")
+    assert resp.status_code == 200
+    assert _entry(resp, workspace.id)["has_access"] is True
+
+
+@pytest.mark.django_db
+def test_member_without_live_tenant_lost_access(client, user):
+    tenant = Tenant.objects.create(
+        provider="commcare", external_id="skelly", canonical_name="skelly"
+    )
+    ws = Workspace.objects.create(name="Skelly WS", created_by=user)
+    WorkspaceTenant.objects.create(workspace=ws, tenant=tenant)
+    WorkspaceMembership.objects.create(workspace=ws, user=user, role=WorkspaceRole.MANAGE)
+    # Member, but no live TenantMembership — upstream access was removed.
+
+    client.force_login(user)
+    resp = client.get("/api/workspaces/")
+
+    entry = _entry(resp, ws.id)
+    assert entry["has_access"] is False
+    assert entry["tenants"][0]["provider"] == "commcare"
+
+
+@pytest.mark.django_db
+def test_zero_tenant_workspace_has_access(client, user):
+    ws = Workspace.objects.create(name="Tenantless", created_by=user)
+    WorkspaceMembership.objects.create(workspace=ws, user=user, role=WorkspaceRole.MANAGE)
+
+    client.force_login(user)
+    resp = client.get("/api/workspaces/")
+
+    assert _entry(resp, ws.id)["has_access"] is True
+
+
+@pytest.mark.django_db
+def test_archived_tenant_membership_lost_access(client, user):
+    """An archived (revoked) TenantMembership must not count as live access."""
+    tenant = Tenant.objects.create(
+        provider="commcare", external_id="revoked", canonical_name="Revoked Domain"
+    )
+    ws = Workspace.objects.create(name="Revoked WS", created_by=user)
+    WorkspaceTenant.objects.create(workspace=ws, tenant=tenant)
+    WorkspaceMembership.objects.create(workspace=ws, user=user, role=WorkspaceRole.MANAGE)
+    TenantMembership.all_objects.create(
+        user=user, tenant=tenant, archived_at=timezone.now()
+    )
+
+    client.force_login(user)
+    resp = client.get("/api/workspaces/")
+
+    assert _entry(resp, ws.id)["has_access"] is False


### PR DESCRIPTION
## Why
#340 only put a small message in the chat sidebar when the active workspace's upstream access was removed. In practice the workspace was still fully clickable — every page just showed its own generic "Failed to load…" (each hitting a bare 403), and worse, `scout.dimagi.com` would *default* you into a dead workspace (e.g. `skelly`) because the client picks the first workspace the list API returns and that list includes orphaned memberships. This is the follow-up flagged in the #328/#340 investigation notes.

Two separate problems, both fixed here:
1. **UX** — you can wander a dead workspace with no clear explanation or way out.
2. **Routing** — a workspace you've lost access to shouldn't be your default landing spot or clutter the switcher (but should stay reachable by URL/bookmark for testing).

## Changes
**Backend — `apps/workspaces/api/workspace_views.py`**
- `GET /api/workspaces/` now returns `has_access` per workspace: `true` iff the workspace has no tenants or the user still shares a *live* `TenantMembership` with it — the same rule `apps/workspaces/access.py` gates each request with. One extra query for the whole list (tenants already prefetched). Rows are **annotated, not dropped**, so orphaned workspaces stay addressable by URL.

**Frontend — routing**
- Shared `workspaceHasAccess()` helper (missing flag ⇒ accessible, so a stale cached payload never locks the app out).
- `fetchDomains` defaults to the first *accessible* workspace instead of `domains[0]`.
- `WorkspaceSwitcher` lists only accessible workspaces in its segments / recent / search, and shows lost-access ones in a separate **disabled "No access" section** (visible for context, not selectable).

**Frontend — modal**
- New `LostAccessModal`, mounted in `AppLayout`: when the active workspace's `has_access === false` (stale default or deep link), a **non-dismissible** modal over a grayed backdrop. It names the provider (e.g. "This is a **CommCare** workspace"), explains access was removed upstream, points to the workspace owner / an admin, and offers a **picker of workspaces you can still access** — the only way out. Handles the no-accessible-workspaces case with guidance instead of an empty picker.

## Tests
- Backend: `tests/test_workspace_list_has_access.py` (live tenant / lost / zero-tenant / archived-tombstone). Broader workspace suite + `test_authorizer_is_sole_gate` still green (81 passed).
- Frontend: `LostAccessModal.test.tsx` (gating, provider naming, picker filtering, switch-on-click, no-access case) + `domainSlice.test.ts` default-pick cases. Full FE suite 73 passed; `tsc`/`bun run build`/`eslint`/`ruff` clean.

## Notes / not in this PR
- Visual QA on a real deploy still worth doing (I couldn't reproduce a lost-access workspace locally without prod-like data).
- Auto-reaping / de-duping orphaned auto-created workspaces (the `skelly` vs `skelly-1` slug/display collision) remains a separate ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)