### PR TITLE
fix: decode URL-encoded credentials in dbt profile generation

### DIFF
--- a/mcp_server/services/dbt_runner.py
+++ b/mcp_server/services/dbt_runner.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import logging
 import threading
 from pathlib import Path
-from urllib.parse import urlparse
+from urllib.parse import unquote, urlparse
 
 import yaml
 from dbt.cli.main import dbtRunner
@@ -58,12 +58,17 @@ def generate_profiles_yml(
             ``None`` the ``role`` key is omitted (dbt connects as the URL user).
     """
     parsed = urlparse(db_url)
+    # urlparse leaves username/password percent-encoded; resolve-database-url.sh
+    # URL-encodes the RDS-managed password (which rotates to values with special
+    # chars). psycopg/Django decode automatically, but dbt receives whatever we
+    # write here verbatim, so decode to match — otherwise auth fails whenever the
+    # password contains an encoded char (SCOUT-DJANGO-1T).
     output = {
         "type": "postgres",
         "host": parsed.hostname or "localhost",
         "port": parsed.port or 5432,
-        "user": parsed.username or "",
-        "password": parsed.password or "",
+        "user": unquote(parsed.username) if parsed.username else "",
+        "password": unquote(parsed.password) if parsed.password else "",
         "dbname": parsed.path.lstrip("/") if parsed.path else "",
         "schema": schema_name,
         # Confine resolution to the target schema only — see docstring.

--- a/tests/test_dbt_runner.py
+++ b/tests/test_dbt_runner.py
@@ -41,6 +41,25 @@ class TestGenerateProfilesYml:
         assert profile["user"] == "myuser"
         assert profile["dbname"] == "analytics"
 
+    def test_percent_encoded_password_is_decoded(self, tmp_path):
+        """resolve-database-url.sh URL-encodes the RDS password; the profile must
+        decode it so dbt authenticates like psycopg/Django do (SCOUT-DJANGO-1T)."""
+        from urllib.parse import quote
+
+        from mcp_server.services.dbt_runner import generate_profiles_yml
+
+        raw_password = "p(a<s>s?[word"
+        db_url = f"postgresql://plat%40form:{quote(raw_password, safe='')}@h:5432/db"
+
+        path = tmp_path / "profiles.yml"
+        generate_profiles_yml(output_path=path, schema_name="s", db_url=db_url)
+
+        import yaml
+
+        profile = yaml.safe_load(path.read_text())["data_explorer"]["outputs"]["tenant_schema"]
+        assert profile["password"] == raw_password
+        assert profile["user"] == "plat@form"
+
     def test_search_path_confined_to_target_schema(self, tmp_path):
         """The profile must pin search_path to the tenant schema only (issue #241,
         04#4): without it dbt creates the relation in the tenant schema but runs


### PR DESCRIPTION
## Problem

The transform (dbt) stage fails with `password authentication failed` — surfaced to users as *"transform stage failed due to a database authentication error"* while raw data loads and queries work fine. Sentry `SCOUT-DJANGO-1T` has fired repeatedly since mid-June on both prod and staging.

## Root cause

`generate_profiles_yml` (`mcp_server/services/dbt_runner.py`) read `urlparse(db_url).password` and wrote it into the dbt profile verbatim. `urlparse()` does **not** decode percent-encoding, but `scripts/resolve-database-url.sh` URL-encodes the DB password when building `DATABASE_URL`/`MANAGED_DATABASE_URL`. psycopg and Django decode transparently, so the app authenticates fine — dbt received the still-encoded string.

The bug stayed latent until the managed password rotated to a value containing characters that require URL-encoding; every transform has failed since. This is unrelated to the connection-limit incident — that was connection *count*, this is credential *parsing*.

## Fix

`unquote()` the username and password so dbt authenticates identically to psycopg/Django. Added a regression test covering a password with encode-requiring characters.

## Test

```
uv run pytest tests/test_dbt_runner.py::TestGenerateProfilesYml -q   # 6 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)