### PR TITLE
wave0(1/4): consolidate duplicate auth errors + add expected-state taxonomy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,6 +70,9 @@ SENTRY_DSN=
 # SENTRY_RELEASE=
 # SENTRY_TRACES_SAMPLE_RATE=0.0
 # SENTRY_SEND_DEFAULT_PII=False
+# Drop known operational states (apps/common/errors.py ExpectedStateError) before
+# they reach Sentry. Set to False to report everything again during an incident.
+# SENTRY_SUPPRESS_EXPECTED_STATES=True
 
 # Task Badger background-task tracking (optional — leave TASKBADGER_API_KEY blank to disable)
 # Use a project API key (base64-encoded org/project/key).

--- a/.env.example
+++ b/.env.example
@@ -71,7 +71,7 @@ SENTRY_DSN=
 # SENTRY_TRACES_SAMPLE_RATE=0.0
 # SENTRY_SEND_DEFAULT_PII=False
 # Drop known operational states (apps/common/errors.py ExpectedStateError) before
-# they reach Sentry. Set to False to report everything again during an incident.
+# they reach Sentry. Set to False to report them again.
 # SENTRY_SUPPRESS_EXPECTED_STATES=True
 
 # Task Badger background-task tracking (optional — leave TASKBADGER_API_KEY blank to disable)

--- a/apps/common/errors.py
+++ b/apps/common/errors.py
@@ -58,9 +58,7 @@ class ExpectedUpstreamError(ExpectedStateError):
     provider: str | None = None
 
 
-# --- Provider auth errors -------------------------------------------------
-#
-# These were each defined TWICE as unrelated classes — once in
+# These provider auth errors were each defined TWICE as unrelated classes — once in
 # ``apps/users/services/tenant_resolution.py`` and once in the matching
 # ``mcp_server/loaders/*_base.py`` — so an ``except OCSAuthError`` that imported
 # one sailed straight past the other (#371). They are defined here once and

--- a/apps/common/errors.py
+++ b/apps/common/errors.py
@@ -1,16 +1,7 @@
 """Scout's error taxonomy: expected operational states vs. defects.
 
-Scout had no way to say *"this failure is a known state, not a bug."* Every
-condition — a revoked OAuth token, a tenant that has not been materialized yet,
-an LLM emitting a malformed payload — was raised as a bare exception,
-``logger.exception``'d, and escalated into Sentry. Measured over 90 days, 59% of
-Sentry's event volume was routine states (#386). They crowd out real defects and
-page ``#scout-ops`` on every new fingerprint.
-
-``ExpectedStateError`` is the missing distinction. Anything raised as one is
-dropped by ``config.sentry.before_send``. It is still *logged* — the record
-survives in CloudWatch at WARNING — it just stops minting Sentry issues and
-paging people.
+An ``ExpectedStateError`` is dropped by ``config.sentry.before_send``. It is
+still logged — it just stops minting Sentry issues and paging people.
 
 Because raising one silences an alert, the bar is deliberately explicit. Raise
 ``ExpectedStateError`` only when **all four** hold:
@@ -24,14 +15,14 @@ Because raising one silences an alert, the bar is deliberately explicit. Raise
 4. **Resolved** — there is a defined next step (the user reconnects, the run
    retries), or the condition is a legitimate no-op.
 
-(3) is the load-bearing one and the easiest to wave through. It is why the login
-signal path (``apps/users/signals.py``) is deliberately *not* classified as
-expected: a failed tenant resolution there leaves the user with an empty
-data-sources page indistinguishable from "this account has no data", and the
-Sentry event is the only signal that anything went wrong at all.
+(3) is the load-bearing one and the easiest to wave through — an expected state
+nobody is told about is a silent failure, not an expected state. It is why the
+login signal path (``apps/users/signals.py``) is deliberately not classified as
+expected: a failed tenant resolution there leaves the user on an empty
+data-sources page indistinguishable from "this account has no data", so the
+Sentry event is the only signal anything went wrong.
 
-If any of the four fail, raise a plain ``Exception``. **An expected state that
-nobody is told about is not an expected state — it is a silent failure.**
+If any of the four fail, raise a plain ``Exception``.
 """
 
 from __future__ import annotations
@@ -50,19 +41,16 @@ class ExpectedUpstreamError(ExpectedStateError):
     """An expected state whose cause is an upstream provider, not Scout.
 
     ``provider`` lets a handler or a log line name the system that said no
-    without re-parsing the message. Subclasses set it as a *class* attribute so
-    existing ``raise SomeAuthError("message")`` call sites keep working
-    unchanged.
+    without re-parsing the message. It is a *class* attribute so that
+    ``raise SomeAuthError("message")`` call sites need no constructor change.
     """
 
     provider: str | None = None
 
 
