### PR TITLE
fix(workspaces): stop granting the view role access to raw tenant schemas

### DIFF
--- a/apps/workspaces/management/commands/backfill_readonly_roles.py
+++ b/apps/workspaces/management/commands/backfill_readonly_roles.py
@@ -102,39 +102,14 @@ class Command(BaseCommand):
         )
 
     def _backfill_view_schema(self, cursor, mgr, vs) -> None:
-        """Create the view-schema role and grant it access to constituent tenant schemas.
+        """Backfill the view-schema role.
 
-        Mirrors build_view_schema: the role gets SELECT on existing tables in each
-        constituent tenant schema AND default privileges, so a rematerialization
-        that runs between view rebuilds doesn't leave the new tables unreadable.
+        The view role needs access to the view schema ONLY: the views are owned by
+        CURRENT_USER and run with owner privileges, so the role never reads the raw
+        tenant schemas directly. Also revoke any tenant-schema grants left by
+        earlier versions — they widened cross-tenant reach and their default-ACL
+        entries blocked role teardown.
         """
         self._backfill_schema(cursor, mgr, vs.schema_name)
         role = readonly_role_name(vs.schema_name)
-        tenant_schemas_for_ws = TenantSchema.objects.filter(
-            tenant__in=vs.workspace.tenants.all(),
-            state=SchemaState.ACTIVE,
-        )
-        for ts in tenant_schemas_for_ws:
-            cursor.execute(
-                psycopg.sql.SQL("GRANT USAGE ON SCHEMA {} TO {}").format(
-                    psycopg.sql.Identifier(ts.schema_name),
-                    psycopg.sql.Identifier(role),
-                )
-            )
-            cursor.execute(
-                psycopg.sql.SQL("GRANT SELECT ON ALL TABLES IN SCHEMA {} TO {}").format(
-                    psycopg.sql.Identifier(ts.schema_name),
-                    psycopg.sql.Identifier(role),
-                )
-            )
-            # Default privileges so tables created later (by a rematerialization
-            # before the view is rebuilt) are still readable through this role.
-            cursor.execute(
-                psycopg.sql.SQL(
-                    "ALTER DEFAULT PRIVILEGES FOR ROLE CURRENT_USER IN SCHEMA {} "
-                    "GRANT SELECT ON TABLES TO {}"
-                ).format(
-                    psycopg.sql.Identifier(ts.schema_name),
-                    psycopg.sql.Identifier(role),
-                )
-            )
+        mgr._revoke_stale_view_role_grants(cursor, role, {vs.schema_name})

--- a/apps/workspaces/services/schema_manager.py
+++ b/apps/workspaces/services/schema_manager.py
@@ -403,11 +403,18 @@ class SchemaManager:
 
             view_role = readonly_role_name(view_schema_name)
 
-            # The _ro role is reused across rebuilds; revoke grants on tenants no
-            # longer in the workspace, else a removed tenant's data stays reachable
-            # (issue #244).
-            current_schemas = {view_schema_name} | {s for s, _ in tenant_schemas}
-            self._revoke_stale_view_role_grants(cursor, view_role, current_schemas)
+            # The view role needs access to the view schema ONLY. The views are
+            # owned by CURRENT_USER and created with plain CREATE VIEW (no
+            # security_invoker), so reads through them resolve the underlying
+            # tenant tables with the OWNER's privileges — the view role never
+            # touches the raw tenant schemas directly. Granting it USAGE/SELECT
+            # there was therefore unnecessary and widened cross-tenant reach (a
+            # SET ROLE {view_role} session could read raw tenant tables), and the
+            # tenant-schema default-ACL entries it left behind blocked DROP ROLE
+            # at teardown. Revoke any such grants left by earlier versions by
+            # scoping the "keep" set to the view schema alone (issue #244 cleanup
+            # of removed tenants still holds — they're revoked here too).
+            self._revoke_stale_view_role_grants(cursor, view_role, {view_schema_name})
 
             # ALTER DEFAULT PRIVILEGES only covers future tables, not the views
             # just created — grant SELECT on them explicitly.
@@ -417,21 +424,6 @@ class SchemaManager:
                     psycopg.sql.Identifier(view_role),
                 )
             )
-
-            # Views reference the constituent tenant schemas directly.
-            for tenant_schema_name, _ in tenant_schemas:
-                cursor.execute(
-                    psycopg.sql.SQL("GRANT USAGE ON SCHEMA {} TO {}").format(
-                        psycopg.sql.Identifier(tenant_schema_name),
-                        psycopg.sql.Identifier(view_role),
-                    )
-                )
-                cursor.execute(
-                    psycopg.sql.SQL("GRANT SELECT ON ALL TABLES IN SCHEMA {} TO {}").format(
-                        psycopg.sql.Identifier(tenant_schema_name),
-                        psycopg.sql.Identifier(view_role),
-                    )
-                )
 
             cursor.close()
         except Exception as exc:
@@ -562,6 +554,20 @@ class SchemaManager:
         WHERE r.rolname = %s
     """
 
