### PR TITLE
Staging environment on the shared EC2 host

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,100 @@
+name: Deploy Scout (Staging)
+
+# Manual only — staging exists to test a branch before it merges, so the ref
+# comes from the Actions ref picker. Tests are deliberately not a gate: the
+# point is to get work-in-progress onto a real host.
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-staging
+  cancel-in-progress: false
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_TAG: ${{ github.sha }}
+      # The API image is environment-agnostic (env comes from Kamal), so staging
+      # reuses prod's tag. The frontend bakes in the nginx conf and Sentry
+      # environment at build time, so it needs a tag of its own or the two
+      # environments overwrite each other's scout/frontend:<sha>.
+      FRONTEND_TAG: staging-${{ github.sha }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4'
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.SCOUT_GITHUB_DEPLOY_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Login to ECR
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Set deploy env vars
+        run: |
+          echo "SCOUT_EC2_IP=${{ secrets.SCOUT_EC2_IP }}" >> $GITHUB_ENV
+          echo "SCOUT_ECR_REGISTRY=${{ vars.SCOUT_ECR_REGISTRY }}" >> $GITHUB_ENV
+          echo "SCOUT_RDS_SECRET_ARN=${{ secrets.SCOUT_RDS_SECRET_ARN }}" >> $GITHUB_ENV
+          echo "SCOUT_RDS_ENDPOINT=${{ secrets.SCOUT_RDS_ENDPOINT }}" >> $GITHUB_ENV
+          # Points DATABASE_URL at the staging database on the shared RDS
+          # instance (scripts/resolve-database-url.sh). Without it, staging
+          # containers boot against the production database.
+          grep '^export SCOUT_DB_NAME=' config/staging.env | sed 's/^export //' >> $GITHUB_ENV
+
+      - name: Build and push API image
+        run: |
+          docker build -t $SCOUT_ECR_REGISTRY/scout/api:$IMAGE_TAG .
+          docker push $SCOUT_ECR_REGISTRY/scout/api:$IMAGE_TAG
+
+      - name: Build and push Frontend image
+        run: |
+          docker build -t $SCOUT_ECR_REGISTRY/scout/frontend:$FRONTEND_TAG \
+            -f Dockerfile.frontend \
+            --build-arg NGINX_CONF=frontend/nginx.staging-kamal.conf \
+            --build-arg VITE_SENTRY_DSN=${{ secrets.SCOUT_VITE_SENTRY_DSN }} \
+            --build-arg VITE_SENTRY_ENVIRONMENT=staging \
+            --build-arg VITE_SENTRY_RELEASE=$IMAGE_TAG \
+            .
+          docker push $SCOUT_ECR_REGISTRY/scout/frontend:$FRONTEND_TAG
+
+      - name: Install Kamal
+        run: gem install kamal
+
+      - name: Setup SSH
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+
+      - name: Deploy MCP
+        run: kamal deploy -c config/deploy-staging-mcp.yml --version=$IMAGE_TAG
+
+      - name: Deploy API
+        run: kamal deploy -c config/deploy-staging.yml --version=$IMAGE_TAG
+
+      - name: Deploy Worker
+        run: kamal deploy -c config/deploy-staging-worker.yml --version=$IMAGE_TAG
+
+      - name: Deploy Frontend
+        run: kamal deploy -c config/deploy-staging-frontend.yml --version=$FRONTEND_TAG
+
+      - name: Summary
+        run: |
+          {
+            echo "### Staging deploy"
+            echo ""
+            echo "| | |"
+            echo "|---|---|"
+            echo "| Ref | \`${{ github.ref_name }}\` |"
+            echo "| Commit | \`$IMAGE_TAG\` |"
+            echo "| URL | https://scout-staging.dimagi.com |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -41,14 +41,19 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Set deploy env vars
+        # `shell: bash` (not the default `bash -e`) so pipefail is on: the
+        # SCOUT_DB_NAME pipeline below must abort the job when grep finds
+        # nothing rather than exiting 0 on sed's status.
+        shell: bash
         run: |
           echo "SCOUT_EC2_IP=${{ secrets.SCOUT_EC2_IP }}" >> $GITHUB_ENV
           echo "SCOUT_ECR_REGISTRY=${{ vars.SCOUT_ECR_REGISTRY }}" >> $GITHUB_ENV
           echo "SCOUT_RDS_SECRET_ARN=${{ secrets.SCOUT_RDS_SECRET_ARN }}" >> $GITHUB_ENV
           echo "SCOUT_RDS_ENDPOINT=${{ secrets.SCOUT_RDS_ENDPOINT }}" >> $GITHUB_ENV
           # Points DATABASE_URL at the staging database on the shared RDS
-          # instance (scripts/resolve-database-url.sh). Without it, staging
-          # containers boot against the production database.
+          # instance (scripts/resolve-database-url.sh). Silently missing, it
+          # defaults to agent_platform and this job migrates and boots staging
+          # against the PRODUCTION database — so fail hard instead.
           grep '^export SCOUT_DB_NAME=' config/staging.env | sed 's/^export //' >> $GITHUB_ENV
 
       - name: Build and push API image

--- a/.kamal/hooks/pre-connect
+++ b/.kamal/hooks/pre-connect
@@ -5,11 +5,20 @@ echo "Ensuring Docker networks exist on remote server..."
 
 SSH_USER="scout"
 
+# Use the dedicated deploy key if it exists; otherwise fall back to the ssh-agent
+# (same mechanism Kamal itself uses when no key file is present).
+SSH_KEY="${SCOUT_DEPLOY_KEY:-$HOME/.ssh/scout-deploy.pem}"
+if [ -f "$SSH_KEY" ]; then
+  KEY_OPTS=(-o IdentitiesOnly=yes -i "$SSH_KEY")
+else
+  KEY_OPTS=()
+fi
+
 # scout_shared: production. scout_staging_shared: the co-located staging stack.
 # Each stack keeps identical internal aliases (scout-web, scout-mcp-web) on its
 # own network, so the frontend nginx conf and MCP_SERVER_URL are shared verbatim.
 for net in scout_shared scout_staging_shared; do
-  ssh -o StrictHostKeyChecking=no -o IdentitiesOnly=yes -i ~/.ssh/scout-deploy.pem "${SSH_USER}@${KAMAL_HOSTS}" "docker network inspect ${net} >/dev/null 2>&1 || docker network create ${net}"
+  ssh -o StrictHostKeyChecking=no "${KEY_OPTS[@]}" "${SSH_USER}@${KAMAL_HOSTS}" "docker network inspect ${net} >/dev/null 2>&1 || docker network create ${net}"
 done
 
 echo "Network setup complete"

--- a/.kamal/hooks/pre-connect
+++ b/.kamal/hooks/pre-connect
@@ -1,10 +1,15 @@
 #!/bin/bash
 # Ensure shared Docker network exists before any service deploys
 
-echo "Ensuring Docker network 'scout_shared' exists on remote server..."
+echo "Ensuring Docker networks exist on remote server..."
 
 SSH_USER="scout"
 
-ssh -o StrictHostKeyChecking=no -o IdentitiesOnly=yes -i ~/.ssh/scout-deploy.pem "${SSH_USER}@${KAMAL_HOSTS}" "docker network inspect scout_shared >/dev/null 2>&1 || docker network create scout_shared"
+# scout_shared: production. scout_staging_shared: the co-located staging stack.
+# Each stack keeps identical internal aliases (scout-web, scout-mcp-web) on its
+# own network, so the frontend nginx conf and MCP_SERVER_URL are shared verbatim.
+for net in scout_shared scout_staging_shared; do
+  ssh -o StrictHostKeyChecking=no -o IdentitiesOnly=yes -i ~/.ssh/scout-deploy.pem "${SSH_USER}@${KAMAL_HOSTS}" "docker network inspect ${net} >/dev/null 2>&1 || docker network create ${net}"
+done
 
 echo "Network setup complete"

--- a/.kamal/hooks/pre-connect
+++ b/.kamal/hooks/pre-connect
@@ -1,5 +1,9 @@
 #!/bin/bash
 # Ensure shared Docker network exists before any service deploys
+#
+# Fail loudly: without `set -e` the trailing echo masks a failed ssh, and Kamal
+# then deploys against a network that does not exist.
+set -eo pipefail
 
 echo "Ensuring Docker networks exist on remote server..."
 
@@ -15,8 +19,10 @@ else
 fi
 
 # scout_shared: production. scout_staging_shared: the co-located staging stack.
-# Each stack keeps identical internal aliases (scout-web, scout-mcp-web) on its
-# own network, so the frontend nginx conf and MCP_SERVER_URL are shared verbatim.
+# The two stacks must use distinct internal aliases (scout-web vs
+# scout-staging-web) — Kamal 2 registers --network-alias on the shared `kamal`
+# network, not on these, so a reused alias round-robins prod traffic into
+# staging (see config/deploy-staging.yml).
 for net in scout_shared scout_staging_shared; do
   ssh -o StrictHostKeyChecking=no "${KEY_OPTS[@]}" "${SSH_USER}@${KAMAL_HOSTS}" "docker network inspect ${net} >/dev/null 2>&1 || docker network create ${net}"
 done

--- a/.kamal/hooks/pre-connect
+++ b/.kamal/hooks/pre-connect
@@ -23,8 +23,13 @@ fi
 # scout-staging-web) — Kamal 2 registers --network-alias on the shared `kamal`
 # network, not on these, so a reused alias round-robins prod traffic into
 # staging (see config/deploy-staging.yml).
+#
+# `create || inspect` rather than a bare create: prod and staging deploys are in
+# separate concurrency groups, so two runs can pass the inspect check at the same
+# time and one create then loses with "network already exists". Re-inspecting
+# turns that race into success while a genuine failure still exits non-zero.
 for net in scout_shared scout_staging_shared; do
-  ssh -o StrictHostKeyChecking=no "${KEY_OPTS[@]}" "${SSH_USER}@${KAMAL_HOSTS}" "docker network inspect ${net} >/dev/null 2>&1 || docker network create ${net}"
+  ssh -o StrictHostKeyChecking=no "${KEY_OPTS[@]}" "${SSH_USER}@${KAMAL_HOSTS}" "docker network inspect ${net} >/dev/null 2>&1 || docker network create ${net} >/dev/null 2>&1 || docker network inspect ${net} >/dev/null"
 done
 
 echo "Network setup complete"

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -173,6 +173,63 @@ hidden source maps, uploads them to Sentry tagged with the release (git SHA), th
 deletes them from `dist/` so they don't ship to browsers. The auth token is passed as a
 BuildKit secret (`--secret id=sentry_auth_token`) and never lands in an image layer.
 
+## Second environment (staging)
+
+A staging environment (`scout-staging.dimagi.com`) runs **co-located on the
+production EC2 host** for testing branches. It reuses every AWS Secrets Manager
+value, the ECR repos, and the RDS *instance* — but has **its own database**
+(`agent_platform_staging`) and its own Docker network (`scout_staging_shared`),
+so its data and internal services are isolated from production. Config lives in
+`config/deploy-staging*.yml` and is deployed manually (not from CI).
+
+Notes: it runs the API with 2 uvicorn workers (not 4) and no Redis (LocMemCache)
+to limit its footprint on the shared t3.medium, and uses Docker's `json-file` log
+driver so `kamal app logs` works directly.
+
+### One-time setup
+
+1. **Create the database** on the existing RDS instance (uses the prod master
+   role; run from a machine with AWS access):
+   ```bash
+   source .env.deploy
+   DATABASE_URL=$(SCOUT_DB_NAME=postgres ./scripts/resolve-database-url.sh)
+   psql "$DATABASE_URL" -c "CREATE DATABASE agent_platform_staging;"
+   ```
+2. **DNS**: add an A record `scout-staging.dimagi.com` → the EC2 Elastic IP
+   (`SCOUT_EC2_IP` in `.env.deploy`). Kamal's proxy issues the TLS cert once the
+   record resolves.
+3. **OAuth**: the staging host reuses the production OAuth client IDs, so register
+   its callback URLs (`https://scout-staging.dimagi.com/accounts/<provider>/login/callback/`)
+   with each provider (CommCare, Connect, OCS, Google) — otherwise OAuth login
+   fails on staging. `setup_oauth_apps` runs automatically for the staging domain
+   in the API container's entrypoint.
+
+### Deploying (from the branch you want to test)
+
+```bash
+git checkout codex/semantic-model-work
+source .env.deploy && source config/staging.env
+
+# First time
+kamal setup -c config/deploy-staging-mcp.yml
+kamal setup -c config/deploy-staging.yml
+kamal setup -c config/deploy-staging-worker.yml
+kamal setup -c config/deploy-staging-frontend.yml
+
+# Subsequent deploys
+kamal deploy -c config/deploy-staging-mcp.yml
+kamal deploy -c config/deploy-staging.yml
+kamal deploy -c config/deploy-staging-worker.yml
+kamal deploy -c config/deploy-staging-frontend.yml
+```
+
+Migrations run automatically against the staging database when the API container
+starts. Logs: `kamal app logs -c config/deploy-staging.yml`.
+
+> Always `source config/staging.env` before staging commands — it points
+> `DATABASE_URL` at the staging database. A plain `source .env.deploy` (prod)
+> would deploy staging containers against the **production** database.
+
 ## Manual Deployment
 
 For deploying from your local machine (e.g., debugging or first-time setup):

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -182,6 +182,15 @@ value, the ECR repos, and the RDS *instance* — but has **its own database**
 so its data and internal services are isolated from production. Config lives in
 `config/deploy-staging*.yml`.
 
+One thing is *not* isolated: PostgreSQL roles are cluster-scoped, not per-database.
+The `<schema>_ro` / `<schema>_dbt` roles `SchemaManager` mints are named
+deterministically from `(provider, external_id)`, so a tenant provisioned in both
+environments shares a single role object. Expect `DROP ROLE` during schema teardown
+to fail with "objects depend on it … in database agent_platform_staging" (or vice
+versa) and leave a dangling role — the teardown swallows and logs it, so it is
+noise rather than breakage, but it is why staging role errors can appear in
+production logs.
+
 Notes: it runs the API with 2 uvicorn workers (not 4) and no Redis (LocMemCache)
 to limit its footprint on the shared t3.medium, and uses Docker's `json-file` log
 driver so `kamal app logs` works directly.

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -240,14 +240,21 @@ source .env.deploy && source config/staging.env
 kamal setup -c config/deploy-staging-mcp.yml
 kamal setup -c config/deploy-staging.yml
 kamal setup -c config/deploy-staging-worker.yml
-kamal setup -c config/deploy-staging-frontend.yml
+kamal setup -c config/deploy-staging-frontend.yml --version=staging-$(git rev-parse HEAD)
 
 # Subsequent deploys
 kamal deploy -c config/deploy-staging-mcp.yml
 kamal deploy -c config/deploy-staging.yml
 kamal deploy -c config/deploy-staging-worker.yml
-kamal deploy -c config/deploy-staging-frontend.yml
+kamal deploy -c config/deploy-staging-frontend.yml --version=staging-$(git rev-parse HEAD)
 ```
+
+The frontend commands carry an explicit `--version`. Without it Kamal versions the
+build as the bare git SHA and pushes it as `scout/frontend:<sha>` — the same tag
+production uses — but with `nginx.staging-kamal.conf` baked in. A later production
+`kamal rollback`, host reboot, or re-pull of that version would then serve a
+frontend proxying to `scout-staging-web`, putting production traffic on the staging
+API. The API/MCP/worker image is environment-agnostic, so those need no override.
 
 Migrations run automatically against the staging database when the API container
 starts. Logs: `kamal app logs -c config/deploy-staging.yml`.
@@ -255,6 +262,11 @@ starts. Logs: `kamal app logs -c config/deploy-staging.yml`.
 > Always `source config/staging.env` before staging commands — it points
 > `DATABASE_URL` at the staging database. A plain `source .env.deploy` (prod)
 > would deploy staging containers against the **production** database.
+>
+> And `unset SCOUT_DB_NAME` before running any **production** kamal command in
+> that shell. The export survives a re-`source` of `.env.deploy` (which never
+> sets it), so a prod deploy from the same session resolves `DATABASE_URL` to
+> `agent_platform_staging` and points production at the staging database.
 
 ## Manual Deployment
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -180,7 +180,7 @@ production EC2 host** for testing branches. It reuses every AWS Secrets Manager
 value, the ECR repos, and the RDS *instance* — but has **its own database**
 (`agent_platform_staging`) and its own Docker network (`scout_staging_shared`),
 so its data and internal services are isolated from production. Config lives in
-`config/deploy-staging*.yml` and is deployed manually (not from CI).
+`config/deploy-staging*.yml`.
 
 Notes: it runs the API with 2 uvicorn workers (not 4) and no Redis (LocMemCache)
 to limit its footprint on the shared t3.medium, and uses Docker's `json-file` log
@@ -204,7 +204,24 @@ driver so `kamal app logs` works directly.
    fails on staging. `setup_oauth_apps` runs automatically for the staging domain
    in the API container's entrypoint.
 
-### Deploying (from the branch you want to test)
+### Deploying from GitHub Actions
+
+Run the **Deploy Scout (Staging)** workflow and pick the branch to deploy from the
+ref dropdown. It builds and pushes both images, then deploys MCP → API → worker →
+frontend, and needs no secrets beyond the ones production already uses.
+
+Tests are not a gate — staging is for trying work in progress. The workflow is
+`workflow_dispatch`-only, so nothing reaches staging unless someone asks for it.
+
+Frontend images are tagged `staging-<sha>` rather than `<sha>`: the image bakes in
+`nginx.staging-kamal.conf` and `SENTRY_ENVIRONMENT` at build time, so sharing a tag
+with production would mean whichever environment deployed a given commit last wins.
+The API image carries no environment-specific build args and reuses the plain `<sha>`.
+Staging frontend builds skip the Sentry sourcemap upload, so a staging deploy can't
+overwrite the artifacts of a production release with the same SHA — errors still
+report to Sentry under the `staging` environment.
+
+### Deploying from your machine
 
 ```bash
 git checkout codex/semantic-model-work

--- a/config/deploy-staging-frontend.yml
+++ b/config/deploy-staging-frontend.yml
@@ -14,7 +14,7 @@ servers:
       - <%= ENV.fetch('SCOUT_EC2_IP') %>
     options:
       network: "scout_staging_shared"
-      network-alias: "scout-frontend-web"
+      network-alias: "scout-staging-frontend-web"
 
 registry:
   server: <%= ENV.fetch('SCOUT_ECR_REGISTRY') %>
@@ -28,9 +28,10 @@ builder:
   arch: amd64
   dockerfile: Dockerfile.frontend
   args:
-    # Same conf as prod: nginx proxies to "scout-web" / "scout-mcp-web", which
-    # resolve to the staging API/MCP within scout_staging_shared.
-    NGINX_CONF: frontend/nginx.prod-kamal.conf
+    # Staging-specific conf: proxies to "scout-staging-web" so it resolves to the
+    # staging API, not prod's. A shared alias would collide on the `kamal` network
+    # (see nginx.staging-kamal.conf header and deploy-staging.yml).
+    NGINX_CONF: frontend/nginx.staging-kamal.conf
 
 env:
   clear:

--- a/config/deploy-staging-frontend.yml
+++ b/config/deploy-staging-frontend.yml
@@ -1,0 +1,47 @@
+# Scout Frontend — STAGING. Sole public entry point for the staging host.
+# Shares the host's single kamal-proxy with production; routing is by hostname
+# (scout-staging.dimagi.com vs scout.dimagi.com), so both get their own cert.
+#
+# Requires: source .env.deploy && source config/staging.env
+
+service: scout-staging-frontend
+
+image: scout/frontend
+
+servers:
+  web:
+    hosts:
+      - <%= ENV.fetch('SCOUT_EC2_IP') %>
+    options:
+      network: "scout_staging_shared"
+      network-alias: "scout-frontend-web"
+
+registry:
+  server: <%= ENV.fetch('SCOUT_ECR_REGISTRY') %>
+  username: AWS
+  password: <%= %x(./registry_password.sh) %>
+
+ssh:
+  user: scout
+
+builder:
+  arch: amd64
+  dockerfile: Dockerfile.frontend
+  args:
+    # Same conf as prod: nginx proxies to "scout-web" / "scout-mcp-web", which
+    # resolve to the staging API/MCP within scout_staging_shared.
+    NGINX_CONF: frontend/nginx.prod-kamal.conf
+
+env:
+  clear:
+    EMBED_ALLOWED_ORIGINS: "https://labs.connect.dimagi.com"
+
+proxy:
+  host: scout-staging.dimagi.com
+  app_port: 3000
+  ssl: true
+  forward_headers: true
+  healthcheck:
+    interval: 5
+    path: /
+    timeout: 3

--- a/config/deploy-staging-mcp.yml
+++ b/config/deploy-staging-mcp.yml
@@ -1,5 +1,5 @@
 # Scout MCP Server — STAGING. Internal only, reached by the staging API at
-# scout-mcp-web:8100 on the scout_staging_shared network.
+# scout-staging-mcp-web:8100 on the scout_staging_shared network.
 #
 # Requires: source .env.deploy && source config/staging.env
 
@@ -13,7 +13,7 @@ servers:
       - <%= ENV.fetch('SCOUT_EC2_IP') %>
     options:
       network: "scout_staging_shared"
-      network-alias: "scout-mcp-web"
+      network-alias: "scout-staging-mcp-web"
     cmd: "python -m mcp_server --transport streamable-http --host 0.0.0.0 --port 8100"
     proxy: false
 

--- a/config/deploy-staging-mcp.yml
+++ b/config/deploy-staging-mcp.yml
@@ -1,0 +1,43 @@
+# Scout MCP Server — STAGING. Internal only, reached by the staging API at
+# scout-mcp-web:8100 on the scout_staging_shared network.
+#
+# Requires: source .env.deploy && source config/staging.env
+
+service: scout-staging-mcp
+
+image: scout/api
+
+servers:
+  web:
+    hosts:
+      - <%= ENV.fetch('SCOUT_EC2_IP') %>
+    options:
+      network: "scout_staging_shared"
+      network-alias: "scout-mcp-web"
+    cmd: "python -m mcp_server --transport streamable-http --host 0.0.0.0 --port 8100"
+    proxy: false
+
+registry:
+  server: <%= ENV.fetch('SCOUT_ECR_REGISTRY') %>
+  username: AWS
+  password: <%= %x(./registry_password.sh) %>
+
+env:
+  clear:
+    DJANGO_SETTINGS_MODULE: config.settings.production
+    SENTRY_ENVIRONMENT: "staging"
+    SENTRY_TRACES_SAMPLE_RATE: "0.1"
+    SENTRY_RELEASE: <%= ENV.fetch('IMAGE_TAG', '') %>
+  secret:
+    - DATABASE_URL
+    - MANAGED_DATABASE_URL
+    - DB_CREDENTIAL_KEY
+    - DJANGO_SECRET_KEY
+    - SENTRY_DSN
+    - MCP_SHARED_SECRET
+
+ssh:
+  user: scout
+
+builder:
+  arch: amd64

--- a/config/deploy-staging-worker.yml
+++ b/config/deploy-staging-worker.yml
@@ -1,0 +1,52 @@
+# Scout Procrastinate Worker — STAGING. No HTTP interface. Its task queue is
+# the staging PostgreSQL database, so it is isolated from production's worker.
+#
+# Requires: source .env.deploy && source config/staging.env
+
+service: scout-staging-worker
+
+image: scout/api
+
+servers:
+  web:
+    hosts:
+      - <%= ENV.fetch('SCOUT_EC2_IP') %>
+    options:
+      network: "scout_staging_shared"
+    cmd: "python manage.py procrastinate worker"
+    proxy: false
+
+registry:
+  server: <%= ENV.fetch('SCOUT_ECR_REGISTRY') %>
+  username: AWS
+  password: <%= %x(./registry_password.sh) %>
+
+env:
+  clear:
+    DJANGO_SETTINGS_MODULE: config.settings.production
+    SENTRY_ENVIRONMENT: "staging"
+    SENTRY_TRACES_SAMPLE_RATE: "0.1"
+    SENTRY_RELEASE: <%= ENV.fetch('IMAGE_TAG', '') %>
+    MCP_SERVER_URL: "http://scout-mcp-web:8100/mcp"
+    LANGFUSE_BASE_URL: "https://cloud.langfuse.com"
+    SCOUT_BASE_URL: "https://scout-staging.dimagi.com"
+    DEFAULT_FROM_EMAIL: "Scout Staging <noreply@dimagi.com>"
+  secret:
+    - DATABASE_URL
+    - MANAGED_DATABASE_URL
+    - DJANGO_SECRET_KEY
+    - DB_CREDENTIAL_KEY
+    - SENTRY_DSN
+    - ANTHROPIC_API_KEY
+    - LANGFUSE_SECRET_KEY
+    - LANGFUSE_PUBLIC_KEY
+    - TASKBADGER_API_KEY
+    - MCP_SHARED_SECRET
+    - AWS_SES_ACCESS_KEY_ID
+    - AWS_SES_SECRET_ACCESS_KEY
+
+ssh:
+  user: scout
+
+builder:
+  arch: amd64

--- a/config/deploy-staging-worker.yml
+++ b/config/deploy-staging-worker.yml
@@ -27,7 +27,7 @@ env:
     SENTRY_ENVIRONMENT: "staging"
     SENTRY_TRACES_SAMPLE_RATE: "0.1"
     SENTRY_RELEASE: <%= ENV.fetch('IMAGE_TAG', '') %>
-    MCP_SERVER_URL: "http://scout-mcp-web:8100/mcp"
+    MCP_SERVER_URL: "http://scout-staging-mcp-web:8100/mcp"
     LANGFUSE_BASE_URL: "https://cloud.langfuse.com"
     SCOUT_BASE_URL: "https://scout-staging.dimagi.com"
     DEFAULT_FROM_EMAIL: "Scout Staging <noreply@dimagi.com>"

--- a/config/deploy-staging.yml
+++ b/config/deploy-staging.yml
@@ -13,10 +13,12 @@ servers:
     hosts:
       - <%= ENV.fetch('SCOUT_EC2_IP') %>
     options:
-      # Own Docker network so the identical internal aliases below resolve to
-      # the staging containers, not production's.
+      # Distinct alias from prod's scout-web: Kamal 2 applies --network-alias on
+      # the shared `kamal` network, so reusing prod's alias round-robins traffic
+      # across both stacks (a scout.dimagi.com request hitting staging 400s on
+      # ALLOWED_HOSTS). The scout_staging_shared network alone does not isolate.
       network: "scout_staging_shared"
-      network-alias: "scout-web"
+      network-alias: "scout-staging-web"
     # Fewer workers than prod (4): staging shares the t3.medium with production.
     cmd: "uvicorn config.asgi:application --host 0.0.0.0 --port 8000 --workers 2 --timeout-keep-alive 120 --lifespan off --no-access-log"
     proxy: false
@@ -34,7 +36,7 @@ env:
     SCOUT_BASE_URL: "https://scout-staging.dimagi.com"
     DEFAULT_FROM_EMAIL: "Scout Staging <noreply@dimagi.com>"
     SECURE_SSL_REDIRECT: "False"
-    MCP_SERVER_URL: "http://scout-mcp-web:8100/mcp"
+    MCP_SERVER_URL: "http://scout-staging-mcp-web:8100/mcp"
     EMBED_ALLOWED_ORIGINS: "https://labs.connect.dimagi.com"
     MAX_CONNECTIONS_PER_PROJECT: 5
     MAX_QUERIES_PER_MINUTE: 60

--- a/config/deploy-staging.yml
+++ b/config/deploy-staging.yml
@@ -1,0 +1,72 @@
+# Scout Django API — STAGING (second environment, co-located on the prod EC2)
+# Internal only (no proxy) — reached via nginx in the staging frontend container.
+#
+# Requires: source .env.deploy && source config/staging.env
+# See DEPLOYMENT.md → "Second environment (staging)".
+
+service: scout-staging
+
+image: scout/api
+
+servers:
+  web:
+    hosts:
+      - <%= ENV.fetch('SCOUT_EC2_IP') %>
+    options:
+      # Own Docker network so the identical internal aliases below resolve to
+      # the staging containers, not production's.
+      network: "scout_staging_shared"
+      network-alias: "scout-web"
+    # Fewer workers than prod (4): staging shares the t3.medium with production.
+    cmd: "uvicorn config.asgi:application --host 0.0.0.0 --port 8000 --workers 2 --timeout-keep-alive 120 --lifespan off --no-access-log"
+    proxy: false
+
+registry:
+  server: <%= ENV.fetch('SCOUT_ECR_REGISTRY') %>
+  username: AWS
+  password: <%= %x(./registry_password.sh) %>
+
+env:
+  clear:
+    DJANGO_SETTINGS_MODULE: config.settings.production
+    DJANGO_ALLOWED_HOSTS: "scout-staging.dimagi.com"
+    CSRF_TRUSTED_ORIGINS: "https://scout-staging.dimagi.com"
+    SCOUT_BASE_URL: "https://scout-staging.dimagi.com"
+    DEFAULT_FROM_EMAIL: "Scout Staging <noreply@dimagi.com>"
+    SECURE_SSL_REDIRECT: "False"
+    MCP_SERVER_URL: "http://scout-mcp-web:8100/mcp"
+    EMBED_ALLOWED_ORIGINS: "https://labs.connect.dimagi.com"
+    MAX_CONNECTIONS_PER_PROJECT: 5
+    MAX_QUERIES_PER_MINUTE: 60
+    LANGFUSE_BASE_URL: "https://cloud.langfuse.com"
+    SENTRY_ENVIRONMENT: "staging"
+    SENTRY_TRACES_SAMPLE_RATE: "0.1"
+    SENTRY_RELEASE: <%= ENV.fetch('IMAGE_TAG', '') %>
+  secret:
+    # DATABASE_URL resolves to the staging database via SCOUT_DB_NAME
+    # (config/staging.env). No REDIS_URL — staging falls back to LocMemCache.
+    - DATABASE_URL
+    - MANAGED_DATABASE_URL
+    - DJANGO_SECRET_KEY
+    - DB_CREDENTIAL_KEY
+    - ANTHROPIC_API_KEY
+    - LANGFUSE_SECRET_KEY
+    - LANGFUSE_PUBLIC_KEY
+    - COMMCARE_OAUTH_CLIENT_ID
+    - COMMCARE_OAUTH_CLIENT_SECRET
+    - CONNECT_OAUTH_CLIENT_ID
+    - CONNECT_OAUTH_CLIENT_SECRET
+    - OCS_OAUTH_CLIENT_ID
+    - OCS_OAUTH_CLIENT_SECRET
+    - SENTRY_DSN
+    - TASKBADGER_API_KEY
+    - MCP_SHARED_SECRET
+
+ssh:
+  user: scout
+
+builder:
+  arch: amd64
+
+# No awslogs block: staging uses Docker's json-file driver so `kamal app logs
+# -c config/deploy-staging.yml` works directly for debugging.

--- a/config/staging.env
+++ b/config/staging.env
@@ -1,0 +1,9 @@
+# Staging (second environment) deploy overrides — source AFTER .env.deploy.
+# Non-secret: it only selects which database/host the shared secrets resolve to.
+#
+#   source .env.deploy && source config/staging.env
+#
+# Reuses every AWS Secrets Manager value and the prod RDS instance; the only
+# difference is the target database (its own) — see DEPLOYMENT.md.
+
+export SCOUT_DB_NAME=agent_platform_staging

--- a/frontend/nginx.staging-kamal.conf
+++ b/frontend/nginx.staging-kamal.conf
@@ -1,0 +1,162 @@
+# STAGING variant of nginx.prod-kamal.conf. IDENTICAL to that file except the
+# $api_upstream value below — keep the two in sync when editing either. Staging
+# needs a distinct upstream alias because Kamal 2 applies --network-alias on the
+# shared `kamal` network, so a shared `scout-web` alias collides with production
+# and round-robins staging traffic onto prod (and vice versa).
+server {
+    listen 3000;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Docker embedded DNS — re-resolve upstream hostnames every 10s so
+    # nginx picks up new container IPs after API redeploys.
+    resolver 127.0.0.11 valid=10s;
+    set $api_upstream scout-staging-web;
+
+    # Security headers
+    add_header X-Content-Type-Options nosniff always;
+    add_header X-Frame-Options SAMEORIGIN always;
+    add_header Referrer-Policy strict-origin-when-cross-origin always;
+    add_header Permissions-Policy "camera=(), microphone=()" always;
+
+    client_max_body_size 10m;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Embed route: cross-origin-friendly framing. CSP frame-ancestors replaces
+    # X-Frame-Options and is driven by the EMBED_ALLOWED_ORIGINS env var
+    # (substituted by the nginx image's envsubst entrypoint at container start).
+    # When EMBED_ALLOWED_ORIGINS is empty the policy collapses to 'self',
+    # matching SAMEORIGIN behavior — so this is a safe default for every deploy.
+    #
+    # SPA fallback uses a named location (@embed_index) instead of falling
+    # through to /index.html. A try_files fallback to /index.html triggers an
+    # internal redirect that re-runs location matching against `location /`,
+    # which would replace these embed-specific headers with X-Frame-Options:
+    # SAMEORIGIN. The named location keeps the response in the embed context.
+    location /embed/ {
+        try_files $uri $uri/ @embed_index;
+        # Re-declare headers — nginx add_header does not inherit when a location
+        # block defines its own. X-Frame-Options is intentionally omitted.
+        add_header X-Content-Type-Options nosniff always;
+        add_header Referrer-Policy strict-origin-when-cross-origin always;
+        add_header Permissions-Policy "camera=(), microphone=()" always;
+        add_header Content-Security-Policy "frame-ancestors 'self' ${EMBED_ALLOWED_ORIGINS}" always;
+    }
+
+    location @embed_index {
+        # Serve the SPA shell for any /embed/* path that doesn't match a real
+        # file. `rewrite ... break` rewrites within this location instead of
+        # doing an internal redirect, so the embed headers below are what the
+        # client receives.
+        rewrite ^ /index.html break;
+        add_header X-Content-Type-Options nosniff always;
+        add_header Referrer-Policy strict-origin-when-cross-origin always;
+        add_header Permissions-Policy "camera=(), microphone=()" always;
+        add_header Content-Security-Policy "frame-ancestors 'self' ${EMBED_ALLOWED_ORIGINS}" always;
+    }
+
+    # Public share-link endpoints carry the bearer capability in the URL path
+    # (the share token). nginx's access log writes the full request line and
+    # ships it to the /scout/frontend CloudWatch group, where a reader could
+    # harvest live tokens (arch #257, finding 08#6). A regex location (higher
+    # priority than the `location /api/` prefix) disables logging for exactly
+    # these capability-bearing paths while general /api/ logging is unaffected.
+    location ~ ^/api/(chat/threads|recipes/runs)/shared/ {
+        access_log off;
+        proxy_pass http://$api_upstream:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_buffering off;
+        proxy_cache off;
+        chunked_transfer_encoding on;
+        proxy_read_timeout 120s;
+        proxy_send_timeout 120s;
+    }
+
+    location /api/ {
+        proxy_pass http://$api_upstream:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_buffering off;
+        proxy_cache off;
+        chunked_transfer_encoding on;
+        # Defense-in-depth: with the procrastinate-backed materialization
+        # flow (3s polling), the SSE upstream should never fall silent for
+        # more than a handful of seconds. 120s is a generous backstop above
+        # nginx's 60s default that tolerates one missed poll plus jitter
+        # without dropping the connection on slow networks.
+        proxy_read_timeout 120s;
+        proxy_send_timeout 120s;
+    }
+
+    # Serve the embed widget SDK with CORS so cross-origin host pages can load
+    # it (issue #248, 04#8d). Without an explicit location it falls through to
+    # `location /` and is served without Access-Control-Allow-Origin, so a
+    # cross-origin <script src> embed is blocked.
+    location = /widget.js {
+        alias /usr/share/nginx/html/widget.js;
+        add_header Access-Control-Allow-Origin *;
+        add_header Cache-Control "public, max-age=300";
+        # Re-declare inherited security headers (nginx drops them when a
+        # location defines its own add_header). X-Frame-Options omitted so the
+        # script can be embedded cross-origin.
+        add_header X-Content-Type-Options nosniff always;
+        add_header Referrer-Policy strict-origin-when-cross-origin always;
+        add_header Permissions-Policy "camera=(), microphone=()" always;
+    }
+
+    location /static/ {
+        proxy_pass http://$api_upstream:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_cache_valid 200 1d;
+        expires 1d;
+        add_header Cache-Control "public";
+        # Must re-declare — nginx does not inherit add_header from parent when this block defines its own
+        add_header X-Content-Type-Options nosniff always;
+        add_header X-Frame-Options SAMEORIGIN always;
+        add_header Referrer-Policy strict-origin-when-cross-origin always;
+        add_header Permissions-Policy "camera=(), microphone=()" always;
+    }
+
+    location /admin/ {
+        proxy_pass http://$api_upstream:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+    }
+
+    location /accounts/ {
+        # OAuth callbacks land here carrying ?code=<authorization code> in the
+        # query string; nginx logs the full request line into the /scout/frontend
+        # CloudWatch group. The code is short-lived but is still a bearer secret,
+        # so don't log these requests (arch #257, finding 08#6).
+        access_log off;
+        proxy_pass http://$api_upstream:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+    }
+
+    location /health/ {
+        proxy_pass http://$api_upstream:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto https;
+    }
+
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript text/xml;
+    gzip_min_length 256;
+}

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -1021,7 +1021,13 @@ def _run_streamable_http(args: argparse.Namespace) -> None:
     # The MCP server is internal-only; DNS rebinding protection is still on.
     mcp.settings.transport_security = TransportSecuritySettings(
         enable_dns_rebinding_protection=True,
-        allowed_hosts=["127.0.0.1:*", "localhost:*", "[::1]:*", "scout-mcp-web:*"],
+        allowed_hosts=[
+            "127.0.0.1:*",
+            "localhost:*",
+            "[::1]:*",
+            "scout-mcp-web:*",
+            "scout-staging-mcp-web:*",
+        ],
     )
 
     app = mcp.streamable_http_app()

--- a/scripts/resolve-database-url.sh
+++ b/scripts/resolve-database-url.sh
@@ -34,4 +34,6 @@ RDS_SECRET=$(aws secretsmanager get-secret-value \
 DB_PASSWORD=$(echo "$RDS_SECRET" | python3 -c "import sys,json; print(json.load(sys.stdin)['password'])")
 DB_PASSWORD_ENCODED=$(python3 -c "import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=''))" "$DB_PASSWORD")
 
-echo "postgresql://platform:${DB_PASSWORD_ENCODED}@${SCOUT_RDS_ENDPOINT}:5432/agent_platform"
+# Second environments share the RDS instance/master role but use their own
+# database — set SCOUT_DB_NAME (e.g. agent_platform_staging) to target it.
+echo "postgresql://platform:${DB_PASSWORD_ENCODED}@${SCOUT_RDS_ENDPOINT}:5432/${SCOUT_DB_NAME:-agent_platform}"


### PR DESCRIPTION
Gives us somewhere to put a branch in front of people before it merges. Staging is co-located with production on the same t3.medium and the same RDS instance, with its own database (`agent_platform_staging`), its own ECR tags, and its own Kamal service names. Deploy is manual `workflow_dispatch` off any ref — tests are deliberately not a gate, since the point is to get work-in-progress onto a real host.

Where to look:

- **`.kamal/hooks/pre-connect`** — the co-location is the risky part. Kamal 2 registers `--network-alias` on the shared `kamal` network, so a reused alias round-robins production traffic into staging. Staging gets distinct aliases and its own `scout_staging_shared` network; the MCP DNS-rebinding allowlist in `mcp_server/server.py` had to learn the new name.
- **`config/deploy-staging-frontend.yml` / `nginx.staging-kamal.conf`** — the frontend image bakes its nginx conf, so staging needs a separate image and a non-colliding tag. The workflow pins `FRONTEND_TAG`; without it the staging build would overwrite `scout/frontend:<sha>` and a production rollback would serve a frontend proxying to the staging API.
- **`scripts/resolve-database-url.sh`** — `SCOUT_DB_NAME` now selects the database off the shared RDS secret. Every path that can drop it silently ends with staging migrating production, so the workflow step runs with `pipefail` and DEPLOYMENT.md says to `unset` it before any production command.

Known rough edge left in: `nginx.staging-kamal.conf` is a verbatim copy of the prod conf differing in one `set $api_upstream` line. Collapsing them onto a runtime `API_UPSTREAM` env var via nginx's envsubst entrypoint means changing how the production image builds, which I didn't want to fold into this.

## Sibling sweep

- **Grep used:** `grep -rn 'GITHUB_ENV\|GITHUB_OUTPUT' .github/workflows/ | grep '|'` and `grep -rn 'network inspect\|network create' .kamal/ scripts/ .github/ config/`
- **Sibling sites found & disposition:**
  - [x] The unguarded pipeline into `$GITHUB_ENV` and the `inspect || create` race are both single sites, introduced here. No others.

## Testing

Not yet exercised end-to-end — the first `workflow_dispatch` run is the real test. Worth watching on that run: that prod keeps its own containers and database, and that `kamal app logs` works against both stacks.