### PR TITLE
wave0(2/4): split 401 from 403 and classify loader auth failures as expected

### DIFF
--- a/apps/common/error_codes.py
+++ b/apps/common/error_codes.py
@@ -1,0 +1,53 @@
+"""The one registry of Scout error codes.
+
+A code is the **machine-readable** half of an error. It is stable, never
+localised, and never reworded — handlers, UI, and prompts branch on it. The
+message beside it is the **human-readable** half: free to change, and never
+parsed.
+
+Every error that crosses a boundary carries both. Neither is derived from the
+other. Recovering a category by substring-matching a message is a bug: Scout has
+already been burned by it once, when matching ``'"code": "NOT_FOUND"'`` in tool
+output broke the moment FastMCP's JSON separators changed (see
+``apps/agents/graph/base.py`` and finding 06#1).
+
+These began as string constants in ``mcp_server.envelope``, which still re-exports
+them so the ~30 ``error_response(...)`` call sites in ``mcp_server/server.py``
+keep working. They live here because ``apps.common.errors`` attaches them to
+exception classes and must not import from ``mcp_server``.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class ErrorCode(StrEnum):
+    """Stable error identifiers. Values are the wire format — do not rename."""
+
+    VALIDATION_ERROR = "VALIDATION_ERROR"
+    CONNECTION_ERROR = "CONNECTION_ERROR"
+    QUERY_TIMEOUT = "QUERY_TIMEOUT"
+    NOT_FOUND = "NOT_FOUND"
+    INTERNAL_ERROR = "INTERNAL_ERROR"
+    SCHEMA_BUILD_FAILED = "SCHEMA_BUILD_FAILED"
+
+    # HTTP 401 upstream: the credential is dead and reconnecting mints a working
+    # one. Shared deliberately by the loaders and by credential_resolver's
+    # pre-flight check — one condition, one code, however it is detected.
+    AUTH_TOKEN_EXPIRED = "AUTH_TOKEN_EXPIRED"  # noqa: S105 — error code, not a credential
+
+    # HTTP 403 upstream: the credential is valid and has no access here.
+    # Reconnecting mints an identically-scoped credential that fails the same
+    # way, so this must never be collapsed into AUTH_TOKEN_EXPIRED (#372).
+    AUTH_ACCESS_DENIED = "AUTH_ACCESS_DENIED"
+
+
+def code_of(exc: BaseException) -> str:
+    """Return the ``ErrorCode`` an exception declares, defaulting to INTERNAL_ERROR.
+
+    Reads the class attribute rather than the class *name*: the name is a
+    refactoring hazard and cannot be a stable wire value.
+    """
+    code = getattr(exc, "code", None)
+    return str(code) if code else str(ErrorCode.INTERNAL_ERROR)

--- a/apps/common/errors.py
+++ b/apps/common/errors.py
@@ -63,15 +63,90 @@ class ExpectedUpstreamError(ExpectedStateError):
 # ``mcp_server/loaders/*_base.py`` — so an ``except OCSAuthError`` that imported
 # one sailed straight past the other (#371). They are defined here once and
 # imported by both: the point is identity, not a shared name.
+#
+# There are two axes, because callers need both:
+#
+#   *provider* — OCS / CommCare / Connect. Load-bearing beyond ``except``:
+#       ``_summarize_error`` serialises ``exc.__class__.__name__`` into
+#       ``MaterializationRun.result``, so the class name is what survives the
+#       JSON round-trip to the user-facing failure summary.
+#   *cause*    — 401 (the credential is dead) vs 403 (the credential is fine and
+#       has no access to this resource). #372: these need opposite advice, and a
+#       403 is an authoritative per-tenant revocation signal.
+#
+# The leaves inherit from both, so ``except OCSAuthError`` still catches every
+# OCS auth failure and ``except UpstreamAccessDenied`` catches every 403 across
+# providers.
+
+
+class UpstreamTokenExpired(Exception):
+    """HTTP 401 — the credential is dead. Reconnecting mints a working one."""
+
+
+class UpstreamAccessDenied(Exception):
+    """HTTP 403 — the credential is valid but has no access to this resource.
+
+    Distinct from a 401 because **reconnecting cannot fix it**: it mints an
+    identically-scoped credential that fails identically, so telling the user to
+    reconnect puts them in a loop (#372). The real causes are upstream access
+    removal, the resource moving to another team, or a token scoped to a
+    different team — none of which re-authenticating resolves.
+
+    Also the authoritative per-tenant revocation signal the access-revocation
+    work (#378/#384) needs: ``except UpstreamAccessDenied`` catches every 403
+    across all three providers.
+    """
+
+
+# The provider classes below are deliberately NOT expected states. They are the
+# base that ``apps/users/services/tenant_resolution.py`` raises from the login
+# signal, which today has NO user-facing surface at all — a failed resolution
+# leaves the user on an empty data-sources page and the Sentry event is the only
+# signal anything broke (#371's precondition; see rule 3 in the module
+# docstring). Classifying the base would silence that path without replacing it.
+#
+# Expectedness therefore lives on the leaf classes, which only the loaders raise.
+# The loader path DOES satisfy rule 3 — its failures reach the user through the
+# materialization failure summary in chat (apps/workspaces/tasks.py:161).
 
 
 class CommCareAuthError(Exception):
-    """Raised when CommCare HQ returns a 401 or 403."""
+    """Raised when CommCare HQ refuses our credential."""
+
+    provider = "commcare"
+
+
+class CommCareTokenExpiredError(CommCareAuthError, UpstreamTokenExpired):
+    """CommCare HQ returned 401 for a domain load."""
+
+
+class CommCareAccessDeniedError(CommCareAuthError, UpstreamAccessDenied):
+    """CommCare HQ returned 403 for a specific domain."""
 
 
 class ConnectAuthError(Exception):
-    """Raised when CommCare Connect returns a 401 or 403."""
+    """Raised when CommCare Connect refuses our credential."""
+
+    provider = "commcare_connect"
+
+
+class ConnectTokenExpiredError(ConnectAuthError, UpstreamTokenExpired):
+    """Connect returned 401 for an opportunity load."""
+
+
+class ConnectAccessDeniedError(ConnectAuthError, UpstreamAccessDenied):
+    """Connect returned 403 for a specific opportunity."""
 
 
 class OCSAuthError(Exception):
-    """Raised when Open Chat Studio returns a 401 or 403."""
+    """Raised when Open Chat Studio refuses our credential."""
+
+    provider = "ocs"
+
+
+class OCSTokenExpiredError(OCSAuthError, UpstreamTokenExpired):
+    """OCS returned 401 for an experiment load."""
+
+
+class OCSAccessDeniedError(OCSAuthError, UpstreamAccessDenied):
+    """OCS returned 403 for a specific experiment."""

--- a/apps/common/errors.py
+++ b/apps/common/errors.py
@@ -36,6 +36,8 @@ nobody is told about is not an expected state — it is a silent failure.**
 
 from __future__ import annotations
 
+from apps.common.error_codes import ErrorCode
+
 
 class ExpectedStateError(Exception):
     """A known, routine operational condition — not a defect.
@@ -49,13 +51,14 @@ class ExpectedStateError(Exception):
 class ExpectedUpstreamError(ExpectedStateError):
     """An expected state whose cause is an upstream provider, not Scout.
 
-    ``provider`` lets a handler or a log line name the system that said no
-    without re-parsing the message. Subclasses set it as a *class* attribute so
-    existing ``raise SomeAuthError("message")`` call sites keep working
-    unchanged.
+    ``provider`` and ``code`` let a handler, a log line, or a serialiser name the
+    system that said no and the condition it reported without re-parsing the
+    message. Both are *class* attributes so existing
+    ``raise SomeAuthError("message")`` call sites keep working unchanged.
     """
 
     provider: str | None = None
+    code: ErrorCode | None = None
 
 
 # These provider auth errors were each defined TWICE as unrelated classes — once in
@@ -66,10 +69,7 @@ class ExpectedUpstreamError(ExpectedStateError):
 #
 # There are two axes, because callers need both:
 #
-#   *provider* — OCS / CommCare / Connect. Load-bearing beyond ``except``:
-#       ``_summarize_error`` serialises ``exc.__class__.__name__`` into
-#       ``MaterializationRun.result``, so the class name is what survives the
-#       JSON round-trip to the user-facing failure summary.
+#   *provider* — OCS / CommCare / Connect.
 #   *cause*    — 401 (the credential is dead) vs 403 (the credential is fine and
 #       has no access to this resource). #372: these need opposite advice, and a
 #       403 is an authoritative per-tenant revocation signal.
@@ -77,6 +77,10 @@ class ExpectedUpstreamError(ExpectedStateError):
 # The leaves inherit from both, so ``except OCSAuthError`` still catches every
 # OCS auth failure and ``except UpstreamAccessDenied`` catches every 403 across
 # providers.
+#
+# The *cause* classes carry the ``code``, because that is the axis consumers
+# branch on. It is what crosses the JSON boundary into
+# ``MaterializationRun.result``; the class name is not a wire value.
 
 
 class UpstreamTokenExpired(ExpectedUpstreamError):
@@ -84,9 +88,14 @@ class UpstreamTokenExpired(ExpectedUpstreamError):
 
     Expected under the module's four-part test: known (the provider told us),
     routine (OAuth tokens expire and get revoked in normal operation), surfaced
-    (``_REAUTH_GUIDANCE`` reaches the user in the chat failure summary), and
+    (the reconnect guidance reaches the user in the chat failure summary), and
     resolved (reconnect, re-run).
+
+    Shares ``AUTH_TOKEN_EXPIRED`` with ``CredentialResolutionError``'s pre-flight
+    check: one condition gets one code however it was detected.
     """
+
+    code = ErrorCode.AUTH_TOKEN_EXPIRED
 
 
 class UpstreamAccessDenied(ExpectedUpstreamError):
@@ -107,6 +116,8 @@ class UpstreamAccessDenied(ExpectedUpstreamError):
     Classifying it before that would have silenced a condition whose only
     user-facing advice was wrong.
     """
+
+    code = ErrorCode.AUTH_ACCESS_DENIED
 
 
 # The provider classes below are deliberately NOT expected states. They are the

--- a/apps/common/errors.py
+++ b/apps/common/errors.py
@@ -79,11 +79,17 @@ class ExpectedUpstreamError(ExpectedStateError):
 # providers.
 
 
-class UpstreamTokenExpired(Exception):
-    """HTTP 401 — the credential is dead. Reconnecting mints a working one."""
+class UpstreamTokenExpired(ExpectedUpstreamError):
+    """HTTP 401 — the credential is dead. Reconnecting mints a working one.
+
+    Expected under the module's four-part test: known (the provider told us),
+    routine (OAuth tokens expire and get revoked in normal operation), surfaced
+    (``_REAUTH_GUIDANCE`` reaches the user in the chat failure summary), and
+    resolved (reconnect, re-run).
+    """
 
 
-class UpstreamAccessDenied(Exception):
+class UpstreamAccessDenied(ExpectedUpstreamError):
     """HTTP 403 — the credential is valid but has no access to this resource.
 
     Distinct from a 401 because **reconnecting cannot fix it**: it mints an
@@ -95,6 +101,11 @@ class UpstreamAccessDenied(Exception):
     Also the authoritative per-tenant revocation signal the access-revocation
     work (#378/#384) needs: ``except UpstreamAccessDenied`` catches every 403
     across all three providers.
+
+    Expected under the module's four-part test — and note rule 3 only started
+    holding for a 403 once the guidance stopped saying "reconnect" (#372).
+    Classifying it before that would have silenced a condition whose only
+    user-facing advice was wrong.
     """
 
 

--- a/apps/users/services/tenant_resolution.py
+++ b/apps/users/services/tenant_resolution.py
@@ -123,7 +123,8 @@ async def resolve_connect_opportunities(user, access_token: str) -> list[TenantM
         resp = await client.get(url, headers={"Authorization": f"Bearer {access_token}"})
     if resp.status_code in (401, 403):
         raise ConnectAuthError(
-            f"Connect returned {resp.status_code} — access token may have expired"
+            f"Connect returned {resp.status_code} while listing opportunities — the "
+            f"access token is expired, revoked, or not authorized for this API"
         )
     resp.raise_for_status()
 
@@ -173,7 +174,8 @@ async def resolve_ocs_chatbots(user, access_token: str) -> list[TenantMembership
             resp = await client.get(url, headers={"Authorization": f"Bearer {access_token}"})
             if resp.status_code in (401, 403):
                 raise OCSAuthError(
-                    f"OCS returned {resp.status_code} — access token may have expired"
+                    f"OCS returned {resp.status_code} while listing experiments — the "
+                    f"access token is expired, revoked, or not authorized for this team"
                 )
             resp.raise_for_status()
             payload = resp.json()
@@ -220,7 +222,8 @@ async def _fetch_all_domains(access_token: str) -> list[dict]:
             resp = await client.get(url, headers={"Authorization": f"Bearer {access_token}"})
             if resp.status_code in (401, 403):
                 raise CommCareAuthError(
-                    f"CommCare returned {resp.status_code} — access token may have expired"
+                    f"CommCare returned {resp.status_code} while listing domains — the "
+                    f"access token is expired, revoked, or not authorized for this API"
                 )
             resp.raise_for_status()
             data = resp.json()

--- a/apps/workspaces/tasks.py
+++ b/apps/workspaces/tasks.py
@@ -4,7 +4,9 @@ import asyncio
 import contextlib
 import logging
 import time
+from collections.abc import Iterable
 from datetime import timedelta
+from typing import NamedTuple
 
 import sentry_sdk
 from django.conf import settings
@@ -19,6 +21,7 @@ from apps.agents.mcp_client import get_mcp_tools
 from apps.chat.checkpointer import ensure_checkpointer
 from apps.chat.constants import SYSTEM_RESUME_MARKER
 from apps.chat.models import Thread, ThreadJob
+from apps.common.error_codes import ErrorCode
 from apps.transformations.models import TransformationRunStatus
 from apps.users.models import TenantMembership
 from apps.users.services.credential_resolver import (
@@ -67,44 +70,54 @@ MATERIALIZATION_FAILED_MESSAGE = (
 logger = logging.getLogger(__name__)
 
 
-# Substrings that mark a per-source failure as a credential problem so the user
-# gets actionable advice rather than just "check the connection" (arch #252,
-# finding 14#4). Matching is on the serialized string because _summarize_error
-# persists "{ClassName}: {message}" into MaterializationRun.result — the class
-# name is the half that survives the JSON round-trip, so it anchors each set.
-_AUTH_FAILURE_MARKERS = ("AuthError", "TokenExpiredError", "reconnect your", "HTTP 401")
-_ACCESS_DENIED_MARKERS = ("AccessDeniedError", "HTTP 403")
-_REAUTH_GUIDANCE = (
-    "This looks like an expired or revoked sign-in — reconnect the affected "
-    "account (Settings → Connections) and re-run materialization."
-)
-_ACCESS_DENIED_GUIDANCE = (
-    "This is access that was removed upstream, not an expired sign-in — "
-    "reconnecting will NOT restore it, because it mints a token with exactly the "
-    "same access. Ask an admin on the affected provider to restore access, or "
-    "remove that data source from the workspace."
-)
+# Remediation copy for the credential problems a run can report, keyed by the
+# ``error_code`` the materializer recorded per source (arch #252, finding 14#4).
+#
+# This copy lives here and NOT at the raise site. A loader describes what the
+# provider said; deciding what the user should do about it is a presentation
+# concern, and when both layers wrote advice the user got it twice in two
+# different phrasings.
+#
+# Fragments, not sentences: _credential_guidance prefixes each with the sources
+# it applies to. A 401 and a 403 in one run need *opposite* advice, so an
+# unattributed pair reads as a flat contradiction (#372).
+_CREDENTIAL_GUIDANCE: dict[str, str] = {
+    ErrorCode.AUTH_TOKEN_EXPIRED: (
+        "expired or revoked sign-in — reconnect the affected account "
+        "(Settings → Connections) and re-run materialization."
+    ),
+    ErrorCode.AUTH_ACCESS_DENIED: (
+        "access was removed upstream, not an expired sign-in — reconnecting will "
+        "NOT restore it, because it mints a token with exactly the same access. "
+        "Ask an admin on the affected provider to restore access, or remove that "
+        "data source from the workspace."
+    ),
+}
 
 
-def _looks_like_access_denied(error: str | None) -> bool:
-    """True when a per-source error reads as an upstream 403 (access removed)."""
-    if not error:
-        return False
-    return any(marker in error for marker in _ACCESS_DENIED_MARKERS)
+class _SourceFailure(NamedTuple):
+    """One failed source, as recorded in ``run.result["sources"][name]``."""
+
+    name: str
+    error: str
+    code: str
 
 
-def _looks_like_auth_failure(error: str | None) -> bool:
-    """True when a per-source error reads as a dead *credential* (401).
+def _credential_guidance(failures: Iterable[_SourceFailure]) -> list[str]:
+    """Return one guidance line per distinct credential problem, naming its sources.
 
-    A 403 is deliberately excluded. There the credential is valid, so reconnect
-    guidance is not merely unhelpful but wrong — it mints an identically-scoped
-    token that fails the same way, and the user loops (#372).
+    Ordered by ``_CREDENTIAL_GUIDANCE`` rather than by encounter order so the
+    wording is stable regardless of which source failed first.
     """
-    if not error:
-        return False
-    if _looks_like_access_denied(error):
-        return False
-    return any(marker in error for marker in _AUTH_FAILURE_MARKERS)
+    by_code: dict[str, list[str]] = {}
+    for failure in failures:
+        if failure.code in _CREDENTIAL_GUIDANCE:
+            by_code.setdefault(failure.code, []).append(failure.name)
+    return [
+        f"{', '.join(by_code[code])}: {guidance}"
+        for code, guidance in _CREDENTIAL_GUIDANCE.items()
+        if code in by_code
+    ]
 
 
 def _no_pipeline_error(registry, provider: str) -> str:
@@ -135,7 +148,7 @@ def _compose_failure_summary(runs: list[MaterializationRun]) -> str:
     if not runs:
         return ""
 
-    failed_sources: list[tuple[str, str]] = []
+    failed_sources: list[_SourceFailure] = []
     completed_sources: list[tuple[str, int]] = []
     skipped_sources: list[str] = []
     cancelled_sources: list[str] = []
@@ -149,7 +162,13 @@ def _compose_failure_summary(runs: list[MaterializationRun]) -> str:
                 continue
             state = info.get("state")
             if state == "failed":
-                failed_sources.append((name, str(info.get("error") or "unknown error")))
+                failed_sources.append(
+                    _SourceFailure(
+                        name=name,
+                        error=str(info.get("error") or "unknown error"),
+                        code=str(info.get("error_code") or ErrorCode.INTERNAL_ERROR),
+                    )
+                )
             elif state == "completed":
                 completed_sources.append((name, int(info.get("rows") or 0)))
             elif state == "skipped":
@@ -161,10 +180,10 @@ def _compose_failure_summary(runs: list[MaterializationRun]) -> str:
     if failed_sources:
         first = failed_sources[0]
         if len(failed_sources) == 1:
-            parts.append(f"{first[0]} failed: {first[1]}")
+            parts.append(f"{first.name} failed: {first.error}")
         else:
-            others = ", ".join(n for n, _ in failed_sources[1:])
-            parts.append(f"{first[0]} failed ({first[1]}); also failed: {others}")
+            others = ", ".join(f.name for f in failed_sources[1:])
+            parts.append(f"{first.name} failed ({first.error}); also failed: {others}")
     if completed_sources:
         total_rows = sum(rows for _, rows in completed_sources)
         names = ", ".join(n for n, _ in completed_sources)
@@ -179,12 +198,8 @@ def _compose_failure_summary(runs: list[MaterializationRun]) -> str:
         states = sorted({r.state for r in runs})
         return f"Materialization {'/'.join(states)}."
     summary = ". ".join(parts) + "."
-    # Not mutually exclusive: one tenant's token can be dead while another's
-    # access was revoked, and the two need opposite advice.
-    if any(_looks_like_auth_failure(err) for _, err in failed_sources):
-        summary += " " + _REAUTH_GUIDANCE
-    if any(_looks_like_access_denied(err) for _, err in failed_sources):
-        summary += " " + _ACCESS_DENIED_GUIDANCE
+    for line in _credential_guidance(failed_sources):
+        summary += " " + line
     return summary
 
 
@@ -1372,7 +1387,8 @@ async def _aggregate_materialization_state(procrastinate_job_id: int) -> tuple[s
             "users":   {"state": "completed", "rows": 100},
             "visits":  {"state": "completed", "rows": 98869},
             "completed_works": {"state": "failed",  "rows": 0,
-                                "error": "ConnectionError: 500 ..."},
+                                "error": "ConnectionError: 500 ...",
+                                "error_code": "INTERNAL_ERROR"},
             "payments": {"state": "skipped", "rows": 0},
             ...
         },
@@ -1406,6 +1422,8 @@ async def _aggregate_materialization_state(procrastinate_job_id: int) -> tuple[s
                 detail = {"state": src_state, "rows": info.get("rows", 0)}
                 if "error" in info:
                     detail["error"] = info["error"]
+                if "error_code" in info:
+                    detail["error_code"] = info["error_code"]
                 # Expose cursor_state.last_id so the resume prompt can tell the
                 # agent where a partial load will continue from (issue #187).
                 cursor_state = info.get("cursor_state")
@@ -1494,26 +1512,22 @@ async def resume_thread_after_materialization(context, thread_job_id: str) -> di
     # pre-CAS tj.state snapshot, which mislabelled a Stop-click that raced with
     # completion as "cancelled" when the data had actually loaded).
     status, summary = await _aggregate_materialization_state(tj.procrastinate_job_id)
-    source_errors = [
-        str(src.get("error"))
+    # Named per source, because a run can carry a dead token on one and revoked
+    # access on another — opposite advice, and the agent has to tell them apart to
+    # relay either honestly.
+    guidance_lines = _credential_guidance(
+        _SourceFailure(
+            name=name,
+            error=str(src.get("error") or ""),
+            code=str(src.get("error_code") or ErrorCode.INTERNAL_ERROR),
+        )
         for tenant in summary
-        for src in (tenant.get("sources") or {}).values()
-    ]
-    auth_failure = any(_looks_like_auth_failure(e) for e in source_errors)
-    access_denied = any(_looks_like_access_denied(e) for e in source_errors)
-    # Both may apply in one run: different sources can fail for different
-    # reasons, and the two need opposite advice.
-    credential_guidance = (
-        f" At least one source failed authentication: {_REAUTH_GUIDANCE} Tell the "
-        f"user explicitly to reconnect the affected account."
-        if auth_failure
-        else ""
+        for name, src in (tenant.get("sources") or {}).items()
     )
-    credential_guidance += (
-        f" At least one source was refused because access was removed upstream: "
-        f"{_ACCESS_DENIED_GUIDANCE} Tell the user explicitly that reconnecting will "
-        f"NOT fix this one, and name the affected data source."
-        if access_denied
+    credential_guidance = (
+        " Credential problems, per source — relay these verbatim, naming the "
+        f"source each applies to: {' '.join(guidance_lines)}"
+        if guidance_lines
         else ""
     )
 

--- a/apps/workspaces/tasks.py
+++ b/apps/workspaces/tasks.py
@@ -1501,15 +1501,15 @@ async def resume_thread_after_materialization(context, thread_job_id: str) -> di
     ]
     auth_failure = any(_looks_like_auth_failure(e) for e in source_errors)
     access_denied = any(_looks_like_access_denied(e) for e in source_errors)
-    reauth_line = (
+    # Both may apply in one run: different sources can fail for different
+    # reasons, and the two need opposite advice.
+    credential_guidance = (
         f" At least one source failed authentication: {_REAUTH_GUIDANCE} Tell the "
         f"user explicitly to reconnect the affected account."
         if auth_failure
         else ""
     )
-    # Appended alongside reauth_line, not instead of it — different sources can
-    # fail for different reasons in one run.
-    reauth_line += (
+    credential_guidance += (
         f" At least one source was refused because access was removed upstream: "
         f"{_ACCESS_DENIED_GUIDANCE} Tell the user explicitly that reconnecting will "
         f"NOT fix this one, and name the affected data source."
@@ -1583,7 +1583,7 @@ async def resume_thread_after_materialization(context, thread_job_id: str) -> di
             f"failed or skipped. A source with state=in_progress or state=failed "
             f"and a non-null resume_last_id has partially-loaded rows that the "
             f"next materialization will continue from — do NOT query its table "
-            f"as if it were complete.{reauth_line} Per-tenant: {summary}"
+            f"as if it were complete.{credential_guidance} Per-tenant: {summary}"
         )
     elif status == "failed":
         body = (
@@ -1594,7 +1594,7 @@ async def resume_thread_after_materialization(context, thread_job_id: str) -> di
             f"that the data load failed (this is commonly caused by expired or "
             f"revoked credentials), summarize the per-source errors below, and "
             f"suggest checking the workspace's connection before retrying. Do NOT "
-            f"silently re-run materialization.{reauth_line} Per-tenant: {summary}"
+            f"silently re-run materialization.{credential_guidance} Per-tenant: {summary}"
         )
     elif status == "cancelled":
         body = (

--- a/apps/workspaces/tasks.py
+++ b/apps/workspaces/tasks.py
@@ -67,21 +67,42 @@ MATERIALIZATION_FAILED_MESSAGE = (
 logger = logging.getLogger(__name__)
 
 
-# Substrings that mark a per-source failure as an expired/revoked-credential
-# problem so the user is told to reconnect rather than just "check the
-# connection" (arch #252, finding 14#4). Loader auth errors carry both the
-# class-name suffix and the actionable "reconnect your ... account" guidance;
-# an HTTP 401 anywhere on the seam is the underlying signal.
-_AUTH_FAILURE_MARKERS = ("AuthError", "reconnect your", "HTTP 401")
+# Substrings that mark a per-source failure as a credential problem so the user
+# gets actionable advice rather than just "check the connection" (arch #252,
+# finding 14#4). Matching is on the serialized string because _summarize_error
+# persists "{ClassName}: {message}" into MaterializationRun.result — the class
+# name is the half that survives the JSON round-trip, so it anchors each set.
+_AUTH_FAILURE_MARKERS = ("AuthError", "TokenExpiredError", "reconnect your", "HTTP 401")
+_ACCESS_DENIED_MARKERS = ("AccessDeniedError", "HTTP 403")
 _REAUTH_GUIDANCE = (
     "This looks like an expired or revoked sign-in — reconnect the affected "
     "account (Settings → Connections) and re-run materialization."
 )
+_ACCESS_DENIED_GUIDANCE = (
+    "This is access that was removed upstream, not an expired sign-in — "
+    "reconnecting will NOT restore it, because it mints a token with exactly the "
+    "same access. Ask an admin on the affected provider to restore access, or "
+    "remove that data source from the workspace."
+)
+
+
+def _looks_like_access_denied(error: str | None) -> bool:
+    """True when a per-source error reads as an upstream 403 (access removed)."""
+    if not error:
+        return False
+    return any(marker in error for marker in _ACCESS_DENIED_MARKERS)
 
 
 def _looks_like_auth_failure(error: str | None) -> bool:
-    """True when a per-source error string reads as a credential/401 failure."""
+    """True when a per-source error reads as a dead *credential* (401).
+
+    A 403 is deliberately excluded. There the credential is valid, so reconnect
+    guidance is not merely unhelpful but wrong — it mints an identically-scoped
+    token that fails the same way, and the user loops (#372).
+    """
     if not error:
+        return False
+    if _looks_like_access_denied(error):
         return False
     return any(marker in error for marker in _AUTH_FAILURE_MARKERS)
 
@@ -158,8 +179,12 @@ def _compose_failure_summary(runs: list[MaterializationRun]) -> str:
         states = sorted({r.state for r in runs})
         return f"Materialization {'/'.join(states)}."
     summary = ". ".join(parts) + "."
+    # Not mutually exclusive: one tenant's token can be dead while another's
+    # access was revoked, and the two need opposite advice.
     if any(_looks_like_auth_failure(err) for _, err in failed_sources):
         summary += " " + _REAUTH_GUIDANCE
+    if any(_looks_like_access_denied(err) for _, err in failed_sources):
+        summary += " " + _ACCESS_DENIED_GUIDANCE
     return summary
 
 
@@ -1469,15 +1494,26 @@ async def resume_thread_after_materialization(context, thread_job_id: str) -> di
     # pre-CAS tj.state snapshot, which mislabelled a Stop-click that raced with
     # completion as "cancelled" when the data had actually loaded).
     status, summary = await _aggregate_materialization_state(tj.procrastinate_job_id)
-    auth_failure = any(
-        _looks_like_auth_failure(str(src.get("error")))
+    source_errors = [
+        str(src.get("error"))
         for tenant in summary
         for src in (tenant.get("sources") or {}).values()
-    )
+    ]
+    auth_failure = any(_looks_like_auth_failure(e) for e in source_errors)
+    access_denied = any(_looks_like_access_denied(e) for e in source_errors)
     reauth_line = (
         f" At least one source failed authentication: {_REAUTH_GUIDANCE} Tell the "
         f"user explicitly to reconnect the affected account."
         if auth_failure
+        else ""
+    )
+    # Appended alongside reauth_line, not instead of it — different sources can
+    # fail for different reasons in one run.
+    reauth_line += (
+        f" At least one source was refused because access was removed upstream: "
+        f"{_ACCESS_DENIED_GUIDANCE} Tell the user explicitly that reconnecting will "
+        f"NOT fix this one, and name the affected data source."
+        if access_denied
         else ""
     )
 

--- a/mcp_server/envelope.py
+++ b/mcp_server/envelope.py
@@ -19,6 +19,8 @@ from typing import Any
 from asgiref.sync import sync_to_async
 from django.db import close_old_connections
 
+from apps.common.error_codes import ErrorCode
+
 logger = logging.getLogger(__name__)
 
 # Dead-DB-connection hygiene for the long-lived MCP server process (arch #253,
@@ -35,13 +37,18 @@ _aclose_old_connections = sync_to_async(close_old_connections, thread_sensitive=
 # Audit logger — separate from the module logger so it can be filtered/routed
 audit_logger = logging.getLogger("mcp_server.audit")
 
-VALIDATION_ERROR = "VALIDATION_ERROR"
-CONNECTION_ERROR = "CONNECTION_ERROR"
-QUERY_TIMEOUT = "QUERY_TIMEOUT"
-NOT_FOUND = "NOT_FOUND"
-INTERNAL_ERROR = "INTERNAL_ERROR"
-SCHEMA_BUILD_FAILED = "SCHEMA_BUILD_FAILED"
-AUTH_TOKEN_EXPIRED = "AUTH_TOKEN_EXPIRED"  # noqa: S105 — error code constant, not a credential
+# Aliases onto the single registry in apps.common.error_codes. Kept as
+# module-level names so the ~30 error_response() call sites in server.py — and
+# the tests asserting on them — are unaffected; StrEnum members are str, so they
+# serialise into the envelope unchanged.
+VALIDATION_ERROR = ErrorCode.VALIDATION_ERROR
+CONNECTION_ERROR = ErrorCode.CONNECTION_ERROR
+QUERY_TIMEOUT = ErrorCode.QUERY_TIMEOUT
+NOT_FOUND = ErrorCode.NOT_FOUND
+INTERNAL_ERROR = ErrorCode.INTERNAL_ERROR
+SCHEMA_BUILD_FAILED = ErrorCode.SCHEMA_BUILD_FAILED
+AUTH_TOKEN_EXPIRED = ErrorCode.AUTH_TOKEN_EXPIRED
+AUTH_ACCESS_DENIED = ErrorCode.AUTH_ACCESS_DENIED
 
 
 def success_response(

--- a/mcp_server/loaders/commcare_base.py
+++ b/mcp_server/loaders/commcare_base.py
@@ -13,7 +13,11 @@ from urllib.parse import urljoin
 import requests
 from requests.adapters import HTTPAdapter
 
-from apps.common.errors import CommCareAuthError
+from apps.common.errors import (
+    CommCareAccessDeniedError,
+    CommCareAuthError,  # noqa: F401  — re-exported; callers catch the provider base
+    CommCareTokenExpiredError,
+)
 from mcp_server.loaders._http import build_retry, get_with_auth_refresh
 
 logger = logging.getLogger(__name__)
@@ -85,11 +89,21 @@ class CommCareBaseLoader:
         resp = get_with_auth_refresh(
             self._session, url, refresh=self._refresh, params=params, timeout=HTTP_TIMEOUT
         )
-        if resp.status_code in (401, 403):
-            raise CommCareAuthError(
+        if resp.status_code == 403:
+            # Reconnecting mints an identically-scoped token and fails the same
+            # way, so do NOT offer that advice here (#372).
+            raise CommCareAccessDeniedError(
+                f"Your CommCare account no longer has access to project space "
+                f"{self.domain} (HTTP 403). Your sign-in is still valid, so "
+                f"reconnecting will not help — your membership or API access for "
+                f"this project space may have been removed. Ask a CommCare project "
+                f"admin to restore access, or remove this data source."
+            )
+        if resp.status_code == 401:
+            raise CommCareTokenExpiredError(
                 f"CommCare authentication failed for domain {self.domain} "
-                f"(HTTP {resp.status_code}). Your CommCare sign-in has likely expired "
-                f"or been revoked — please reconnect your CommCare account and retry."
+                f"(HTTP 401). Your CommCare sign-in has expired or been revoked — "
+                f"please reconnect your CommCare account and retry."
             )
         if resp.status_code >= 400:
             raise CommCareExportError(

--- a/mcp_server/loaders/connect_base.py
+++ b/mcp_server/loaders/connect_base.py
@@ -14,7 +14,11 @@ from urllib.parse import parse_qs, urlparse
 import requests
 from requests.adapters import HTTPAdapter
 
-from apps.common.errors import ConnectAuthError
+from apps.common.errors import (
+    ConnectAccessDeniedError,
+    ConnectAuthError,  # noqa: F401  — re-exported; callers catch the provider base
+    ConnectTokenExpiredError,
+)
 from mcp_server.loaders._http import (
     RETRY_STATUS_FORCELIST,
     RETRY_TOTAL,
@@ -116,16 +120,35 @@ class ConnectBaseLoader:
         self._session.mount("https://", adapter)
         self._session.mount("http://", adapter)
 
+    def _raise_for_auth(self, status_code: int) -> None:
+        """Raise the right auth error for a 401/403; return for anything else.
+
+        401 and 403 need opposite advice, so they are separate types (#372).
+        Both paginated and ad-hoc GETs go through here so the two cannot drift.
+        """
+        if status_code == 403:
+            # Reconnecting mints an identically-scoped token and fails the same
+            # way, so do NOT offer that advice here.
+            raise ConnectAccessDeniedError(
+                f"Your CommCare Connect account no longer has access to opportunity "
+                f"{self.opportunity_id} (HTTP 403). Your sign-in is still valid, so "
+                f"reconnecting will not help — your access to this opportunity may "
+                f"have been removed. Ask a Connect admin to restore access, or "
+                f"remove this data source."
+            )
+        if status_code == 401:
+            raise ConnectTokenExpiredError(
+                f"Connect authentication failed for opportunity {self.opportunity_id} "
+                f"(HTTP 401). Your CommCare Connect sign-in has expired or been "
+                f"revoked — please reconnect your account and retry."
+            )
+
     def _get(self, url: str, params: dict | None = None) -> requests.Response:
-        """GET a URL, raising ConnectAuthError on 401/403."""
+        """GET a URL, raising ConnectAuthError on 401 / ConnectAccessDeniedError on 403."""
         resp = get_with_auth_refresh(
             self._session, url, refresh=self._refresh, params=params, timeout=HTTP_TIMEOUT
         )
-        if resp.status_code in (401, 403):
-            raise ConnectAuthError(
-                f"Connect auth failed for opportunity {self.opportunity_id}: "
-                f"HTTP {resp.status_code}"
-            )
+        self._raise_for_auth(resp.status_code)
         resp.raise_for_status()
         return resp
 
@@ -157,7 +180,8 @@ class ConnectBaseLoader:
         ``[]`` so callers can rely on the loop terminating naturally.
 
         Raises:
-            ConnectAuthError: on 401/403.
+            ConnectAuthError: on 401 (credential dead).
+            ConnectAccessDeniedError: on 403 (credential valid, no access here).
             ConnectExportError: when the response is not valid JSON, is
                 missing the ``results`` key, or returns a non-2xx status
                 that survives the configured retry policy. On retry
@@ -189,11 +213,7 @@ class ConnectBaseLoader:
                 headers=headers,
                 timeout=HTTP_TIMEOUT,
             )
-            if resp.status_code in (401, 403):
-                raise ConnectAuthError(
-                    f"Connect auth failed for opportunity {self.opportunity_id}: "
-                    f"HTTP {resp.status_code}"
-                )
+            self._raise_for_auth(resp.status_code)
             if not resp.ok:
                 # A status in the forcelist means the urllib3 Retry policy
                 # ran to exhaustion (RETRY_TOTAL retries on top of the initial

--- a/mcp_server/loaders/connect_base.py
+++ b/mcp_server/loaders/connect_base.py
@@ -144,7 +144,7 @@ class ConnectBaseLoader:
             )
 
     def _get(self, url: str, params: dict | None = None) -> requests.Response:
-        """GET a URL, raising ConnectAuthError on 401 / ConnectAccessDeniedError on 403."""
+        """GET a URL, raising on 401/403 via ``_raise_for_auth``."""
         resp = get_with_auth_refresh(
             self._session, url, refresh=self._refresh, params=params, timeout=HTTP_TIMEOUT
         )
@@ -180,7 +180,7 @@ class ConnectBaseLoader:
         ``[]`` so callers can rely on the loop terminating naturally.
 
         Raises:
-            ConnectAuthError: on 401 (credential dead).
+            ConnectTokenExpiredError: on 401 (credential dead).
             ConnectAccessDeniedError: on 403 (credential valid, no access here).
             ConnectExportError: when the response is not valid JSON, is
                 missing the ``results`` key, or returns a non-2xx status

--- a/mcp_server/loaders/ocs_base.py
+++ b/mcp_server/loaders/ocs_base.py
@@ -9,7 +9,11 @@ import requests
 from django.conf import settings
 from requests.adapters import HTTPAdapter
 
-from apps.common.errors import OCSAuthError
+from apps.common.errors import (
+    OCSAccessDeniedError,
+    OCSAuthError,  # noqa: F401  — re-exported; callers catch the provider base
+    OCSTokenExpiredError,
+)
 from mcp_server.loaders._http import build_retry, get_with_auth_refresh
 
 logger = logging.getLogger(__name__)
@@ -73,11 +77,21 @@ class OCSBaseLoader:
         resp = get_with_auth_refresh(
             self._session, url, refresh=self._refresh, params=params, timeout=HTTP_TIMEOUT
         )
-        if resp.status_code in (401, 403):
-            raise OCSAuthError(
+        if resp.status_code == 403:
+            # Reconnecting mints an identically-scoped token and fails the same
+            # way, so do NOT offer that advice here (#372).
+            raise OCSAccessDeniedError(
+                f"Your Open Chat Studio account no longer has access to chatbot "
+                f"{self.experiment_id} (HTTP 403). Your sign-in is still valid, so "
+                f"reconnecting will not help — the chatbot may have moved teams, or "
+                f"your access to it may have been removed. Ask an OCS admin to "
+                f"restore access, or remove this data source."
+            )
+        if resp.status_code == 401:
+            raise OCSTokenExpiredError(
                 f"OCS authentication failed for experiment {self.experiment_id} "
-                f"(HTTP {resp.status_code}). Your Open Chat Studio sign-in has likely "
-                f"expired or been revoked — please reconnect your account and retry."
+                f"(HTTP 401). Your Open Chat Studio sign-in has expired or been "
+                f"revoked — please reconnect your account and retry."
             )
         if resp.status_code >= 400:
             raise OCSExportError(

--- a/mcp_server/services/materializer.py
+++ b/mcp_server/services/materializer.py
@@ -347,10 +347,17 @@ def run_pipeline(
                     }
                 raise
             except Exception as e:
-                logger.exception(
+                # WARNING, not ERROR, because this handler RE-RAISES and the
+                # caller logs the same exception at ERROR. Two logger.exception
+                # calls on one failure minted two Sentry groups every time —
+                # confirmed in production as identical pairs differing only in
+                # `logger` (#371). At WARNING this becomes a breadcrumb on the
+                # caller's single event, so the source/schema context survives.
+                logger.warning(
                     "Source %s failed for schema %s; earlier sources stay committed",
                     source.name,
                     schema_name,
+                    exc_info=True,
                 )
                 # Preserve any cursor_state advanced by per-page commits so the
                 # next run resumes from the last durable watermark (#187).
@@ -426,7 +433,13 @@ def run_pipeline(
         # Idempotent w.r.t. the per-source loop handler: if completed_at was
         # already stamped there, leave the recorded state untouched.
         if run.completed_at is None:
-            logger.exception("Materialization run %s failed before any source committed", run.id)
+            # WARNING for the same reason as the per-source handler above: this
+            # path re-raises and the caller logs the single ERROR (#371).
+            logger.warning(
+                "Materialization run %s failed before any source committed",
+                run.id,
+                exc_info=True,
+            )
             now = datetime.now(UTC)
             MaterializationRun.objects.filter(id=run.id, completed_at__isnull=True).update(
                 state=MaterializationRun.RunState.FAILED,

--- a/mcp_server/services/materializer.py
+++ b/mcp_server/services/materializer.py
@@ -50,6 +50,7 @@ from asgiref.sync import async_to_sync
 from django.utils import timezone
 from psycopg import sql as psql
 
+from apps.common.error_codes import code_of
 from apps.knowledge.services.column_note_generator import sync_column_notes
 from apps.transformations.models import TransformationAsset
 from apps.transformations.services.commcare_staging import upsert_system_assets
@@ -366,6 +367,8 @@ def run_pipeline(
                     "state": "failed",
                     "rows": (source_results.get(source.name) or {}).get("rows", 0),
                     "error": _summarize_error(e),
+                    "error_code": code_of(e),
+                    "provider": getattr(e, "provider", None) or pipeline.provider,
                     "attempts": getattr(e, "attempts", 1),
                     "failed_at": datetime.now(UTC).isoformat(),
                     "cursor_state": prior_cursor,
@@ -448,6 +451,7 @@ def run_pipeline(
                     "pipeline": pipeline.name,
                     "sources": source_results,
                     "error": _summarize_error(e),
+                    "error_code": code_of(e),
                 },
             )
         raise
@@ -688,9 +692,14 @@ def _has_committed_cursor(entry: dict) -> bool:
 def _summarize_error(exc: BaseException) -> str:
     """Return a short, single-line error description for ``result["sources"][n].error``.
 
-    The string is surfaced to the agent in the resume prompt and (eventually)
-    to the end user, so it must be safe to display: no stack trace, no
-    sensitive headers, just the exception type and message.
+    The string is surfaced to the agent in the resume prompt and to the end user,
+    so it must be safe to display: no stack trace, no sensitive headers, just the
+    exception type and message.
+
+    This is the **human** half only. Consumers deciding what to *do* about a
+    failure read the sibling ``error_code`` — never this string. The class name
+    stays on the front for operator legibility in logs and prompts, not as
+    something to match on.
     """
     msg = str(exc).strip().splitlines()[0] if str(exc).strip() else exc.__class__.__name__
     if len(msg) > 200:

--- a/tests/test_error_taxonomy.py
+++ b/tests/test_error_taxonomy.py
@@ -120,6 +120,21 @@ class TestBeforeSend:
         event = {"event": 1}
         assert before_send(event, self._hint(auth_error("HTTP 401"))) is event
 
+    @pytest.mark.parametrize(
+        "leaf",
+        [
+            CommCareTokenExpiredError,
+            CommCareAccessDeniedError,
+            ConnectTokenExpiredError,
+            ConnectAccessDeniedError,
+            OCSTokenExpiredError,
+            OCSAccessDeniedError,
+        ],
+    )
+    def test_loader_leaf_classes_are_dropped(self, leaf):
+        """The loader path is classified: it reaches the user via the chat summary."""
+        assert before_send({"event": 1}, self._hint(leaf("upstream said no"))) is None
+
 
 class TestAuthErrorAxes:
     """Both axes must be catchable: by provider, and by cause."""

--- a/tests/test_error_taxonomy.py
+++ b/tests/test_error_taxonomy.py
@@ -7,11 +7,19 @@ both directions — what gets dropped AND what must keep coming through.
 import pytest
 
 from apps.common.errors import (
+    CommCareAccessDeniedError,
     CommCareAuthError,
+    CommCareTokenExpiredError,
+    ConnectAccessDeniedError,
     ConnectAuthError,
+    ConnectTokenExpiredError,
     ExpectedStateError,
     ExpectedUpstreamError,
+    OCSAccessDeniedError,
     OCSAuthError,
+    OCSTokenExpiredError,
+    UpstreamAccessDenied,
+    UpstreamTokenExpired,
 )
 from apps.users.services.tenant_resolution import CommCareAuthError as resolution_commcare
 from apps.users.services.tenant_resolution import ConnectAuthError as resolution_connect
@@ -100,12 +108,59 @@ class TestBeforeSend:
         [CommCareAuthError, ConnectAuthError, OCSAuthError],
         ids=["commcare", "connect", "ocs"],
     )
-    def test_provider_auth_errors_are_not_yet_classified(self, auth_error):
-        """Scope pin: this PR adds the mechanism, it does not classify anything.
+    def test_provider_base_classes_are_not_classified(self, auth_error):
+        """The bare provider classes must keep reaching Sentry.
 
-        The provider auth errors still reach Sentry exactly as they do today, so
-        this change is a no-op on event volume. Reclassifying them (and
-        splitting 401 from 403) is #371/#372, which inverts this assertion.
+        This is the guard on #371's precondition, and it is deliberate rather
+        than incidental. ``tenant_resolution`` raises these bare from the login
+        signal, whose only failure signal today IS the Sentry event — the user
+        just gets an empty data-sources page. Classifying the base would silence
+        that path without replacing it, so expectedness lives on the leaves.
         """
         event = {"event": 1}
         assert before_send(event, self._hint(auth_error("HTTP 401"))) is event
+
+
+class TestAuthErrorAxes:
+    """Both axes must be catchable: by provider, and by cause."""
+
+    @pytest.mark.parametrize(
+        ("base", "expired", "denied"),
+        [
+            (CommCareAuthError, CommCareTokenExpiredError, CommCareAccessDeniedError),
+            (ConnectAuthError, ConnectTokenExpiredError, ConnectAccessDeniedError),
+            (OCSAuthError, OCSTokenExpiredError, OCSAccessDeniedError),
+        ],
+        ids=["commcare", "connect", "ocs"],
+    )
+    def test_provider_base_catches_both_causes(self, base, expired, denied):
+        """Existing `except <Provider>AuthError` keeps working after the split."""
+        assert issubclass(expired, base)
+        assert issubclass(denied, base)
+
+    @pytest.mark.parametrize(
+        "denied",
+        [CommCareAccessDeniedError, ConnectAccessDeniedError, OCSAccessDeniedError],
+        ids=["commcare", "connect", "ocs"],
+    )
+    def test_access_denied_is_catchable_across_providers(self, denied):
+        """The hook the revocation work (#378/#384) needs: one except for every 403."""
+        assert issubclass(denied, UpstreamAccessDenied)
+
+    @pytest.mark.parametrize(
+        "expired",
+        [CommCareTokenExpiredError, ConnectTokenExpiredError, OCSTokenExpiredError],
+        ids=["commcare", "connect", "ocs"],
+    )
+    def test_expiry_is_catchable_across_providers(self, expired):
+        assert issubclass(expired, UpstreamTokenExpired)
+
+    def test_the_two_causes_do_not_catch_each_other(self):
+        """The whole point of #372 — a 403 must not be handled as an expiry."""
+        assert not issubclass(OCSAccessDeniedError, UpstreamTokenExpired)
+        assert not issubclass(OCSTokenExpiredError, UpstreamAccessDenied)
+
+    def test_provider_is_reported(self):
+        assert OCSAccessDeniedError("x").provider == "ocs"
+        assert CommCareTokenExpiredError("x").provider == "commcare"
+        assert ConnectAccessDeniedError("x").provider == "commcare_connect"

--- a/tests/test_loader_401_403_split.py
+++ b/tests/test_loader_401_403_split.py
@@ -1,0 +1,142 @@
+"""401 and 403 must not be conflated in any loader (#372).
+
+A 401 means the credential is dead and reconnecting mints a working one. A 403
+means the credential is *fine* and simply has no access to that resource, so
+reconnecting mints an identically-scoped token and fails the same way — the
+advice loops the user. Every loader raise site is pinned here, in both
+directions, including that the 403 copy does not tell anyone to reconnect.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from apps.common.errors import (
+    CommCareAccessDeniedError,
+    CommCareTokenExpiredError,
+    ConnectAccessDeniedError,
+    ConnectTokenExpiredError,
+    OCSAccessDeniedError,
+    OCSTokenExpiredError,
+)
+from mcp_server.loaders.commcare_base import CommCareBaseLoader
+from mcp_server.loaders.connect_base import ConnectBaseLoader
+from mcp_server.loaders.ocs_base import OCSBaseLoader
+
+CREDENTIAL = {"type": "oauth", "value": "tok"}
+
+
+def _response(status: int) -> Mock:
+    resp = Mock()
+    resp.status_code = status
+    resp.ok = status < 400
+    resp.headers = {}
+    return resp
+
+
+def _ocs():
+    return OCSBaseLoader("exp-1", CREDENTIAL, base_url="https://ocs.test")
+
+
+def _commcare():
+    return CommCareBaseLoader("dom-1", CREDENTIAL)
+
+
+def _connect():
+    return ConnectBaseLoader(765, CREDENTIAL, base_url="https://connect.test")
+
+
+# (label, loader factory, call, 401 class, 403 class, resource name in the copy)
+CASES = [
+    (
+        "ocs._get",
+        _ocs,
+        lambda ldr: ldr._get("https://ocs.test/api/experiments/exp-1/"),
+        OCSTokenExpiredError,
+        OCSAccessDeniedError,
+        "exp-1",
+    ),
+    (
+        "commcare._get",
+        _commcare,
+        lambda ldr: ldr._get("https://hq.test/a/dom-1/api/case/v2/"),
+        CommCareTokenExpiredError,
+        CommCareAccessDeniedError,
+        "dom-1",
+    ),
+    (
+        "connect._get",
+        _connect,
+        lambda ldr: ldr._get("https://connect.test/export/opportunity/765/meta/"),
+        ConnectTokenExpiredError,
+        ConnectAccessDeniedError,
+        "765",
+    ),
+    (
+        "connect._paginate_export_pages",
+        _connect,
+        lambda ldr: list(ldr._paginate_export_pages("visits")),
+        ConnectTokenExpiredError,
+        ConnectAccessDeniedError,
+        "765",
+    ),
+]
+IDS = [c[0] for c in CASES]
+
+
+@pytest.mark.parametrize(
+    ("_label", "factory", "call", "expired_cls", "_denied", "_res"), CASES, ids=IDS
+)
+def test_401_raises_token_expired(_label, factory, call, expired_cls, _denied, _res):
+    loader = factory()
+    with patch.object(loader._session, "get", return_value=_response(401)):
+        with pytest.raises(expired_cls) as exc:
+            call(loader)
+    assert "reconnect" in str(exc.value).lower()
+
+
+@pytest.mark.parametrize(
+    ("_label", "factory", "call", "_expired", "denied_cls", "resource"), CASES, ids=IDS
+)
+def test_403_raises_access_denied(_label, factory, call, _expired, denied_cls, resource):
+    loader = factory()
+    with patch.object(loader._session, "get", return_value=_response(403)):
+        with pytest.raises(denied_cls) as exc:
+            call(loader)
+    message = str(exc.value)
+    assert resource in message, "the 403 must name the resource the user lost access to"
+    assert "will not help" in message.lower()
+
+
+@pytest.mark.parametrize(
+    ("_label", "factory", "call", "_expired", "denied_cls", "_res"), CASES, ids=IDS
+)
+def test_403_does_not_advise_reconnecting(_label, factory, call, _expired, denied_cls, _res):
+    """The bug in #372: reconnecting mints the same token and the user loops."""
+    loader = factory()
+    with patch.object(loader._session, "get", return_value=_response(403)):
+        with pytest.raises(denied_cls) as exc:
+            call(loader)
+    message = str(exc.value).lower()
+    assert "reconnect your" not in message
+    assert "please reconnect" not in message
+
+
+@pytest.mark.parametrize(
+    ("_label", "factory", "call", "expired_cls", "denied_cls", "_res"), CASES, ids=IDS
+)
+def test_403_is_not_refresh_retried(_label, factory, call, expired_cls, denied_cls, _res):
+    """_http.get_with_auth_refresh consults the refresher only on 401.
+
+    Pinned here because the transport already drew this distinction and the
+    loaders were the layer discarding it.
+    """
+    refresher = Mock(return_value="new-token")
+    loader = factory()
+    loader._refresh = refresher
+    with patch.object(loader._session, "get", return_value=_response(403)):
+        with pytest.raises(denied_cls):
+            call(loader)
+    refresher.assert_not_called()

--- a/tests/test_reauth_failure_mapping.py
+++ b/tests/test_reauth_failure_mapping.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
-from apps.workspaces.tasks import _compose_failure_summary, _looks_like_auth_failure
+from apps.workspaces.tasks import (
+    _compose_failure_summary,
+    _looks_like_access_denied,
+    _looks_like_auth_failure,
+)
 
 
 def _run(sources: dict, state: str = "failed"):
@@ -53,3 +57,52 @@ def test_summary_omits_reauth_guidance_for_non_auth_failure():
     ]
     summary = _compose_failure_summary(runs)
     assert "reconnect" not in summary.lower()
+
+
+# --- 403 must NOT be routed to the reauth advice (#372) --------------------
+
+_DENIED_ERROR = (
+    "OCSAccessDeniedError: Your Open Chat Studio account no longer has access to "
+    "chatbot 514e2e67 (HTTP 403). Your sign-in is still valid, so reconnecting "
+    "will not help."
+)
+_EXPIRED_ERROR = (
+    "OCSTokenExpiredError: OCS authentication failed for experiment cdec8c04 "
+    "(HTTP 401). Your Open Chat Studio sign-in has expired or been revoked — "
+    "please reconnect your account and retry."
+)
+
+
+def test_403_is_not_classified_as_a_reauthable_failure():
+    assert _looks_like_access_denied(_DENIED_ERROR)
+    assert not _looks_like_auth_failure(_DENIED_ERROR)
+
+
+def test_401_is_classified_as_reauthable_and_not_access_denied():
+    assert _looks_like_auth_failure(_EXPIRED_ERROR)
+    assert not _looks_like_access_denied(_EXPIRED_ERROR)
+
+
+def test_summary_tells_the_user_reconnecting_will_not_fix_a_403():
+    summary = _compose_failure_summary(
+        [_run({"sessions": {"state": "failed", "rows": 0, "error": _DENIED_ERROR}})]
+    )
+    assert "will not restore it" in summary.lower()
+    # The old behaviour — the loop this issue is about.
+    assert "reconnect the affected account" not in summary.lower()
+
+
+def test_summary_carries_both_when_two_sources_fail_differently():
+    """One tenant's token can be dead while another's access was revoked."""
+    summary = _compose_failure_summary(
+        [
+            _run(
+                {
+                    "sessions": {"state": "failed", "rows": 0, "error": _DENIED_ERROR},
+                    "messages": {"state": "failed", "rows": 0, "error": _EXPIRED_ERROR},
+                }
+            )
+        ]
+    )
+    assert "reconnect the affected account" in summary.lower()
+    assert "will not restore it" in summary.lower()

--- a/tests/test_reauth_failure_mapping.py
+++ b/tests/test_reauth_failure_mapping.py
@@ -1,106 +1,129 @@
-"""Reauth guidance mapping in the failure summary (arch #252, finding 14#4)."""
+"""Credential guidance in the failure summary (arch #252, finding 14#4; #372).
+
+Guidance is selected by ``error_code`` — the machine half of the per-source
+failure record — never by matching the human message. These tests deliberately
+pair a code with a *contradictory* message to pin that: if a future change goes
+back to reading the prose, they fail.
+"""
 
 from __future__ import annotations
 
 from types import SimpleNamespace
 
-from apps.workspaces.tasks import (
-    _compose_failure_summary,
-    _looks_like_access_denied,
-    _looks_like_auth_failure,
+from apps.common.error_codes import ErrorCode
+from apps.workspaces.tasks import _compose_failure_summary, _credential_guidance, _SourceFailure
+
+_DENIED_ERROR = (
+    "OCSAccessDeniedError: Your Open Chat Studio account no longer has access to "
+    "chatbot 514e2e67 (HTTP 403)."
 )
+_EXPIRED_ERROR = (
+    "OCSTokenExpiredError: OCS authentication failed for experiment cdec8c04 (HTTP 401)."
+)
+
+
+def _failed(error: str, code: str) -> dict:
+    return {"state": "failed", "rows": 0, "error": error, "error_code": code}
 
 
 def _run(sources: dict, state: str = "failed"):
     return SimpleNamespace(result={"sources": sources}, state=state)
 
 
-def test_looks_like_auth_failure_detects_markers():
-    assert _looks_like_auth_failure(
-        "CommCareAuthError: CommCare authentication failed ... reconnect your CommCare account"
+def test_guidance_is_keyed_on_the_code_not_the_message():
+    """A message saying "401" with a 403 code gets 403 advice, and vice versa.
+
+    The whole point of the code: prose is not evidence.
+    """
+    lines = _credential_guidance(
+        [
+            _SourceFailure(
+                "sessions", "HTTP 401 reconnect your account", ErrorCode.AUTH_ACCESS_DENIED
+            ),
+            _SourceFailure("messages", "HTTP 403 access removed", ErrorCode.AUTH_TOKEN_EXPIRED),
+        ]
     )
-    assert _looks_like_auth_failure("OCSAuthError: HTTP 401")
-    assert not _looks_like_auth_failure("ConnectExportError: HTTP 500 for ...")
-    assert not _looks_like_auth_failure(None)
+    assert "sessions: access was removed upstream" in " ".join(lines)
+    assert "messages: expired or revoked sign-in" in " ".join(lines)
 
 
-def test_summary_appends_reauth_guidance_on_auth_failure():
-    runs = [
-        _run(
-            {
-                "cases": {
-                    "state": "failed",
-                    "rows": 0,
-                    "error": (
-                        "CommCareAuthError: CommCare authentication failed for domain d "
-                        "(HTTP 401). Please reconnect your CommCare account and retry."
-                    ),
-                }
-            }
-        )
-    ]
-    summary = _compose_failure_summary(runs)
+def test_no_guidance_without_a_credential_code():
+    assert (
+        _credential_guidance([_SourceFailure("visits", "HTTP 500", ErrorCode.INTERNAL_ERROR)]) == []
+    )
+
+
+def test_guidance_groups_every_source_sharing_a_code():
+    lines = _credential_guidance(
+        [
+            _SourceFailure("sessions", "", ErrorCode.AUTH_TOKEN_EXPIRED),
+            _SourceFailure("messages", "", ErrorCode.AUTH_TOKEN_EXPIRED),
+        ]
+    )
+    assert len(lines) == 1
+    assert lines[0].startswith("sessions, messages: ")
+
+
+def test_summary_appends_reauth_guidance_on_a_401():
+    summary = _compose_failure_summary(
+        [_run({"cases": _failed(_EXPIRED_ERROR, ErrorCode.AUTH_TOKEN_EXPIRED)})]
+    )
     assert "reconnect the affected account" in summary.lower()
 
 
-def test_summary_omits_reauth_guidance_for_non_auth_failure():
-    runs = [
-        _run(
-            {
-                "visits": {
-                    "state": "failed",
-                    "rows": 0,
-                    "error": "ConnectExportError: HTTP 500 for /export/...",
-                }
-            }
-        )
-    ]
-    summary = _compose_failure_summary(runs)
-    assert "reconnect" not in summary.lower()
-
-
-_DENIED_ERROR = (
-    "OCSAccessDeniedError: Your Open Chat Studio account no longer has access to "
-    "chatbot 514e2e67 (HTTP 403). Your sign-in is still valid, so reconnecting "
-    "will not help."
-)
-_EXPIRED_ERROR = (
-    "OCSTokenExpiredError: OCS authentication failed for experiment cdec8c04 "
-    "(HTTP 401). Your Open Chat Studio sign-in has expired or been revoked — "
-    "please reconnect your account and retry."
-)
-
-
-def test_403_is_not_classified_as_a_reauthable_failure():
-    assert _looks_like_access_denied(_DENIED_ERROR)
-    assert not _looks_like_auth_failure(_DENIED_ERROR)
-
-
-def test_401_is_classified_as_reauthable_and_not_access_denied():
-    assert _looks_like_auth_failure(_EXPIRED_ERROR)
-    assert not _looks_like_access_denied(_EXPIRED_ERROR)
-
-
-def test_summary_tells_the_user_reconnecting_will_not_fix_a_403():
-    summary = _compose_failure_summary(
-        [_run({"sessions": {"state": "failed", "rows": 0, "error": _DENIED_ERROR}})]
-    )
-    assert "will not restore it" in summary.lower()
-    # The old behaviour — the loop this issue is about.
-    assert "reconnect the affected account" not in summary.lower()
-
-
-def test_summary_carries_both_when_two_sources_fail_differently():
-    """One tenant's token can be dead while another's access was revoked."""
+def test_summary_omits_reauth_guidance_for_a_non_credential_failure():
     summary = _compose_failure_summary(
         [
             _run(
                 {
-                    "sessions": {"state": "failed", "rows": 0, "error": _DENIED_ERROR},
-                    "messages": {"state": "failed", "rows": 0, "error": _EXPIRED_ERROR},
+                    "visits": _failed(
+                        "ConnectExportError: HTTP 500 for /export/...",
+                        ErrorCode.INTERNAL_ERROR,
+                    )
                 }
             )
         ]
     )
-    assert "reconnect the affected account" in summary.lower()
+    assert "reconnect" not in summary.lower()
+
+
+def test_summary_tells_the_user_reconnecting_will_not_fix_a_403():
+    summary = _compose_failure_summary(
+        [_run({"sessions": _failed(_DENIED_ERROR, ErrorCode.AUTH_ACCESS_DENIED)})]
+    )
     assert "will not restore it" in summary.lower()
+    # The loop #372 is about: a 403 must never draw reconnect advice.
+    assert "reconnect the affected account" not in summary.lower()
+
+
+def test_summary_attributes_each_kind_of_advice_to_its_own_source():
+    """A dead token on one source and revoked access on another.
+
+    The two need opposite advice, so both must name their source — unattributed,
+    "reconnect" followed by "reconnecting will NOT restore it" reads as a
+    contradiction the user cannot act on (#372).
+    """
+    summary = _compose_failure_summary(
+        [
+            _run(
+                {
+                    "sessions": _failed(_DENIED_ERROR, ErrorCode.AUTH_ACCESS_DENIED),
+                    "messages": _failed(_EXPIRED_ERROR, ErrorCode.AUTH_TOKEN_EXPIRED),
+                }
+            )
+        ]
+    )
+    assert "messages: expired or revoked sign-in" in summary
+    assert "sessions: access was removed upstream" in summary
+
+
+def test_summary_survives_a_failure_record_with_no_code():
+    """An in-flight run written by the previous release carries no error_code.
+
+    It degrades to "no credential guidance", never to a crash or to wrong advice.
+    """
+    summary = _compose_failure_summary(
+        [_run({"cases": {"state": "failed", "rows": 0, "error": _EXPIRED_ERROR}})]
+    )
+    assert _EXPIRED_ERROR in summary
+    assert "reconnect" not in summary.lower()

--- a/tests/test_reauth_failure_mapping.py
+++ b/tests/test_reauth_failure_mapping.py
@@ -59,8 +59,6 @@ def test_summary_omits_reauth_guidance_for_non_auth_failure():
     assert "reconnect" not in summary.lower()
 
 
-# --- 403 must NOT be routed to the reauth advice (#372) --------------------
-
 _DENIED_ERROR = (
     "OCSAccessDeniedError: Your Open Chat Studio account no longer has access to "
     "chatbot 514e2e67 (HTTP 403). Your sign-in is still valid, so reconnecting "

--- a/tests/test_single_log_per_failure.py
+++ b/tests/test_single_log_per_failure.py
@@ -1,0 +1,102 @@
+"""One failure must produce one Sentry-eligible log record (#371).
+
+Sentry's LoggingIntegration promotes every ERROR record into an event, so a
+handler that logs at ERROR *and* re-raises produces two events and two issue
+groups for one failure. Production showed exactly that: identical pairs of
+groups differing only in ``logger`` (SCOUT-DJANGO-2W/2V, 2X/2Y), with matching
+timestamps and event counts.
+
+The rule this pins: **a handler that re-raises logs at WARNING; the handler
+that stops propagation logs at ERROR.** The WARNING still reaches CloudWatch
+and becomes a breadcrumb on the single event.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import textwrap
+
+import pytest
+
+from mcp_server.services import materializer
+
+# Handlers in run_pipeline that swallow the exception rather than re-raising.
+# These are the ONLY log of their failure, so they legitimately stay at ERROR.
+_SWALLOWING_HANDLERS = {
+    "Failed to generate system assets for %s; continuing pipeline",
+    "Failed to generate Connect assets for %s; continuing pipeline",
+    "Transform phase failed for schema %s",
+    "Rollback failed for source %s; connection may be in a broken state",
+}
+
+
+def _first_string_arg(call: ast.Call) -> str | None:
+    if call.args and isinstance(call.args[0], ast.Constant):
+        value = call.args[0].value
+        if isinstance(value, str):
+            return value
+    return None
+
+
+def _handler_reraises(handler: ast.ExceptHandler) -> bool:
+    """True if the handler ends by propagating, i.e. a bare `raise`."""
+    return any(isinstance(node, ast.Raise) and node.exc is None for node in ast.walk(handler))
+
+
+def _exception_logs_in_reraising_handlers() -> list[str]:
+    """Message templates logged via logger.exception inside a re-raising handler."""
+    tree = ast.parse(textwrap.dedent(inspect.getsource(materializer)))
+    offenders = []
+    for handler in (n for n in ast.walk(tree) if isinstance(n, ast.ExceptHandler)):
+        if not _handler_reraises(handler):
+            continue
+        for node in ast.walk(handler):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "exception"
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "logger"
+            ):
+                message = _first_string_arg(node)
+                if message and message not in _SWALLOWING_HANDLERS:
+                    offenders.append(message)
+    return offenders
+
+
+def test_no_reraising_handler_logs_at_error():
+    """A re-raising handler must not log.exception — the caller already does.
+
+    Static rather than behavioural because the double-log is a property of the
+    code shape, and this catches a new one being added anywhere in the module
+    rather than only on the paths a test happens to exercise.
+    """
+    offenders = _exception_logs_in_reraising_handlers()
+    assert offenders == [], (
+        "These handlers log at ERROR and then re-raise, so the caller's own "
+        f"ERROR log mints a second Sentry group for the same failure: {offenders}. "
+        "Use logger.warning(..., exc_info=True) — it still reaches CloudWatch and "
+        "becomes a breadcrumb on the caller's event."
+    )
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "Source %s failed for schema %s; earlier sources stay committed",
+        "Materialization run %s failed before any source committed",
+    ],
+)
+def test_the_two_known_double_log_sites_are_warnings(message):
+    """Pin the specific sites from #371 at WARNING, not merely 'not ERROR'.
+
+    WARNING is below LoggingIntegration's default ``event_level`` of ERROR, so
+    the record becomes a breadcrumb instead of an event.
+    """
+    source = inspect.getsource(materializer)
+    idx = source.index(message)
+    call_start = source[:idx].rindex("logger.")
+    assert source[call_start:idx].startswith("logger.warning"), (
+        f"{message!r} must be logged at WARNING; it re-raises and the caller logs the ERROR."
+    )


### PR DESCRIPTION
## What & why

Wave 0 of #386, PR 2 of 4. **Stacked on #387 — review that first; this PR's diff is against it.**

Closes #372. Part of #371 (the remaining half of #371 is PR 4's dbt noise).

Three things, one per commit:

1. **401 and 403 stop being the same thing.** All three loaders merged them into one exception asserting the sign-in "has likely expired… please reconnect your account". For a 403 that is wrong: the token is *valid* and simply has no access to that resource, so reconnecting mints an identically-scoped token and fails the same way — the user loops.
2. **The loader auth failures are classified as expected states,** so they stop paging. This is the two-line diff that matters; the rest is tests pinning what it means.
3. **One failure now produces one log record,** not one per layer.

### Verified against production Sentry (read-only)

Every auth group's culprit is a **loader**, not the login path:

| Group | Events (90d) | Logger | Culprit |
|---|---|---|---|
| `SCOUT-DJANGO-Y` | 46 | `apps.workspaces.tasks` | `commcare_base in _get` |
| `2Y` / `2X` | 5 / 5 | `materializer` / `tasks` | `ocs_base in _get` (401) |
| `2W` / `2V` | 2 / 2 | `tasks` / `materializer` | `ocs_base in _get` (403) |
| `12` | 1 | `apps.workspaces.tasks` | `commcare_base in _get` |

The `2Y`/`2X` and `2W`/`2V` pairs are the double-log: same culprit, same count, differing only in `logger`.

`sentry issue list --query "logger:apps.users.signals" --period 90d` returns **`"data": []`** — the login-signal path emits nothing at all. That fact drives the scope decision below.

## Before/after: what reaches Sentry

| Condition | Before | After | Why |
|---|---|---|---|
| Loader 401 (`*TokenExpiredError`) | ✅ **2 events, 2 groups** per failure | 🚫 **dropped** | expected: the user gets `_REAUTH_GUIDANCE` in the chat failure summary |
| Loader 403 (`*AccessDeniedError`) | ✅ **2 events, 2 groups** per failure | 🚫 **dropped** | expected *only now* — its guidance became correct in commit 2 |
| **Login-signal auth failure** (`signals.py:139-146`) | ✅ reaches Sentry | ✅ **unchanged — still reaches Sentry** | **the hard constraint.** No user-facing surface exists, so it stays loud |
| `tenant_resolution` shape drift (`TenantResolutionError`) | ✅ | ✅ **unchanged** | not classified; aborts archival, genuinely unexpected |
| Any non-auth source failure (5xx, timeout, bad JSON) | ✅ **2 events, 2 groups** | ✅ **1 event, 1 group** | double-log removed; the inner WARNING becomes a breadcrumb |
| Materialization run failing before any source commits | ✅ 2 events | ✅ **1 event** | same |
| Asset-generation / transform / rollback failures | ✅ | ✅ **unchanged** | those handlers *swallow*, so their log is the only record — they stay ERROR |
| A bug raised while handling an auth error | ✅ | ✅ **kept** | `before_send` does not walk `__cause__` |
| Raw dbt stdout (340 events) | ✅ | ✅ **unchanged** | no exception attached; needs `ignore_logger` (PR 4) |

**Net: 61 auth events → 0, and every remaining materialization failure halves from 2 events to 1.** Estimated ~7 fewer new-issue Slack pings to `#scout-ops` per auth incident (today 2 user problems → 4 groups → 4 pings).

### The hard constraint, and why it needed a structural answer

The obvious implementation — reparent `OCSAuthError` under `ExpectedUpstreamError` — would have silenced `signals.py:139-146` **without anyone editing that file**, because `tenant_resolution` raises the same class. That's precisely the precondition #371 warns about: a failed resolution at login leaves the user on an empty data-sources page that reads as "this account has no data", and the Sentry event is the only signal anything broke.

So expectedness lives on the **leaf** classes, which only the loaders raise:

```
OCSAuthError(Exception)                     ← tenant_resolution raises this. NOT expected. Still pages.
├── OCSTokenExpiredError(…, UpstreamTokenExpired)   ← loader 401. Expected.
└── OCSAccessDeniedError(…, UpstreamAccessDenied)   ← loader 403. Expected.
```

`test_provider_base_classes_are_not_classified` pins it, so a future reparenting has to argue with a test. The reasoning is that rule 3 of the taxonomy ("someone who can act on it is told, through a channel that is not Sentry") is a property of the **raise site**, not the exception type — and the loader path satisfies it while the login path does not.

Giving the login path a real surface is a follow-up, not smuggled in here: a `needs_reconnect` value on the `status` field `providers_view` already returns, which `ConnectionsPage.tsx:200-243` already renders as an amber "Reconnect" CTA (~30 lines, no migration). Nothing forces it now — that path emits zero events.

### Two axes, and why both

`except OCSAuthError` still catches everything OCS. `except UpstreamAccessDenied` now catches every 403 across all three providers — the hook #378/#384 need, since a 403 is an authoritative per-tenant revocation signal.

The provider axis is load-bearing beyond `except`: `_summarize_error` serialises `exc.__class__.__name__` into `MaterializationRun.result`, so the class name is the part that survives the JSON round-trip into the user-facing summary. That's also why the guidance predicates match on class name rather than prose.

## Sibling sweep (required on bug/incident fixes)

**Pattern A — `if resp.status_code in (401, 403)` conflating two different conditions.**

- **Grep used:** `grep -rn --include="*.py" "status_code in (401, 403)" apps mcp_server`

  - [x] `mcp_server/loaders/ocs_base.py:79` — **fixed** (split; 403 names the chatbot, does not say reconnect)
  - [x] `mcp_server/loaders/commcare_base.py:92` — **fixed**
  - [x] `mcp_server/loaders/connect_base.py:128` — **fixed** (routed through one `_raise_for_auth`)
  - [x] `mcp_server/loaders/connect_base.py:196` — **fixed** (the duplicate raise; same helper, so they cannot drift)
  - [x] `apps/users/services/tenant_resolution.py:124, :174, :221` — **partially fixed, deliberately.** Message corrected (no longer asserts expiry on a 403), but NOT split into typed classes: these are *collection* endpoints where a 403 means the token can't enumerate at all, and re-consenting against a different team genuinely may help. The loaders' "reconnecting will not help" copy would be wrong here. No type/control-flow change, so revocation safety is untouched.
  - [ ] `apps/users/services/api_key_providers/commcare.py:25` — **not applicable.** Raises `CredentialVerificationError` with `"CommCare rejected the API key (HTTP {status})"` — already status-accurate, gives no wrong advice, and runs synchronously while the user is looking at the form.
  - [ ] `apps/users/services/api_key_providers/ocs.py:38` — **not applicable**, same shape.

**Pattern B — `logger.exception` in a handler that re-raises (mints a second Sentry group).**

- **Grep used:** `grep -n "logger.exception" mcp_server/services/materializer.py`, then classified each by whether its handler re-raises.

  - [x] `materializer.py:350` per-source failure — **fixed** → WARNING (re-raises; `tasks.py` logs the ERROR)
  - [x] `materializer.py:429` pre-loop failure — **fixed** → WARNING (same)
  - [ ] `materializer.py:235` system-asset generation — **not applicable**: swallows ("continuing pipeline"), so this is the only record
  - [ ] `materializer.py:258` Connect-asset generation — **not applicable**: swallows
  - [ ] `materializer.py:466` transform phase — **not applicable**: swallows into `transform_result`. (Also PR 4 territory.)
  - [ ] `materializer.py:732` rollback failure — **not applicable**: logs a *different* exception (the failed rollback) than the one re-raised; a broken connection is its own defect
  - [ ] `apps/workspaces/tasks.py:335, :360, :374` — **not applicable**: these are the handlers that *stop* propagation. They are the single ERROR and must stay.

Verified there is no path where downgrading loses the only log: every live caller of `run_pipeline` logs at ERROR, and the one entry point that doesn't (`run_commcare_sync`) has zero callers.

## Testing

Full suite: **1751 passed, 5 skipped**. No existing test needed editing.

New:
- `tests/test_loader_401_403_split.py` (16) — all four raise sites × {401 → `*TokenExpiredError` and says reconnect; 403 → `*AccessDeniedError`, names the resource, says reconnecting will *not* help, and never says "reconnect your"}. Plus: a 403 is not refresh-retried, pinning that the transport-layer distinction is now preserved rather than discarded.
- `tests/test_single_log_per_failure.py` (3) — a **static AST check** over the whole materializer: no handler may call `logger.exception` and then re-raise. Written statically so a *newly added* offender fails the build rather than only the paths a test happens to exercise. The four legitimately-swallowing handlers are listed explicitly. **Verified non-vacuous** — reverted each site and confirmed both tests fail.
- `tests/test_error_taxonomy.py` (+15) — both inheritance axes, that the two causes don't catch each other, and the two `before_send` directions including the login-path guard.
- `tests/test_reauth_failure_mapping.py` (+4) — a 403 gets the access-removed guidance and *not* the reauth guidance; a run with one dead token and one revoked access carries both.

## Notes for reviewers

- **The judgment call to check is commit 3** (`feat(errors): classify loader auth failures…`). It's ~2 lines of source. Everything else is mechanical.
- **Ordering matters and is intentional:** the 403 could not honestly be called "expected" until its user-facing guidance stopped being wrong. That's why the split lands before the classification, in that order.
- **The `provider` class attribute** on the base classes shadows `ExpectedUpstreamError.provider` for the leaves via MRO. Intentional, tested.
- **Sentry rule changes are still only proposed** (Sentry is read-only for this work). Restating from #387: the `#scout-ops` rule (`10003423453`) has no filters and fires on first-seen. Even with this PR, any *new* fingerprint pages. Worth adding a `level:error` filter or swapping `FirstSeenEventCondition` for a frequency threshold.
- **Not done here:** wiring `UpstreamAccessDenied` to actually archive the membership. That's #378/#384 in wave 2 — this PR only makes the signal available and typed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