+    # Finds (schema, owning-role) pairs where the role is a grantee in a schema's
+    # DEFAULT PRIVILEGES. These pg_default_acl entries also survive DROP SCHEMA
+    # CASCADE (the schema they target may be a *different* one that still exists)
+    # and, like direct ACLs, block DROP ROLE. Earlier versions set such entries on
+    # the constituent tenant schemas for the workspace view role.
+    _SCHEMAS_WITH_ROLE_DEFAULT_ACLS_SQL = """
+        SELECT DISTINCT n.nspname, pg_get_userbyid(d.defaclrole) AS owner_role
+        FROM pg_default_acl d
+        JOIN pg_namespace n ON n.oid = d.defaclnamespace
+        CROSS JOIN aclexplode(d.defaclacl) AS acl
+        JOIN pg_roles r ON r.oid = acl.grantee
+        WHERE r.rolname = %s AND d.defaclobjtype = 'r'
+    """
+
     async def _adrop_readonly_role(self, cursor, schema_name: str) -> None:
         """Async version of _drop_readonly_role."""
         role_name = readonly_role_name(schema_name)
@@ -579,6 +585,18 @@ class SchemaManager:
             )
             await cursor.execute(
                 psycopg.sql.SQL("REVOKE ALL PRIVILEGES ON SCHEMA {} FROM {}").format(
+                    psycopg.sql.Identifier(schema),
+                    psycopg.sql.Identifier(role_name),
+                )
+            )
+        await cursor.execute(self._SCHEMAS_WITH_ROLE_DEFAULT_ACLS_SQL, (role_name,))
+        for schema, owner_role in await cursor.fetchall():
+            await cursor.execute(
+                psycopg.sql.SQL(
+                    "ALTER DEFAULT PRIVILEGES FOR ROLE {} IN SCHEMA {} "
+                    "REVOKE ALL ON TABLES FROM {}"
+                ).format(
+                    psycopg.sql.Identifier(owner_role),
                     psycopg.sql.Identifier(schema),
                     psycopg.sql.Identifier(role_name),
                 )
@@ -611,6 +629,18 @@ class SchemaManager:
             )
             cursor.execute(
                 psycopg.sql.SQL("REVOKE ALL PRIVILEGES ON SCHEMA {} FROM {}").format(
+                    psycopg.sql.Identifier(schema),
+                    psycopg.sql.Identifier(role_name),
+                )
+            )
+        cursor.execute(self._SCHEMAS_WITH_ROLE_DEFAULT_ACLS_SQL, (role_name,))
+        for schema, owner_role in cursor.fetchall():
+            cursor.execute(
+                psycopg.sql.SQL(
+                    "ALTER DEFAULT PRIVILEGES FOR ROLE {} IN SCHEMA {} "
+                    "REVOKE ALL ON TABLES FROM {}"
+                ).format(
+                    psycopg.sql.Identifier(owner_role),
                     psycopg.sql.Identifier(schema),
                     psycopg.sql.Identifier(role_name),
                 )

--- a/tests/test_backfill_readonly_roles.py
+++ b/tests/test_backfill_readonly_roles.py
@@ -161,10 +161,12 @@ class TestBackfillReadonlyRoles:
         assert not any("CREATE ROLE" in c for c in calls)
         assert not any("GRANT" in c for c in calls)
 
-    def test_view_schema_grants_default_privileges_on_tenant_schemas(
+    def test_view_schema_backfill_grants_nothing_on_tenant_schemas(
         self, tenant_membership, workspace
     ):
-        """View role must get ALTER DEFAULT PRIVILEGES on constituent tenant schemas (11#8)."""
+        """The view role must NOT be granted any access to raw tenant schemas: the
+        views run with owner privileges, so such grants are unnecessary cross-tenant
+        over-exposure (and their default-ACL entries block role teardown)."""
         ts = TenantSchema.objects.create(
             tenant=tenant_membership.tenant,
             schema_name="ws_tenant",
@@ -181,6 +183,7 @@ class TestBackfillReadonlyRoles:
         mock_conn = MagicMock()
         mock_cursor = MagicMock()
         mock_cursor.fetchone.return_value = None
+        mock_cursor.fetchall.return_value = []
         mock_conn.cursor.return_value = mock_cursor
 
         with patch(
@@ -191,9 +194,10 @@ class TestBackfillReadonlyRoles:
 
         view_role = readonly_role_name(vs.schema_name)
         calls = [str(c) for c in mock_cursor.execute.call_args_list]
-        # The view role must hold ALTER DEFAULT PRIVILEGES on the tenant schema so a
-        # rematerialization between view rebuilds doesn't leave new tables unreadable.
-        assert any(
+        assert not any(
+            "GRANT" in c and ts.schema_name in c and view_role in c for c in calls
+        ), "view role must not be granted access to raw tenant schemas"
+        assert not any(
             "ALTER DEFAULT PRIVILEGES" in c and ts.schema_name in c and view_role in c
             for c in calls
-        ), "view role needs default privileges on constituent tenant schemas"
+        )

--- a/tests/test_schema_manager.py
+++ b/tests/test_schema_manager.py
@@ -517,7 +517,7 @@ class TestBuildViewSchemaProviderSafety:
 
 @pytest.mark.django_db
 class TestViewSchemaRoleCreation:
-    def test_build_view_schema_creates_readonly_role_with_tenant_grants(
+    def test_build_view_schema_creates_readonly_role_without_tenant_grants(
         self, workspace, tenant_membership
     ):
         ts = TenantSchema.objects.create(
@@ -548,14 +548,13 @@ class TestViewSchemaRoleCreation:
         assert any("CREATE ROLE" in c and view_role_name in c for c in calls), (
             f"Expected CREATE ROLE for {view_role_name}"
         )
-        # Should grant USAGE on view schema
+        # Should grant USAGE on the view schema
         assert any("GRANT USAGE ON SCHEMA" in c and vs.schema_name in c for c in calls)
-        # Should grant SELECT on constituent tenant schema tables
-        assert any(
-            "GRANT SELECT ON ALL TABLES IN SCHEMA" in c and ts.schema_name in c for c in calls
+        # Must NOT grant anything to the view role on the raw tenant schema: views
+        # run with owner privileges, so such grants are unnecessary over-exposure.
+        assert not any("GRANT" in c and ts.schema_name in c for c in calls), (
+            "view role must not be granted access to raw tenant schemas"
         )
-        # Should grant USAGE on constituent tenant schema
-        assert any("GRANT USAGE ON SCHEMA" in c and ts.schema_name in c for c in calls)
 
 
 class _AsyncCursor:

--- a/tests/test_view_schema_builder.py
+++ b/tests/test_view_schema_builder.py
@@ -17,7 +17,11 @@ from apps.workspaces.models import (
     WorkspaceTenant,
     WorkspaceViewSchema,
 )
-from apps.workspaces.services.schema_manager import SchemaManager, readonly_role_name
+from apps.workspaces.services.schema_manager import (
+    SchemaManager,
+    dbt_role_name,
+    readonly_role_name,
+)
 
 pytestmark = pytest.mark.skipif(
     not os.environ.get("MANAGED_DATABASE_URL"),
@@ -293,7 +297,9 @@ def test_build_view_schema_three_tables_three_views(two_tenant_workspace, manage
 
 
 def test_build_view_schema_readonly_role_has_access(two_tenant_workspace, managed_db_connection):
-    """Read-only role has access to the view schema and both underlying tenant schemas."""
+    """Read-only role can read through the views but has NO direct access to the raw
+    tenant schemas — views run with owner privileges, so granting the role tenant
+    access is both unnecessary and cross-tenant over-exposure."""
     from apps.workspaces.models import TenantSchema
     from apps.workspaces.services.schema_manager import SchemaManager, readonly_role_name
 
@@ -322,20 +328,35 @@ def test_build_view_schema_readonly_role_has_access(two_tenant_workspace, manage
 
         c2 = conn.cursor()
         try:
-            # View schema USAGE grant
+            # USAGE on the view schema...
             c2.execute(
                 "SELECT has_schema_privilege(%s, %s, 'USAGE')",
                 (view_role, vs.schema_name),
             )
             assert c2.fetchone()[0] is True
 
-            # Tenant schema USAGE grants
+            # ...but NOT on the raw tenant schemas.
             for schema in ("build_domain_a_ro", "build_domain_b_ro"):
                 c2.execute(
                     "SELECT has_schema_privilege(%s, %s, 'USAGE')",
                     (view_role, schema),
                 )
-                assert c2.fetchone()[0] is True
+                assert c2.fetchone()[0] is False, f"view role should not reach {schema}"
+
+            # And it can actually read through the views (owner-privilege path).
+            c2.execute(
+                "SELECT table_name FROM information_schema.views WHERE table_schema = %s",
+                (vs.schema_name,),
+            )
+            view_names = [r[0] for r in c2.fetchall()]
+            assert view_names
+            c2.execute(f'SET ROLE "{view_role}"')
+            try:
+                for vn in view_names:
+                    c2.execute(f'SELECT count(*) FROM "{vs.schema_name}"."{vn}"')
+                    c2.fetchone()
+            finally:
+                c2.execute("RESET ROLE")
         finally:
             c2.close()
     finally:
@@ -859,7 +880,11 @@ def _role_grant_schemas(cursor, role_name: str) -> set[str]:
 
 def test_rebuild_revokes_ro_grants_on_removed_tenant_schema(db, managed_db_connection):
     """Issue #244: after a tenant is removed and the view schema is rebuilt, the
-    _ro role must no longer hold SELECT/USAGE on the removed tenant's schema."""
+    removed tenant's data must be unreachable through the view role.
+
+    Under the owner-privilege view model the role holds NO direct grants on raw
+    tenant schemas, so the property is enforced by (a) the role only ever reaching
+    the view schema and (b) the rebuild dropping the removed tenant's views."""
     User = get_user_model()
     user = User.objects.create_user(email="revoke@example.com", password="pass")
     # Unique schema names so sibling agents sharing the managed DB don't collide.
@@ -900,26 +925,43 @@ def test_rebuild_revokes_ro_grants_on_removed_tenant_schema(db, managed_db_conne
         c2 = conn.cursor()
         try:
             granted = _role_grant_schemas(c2, view_role)
-            # Initially the role can read all three constituent tenant schemas.
-            assert {sa, sb, sc} <= granted
+            # The role reaches ONLY the view schema — never the raw tenant schemas.
+            assert granted == {vs.schema_name}, sorted(granted)
+            # A view over tenant C's tables exists initially.
+            c2.execute(
+                "SELECT count(*) FROM information_schema.views "
+                "WHERE table_schema = %s AND table_name LIKE 'revoke_c_244__%%'",
+                (vs.schema_name,),
+            )
+            assert c2.fetchone()[0] >= 1
         finally:
             c2.close()
 
         # Remove tenant C from the workspace, then rebuild.
         wt_c.delete()
-        tsc_schema = sc
         vs = SchemaManager().build_view_schema(ws)
 
         c3 = conn.cursor()
         try:
             granted_after = _role_grant_schemas(c3, view_role)
-            # The _ro role must NO LONGER reach the removed tenant's schema.
-            assert tsc_schema not in granted_after, (
-                f"_ro role {view_role} still holds grants on removed schema {tsc_schema}: "
-                f"{sorted(granted_after)}"
+            # Still only the view schema; the removed tenant's raw schema was never
+            # (and is not) directly reachable.
+            assert granted_after == {vs.schema_name}, sorted(granted_after)
+            # C's views are gone, so its data is unreachable through the role...
+            c3.execute(
+                "SELECT count(*) FROM information_schema.views "
+                "WHERE table_schema = %s AND table_name LIKE 'revoke_c_244__%%'",
+                (vs.schema_name,),
             )
-            # ...but still reaches the remaining members.
-            assert {sa, sb} <= granted_after
+            assert c3.fetchone()[0] == 0
+            # ...while the remaining members' views persist.
+            c3.execute(
+                "SELECT count(*) FROM information_schema.views "
+                "WHERE table_schema = %s AND (table_name LIKE 'revoke_a_244__%%' "
+                "OR table_name LIKE 'revoke_b_244__%%')",
+                (vs.schema_name,),
+            )
+            assert c3.fetchone()[0] >= 2
         finally:
             c3.close()
     finally:
@@ -949,3 +991,81 @@ def test_rebuild_revokes_ro_grants_on_removed_tenant_schema(db, managed_db_conne
         tsa.delete()
         tsb.delete()
         tsc.delete()
+
+
+def test_teardown_view_schema_drops_role_despite_stale_default_acl(db, managed_db_connection):
+    """A view role that still holds a pg_default_acl entry on a tenant schema (left
+    by an earlier version that granted default privileges there) must not block
+    DROP ROLE at teardown. The tenant schema outlives the view schema, so that
+    entry survives DROP SCHEMA CASCADE and would strand the role."""
+    User = get_user_model()
+    user = User.objects.create_user(email="leak-acl@example.com", password="pass")
+    t = Tenant.objects.create(
+        provider="commcare", external_id="leak-acl-a", canonical_name="leak_acl_a"
+    )
+    ws = Workspace.objects.create(name="Leak ACL WS", created_by=user)
+    WorkspaceMembership.objects.create(workspace=ws, user=user, role=WorkspaceRole.MANAGE)
+    WorkspaceTenant.objects.create(workspace=ws, tenant=t)
+    sa = "leak_acl_a_sch"
+    ts = TenantSchema.objects.create(tenant=t, schema_name=sa, state=SchemaState.ACTIVE)
+
+    conn = managed_db_connection
+    c = conn.cursor()
+    try:
+        c.execute(psycopg_sql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(psycopg_sql.Identifier(sa)))
+        c.execute(
+            psycopg_sql.SQL("CREATE TABLE IF NOT EXISTS {}.cases (id TEXT)").format(
+                psycopg_sql.Identifier(sa)
+            )
+        )
+    finally:
+        c.close()
+
+    mgr = SchemaManager()
+    vs = None
+    try:
+        vs = mgr.build_view_schema(ws)
+        view_role = readonly_role_name(vs.schema_name)
+
+        # Simulate the pre-fix leftover: a default-ACL entry granting the view role
+        # SELECT on future tables in the tenant schema.
+        c2 = conn.cursor()
+        try:
+            c2.execute(
+                psycopg_sql.SQL(
+                    "ALTER DEFAULT PRIVILEGES FOR ROLE CURRENT_USER IN SCHEMA {} "
+                    "GRANT SELECT ON TABLES TO {}"
+                ).format(psycopg_sql.Identifier(sa), psycopg_sql.Identifier(view_role))
+            )
+        finally:
+            c2.close()
+
+        mgr.teardown_view_schema(vs)
+
+        c3 = conn.cursor()
+        try:
+            c3.execute("SELECT 1 FROM pg_roles WHERE rolname = %s", (view_role,))
+            assert c3.fetchone() is None, f"view role {view_role} dangled after teardown"
+        finally:
+            c3.close()
+    finally:
+        c4 = conn.cursor()
+        try:
+            c4.execute(
+                psycopg_sql.SQL("DROP SCHEMA IF EXISTS {} CASCADE").format(psycopg_sql.Identifier(sa))
+            )
+            for role in (readonly_role_name(sa), dbt_role_name(sa)):
+                c4.execute(
+                    psycopg_sql.SQL("DROP ROLE IF EXISTS {}").format(psycopg_sql.Identifier(role))
+                )
+            if vs:
+                c4.execute(
+                    psycopg_sql.SQL("DROP ROLE IF EXISTS {}").format(
+                        psycopg_sql.Identifier(readonly_role_name(vs.schema_name))
+                    )
+                )
+        finally:
+            c4.close()
+        if vs:
+            vs.delete()
+        ts.delete()


### PR DESCRIPTION
Follow-up to #346. Removes cross-tenant over-exposure and a role-teardown leak in the workspace view-schema role.

## Problem

The workspace view role (`{view_schema}_ro`) was granted `USAGE` + `SELECT ON ALL TABLES` on every constituent raw tenant schema, plus (in `backfill_readonly_roles`) `ALTER DEFAULT PRIVILEGES` there. None of it is needed: workspace views are created with plain `CREATE VIEW` (no `security_invoker`), so reads through them resolve the underlying tenant tables with the **owner's** (CURRENT_USER's) privileges. The view role only needs access to the view schema.

Two issues with the old grants:

1. **Over-exposure** — a `SET ROLE {view_schema}_ro` session could read raw tenant tables directly, across tenant boundaries, instead of only through the workspace's namespaced views.
2. **Role-teardown leak** — the `ALTER DEFAULT PRIVILEGES` entries live in the tenant schemas (`pg_default_acl`), which outlive the view schema. `teardown_view_schema` drops only the view schema, so those entries survive `DROP SCHEMA CASCADE` and block `DROP ROLE`, leaving dangling roles (the error is best-effort-swallowed in teardown, so it accumulated silently).

## Changes

- `build_view_schema`: drop the per-tenant `USAGE`/`SELECT` grants; scope the stale-grant revoke to the view schema so a rebuild also strips grants left by older versions.
- `backfill_readonly_roles`: stop granting on tenant schemas; revoke stale grants instead, so running it remediates already-over-exposed roles.
- `_drop_readonly_role` / `_adrop_readonly_role`: also revoke `pg_default_acl` entries the role is a grantee of (keyed to the owning role) before `DROP ROLE`, so historical default-ACL leftovers no longer strand the role.

## Tests

- View role reads through the views but has no direct tenant access.
- Rebuild makes a removed tenant unreachable (no view + no grant).
- Backfill grants nothing on tenant schemas.
- Teardown drops the role despite a stale default-ACL entry (fails without the revoke with `DependentObjectsStillExist`).

## Remediation

Running `manage.py backfill_readonly_roles` on prod (already needed for #346) also revokes the stale over-exposing grants on existing view roles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)