### PR TITLE
fix(workspaces): grant _ro SELECT on dbt-materialized tables

### DIFF
--- a/apps/workspaces/services/schema_manager.py
+++ b/apps/workspaces/services/schema_manager.py
@@ -703,6 +703,23 @@ class SchemaManager:
             )
         )
         self._create_dbt_role(cursor, schema_name)
+        # dbt materializes staging tables while SET ROLE'd to the _dbt confinement
+        # role (issue #241), so those tables are owned by _dbt, not CURRENT_USER —
+        # the CURRENT_USER default-privilege grant above never reaches them, and the
+        # _ro role gets "permission denied for table stg_visits" at query time. Set
+        # default privileges FOR the dbt role too so its future tables are readable
+        # by _ro. Safe because _create_dbt_role granted the dbt role TO CURRENT_USER,
+        # which is the membership ALTER DEFAULT PRIVILEGES FOR ROLE requires.
+        cursor.execute(
+            psycopg.sql.SQL(
+                "ALTER DEFAULT PRIVILEGES FOR ROLE {} IN SCHEMA {} "
+                "GRANT SELECT ON TABLES TO {}"
+            ).format(
+                psycopg.sql.Identifier(dbt_role_name(schema_name)),
+                psycopg.sql.Identifier(schema_name),
+                psycopg.sql.Identifier(role_name),
+            )
+        )
 
     def _revoke_stale_view_role_grants(
         self, cursor, role_name: str, current_schemas: set[str]

--- a/tests/test_dbt_confinement.py
+++ b/tests/test_dbt_confinement.py
@@ -173,6 +173,42 @@ def test_generated_staging_model_resolves_raw_cases(confinement_schemas, setting
 
 
 @pytest.mark.django_db(transaction=True)
+def test_readonly_role_can_read_dbt_materialized_table(confinement_schemas, managed_conn):
+    """The ``_ro`` query role can SELECT a table dbt materialized under the ``_dbt``
+    confinement role.
+
+    Regression for the prod ``permission denied for table stg_visits`` error: since
+    issue #241 dbt owns the tables it creates, so the CURRENT_USER default-privilege
+    grant never reached them and the ``_ro`` role (used by the MCP query path via
+    ``SET ROLE``) could not read freshly materialized staging tables.
+    """
+    attacker_schema, _, attacker_tenant = confinement_schemas
+
+    TransformationAsset.objects.create(
+        name="stg_case_patient",
+        scope=TransformationScope.SYSTEM,
+        tenant=attacker_tenant,
+        sql_content="SELECT case_id, case_type FROM raw_cases WHERE case_type = 'patient'",
+    )
+    run = run_transformation_pipeline(tenant=attacker_tenant, schema_name=attacker_schema)
+    assert run.status == TransformationRunStatus.COMPLETED, run.error_message
+
+    ro_role = f"{attacker_schema}_ro"
+    cur = managed_conn.cursor()
+    cur.execute(psycopg.sql.SQL("SET ROLE {}").format(psycopg.sql.Identifier(ro_role)))
+    try:
+        cur.execute(
+            psycopg.sql.SQL("SELECT count(*) FROM {}.stg_case_patient").format(
+                psycopg.sql.Identifier(attacker_schema)
+            )
+        )
+        assert cur.fetchone()[0] == 1
+    finally:
+        managed_conn.rollback()
+        cur.execute("RESET ROLE")
+
+
+@pytest.mark.django_db(transaction=True)
 def test_cross_tenant_asset_cannot_materialize(confinement_schemas):
     """A SYSTEM asset whose free-text SQL reaches into ANOTHER tenant's schema
     cannot materialize: dbt runs it under the confinement role, which lacks USAGE


### PR DESCRIPTION
## Problem

The MCP query path runs `SET ROLE {schema}_ro` and reads tenant tables directly, but the read-only role could not SELECT tables materialized by dbt, failing with `permission denied`.

Root cause: since issue #241, dbt materializes staging tables while `SET ROLE`'d to the per-schema `{schema}_dbt` confinement role, so those tables are **owned by `_dbt`**, not the managed-DB user. The `_ro` role's only SELECT grant came from `ALTER DEFAULT PRIVILEGES FOR ROLE CURRENT_USER … GRANT SELECT … TO {ro}`, and Postgres keys default privileges to the **creating** role — so dbt-owned tables were never covered. (Before #241 dbt ran as CURRENT_USER, so the grant applied; #241 regressed it.)

## Fix

In `_create_readonly_role`, also set `ALTER DEFAULT PRIVILEGES FOR ROLE {dbt_role} IN SCHEMA {schema} GRANT SELECT ON TABLES TO {ro}`. Valid because `_create_dbt_role` already grants the dbt role `TO CURRENT_USER`, which is the membership `ALTER DEFAULT PRIVILEGES FOR ROLE` requires.

Covers schemas provisioned/refreshed going forward. **Existing** schemas need `manage.py backfill_readonly_roles`, which grants SELECT on already-materialized tables and (with this change) sets the corrected default privileges.

## Test

Real-DB regression test in `tests/test_dbt_confinement.py`: materializes a staging model owned by the `_dbt` role, then asserts the `_ro` role can SELECT it. Fails without the fix with `permission denied`; passes with it.

## Follow-ups (separate PR)

- The workspace view role holds `USAGE`+`SELECT` on raw tenant schemas it doesn't need (views run with owner privileges), causing cross-tenant over-exposure and a `pg_default_acl` role-teardown leak.
- `materialized_view` assets aren't covered by `ALTER DEFAULT PRIVILEGES … ON TABLES` and need an explicit post-materialization grant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)