### PR TITLE
fix: stg_visits transform fails on nonexistent user_id column

### DIFF
--- a/apps/transformations/services/connect_staging.py
+++ b/apps/transformations/services/connect_staging.py
@@ -24,11 +24,14 @@ from apps.transformations.services.commcare_staging import (
 
 logger = logging.getLogger(__name__)
 
-# Base columns always present on raw_visits.
+# Base columns always present on raw_visits — must match the raw_visits DDL in
+# mcp_server/services/materializer.py. The loader emits "username" (there is no
+# "user_id" column); listing user_id here made every stg_visits build fail with
+# 'column "user_id" does not exist'.
 _VISIT_BASE_COLUMNS = [
     "visit_id",
     "opportunity_id",
-    "user_id",
+    "username",
     "entity_id",
     "status",
     "deliver_unit_id",

--- a/mcp_server/services/dbt_runner.py
+++ b/mcp_server/services/dbt_runner.py
@@ -129,7 +129,23 @@ def run_dbt(
         res = dbt.invoke(cli_args)
 
     if not res.success:
-        error_msg = str(res.exception) if res.exception else "dbt run failed"
+        # A node-level model failure sets res.success=False but leaves
+        # res.exception None — the real cause (e.g. 'column "x" does not exist')
+        # lives in each node's message. Surface those instead of the opaque
+        # "dbt run failed" so callers/Sentry don't have to dig through dbt logs.
+        node_errors = [
+            f"{r.node.name}: {r.message}"
+            for r in (res.result or [])
+            if hasattr(r, "node")
+            and str(getattr(r, "status", "")) in ("error", "fail")
+            and getattr(r, "message", None)
+        ]
+        if res.exception:
+            error_msg = str(res.exception)
+        elif node_errors:
+            error_msg = "; ".join(node_errors)
+        else:
+            error_msg = "dbt run failed"
         logger.error("dbt run failed: %s", error_msg)
         return {"success": False, "error": error_msg, "models": {}}
 

--- a/tests/test_connect_staging.py
+++ b/tests/test_connect_staging.py
@@ -49,6 +49,19 @@ def connect_tenant(db):
 
 
 @pytest.mark.django_db(transaction=True)
+def test_stg_visits_selects_only_real_raw_visits_columns(connect_tenant):
+    """Base columns must match the raw_visits DDL (materializer.py): the loader
+    emits `username`, not `user_id`. Guards against the mismatch that made every
+    stg_visits build fail with 'column "user_id" does not exist'."""
+    assets = generate_connect_assets(FORM_DEFS, connect_tenant)
+    sql = {a.name: a for a in assets}["stg_visits"].sql_content
+
+    assert "username" in sql
+    # user_id is not a raw_visits column and must never be selected.
+    assert "user_id" not in sql
+
+
+@pytest.mark.django_db(transaction=True)
 def test_generates_visit_staging_with_typed_columns(connect_tenant):
     assets = generate_connect_assets(FORM_DEFS, connect_tenant)
     by_name = {a.name: a for a in assets}

--- a/tests/test_dbt_runner.py
+++ b/tests/test_dbt_runner.py
@@ -169,6 +169,35 @@ class TestRunDbt:
         assert result["success"] is False
         assert "error" in result
 
+    def test_surfaces_node_error_when_no_exception(self, tmp_path):
+        """Node-level model failures (success=False, exception=None) must surface
+        the per-node message, not the opaque 'dbt run failed' (SCOUT-DJANGO-1T)."""
+        from mcp_server.services.dbt_runner import run_dbt
+
+        node = MagicMock()
+        node.name = "stg_visits"
+        failed = MagicMock(node=node, status="error")
+        failed.message = 'column "user_id" does not exist'
+
+        mock_result = MagicMock()
+        mock_result.success = False
+        mock_result.exception = None
+        mock_result.result = [failed]
+
+        mock_runner = MagicMock()
+        mock_runner.invoke.return_value = mock_result
+
+        with patch("mcp_server.services.dbt_runner.dbtRunner", return_value=mock_runner):
+            result = run_dbt(
+                dbt_project_dir=str(tmp_path),
+                profiles_dir=str(tmp_path),
+                models=["stg_visits"],
+            )
+
+        assert result["success"] is False
+        assert "stg_visits" in result["error"]
+        assert 'column "user_id" does not exist' in result["error"]
+
     def test_passes_correct_cli_args(self, tmp_path):
         from mcp_server.services.dbt_runner import run_dbt
 


### PR DESCRIPTION
## Problem

After #342 fixed the dbt auth error, the transform stage still fails: `Stage 'system' failed: dbt run failed`. The real cause (buried in dbt logs) is:

```
Database Error in model stg_visits (models/stg_visits.sql)
  column "user_id" does not exist
```

Every `stg_visits` build has failed, so no staging/`stg_*` models exist for Connect tenants. It was masked by the auth bug — dbt never executed the SQL until #342 landed.

## Root cause

`connect_staging._VISIT_BASE_COLUMNS` lists `user_id`, but the `raw_visits` loader (`mcp_server/services/materializer.py`) creates the table with `username` — there is no `user_id` column. Confirmed against all 17 tenant `raw_visits` tables in production. The mismatch has existed since the file was first added.

## Fix

1. **`user_id` → `username`** in `_VISIT_BASE_COLUMNS` so staging selects the column the loader actually produces. Verified the corrected base-column `SELECT` resolves against real tenant `raw_visits` tables.
2. **Surface per-model dbt errors.** `run_dbt` returned the opaque `"dbt run failed"` whenever a node failed without a top-level exception, discarding each node's message. It now joins the failed nodes' messages so the real reason reaches the caller / `TransformationAssetRun.logs` / Sentry — this is what forced a CloudWatch dig to diagnose.

## Tests

```
uv run pytest tests/test_connect_staging.py tests/test_dbt_runner.py -q
```

New regression tests: `stg_visits` never selects `user_id`; `run_dbt` surfaces node-level error messages.

Note: takes effect after deploy + a fresh materialization (the stg_visits asset SQL is regenerated per run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)