### PR TITLE
Port materialization + _ro grant fixes onto staging-semantic (for staging deploy)

### DIFF
--- a/apps/transformations/services/connect_staging.py
+++ b/apps/transformations/services/connect_staging.py
@@ -24,7 +24,10 @@ from apps.transformations.services.commcare_staging import (
 
 logger = logging.getLogger(__name__)
 
-# Base columns always present on raw_visits.
+# Base columns always present on raw_visits — must match the raw_visits DDL in
+# mcp_server/services/materializer.py. The loader emits "username" (there is no
+# "user_id" column); listing user_id here made every stg_visits build fail with
+# 'column "user_id" does not exist'.
 _VISIT_BASE_COLUMNS = [
     "visit_id",
     "opportunity_id",

--- a/apps/workspaces/management/commands/backfill_readonly_roles.py
+++ b/apps/workspaces/management/commands/backfill_readonly_roles.py
@@ -104,39 +104,14 @@ class Command(BaseCommand):
         )
 
     def _backfill_view_schema(self, cursor, mgr, vs) -> None:
-        """Create the view-schema role and grant it access to constituent tenant schemas.
+        """Backfill the view-schema role.
 
-        Mirrors build_view_schema: the role gets SELECT on existing tables in each
-        constituent tenant schema AND default privileges, so a rematerialization
-        that runs between view rebuilds doesn't leave the new tables unreadable.
+        The view role needs access to the view schema ONLY: the views are owned by
+        CURRENT_USER and run with owner privileges, so the role never reads the raw
+        tenant schemas directly. Also revoke any tenant-schema grants left by
+        earlier versions — they widened cross-tenant reach and their default-ACL
+        entries blocked role teardown.
         """
         self._backfill_schema(cursor, mgr, vs.schema_name)
         role = readonly_role_name(vs.schema_name)
-        tenant_schemas_for_ws = TenantSchema.objects.filter(
-            tenant__in=vs.workspace.tenants.all(),
-            state=SchemaState.ACTIVE,
-        )
-        for ts in tenant_schemas_for_ws:
-            cursor.execute(
-                psycopg.sql.SQL("GRANT USAGE ON SCHEMA {} TO {}").format(
-                    psycopg.sql.Identifier(ts.schema_name),
-                    psycopg.sql.Identifier(role),
-                )
-            )
-            cursor.execute(
-                psycopg.sql.SQL("GRANT SELECT ON ALL TABLES IN SCHEMA {} TO {}").format(
-                    psycopg.sql.Identifier(ts.schema_name),
-                    psycopg.sql.Identifier(role),
-                )
-            )
-            # Default privileges so tables created later (by a rematerialization
-            # before the view is rebuilt) are still readable through this role.
-            cursor.execute(
-                psycopg.sql.SQL(
-                    "ALTER DEFAULT PRIVILEGES FOR ROLE CURRENT_USER IN SCHEMA {} "
-                    "GRANT SELECT ON TABLES TO {}"
-                ).format(
-                    psycopg.sql.Identifier(ts.schema_name),
-                    psycopg.sql.Identifier(role),
-                )
-            )
+        mgr._revoke_stale_view_role_grants(cursor, role, {vs.schema_name})

--- a/apps/workspaces/services/schema_manager.py
+++ b/apps/workspaces/services/schema_manager.py
@@ -766,6 +766,13 @@ class SchemaManager:
         )
         # Confinement role for the dbt transform phase (issue #241).
         self._create_dbt_role(cursor, schema_name)
+        # dbt materializes staging tables while SET ROLE'd to the _dbt confinement
+        # role (issue #241), so those tables are owned by _dbt, not CURRENT_USER —
+        # the CURRENT_USER default-privilege grant above never reaches them, and the
+        # _ro role gets "permission denied for table stg_visits" at query time. Set
+        # default privileges FOR the dbt role too so its future tables are readable
+        # by _ro. Safe because _create_dbt_role granted the dbt role TO CURRENT_USER,
+        # which is the membership ALTER DEFAULT PRIVILEGES FOR ROLE requires.
         cursor.execute(
             psycopg.sql.SQL(
                 "ALTER DEFAULT PRIVILEGES FOR ROLE {} IN SCHEMA {} "

--- a/apps/workspaces/services/schema_manager.py
+++ b/apps/workspaces/services/schema_manager.py
@@ -438,13 +438,18 @@ class SchemaManager:
 
             view_role = readonly_role_name(view_schema_name)
 
-            # Revoke grants the role still holds on tenant schemas that are no
-            # longer part of this workspace. The role is reused across rebuilds,
-            # so without this a removed tenant's schema keeps SELECT/USAGE for
-            # the _ro role — leaving the prior tenant's data reachable through a
-            # role that should only see the current members (issue #244).
-            current_schemas = {view_schema_name} | {s for s, _ in tenant_schemas}
-            self._revoke_stale_view_role_grants(cursor, view_role, current_schemas)
+            # The view role needs access to the view schema ONLY. The views are
+            # owned by CURRENT_USER and created with plain CREATE VIEW (no
+            # security_invoker), so reads through them resolve the underlying
+            # tenant tables with the OWNER's privileges — the view role never
+            # touches the raw tenant schemas directly. Granting it USAGE/SELECT
+            # there was therefore unnecessary and widened cross-tenant reach (a
+            # SET ROLE {view_role} session could read raw tenant tables), and the
+            # tenant-schema default-ACL entries it left behind blocked DROP ROLE
+            # at teardown. Revoke any such grants left by earlier versions by
+            # scoping the "keep" set to the view schema alone (issue #244 cleanup
+            # of removed tenants still holds — they're revoked here too).
+            self._revoke_stale_view_role_grants(cursor, view_role, {view_schema_name})
 
             # Grant SELECT on the views themselves (ALTER DEFAULT PRIVILEGES
             # only covers future tables, not the views just created above)
@@ -454,22 +459,6 @@ class SchemaManager:
                     psycopg.sql.Identifier(view_role),
                 )
             )
-
-            # Grant read access to each constituent tenant schema
-            # (views reference tables in these schemas directly)
-            for tenant_schema_name, _ in tenant_schemas:
-                cursor.execute(
-                    psycopg.sql.SQL("GRANT USAGE ON SCHEMA {} TO {}").format(
-                        psycopg.sql.Identifier(tenant_schema_name),
-                        psycopg.sql.Identifier(view_role),
-                    )
-                )
-                cursor.execute(
-                    psycopg.sql.SQL("GRANT SELECT ON ALL TABLES IN SCHEMA {} TO {}").format(
-                        psycopg.sql.Identifier(tenant_schema_name),
-                        psycopg.sql.Identifier(view_role),
-                    )
-                )
 
             cursor.close()
         except Exception as exc:
@@ -600,6 +589,20 @@ class SchemaManager:
         WHERE r.rolname = %s
     """
 
+    # Finds (schema, owning-role) pairs where the role is a grantee in a schema's
+    # DEFAULT PRIVILEGES. These pg_default_acl entries also survive DROP SCHEMA
+    # CASCADE (the schema they target may be a *different* one that still exists)
+    # and, like direct ACLs, block DROP ROLE. Earlier versions set such entries on
+    # the constituent tenant schemas for the workspace view role.
+    _SCHEMAS_WITH_ROLE_DEFAULT_ACLS_SQL = """
+        SELECT DISTINCT n.nspname, pg_get_userbyid(d.defaclrole) AS owner_role
+        FROM pg_default_acl d
+        JOIN pg_namespace n ON n.oid = d.defaclnamespace
+        CROSS JOIN aclexplode(d.defaclacl) AS acl
+        JOIN pg_roles r ON r.oid = acl.grantee
+        WHERE r.rolname = %s AND d.defaclobjtype = 'r'
+    """
+
     async def _adrop_readonly_role(self, cursor, schema_name: str) -> None:
         """Async version of _drop_readonly_role."""
         role_name = readonly_role_name(schema_name)
@@ -617,6 +620,18 @@ class SchemaManager:
             )
             await cursor.execute(
                 psycopg.sql.SQL("REVOKE ALL PRIVILEGES ON SCHEMA {} FROM {}").format(
+                    psycopg.sql.Identifier(schema),
+                    psycopg.sql.Identifier(role_name),
+                )
+            )
+        await cursor.execute(self._SCHEMAS_WITH_ROLE_DEFAULT_ACLS_SQL, (role_name,))
+        for schema, owner_role in await cursor.fetchall():
+            await cursor.execute(
+                psycopg.sql.SQL(
+                    "ALTER DEFAULT PRIVILEGES FOR ROLE {} IN SCHEMA {} "
+                    "REVOKE ALL ON TABLES FROM {}"
+                ).format(
+                    psycopg.sql.Identifier(owner_role),
                     psycopg.sql.Identifier(schema),
                     psycopg.sql.Identifier(role_name),
                 )
@@ -655,6 +670,18 @@ class SchemaManager:
             )
             cursor.execute(
                 psycopg.sql.SQL("REVOKE ALL PRIVILEGES ON SCHEMA {} FROM {}").format(
+                    psycopg.sql.Identifier(schema),
+                    psycopg.sql.Identifier(role_name),
+                )
+            )
+        cursor.execute(self._SCHEMAS_WITH_ROLE_DEFAULT_ACLS_SQL, (role_name,))
+        for schema, owner_role in cursor.fetchall():
+            cursor.execute(
+                psycopg.sql.SQL(
+                    "ALTER DEFAULT PRIVILEGES FOR ROLE {} IN SCHEMA {} "
+                    "REVOKE ALL ON TABLES FROM {}"
+                ).format(
+                    psycopg.sql.Identifier(owner_role),
                     psycopg.sql.Identifier(schema),
                     psycopg.sql.Identifier(role_name),
                 )

--- a/mcp_server/services/dbt_runner.py
+++ b/mcp_server/services/dbt_runner.py
@@ -129,7 +129,23 @@ def run_dbt(
         res = dbt.invoke(cli_args)
 
     if not res.success:
-        error_msg = str(res.exception) if res.exception else "dbt run failed"
+        # A node-level model failure sets res.success=False but leaves
+        # res.exception None — the real cause (e.g. 'column "x" does not exist')
+        # lives in each node's message. Surface those instead of the opaque
+        # "dbt run failed" so callers/Sentry don't have to dig through dbt logs.
+        node_errors = [
+            f"{r.node.name}: {r.message}"
+            for r in (res.result or [])
+            if hasattr(r, "node")
+            and str(getattr(r, "status", "")) in ("error", "fail")
+            and getattr(r, "message", None)
+        ]
+        if res.exception:
+            error_msg = str(res.exception)
+        elif node_errors:
+            error_msg = "; ".join(node_errors)
+        else:
+            error_msg = "dbt run failed"
         logger.error("dbt run failed: %s", error_msg)
         return {"success": False, "error": error_msg, "models": {}}
 

--- a/mcp_server/services/dbt_runner.py
+++ b/mcp_server/services/dbt_runner.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import logging
 import threading
 from pathlib import Path
-from urllib.parse import urlparse
+from urllib.parse import unquote, urlparse
 
 import yaml
 from dbt.cli.main import dbtRunner
@@ -58,12 +58,17 @@ def generate_profiles_yml(
             ``None`` the ``role`` key is omitted (dbt connects as the URL user).
     """
     parsed = urlparse(db_url)
+    # urlparse leaves username/password percent-encoded; resolve-database-url.sh
+    # URL-encodes the RDS-managed password (which rotates to values with special
+    # chars). psycopg/Django decode automatically, but dbt receives whatever we
+    # write here verbatim, so decode to match — otherwise auth fails whenever the
+    # password contains an encoded char (SCOUT-DJANGO-1T).
     output = {
         "type": "postgres",
         "host": parsed.hostname or "localhost",
         "port": parsed.port or 5432,
-        "user": parsed.username or "",
-        "password": parsed.password or "",
+        "user": unquote(parsed.username) if parsed.username else "",
+        "password": unquote(parsed.password) if parsed.password else "",
         "dbname": parsed.path.lstrip("/") if parsed.path else "",
         "schema": schema_name,
         # Confine resolution to the target schema only — see docstring.

--- a/tests/test_backfill_readonly_roles.py
+++ b/tests/test_backfill_readonly_roles.py
@@ -161,10 +161,12 @@ class TestBackfillReadonlyRoles:
         assert not any("CREATE ROLE" in c for c in calls)
         assert not any("GRANT" in c for c in calls)
 
-    def test_view_schema_grants_default_privileges_on_tenant_schemas(
+    def test_view_schema_backfill_grants_nothing_on_tenant_schemas(
         self, tenant_membership, workspace
     ):
-        """View role must get ALTER DEFAULT PRIVILEGES on constituent tenant schemas (11#8)."""
+        """The view role must NOT be granted any access to raw tenant schemas: the
+        views run with owner privileges, so such grants are unnecessary cross-tenant
+        over-exposure (and their default-ACL entries block role teardown)."""
         ts = TenantSchema.objects.create(
             tenant=tenant_membership.tenant,
             schema_name="ws_tenant",
@@ -181,6 +183,7 @@ class TestBackfillReadonlyRoles:
         mock_conn = MagicMock()
         mock_cursor = MagicMock()
         mock_cursor.fetchone.return_value = None
+        mock_cursor.fetchall.return_value = []
         mock_conn.cursor.return_value = mock_cursor
 
         with patch(
@@ -191,9 +194,10 @@ class TestBackfillReadonlyRoles:
 
         view_role = readonly_role_name(vs.schema_name)
         calls = [str(c) for c in mock_cursor.execute.call_args_list]
-        # The view role must hold ALTER DEFAULT PRIVILEGES on the tenant schema so a
-        # rematerialization between view rebuilds doesn't leave new tables unreadable.
-        assert any(
+        assert not any(
+            "GRANT" in c and ts.schema_name in c and view_role in c for c in calls
+        ), "view role must not be granted access to raw tenant schemas"
+        assert not any(
             "ALTER DEFAULT PRIVILEGES" in c and ts.schema_name in c and view_role in c
             for c in calls
-        ), "view role needs default privileges on constituent tenant schemas"
+        )

--- a/tests/test_connect_staging.py
+++ b/tests/test_connect_staging.py
@@ -49,6 +49,19 @@ def connect_tenant(db):
 
 
 @pytest.mark.django_db(transaction=True)
+def test_stg_visits_selects_only_real_raw_visits_columns(connect_tenant):
+    """Base columns must match the raw_visits DDL (materializer.py): the loader
+    emits `username`, not `user_id`. Guards against the mismatch that made every
+    stg_visits build fail with 'column "user_id" does not exist'."""
+    assets = generate_connect_assets(FORM_DEFS, connect_tenant)
+    sql = {a.name: a for a in assets}["stg_visits"].sql_content
+
+    assert "username" in sql
+    # user_id is not a raw_visits column and must never be selected.
+    assert "user_id" not in sql
+
+
+@pytest.mark.django_db(transaction=True)
 def test_generates_visit_staging_with_typed_columns(connect_tenant):
     assets = generate_connect_assets(FORM_DEFS, connect_tenant)
     by_name = {a.name: a for a in assets}

--- a/tests/test_dbt_confinement.py
+++ b/tests/test_dbt_confinement.py
@@ -195,6 +195,42 @@ def test_generated_staging_model_resolves_raw_cases(confinement_schemas, setting
 
 
 @pytest.mark.django_db(transaction=True)
+def test_readonly_role_can_read_dbt_materialized_table(confinement_schemas, managed_conn):
+    """The ``_ro`` query role can SELECT a table dbt materialized under the ``_dbt``
+    confinement role.
+
+    Regression for the prod ``permission denied for table stg_visits`` error: since
+    issue #241 dbt owns the tables it creates, so the CURRENT_USER default-privilege
+    grant never reached them and the ``_ro`` role (used by the MCP query path via
+    ``SET ROLE``) could not read freshly materialized staging tables.
+    """
+    attacker_schema, _, attacker_tenant = confinement_schemas
+
+    TransformationAsset.objects.create(
+        name="stg_case_patient",
+        scope=TransformationScope.SYSTEM,
+        tenant=attacker_tenant,
+        sql_content="SELECT case_id, case_type FROM raw_cases WHERE case_type = 'patient'",
+    )
+    run = run_transformation_pipeline(tenant=attacker_tenant, schema_name=attacker_schema)
+    assert run.status == TransformationRunStatus.COMPLETED, run.error_message
+
+    ro_role = f"{attacker_schema}_ro"
+    cur = managed_conn.cursor()
+    cur.execute(psycopg.sql.SQL("SET ROLE {}").format(psycopg.sql.Identifier(ro_role)))
+    try:
+        cur.execute(
+            psycopg.sql.SQL("SELECT count(*) FROM {}.stg_case_patient").format(
+                psycopg.sql.Identifier(attacker_schema)
+            )
+        )
+        assert cur.fetchone()[0] == 1
+    finally:
+        managed_conn.rollback()
+        cur.execute("RESET ROLE")
+
+
+@pytest.mark.django_db(transaction=True)
 def test_cross_tenant_asset_cannot_materialize(confinement_schemas):
     """A SYSTEM asset whose free-text SQL reaches into ANOTHER tenant's schema
     cannot materialize: dbt runs it under the confinement role, which lacks USAGE

--- a/tests/test_dbt_runner.py
+++ b/tests/test_dbt_runner.py
@@ -41,6 +41,25 @@ class TestGenerateProfilesYml:
         assert profile["user"] == "myuser"
         assert profile["dbname"] == "analytics"
 
+    def test_percent_encoded_password_is_decoded(self, tmp_path):
+        """resolve-database-url.sh URL-encodes the RDS password; the profile must
+        decode it so dbt authenticates like psycopg/Django do (SCOUT-DJANGO-1T)."""
+        from urllib.parse import quote
+
+        from mcp_server.services.dbt_runner import generate_profiles_yml
+
+        raw_password = "p(a<s>s?[word"
+        db_url = f"postgresql://plat%40form:{quote(raw_password, safe='')}@h:5432/db"
+
+        path = tmp_path / "profiles.yml"
+        generate_profiles_yml(output_path=path, schema_name="s", db_url=db_url)
+
+        import yaml
+
+        profile = yaml.safe_load(path.read_text())["data_explorer"]["outputs"]["tenant_schema"]
+        assert profile["password"] == raw_password
+        assert profile["user"] == "plat@form"
+
     def test_search_path_confined_to_target_schema(self, tmp_path):
         """The profile must pin search_path to the tenant schema only (issue #241,
         04#4): without it dbt creates the relation in the tenant schema but runs

--- a/tests/test_dbt_runner.py
+++ b/tests/test_dbt_runner.py
@@ -169,6 +169,35 @@ class TestRunDbt:
         assert result["success"] is False
         assert "error" in result
 
+    def test_surfaces_node_error_when_no_exception(self, tmp_path):
+        """Node-level model failures (success=False, exception=None) must surface
+        the per-node message, not the opaque 'dbt run failed' (SCOUT-DJANGO-1T)."""
+        from mcp_server.services.dbt_runner import run_dbt
+
+        node = MagicMock()
+        node.name = "stg_visits"
+        failed = MagicMock(node=node, status="error")
+        failed.message = 'column "user_id" does not exist'
+
+        mock_result = MagicMock()
+        mock_result.success = False
+        mock_result.exception = None
+        mock_result.result = [failed]
+
+        mock_runner = MagicMock()
+        mock_runner.invoke.return_value = mock_result
+
+        with patch("mcp_server.services.dbt_runner.dbtRunner", return_value=mock_runner):
+            result = run_dbt(
+                dbt_project_dir=str(tmp_path),
+                profiles_dir=str(tmp_path),
+                models=["stg_visits"],
+            )
+
+        assert result["success"] is False
+        assert "stg_visits" in result["error"]
+        assert 'column "user_id" does not exist' in result["error"]
+
     def test_passes_correct_cli_args(self, tmp_path):
         from mcp_server.services.dbt_runner import run_dbt
 

--- a/tests/test_schema_manager.py
+++ b/tests/test_schema_manager.py
@@ -527,7 +527,7 @@ class TestBuildViewSchemaProviderSafety:
 
 @pytest.mark.django_db
 class TestViewSchemaRoleCreation:
-    def test_build_view_schema_creates_readonly_role_with_tenant_grants(
+    def test_build_view_schema_creates_readonly_role_without_tenant_grants(
         self, workspace, tenant_membership
     ):
         ts = TenantSchema.objects.create(
@@ -558,14 +558,13 @@ class TestViewSchemaRoleCreation:
         assert any("CREATE ROLE" in c and view_role_name in c for c in calls), (
             f"Expected CREATE ROLE for {view_role_name}"
         )
-        # Should grant USAGE on view schema
+        # Should grant USAGE on the view schema
         assert any("GRANT USAGE ON SCHEMA" in c and vs.schema_name in c for c in calls)
-        # Should grant SELECT on constituent tenant schema tables
-        assert any(
-            "GRANT SELECT ON ALL TABLES IN SCHEMA" in c and ts.schema_name in c for c in calls
+        # Must NOT grant anything to the view role on the raw tenant schema: views
+        # run with owner privileges, so such grants are unnecessary over-exposure.
+        assert not any("GRANT" in c and ts.schema_name in c for c in calls), (
+            "view role must not be granted access to raw tenant schemas"
         )
-        # Should grant USAGE on constituent tenant schema
-        assert any("GRANT USAGE ON SCHEMA" in c and ts.schema_name in c for c in calls)
 
 
 class _AsyncCursor:

--- a/tests/test_view_schema_builder.py
+++ b/tests/test_view_schema_builder.py
@@ -15,7 +15,11 @@ from apps.workspaces.models import (
     WorkspaceTenant,
     WorkspaceViewSchema,
 )
-from apps.workspaces.services.schema_manager import SchemaManager, readonly_role_name
+from apps.workspaces.services.schema_manager import (
+    SchemaManager,
+    dbt_role_name,
+    readonly_role_name,
+)
 
 pytestmark = pytest.mark.skipif(
     not os.environ.get("MANAGED_DATABASE_URL"),
@@ -291,7 +295,9 @@ def test_build_view_schema_three_tables_three_views(two_tenant_workspace, manage
 
 
 def test_build_view_schema_readonly_role_has_access(two_tenant_workspace, managed_db_connection):
-    """Read-only role has access to the view schema and both underlying tenant schemas."""
+    """Read-only role can read through the views but has NO direct access to the raw
+    tenant schemas — views run with owner privileges, so granting the role tenant
+    access is both unnecessary and cross-tenant over-exposure."""
     from apps.workspaces.models import TenantSchema
     from apps.workspaces.services.schema_manager import SchemaManager, readonly_role_name
 
@@ -320,20 +326,35 @@ def test_build_view_schema_readonly_role_has_access(two_tenant_workspace, manage
 
         c2 = conn.cursor()
         try:
-            # View schema USAGE grant
+            # USAGE on the view schema...
             c2.execute(
                 "SELECT has_schema_privilege(%s, %s, 'USAGE')",
                 (view_role, vs.schema_name),
             )
             assert c2.fetchone()[0] is True
 
-            # Tenant schema USAGE grants
+            # ...but NOT on the raw tenant schemas.
             for schema in ("build_domain_a_ro", "build_domain_b_ro"):
                 c2.execute(
                     "SELECT has_schema_privilege(%s, %s, 'USAGE')",
                     (view_role, schema),
                 )
-                assert c2.fetchone()[0] is True
+                assert c2.fetchone()[0] is False, f"view role should not reach {schema}"
+
+            # And it can actually read through the views (owner-privilege path).
+            c2.execute(
+                "SELECT table_name FROM information_schema.views WHERE table_schema = %s",
+                (vs.schema_name,),
+            )
+            view_names = [r[0] for r in c2.fetchall()]
+            assert view_names
+            c2.execute(f'SET ROLE "{view_role}"')
+            try:
+                for vn in view_names:
+                    c2.execute(f'SELECT count(*) FROM "{vs.schema_name}"."{vn}"')
+                    c2.fetchone()
+            finally:
+                c2.execute("RESET ROLE")
         finally:
             c2.close()
     finally:
@@ -806,7 +827,11 @@ def _role_grant_schemas(cursor, role_name: str) -> set[str]:
 
 def test_rebuild_revokes_ro_grants_on_removed_tenant_schema(db, managed_db_connection):
     """Issue #244: after a tenant is removed and the view schema is rebuilt, the
-    _ro role must no longer hold SELECT/USAGE on the removed tenant's schema."""
+    removed tenant's data must be unreachable through the view role.
+
+    Under the owner-privilege view model the role holds NO direct grants on raw
+    tenant schemas, so the property is enforced by (a) the role only ever reaching
+    the view schema and (b) the rebuild dropping the removed tenant's views."""
     User = get_user_model()
     user = User.objects.create_user(email="revoke@example.com", password="pass")
     # Unique schema names so sibling agents sharing the managed DB don't collide.
@@ -847,26 +872,43 @@ def test_rebuild_revokes_ro_grants_on_removed_tenant_schema(db, managed_db_conne
         c2 = conn.cursor()
         try:
             granted = _role_grant_schemas(c2, view_role)
-            # Initially the role can read all three constituent tenant schemas.
-            assert {sa, sb, sc} <= granted
+            # The role reaches ONLY the view schema — never the raw tenant schemas.
+            assert granted == {vs.schema_name}, sorted(granted)
+            # A view over tenant C's tables exists initially.
+            c2.execute(
+                "SELECT count(*) FROM information_schema.views "
+                "WHERE table_schema = %s AND table_name LIKE 'revoke_c_244__%%'",
+                (vs.schema_name,),
+            )
+            assert c2.fetchone()[0] >= 1
         finally:
             c2.close()
 
         # Remove tenant C from the workspace, then rebuild.
         wt_c.delete()
-        tsc_schema = sc
         vs = SchemaManager().build_view_schema(ws)
 
         c3 = conn.cursor()
         try:
             granted_after = _role_grant_schemas(c3, view_role)
-            # The _ro role must NO LONGER reach the removed tenant's schema.
-            assert tsc_schema not in granted_after, (
-                f"_ro role {view_role} still holds grants on removed schema {tsc_schema}: "
-                f"{sorted(granted_after)}"
+            # Still only the view schema; the removed tenant's raw schema was never
+            # (and is not) directly reachable.
+            assert granted_after == {vs.schema_name}, sorted(granted_after)
+            # C's views are gone, so its data is unreachable through the role...
+            c3.execute(
+                "SELECT count(*) FROM information_schema.views "
+                "WHERE table_schema = %s AND table_name LIKE 'revoke_c_244__%%'",
+                (vs.schema_name,),
             )
-            # ...but still reaches the remaining members.
-            assert {sa, sb} <= granted_after
+            assert c3.fetchone()[0] == 0
+            # ...while the remaining members' views persist.
+            c3.execute(
+                "SELECT count(*) FROM information_schema.views "
+                "WHERE table_schema = %s AND (table_name LIKE 'revoke_a_244__%%' "
+                "OR table_name LIKE 'revoke_b_244__%%')",
+                (vs.schema_name,),
+            )
+            assert c3.fetchone()[0] >= 2
         finally:
             c3.close()
     finally:
@@ -896,3 +938,81 @@ def test_rebuild_revokes_ro_grants_on_removed_tenant_schema(db, managed_db_conne
         tsa.delete()
         tsb.delete()
         tsc.delete()
+
+
+def test_teardown_view_schema_drops_role_despite_stale_default_acl(db, managed_db_connection):
+    """A view role that still holds a pg_default_acl entry on a tenant schema (left
+    by an earlier version that granted default privileges there) must not block
+    DROP ROLE at teardown. The tenant schema outlives the view schema, so that
+    entry survives DROP SCHEMA CASCADE and would strand the role."""
+    User = get_user_model()
+    user = User.objects.create_user(email="leak-acl@example.com", password="pass")
+    t = Tenant.objects.create(
+        provider="commcare", external_id="leak-acl-a", canonical_name="leak_acl_a"
+    )
+    ws = Workspace.objects.create(name="Leak ACL WS", created_by=user)
+    WorkspaceMembership.objects.create(workspace=ws, user=user, role=WorkspaceRole.MANAGE)
+    WorkspaceTenant.objects.create(workspace=ws, tenant=t)
+    sa = "leak_acl_a_sch"
+    ts = TenantSchema.objects.create(tenant=t, schema_name=sa, state=SchemaState.ACTIVE)
+
+    conn = managed_db_connection
+    c = conn.cursor()
+    try:
+        c.execute(psycopg_sql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(psycopg_sql.Identifier(sa)))
+        c.execute(
+            psycopg_sql.SQL("CREATE TABLE IF NOT EXISTS {}.cases (id TEXT)").format(
+                psycopg_sql.Identifier(sa)
+            )
+        )
+    finally:
+        c.close()
+
+    mgr = SchemaManager()
+    vs = None
+    try:
+        vs = mgr.build_view_schema(ws)
+        view_role = readonly_role_name(vs.schema_name)
+
+        # Simulate the pre-fix leftover: a default-ACL entry granting the view role
+        # SELECT on future tables in the tenant schema.
+        c2 = conn.cursor()
+        try:
+            c2.execute(
+                psycopg_sql.SQL(
+                    "ALTER DEFAULT PRIVILEGES FOR ROLE CURRENT_USER IN SCHEMA {} "
+                    "GRANT SELECT ON TABLES TO {}"
+                ).format(psycopg_sql.Identifier(sa), psycopg_sql.Identifier(view_role))
+            )
+        finally:
+            c2.close()
+
+        mgr.teardown_view_schema(vs)
+
+        c3 = conn.cursor()
+        try:
+            c3.execute("SELECT 1 FROM pg_roles WHERE rolname = %s", (view_role,))
+            assert c3.fetchone() is None, f"view role {view_role} dangled after teardown"
+        finally:
+            c3.close()
+    finally:
+        c4 = conn.cursor()
+        try:
+            c4.execute(
+                psycopg_sql.SQL("DROP SCHEMA IF EXISTS {} CASCADE").format(psycopg_sql.Identifier(sa))
+            )
+            for role in (readonly_role_name(sa), dbt_role_name(sa)):
+                c4.execute(
+                    psycopg_sql.SQL("DROP ROLE IF EXISTS {}").format(psycopg_sql.Identifier(role))
+                )
+            if vs:
+                c4.execute(
+                    psycopg_sql.SQL("DROP ROLE IF EXISTS {}").format(
+                        psycopg_sql.Identifier(readonly_role_name(vs.schema_name))
+                    )
+                )
+        finally:
+            c4.close()
+        if vs:
+            vs.delete()
+        ts.delete()


### PR DESCRIPTION
Ports the materialization + `_ro` grant fixes onto **`staging-semantic`** (the branch staging runs) so they can be validated there. Base is `staging-semantic`, not `main`.

## What's here (5 cherry-picks, in order)
| Commit | Origin | Fix |
|--------|--------|-----|
| decode URL-encoded creds in dbt profile gen | `main` (#342) | dbt profile generation |
| `stg_visits` → real `raw_visits` column | `main` (#344) | staging model column |
| surface per-model dbt errors | `main` | clearer dbt failures |
| grant `_ro` SELECT on dbt-materialized tables | `main` (#346, merged) | fixes the `permission denied for table stg_visits` error |
| stop granting the view role access to raw tenant schemas | **#347 (still OPEN for `main`)** | cross-tenant over-exposure + role-teardown leak |

The first four are already merged to `main`. The last (#347) is still under review for `main` — landing it here first is intentional, since staging is the place to validate it before it ships to prod.

## Validation
All affected suites green against the managed test DB: **71 passed** — `test_dbt_runner`, `test_connect_staging`, `test_dbt_confinement`, `test_schema_manager`, `test_backfill_readonly_roles`, `test_view_schema_builder` (incl. the real-DB negative controls).

## After merge
Needs a manual staging deploy (staging isn't on CI — see `DEPLOYMENT.md`), followed by `manage.py backfill_readonly_roles` against the staging DB to complete the `_ro`/view-role remediation (mirrors the prod remediation for #346).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