-# These provider auth errors were each defined TWICE as unrelated classes — once in
-# ``apps/users/services/tenant_resolution.py`` and once in the matching
-# ``mcp_server/loaders/*_base.py`` — so an ``except OCSAuthError`` that imported
-# one sailed straight past the other (#371). They are defined here once and
-# imported by both: the point is identity, not a shared name.
+# Both apps/users/services/tenant_resolution.py and mcp_server/loaders/*_base.py
+# raise these, and each must catch what the other raises — so they live here, as
+# one class per provider rather than a name per module.
 
 
 class CommCareAuthError(Exception):

--- a/apps/common/errors.py
+++ b/apps/common/errors.py
@@ -1,16 +1,70 @@
-"""Errors shared across Scout's provider integrations.
+"""Scout's error taxonomy: expected operational states vs. defects.
 
-Each provider auth error used to be defined **twice** as two unrelated classes —
-once in ``apps/users/services/tenant_resolution.py`` and once in the matching
-``mcp_server/loaders/*_base.py``. An ``except OCSAuthError`` that imported one
-sailed straight past the other, which is why these reach ``except Exception``
-rather than being handled (#371).
+Scout had no way to say *"this failure is a known state, not a bug."* Every
+condition — a revoked OAuth token, a tenant that has not been materialized yet,
+an LLM emitting a malformed payload — was raised as a bare exception,
+``logger.exception``'d, and escalated into Sentry. Measured over 90 days, 59% of
+Sentry's event volume was routine states (#386). They crowd out real defects and
+page ``#scout-ops`` on every new fingerprint.
 
-They are defined here once and imported by both. The point is *identity*, not a
-shared name.
+``ExpectedStateError`` is the missing distinction. Anything raised as one is
+dropped by ``config.sentry.before_send``. It is still *logged* — the record
+survives in CloudWatch at WARNING — it just stops minting Sentry issues and
+paging people.
+
+Because raising one silences an alert, the bar is deliberately explicit. Raise
+``ExpectedStateError`` only when **all four** hold:
+
+1. **Known** — the condition can be named in advance ("the refresh token is
+   dead"), not "something went wrong in here."
+2. **Routine** — it occurs in the normal operation of a *correct* system. No
+   change to Scout's code would prevent it.
+3. **Surfaced** — somebody who can act on it is told, through a channel that is
+   not Sentry.
+4. **Resolved** — there is a defined next step (the user reconnects, the run
+   retries), or the condition is a legitimate no-op.
+
+(3) is the load-bearing one and the easiest to wave through. It is why the login
+signal path (``apps/users/signals.py``) is deliberately *not* classified as
+expected: a failed tenant resolution there leaves the user with an empty
+data-sources page indistinguishable from "this account has no data", and the
+Sentry event is the only signal that anything went wrong at all.
+
+If any of the four fail, raise a plain ``Exception``. **An expected state that
+nobody is told about is not an expected state — it is a silent failure.**
 """
 
 from __future__ import annotations
+
+
+class ExpectedStateError(Exception):
+    """A known, routine operational condition — not a defect.
+
+    Dropped from Sentry by ``config.sentry.before_send``. See the module
+    docstring for the four-part test a subclass must satisfy before it inherits
+    from this.
+    """
+
+
+class ExpectedUpstreamError(ExpectedStateError):
+    """An expected state whose cause is an upstream provider, not Scout.
+
+    ``provider`` lets a handler or a log line name the system that said no
+    without re-parsing the message. Subclasses set it as a *class* attribute so
+    existing ``raise SomeAuthError("message")`` call sites keep working
+    unchanged.
+    """
+
+    provider: str | None = None
+
+
+# --- Provider auth errors -------------------------------------------------
+#
+# These were each defined TWICE as unrelated classes — once in
+# ``apps/users/services/tenant_resolution.py`` and once in the matching
+# ``mcp_server/loaders/*_base.py`` — so an ``except OCSAuthError`` that imported
+# one sailed straight past the other (#371). They are defined here once and
+# imported by both: the point is identity, not a shared name.
 
 
 class CommCareAuthError(Exception):

--- a/apps/common/errors.py
+++ b/apps/common/errors.py
@@ -1,0 +1,25 @@
+"""Errors shared across Scout's provider integrations.
+
+Each provider auth error used to be defined **twice** as two unrelated classes —
+once in ``apps/users/services/tenant_resolution.py`` and once in the matching
+``mcp_server/loaders/*_base.py``. An ``except OCSAuthError`` that imported one
+sailed straight past the other, which is why these reach ``except Exception``
+rather than being handled (#371).
+
+They are defined here once and imported by both. The point is *identity*, not a
+shared name.
+"""
+
+from __future__ import annotations
+
+
+class CommCareAuthError(Exception):
+    """Raised when CommCare HQ returns a 401 or 403."""
+
+
+class ConnectAuthError(Exception):
+    """Raised when CommCare Connect returns a 401 or 403."""
+
+
+class OCSAuthError(Exception):
+    """Raised when Open Chat Studio returns a 401 or 403."""

--- a/apps/users/services/tenant_resolution.py
+++ b/apps/users/services/tenant_resolution.py
@@ -27,6 +27,7 @@ from allauth.socialaccount.models import SocialAccount
 from django.conf import settings
 from django.utils import timezone
 
+from apps.common.errors import CommCareAuthError, ConnectAuthError, OCSAuthError
 from apps.users.models import Tenant, TenantConnection, TenantMembership
 from apps.users.services.ocs_team import adetect_team_name_from_oauth
 
@@ -39,18 +40,6 @@ async def _ocs_team_slug(user) -> str:
     """The OCS team slug the user's current OAuth token is scoped to (OIDC claim)."""
     acct = await SocialAccount.objects.filter(user=user, provider="ocs").afirst()
     return (acct.extra_data or {}).get("team", "") if acct else ""
-
-
-class CommCareAuthError(Exception):
-    """Raised when CommCare returns a 401/403 during domain resolution."""
-
-
-class ConnectAuthError(Exception):
-    """Raised when Connect returns a 401/403 during opportunity resolution."""
-
-
-class OCSAuthError(Exception):
-    """Raised when OCS returns a 401/403 during chatbot resolution."""
 
 
 class TenantResolutionError(Exception):

--- a/config/sentry.py
+++ b/config/sentry.py
@@ -1,0 +1,37 @@
+"""Sentry event filtering.
+
+Scout's Sentry config had no ``before_send``, so the SDK's default
+``LoggingIntegration`` promoted *every* ERROR-level log record into an event —
+making the issue stream only as accurate as the codebase's log levels. Log
+levels alone cannot carry the load: one failure is logged by two layers (loader
+and task), each minting its own fingerprint, and the ``#scout-ops`` alert rule
+fires on first-seen with ``actionMatch: any`` and no filters. So each new
+variant pages.
+
+``before_send`` is the backstop: a condition Scout has classified as a known
+operational state never becomes an issue, regardless of how many layers log it.
+Dropping happens here rather than in a Sentry-side alert filter so the rule
+lives in the repo, in review, next to the code that raises.
+"""
+
+from __future__ import annotations
+
+from apps.common.errors import ExpectedStateError
+
+
+def before_send(event, hint):
+    """Drop events whose exception is a known operational state.
+
+    Only the exception actually raised is inspected — the chain
+    (``__cause__`` / ``__context__``) deliberately is not. A bug that occurs
+    *while handling* an expected state is still a bug, and walking the chain
+    would swallow it.
+
+    Events with no exception attached (a bare ``logger.error``) are always kept:
+    classification is a property of an exception type, and there is nothing to
+    classify here.
+    """
+    exc_info = hint.get("exc_info")
+    if exc_info and isinstance(exc_info[1], ExpectedStateError):
+        return None
+    return event

--- a/config/sentry.py
+++ b/config/sentry.py
@@ -1,17 +1,11 @@
 """Sentry event filtering.
 
-Scout's Sentry config had no ``before_send``, so the SDK's default
-``LoggingIntegration`` promoted *every* ERROR-level log record into an event —
-making the issue stream only as accurate as the codebase's log levels. Log
-levels alone cannot carry the load: one failure is logged by two layers (loader
-and task), each minting its own fingerprint, and the ``#scout-ops`` alert rule
-fires on first-seen with ``actionMatch: any`` and no filters. So each new
-variant pages.
-
-``before_send`` is the backstop: a condition Scout has classified as a known
-operational state never becomes an issue, regardless of how many layers log it.
-Dropping happens here rather than in a Sentry-side alert filter so the rule
-lives in the repo, in review, next to the code that raises.
+The SDK's default ``LoggingIntegration`` promotes every ERROR-level log record
+into an event, so log levels alone cannot keep known operational states out of
+the issue stream: one failure is often logged by two layers, each minting its own
+fingerprint. ``before_send`` is the backstop — it drops classified states however
+many layers log them, and it lives in the repo, in review, next to the code that
+raises, rather than in a Sentry-side alert filter.
 """
 
 from __future__ import annotations
@@ -25,11 +19,8 @@ def before_send(event, hint):
     Only the exception actually raised is inspected — the chain
     (``__cause__`` / ``__context__``) deliberately is not. A bug that occurs
     *while handling* an expected state is still a bug, and walking the chain
-    would swallow it.
-
-    Events with no exception attached (a bare ``logger.error``) are always kept:
-    classification is a property of an exception type, and there is nothing to
-    classify here.
+    would swallow it. Events with no exception attached (a bare
+    ``logger.error``) have nothing to classify, so they are always kept.
     """
     exc_info = hint.get("exc_info")
     if exc_info and isinstance(exc_info[1], ExpectedStateError):

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -290,9 +290,8 @@ LANGFUSE_BASE_URL = env("LANGFUSE_BASE_URL", default="")
 
 # Sentry error monitoring (optional — leave SENTRY_DSN blank to disable)
 SENTRY_DSN = env("SENTRY_DSN", default="")
-# Kill switch for the expected-state filter (see apps/common/errors.py). Flip to
-# False to make Sentry report everything again — for an incident where a
-# condition we classified as routine turns out not to be — without a deploy.
+# Kill switch: flip to False to report expected states again (see
+# apps/common/errors.py) when one turns out not to be routine, without a deploy.
 SENTRY_SUPPRESS_EXPECTED_STATES = env.bool("SENTRY_SUPPRESS_EXPECTED_STATES", default=True)
 if SENTRY_DSN:
     sentry_sdk.init(

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -11,6 +11,8 @@ from pathlib import Path
 import environ
 import sentry_sdk
 
+from config.sentry import before_send
+
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
 
 env = environ.Env(
@@ -288,6 +290,10 @@ LANGFUSE_BASE_URL = env("LANGFUSE_BASE_URL", default="")
 
 # Sentry error monitoring (optional — leave SENTRY_DSN blank to disable)
 SENTRY_DSN = env("SENTRY_DSN", default="")
+# Kill switch for the expected-state filter (see apps/common/errors.py). Flip to
+# False to make Sentry report everything again — for an incident where a
+# condition we classified as routine turns out not to be — without a deploy.
+SENTRY_SUPPRESS_EXPECTED_STATES = env.bool("SENTRY_SUPPRESS_EXPECTED_STATES", default=True)
 if SENTRY_DSN:
     sentry_sdk.init(
         dsn=SENTRY_DSN,
@@ -295,6 +301,7 @@ if SENTRY_DSN:
         release=env("SENTRY_RELEASE", default="") or None,
         traces_sample_rate=env.float("SENTRY_TRACES_SAMPLE_RATE", default=0.0),
         send_default_pii=env.bool("SENTRY_SEND_DEFAULT_PII", default=False),
+        before_send=before_send if SENTRY_SUPPRESS_EXPECTED_STATES else None,
     )
 
 # Task Badger background-task tracking (optional — leave TASKBADGER_API_KEY blank to disable)

--- a/mcp_server/loaders/commcare_base.py
+++ b/mcp_server/loaders/commcare_base.py
@@ -13,6 +13,7 @@ from urllib.parse import urljoin
 import requests
 from requests.adapters import HTTPAdapter
 
+from apps.common.errors import CommCareAuthError
 from mcp_server.loaders._http import build_retry, get_with_auth_refresh
 
 logger = logging.getLogger(__name__)
@@ -20,10 +21,6 @@ logger = logging.getLogger(__name__)
 # (connect_timeout_seconds, read_timeout_seconds)
 # Read timeout is generous: large CommCare domains may have slow API responses.
 HTTP_TIMEOUT: tuple[int, int] = (10, 120)
-
-
-class CommCareAuthError(Exception):
-    """Raised when CommCare returns a 401 or 403 response."""
 
 
 class CommCareExportError(Exception):

--- a/mcp_server/loaders/connect_base.py
+++ b/mcp_server/loaders/connect_base.py
@@ -14,6 +14,7 @@ from urllib.parse import parse_qs, urlparse
 import requests
 from requests.adapters import HTTPAdapter
 
+from apps.common.errors import ConnectAuthError
 from mcp_server.loaders._http import (
     RETRY_STATUS_FORCELIST,
     RETRY_TOTAL,
@@ -54,10 +55,6 @@ def _extract_last_id(url: str, params: dict | None) -> int | None:
         return int(values[0])
     except (TypeError, ValueError):
         return None
-
-
-class ConnectAuthError(Exception):
-    """Raised when Connect returns a 401 or 403 response."""
 
 
 class ConnectExportError(Exception):

--- a/mcp_server/loaders/ocs_base.py
+++ b/mcp_server/loaders/ocs_base.py
@@ -9,6 +9,7 @@ import requests
 from django.conf import settings
 from requests.adapters import HTTPAdapter
 
+from apps.common.errors import OCSAuthError
 from mcp_server.loaders._http import build_retry, get_with_auth_refresh
 
 logger = logging.getLogger(__name__)
@@ -20,10 +21,6 @@ HTTP_TIMEOUT: tuple[int, int] = (10, 300)
 # the max cuts list-request volume ~10-15x versus the upstream default — the
 # loaders' Connect/CommCare mental model is 1000/page (arch #254, finding 13#1).
 OCS_MAX_PAGE_SIZE = 1500
-
-
-class OCSAuthError(Exception):
-    """Raised when OCS returns a 401 or 403 response."""
 
 
 class OCSExportError(Exception):

--- a/tests/test_error_taxonomy.py
+++ b/tests/test_error_taxonomy.py
@@ -13,7 +13,13 @@ from apps.common.errors import (
     ExpectedUpstreamError,
     OCSAuthError,
 )
+from apps.users.services.tenant_resolution import CommCareAuthError as resolution_commcare
+from apps.users.services.tenant_resolution import ConnectAuthError as resolution_connect
+from apps.users.services.tenant_resolution import OCSAuthError as resolution_ocs
 from config.sentry import before_send
+from mcp_server.loaders.commcare_base import CommCareAuthError as loader_commcare
+from mcp_server.loaders.connect_base import ConnectAuthError as loader_connect
+from mcp_server.loaders.ocs_base import OCSAuthError as loader_ocs
 
 
 class TestAuthErrorConsolidation:
@@ -24,30 +30,18 @@ class TestAuthErrorConsolidation:
     """
 
     def test_ocs_auth_error_is_one_class(self):
-        from apps.users.services.tenant_resolution import OCSAuthError as resolution_cls
-        from mcp_server.loaders.ocs_base import OCSAuthError as loader_cls
-
-        assert resolution_cls is loader_cls is OCSAuthError
+        assert resolution_ocs is loader_ocs is OCSAuthError
 
     def test_commcare_auth_error_is_one_class(self):
-        from apps.users.services.tenant_resolution import CommCareAuthError as resolution_cls
-        from mcp_server.loaders.commcare_base import CommCareAuthError as loader_cls
-
-        assert resolution_cls is loader_cls is CommCareAuthError
+        assert resolution_commcare is loader_commcare is CommCareAuthError
 
     def test_connect_auth_error_is_one_class(self):
-        from apps.users.services.tenant_resolution import ConnectAuthError as resolution_cls
-        from mcp_server.loaders.connect_base import ConnectAuthError as loader_cls
-
-        assert resolution_cls is loader_cls is ConnectAuthError
+        assert resolution_connect is loader_connect is ConnectAuthError
 
     def test_catching_the_loader_class_catches_the_resolver_raise(self):
         """The bug this consolidation fixes, stated as behaviour."""
-        from apps.users.services.tenant_resolution import OCSAuthError as resolution_cls
-        from mcp_server.loaders.ocs_base import OCSAuthError as loader_cls
-
-        with pytest.raises(loader_cls):
-            raise resolution_cls("raised via the tenant-resolution import path")
+        with pytest.raises(loader_ocs):
+            raise resolution_ocs("raised via the tenant-resolution import path")
 
 
 class TestTaxonomy:

--- a/tests/test_error_taxonomy.py
+++ b/tests/test_error_taxonomy.py
@@ -1,7 +1,7 @@
 """Shared provider errors and the Sentry filter built on them (#371, #386).
 
-``TestBeforeSend`` is the alerting contract, so it is asserted explicitly in
-both directions — what gets dropped AND what must keep coming through.
+``TestBeforeSend`` is the alerting contract, so it is asserted in both
+directions — what gets dropped AND what must keep coming through.
 """
 
 import pytest
@@ -25,8 +25,8 @@ from mcp_server.loaders.ocs_base import OCSAuthError as loader_ocs
 class TestAuthErrorConsolidation:
     """The loader and tenant-resolution modules must name the SAME class.
 
-    These assert *identity*, not that both names resolve — two classes sharing a
-    name is exactly the bug (an ``except`` on one misses the other).
+    Identity, not just resolvable names: two classes sharing a name means an
+    ``except`` on one misses the other.
     """
 
     def test_ocs_auth_error_is_one_class(self):
@@ -39,7 +39,6 @@ class TestAuthErrorConsolidation:
         assert resolution_connect is loader_connect is ConnectAuthError
 
     def test_catching_the_loader_class_catches_the_resolver_raise(self):
-        """The bug this consolidation fixes, stated as behaviour."""
         with pytest.raises(loader_ocs):
             raise resolution_ocs("raised via the tenant-resolution import path")
 
@@ -81,11 +80,7 @@ class TestBeforeSend:
         assert before_send(event, {}) is event
 
     def test_does_not_walk_the_exception_chain(self):
-        """A bug raised *while handling* an expected state is still a bug.
-
-        Walking ``__cause__``/``__context__`` would swallow it, so ``before_send``
-        deliberately inspects only the exception that was raised.
-        """
+        """A bug raised *while handling* an expected state is still a bug."""
         try:
             try:
                 raise ExpectedStateError("routine")
@@ -101,11 +96,6 @@ class TestBeforeSend:
         ids=["commcare", "connect", "ocs"],
     )
     def test_provider_auth_errors_are_not_yet_classified(self, auth_error):
-        """Scope pin: this PR adds the mechanism, it does not classify anything.
-
-        The provider auth errors still reach Sentry exactly as they do today, so
-        this change is a no-op on event volume. Reclassifying them (and
-        splitting 401 from 403) is #371/#372, which inverts this assertion.
-        """
+        """Scope pin: the mechanism lands here, the classification in #372."""
         event = {"event": 1}
         assert before_send(event, self._hint(auth_error("HTTP 401"))) is event

--- a/tests/test_error_taxonomy.py
+++ b/tests/test_error_taxonomy.py
@@ -1,0 +1,39 @@
+"""Shared provider errors and the Sentry filter built on them (#371, #386)."""
+
+import pytest
+
+from apps.common.errors import CommCareAuthError, ConnectAuthError, OCSAuthError
+
+
+class TestAuthErrorConsolidation:
+    """The loader and tenant-resolution modules must name the SAME class.
+
+    These assert *identity*, not that both names resolve — two classes sharing a
+    name is exactly the bug (an ``except`` on one misses the other).
+    """
+
+    def test_ocs_auth_error_is_one_class(self):
+        from apps.users.services.tenant_resolution import OCSAuthError as resolution_cls
+        from mcp_server.loaders.ocs_base import OCSAuthError as loader_cls
+
+        assert resolution_cls is loader_cls is OCSAuthError
+
+    def test_commcare_auth_error_is_one_class(self):
+        from apps.users.services.tenant_resolution import CommCareAuthError as resolution_cls
+        from mcp_server.loaders.commcare_base import CommCareAuthError as loader_cls
+
+        assert resolution_cls is loader_cls is CommCareAuthError
+
+    def test_connect_auth_error_is_one_class(self):
+        from apps.users.services.tenant_resolution import ConnectAuthError as resolution_cls
+        from mcp_server.loaders.connect_base import ConnectAuthError as loader_cls
+
+        assert resolution_cls is loader_cls is ConnectAuthError
+
+    def test_catching_the_loader_class_catches_the_resolver_raise(self):
+        """The bug this consolidation fixes, stated as behaviour."""
+        from apps.users.services.tenant_resolution import OCSAuthError as resolution_cls
+        from mcp_server.loaders.ocs_base import OCSAuthError as loader_cls
+
+        with pytest.raises(loader_cls):
+            raise resolution_cls("raised via the tenant-resolution import path")

--- a/tests/test_error_taxonomy.py
+++ b/tests/test_error_taxonomy.py
@@ -1,8 +1,19 @@
-"""Shared provider errors and the Sentry filter built on them (#371, #386)."""
+"""Shared provider errors and the Sentry filter built on them (#371, #386).
+
+``TestBeforeSend`` is the alerting contract, so it is asserted explicitly in
+both directions — what gets dropped AND what must keep coming through.
+"""
 
 import pytest
 
-from apps.common.errors import CommCareAuthError, ConnectAuthError, OCSAuthError
+from apps.common.errors import (
+    CommCareAuthError,
+    ConnectAuthError,
+    ExpectedStateError,
+    ExpectedUpstreamError,
+    OCSAuthError,
+)
+from config.sentry import before_send
 
 
 class TestAuthErrorConsolidation:
@@ -37,3 +48,70 @@ class TestAuthErrorConsolidation:
 
         with pytest.raises(loader_cls):
             raise resolution_cls("raised via the tenant-resolution import path")
+
+
+class TestTaxonomy:
+    def test_upstream_errors_are_expected_states(self):
+        assert issubclass(ExpectedUpstreamError, ExpectedStateError)
+
+    def test_provider_defaults_to_none(self):
+        assert ExpectedUpstreamError("boom").provider is None
+
+    def test_subclasses_name_their_provider_without_a_constructor_change(self):
+        """Class-attribute ``provider`` keeps ``raise Err("msg")`` call sites working."""
+
+        class FakeProviderError(ExpectedUpstreamError):
+            provider = "ocs"
+
+        assert FakeProviderError("boom").provider == "ocs"
+        assert str(FakeProviderError("boom")) == "boom"
+
+
+class TestBeforeSend:
+    def _hint(self, exc):
+        return {"exc_info": (type(exc), exc, None)}
+
+    def test_drops_expected_states(self):
+        assert before_send({"event": 1}, self._hint(ExpectedStateError("routine"))) is None
+
+    def test_drops_expected_upstream_states(self):
+        assert before_send({"event": 1}, self._hint(ExpectedUpstreamError("routine"))) is None
+
+    def test_keeps_unclassified_exceptions(self):
+        event = {"event": 1}
+        assert before_send(event, self._hint(ValueError("a real bug"))) is event
+
+    def test_keeps_events_with_no_exception(self):
+        """A bare ``logger.error`` has nothing to classify, so it is never dropped."""
+        event = {"event": 1}
+        assert before_send(event, {}) is event
+
+    def test_does_not_walk_the_exception_chain(self):
+        """A bug raised *while handling* an expected state is still a bug.
+
+        Walking ``__cause__``/``__context__`` would swallow it, so ``before_send``
+        deliberately inspects only the exception that was raised.
+        """
+        try:
+            try:
+                raise ExpectedStateError("routine")
+            except ExpectedStateError as e:
+                raise ValueError("bug in the handler") from e
+        except ValueError as bug:
+            event = {"event": 1}
+            assert before_send(event, self._hint(bug)) is event
+
+    @pytest.mark.parametrize(
+        "auth_error",
+        [CommCareAuthError, ConnectAuthError, OCSAuthError],
+        ids=["commcare", "connect", "ocs"],
+    )
+    def test_provider_auth_errors_are_not_yet_classified(self, auth_error):
+        """Scope pin: this PR adds the mechanism, it does not classify anything.
+
+        The provider auth errors still reach Sentry exactly as they do today, so
+        this change is a no-op on event volume. Reclassifying them (and
+        splitting 401 from 403) is #371/#372, which inverts this assertion.
+        """
+        event = {"event": 1}
+        assert before_send(event, self._hint(auth_error("HTTP 401"))) is event


### PR DESCRIPTION
## What & why

Wave 0 of #386, PR 1 of 4. Groundwork only — **this PR changes no behaviour and no Sentry event volume.** It lands the two things the other three wave-0 PRs build on:

1. **Each provider auth error is now defined exactly once.** `CommCareAuthError`, `ConnectAuthError` and `OCSAuthError` were each defined *twice* as unrelated classes — once in `apps/users/services/tenant_resolution.py:44,48,52` and once in the matching `mcp_server/loaders/*_base.py`. Same name, different class object, so an `except OCSAuthError` that imported one sailed straight past the other. That is plausibly why these fall through to `except Exception` instead of being handled specifically (bonus bug in #371).

2. **An `ExpectedStateError` primitive plus a Sentry `before_send`.** Scout has no notion of an *expected operational state* as distinct from a bug, which is the single missing abstraction behind 7 of the 34 pair-debug issues and 59% of Sentry's 90-day event volume (#386).

Closes #371 — the classification mechanism #371 says is missing lands here. The remaining reclassification work is tracked separately: #372 (loader 401/403), #373 (token lifecycle), #374 (dbt fingerprints).

### The bar for calling something "expected"

Raising `ExpectedStateError` silences an alert, so the rubric is written into `apps/common/errors.py` and is the thing I'd most like reviewed. All four must hold:

| | Test | |
|---|---|---|
| 1 | **Known** | the condition can be named in advance, not "something went wrong in here" |
| 2 | **Routine** | it happens in the normal operation of a *correct* system; no code change would prevent it |
| 3 | **Surfaced** | somebody who can act on it is told, through a channel that is not Sentry |
| 4 | **Resolved** | there's a defined next step, or it's a legitimate no-op |

(3) is load-bearing and the easiest to wave through. It is exactly why `apps/users/signals.py:139-146` is **not** being reclassified — a failed tenant resolution at login leaves the user on an empty data-sources page indistinguishable from "this account has no data", and the Sentry event is the only signal anything went wrong. An expected state nobody is told about is not expected; it's a silent failure.

## Before/after: what reaches Sentry

**Nothing changes in this PR.** That is the claim being made, and it's pinned by `TestBeforeSend::test_provider_auth_errors_are_not_yet_classified`.

| Condition | Before | After this PR | Why |
|---|---|---|---|
| `OCSAuthError` / `CommCareAuthError` / `ConnectAuthError` (401 or 403) | ✅ reaches Sentry, 2 events + up to 2 new groups per failure | ✅ **unchanged** | classes moved, not reclassified — they still subclass `Exception`. Reclassifying is PR 2 (#371/#372) |
| `TokenRefreshError`, `CredentialResolutionError`, `TenantResolutionError` | ✅ reaches Sentry | ✅ **unchanged** | untouched here; token lifecycle is PR 3 (#373) |
| Raw dbt stdout (`stdout_log` / `file_log` loggers) | ✅ 340 events / 90d | ✅ **unchanged** | these carry no exception, so `before_send` can't see them by design — needs `ignore_logger`, PR 4 (#374) |
| Any exception subclassing `ExpectedStateError` | n/a | 🚫 **dropped** | nothing subclasses it yet, so this row is empty in practice |
| A bug raised *while handling* an expected state | ✅ | ✅ **kept** | `before_send` deliberately does not walk `__cause__`/`__context__` |
| A bare `logger.error` with no exception | ✅ | ✅ **kept** | nothing to classify |

Proposed Sentry-side rule changes are in "Notes for reviewers" — I have not touched any Sentry issue, rule, or alert.

## Sibling sweep (required on bug/incident fixes)

The pattern: **an exception class defined in more than one module, so `except` on one misses the other.**

- **Grep used:** `grep -rn --include="*.py" -E "^class \w*(Auth|Export|Resolution|Refresh)Error" apps mcp_server config`

- **Sibling sites found & disposition:**
  - [x] `apps/users/services/tenant_resolution.py:44` `CommCareAuthError` — **fixed** (moved to `apps/common/errors.py`, imported back)
  - [x] `apps/users/services/tenant_resolution.py:48` `ConnectAuthError` — **fixed**
  - [x] `apps/users/services/tenant_resolution.py:52` `OCSAuthError` — **fixed**
  - [x] `mcp_server/loaders/commcare_base.py:25` `CommCareAuthError` — **fixed** (duplicate definition removed, now imports the shared class)
  - [x] `mcp_server/loaders/connect_base.py:59` `ConnectAuthError` — **fixed**
  - [x] `mcp_server/loaders/ocs_base.py:25` `OCSAuthError` — **fixed**
  - [ ] `mcp_server/loaders/commcare_base.py:29` `CommCareExportError` — **not applicable**: defined once, no duplicate. Left in place.
  - [ ] `mcp_server/loaders/connect_base.py:63` `ConnectExportError` — **not applicable**: defined once. Carries provider-specific structured fields (`status`, `attempts`, `sentry_trace`, `last_id`) that only the Connect loader populates; moving it would be churn.
  - [ ] `mcp_server/loaders/ocs_base.py:29` `OCSExportError` — **not applicable**: defined once.
  - [ ] `apps/users/services/tenant_resolution.py:45` `TenantResolutionError` — **not applicable**: defined once, and specific to tenant resolution (shape-drift guard). Left in place; it gets classified, not moved, in a later PR.
  - [ ] `apps/users/services/token_refresh.py:48` `TokenRefreshError` — **not applicable**: defined once. Touched by PR 3 (#373).
  - [ ] `apps/users/services/credential_resolver.py:41` `CredentialResolutionError` — **not applicable**: defined once.

Also swept for the inverse (a name imported from two places): every existing `from ... import *AuthError` in `apps/`, `mcp_server/` and `tests/` still resolves, and now resolves to the same object — asserted directly in `TestAuthErrorConsolidation`.

## Testing

`tests/test_error_taxonomy.py`, 15 tests:

- **Consolidation** — asserts class *identity* (`resolution_cls is loader_cls`), not just that both names resolve; two classes sharing a name is the bug. Plus one behavioural test: raising via the resolver import path is caught by `except` on the loader import path.
- **`before_send`** — both directions: drops `ExpectedStateError`/`ExpectedUpstreamError`; keeps unclassified exceptions, keeps events with no exception, and keeps a `ValueError` raised `from` an `ExpectedStateError` (the no-chain-walking rule).
- **Scope pin** — the three provider auth errors are asserted *not* to be dropped, which is this PR's "no behaviour change" claim. PR 2 inverts that assertion.

Full backend suite passes (`uv run pytest`). The 142 tests specifically touching these classes and loaders pass unchanged — no test needed editing, which is the point of importing the names back into their old modules.

## Notes for reviewers

- **Import direction.** `mcp_server/loaders/*` now imports from `apps.common.errors`. Precedent: `mcp_server/context.py:15` already imports `apps.common.identifiers`. `apps/common/errors.py` imports nothing, so there's no cycle and no Django-setup ordering hazard (`apps.common` is not an installed app).
- **`config/sentry.py` is imported from `config/settings/base.py`,** i.e. before `django.setup()`. It only imports the exception module, so this is safe — but it's worth a look.
- **`ExpectedUpstreamError` is currently unused.** Deliberate: it lands here so PR 2 is a reparenting diff rather than a new-abstraction diff. If you'd rather it arrive with its first user, say so and I'll move it into PR 2.
- **Proposed Sentry-side rule changes (not applied — Sentry is read-only for this work).** These are complementary to `before_send`, not redundant: `before_send` stops the events, the rule changes stop the *paging* for anything that slips through.
  - Rule "Notify #scout-ops via Slack" (`10003423453`) is `actionMatch: any` with **no filters** and includes `FirstSeenEventCondition`. Suggest adding a filter so it fires only on `level:error` **and** issues not tagged `expected_state`, or dropping `FirstSeenEventCondition` in favour of a frequency threshold — today 2 recoverable user problems produced 4 new groups and 4 Slack pings.
  - Rule `16945063` emails IssueOwners on high-priority issues; `SCOUT-DJANGO-2W` is `priority: high`, so it emailed too.
- **Follow-up, not in wave 0:** the login-signal path (`signals.py:139-146`) needs user-facing feedback before it can ever be downgraded. Cheapest honest option looks like a new `needs_reconnect` value on the `status` field `providers_view` already returns (`apps/users/auth_views.py:266-315`) — the frontend already renders `"expired"` as an amber "Connection expired" + "Reconnect" CTA (`ConnectionsPage.tsx:200-243`), so it's ~30 lines and no migration. Worth its own issue. Note that path currently emits **zero** Sentry events in 90 days (verified: `logger:apps.users.signals` returns nothing), so there is no noise pressure forcing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

